### PR TITLE
Simplify `HandshakingTransportAddressConnector`

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Randomness;
@@ -26,6 +27,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportRequestOptions.Type;
 import org.elasticsearch.transport.TransportService;
 
@@ -72,11 +74,26 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
 
     @Override
     public void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<ProbeConnectionResult> listener) {
-        try {
+        new ConnectionAttempt(transportAddress).run(listener);
+    }
 
+    private class ConnectionAttempt {
+        private final TransportAddress transportAddress;
+
+        ConnectionAttempt(TransportAddress transportAddress) {
+            this.transportAddress = transportAddress;
+        }
+
+        void run(ActionListener<ProbeConnectionResult> listener) {
+            SubscribableListener.newForked(this::openProbeConnection)
+                .andThen(this::handshakeProbeConnection)
+                .andThen(this::openFullConnection)
+                .addListener(listener);
+        }
+
+        private void openProbeConnection(ActionListener<Transport.Connection> listener) {
             // We could skip this if the transportService were already connected to the given address, but the savings would be minimal so
             // we open a new connection anyway.
-
             logger.trace("[{}] opening probe connection", transportAddress);
             transportService.openConnection(
                 new DiscoveryNode(
@@ -95,98 +112,87 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                     )
                 ),
                 handshakeConnectionProfile,
-                listener.delegateFailure((l, connection) -> {
-                    logger.trace("[{}] opened probe connection", transportAddress);
-                    final var probeHandshakeTimeout = handshakeConnectionProfile.getHandshakeTimeout();
-                    // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
-                    // the connection is closed in the onResponse handler
-                    transportService.handshake(connection, probeHandshakeTimeout, ActionListener.notifyOnce(new ActionListener<>() {
-
-                        @Override
-                        public void onResponse(DiscoveryNode remoteNode) {
-                            try {
-                                // success means (amongst other things) that the cluster names match
-                                logger.trace("[{}] handshake successful: {}", transportAddress, remoteNode);
-                                IOUtils.closeWhileHandlingException(connection);
-
-                                if (remoteNode.equals(transportService.getLocalNode())) {
-                                    listener.onFailure(
-                                        new ConnectTransportException(
-                                            remoteNode,
-                                            String.format(
-                                                Locale.ROOT,
-                                                "successfully discovered local node %s at [%s]",
-                                                remoteNode.descriptionWithoutAttributes(),
-                                                transportAddress
-                                            )
-                                        )
-                                    );
-                                } else if (remoteNode.isMasterNode() == false) {
-                                    listener.onFailure(
-                                        new ConnectTransportException(
-                                            remoteNode,
-                                            String.format(
-                                                Locale.ROOT,
-                                                """
-                                                    successfully discovered master-ineligible node %s at [%s]; to suppress this message, \
-                                                    remove address [%s] from your discovery configuration or ensure that traffic to this \
-                                                    address is routed only to master-eligible nodes""",
-                                                remoteNode.descriptionWithoutAttributes(),
-                                                transportAddress,
-                                                transportAddress
-                                            )
-                                        )
-                                    );
-                                } else {
-                                    transportService.connectToNode(remoteNode, new ActionListener<>() {
-                                        @Override
-                                        public void onResponse(Releasable connectionReleasable) {
-                                            logger.trace("[{}] completed full connection with [{}]", transportAddress, remoteNode);
-                                            listener.onResponse(new ProbeConnectionResult(remoteNode, connectionReleasable));
-                                        }
-
-                                        @Override
-                                        public void onFailure(Exception e) {
-                                            // we opened a connection and successfully performed a handshake, so we're definitely
-                                            // talking to a master-eligible node with a matching cluster name and a good version, but
-                                            // the attempt to open a full connection to its publish address failed; a common reason is
-                                            // that the remote node is listening on 0.0.0.0 but has made an inappropriate choice for its
-                                            // publish address.
-                                            logger.warn(
-                                                () -> format(
-                                                    "completed handshake with [%s] at [%s] but followup connection to [%s] failed",
-                                                    remoteNode.descriptionWithoutAttributes(),
-                                                    transportAddress,
-                                                    remoteNode.getAddress()
-                                                ),
-                                                e
-                                            );
-                                            listener.onFailure(e);
-                                        }
-                                    });
-                                }
-                            } catch (Exception e) {
-                                listener.onFailure(e);
-                            }
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            // we opened a connection and successfully performed a low-level handshake, so we were definitely
-                            // talking to an Elasticsearch node, but the high-level handshake failed indicating some kind of
-                            // mismatched configurations (e.g. cluster name) that the user should address
-                            logger.warn(() -> "handshake to [" + transportAddress + "] failed", e);
-                            IOUtils.closeWhileHandlingException(connection);
-                            listener.onFailure(e);
-                        }
-
-                    }));
-
-                })
+                ActionListener.assertOnce(listener)
             );
+        }
 
-        } catch (Exception e) {
-            listener.onFailure(e);
+        private void handshakeProbeConnection(ActionListener<DiscoveryNode> listener, Transport.Connection connection) {
+            logger.trace("[{}] opened probe connection", transportAddress);
+            final var probeHandshakeTimeout = handshakeConnectionProfile.getHandshakeTimeout();
+            transportService.handshake(connection, probeHandshakeTimeout, ActionListener.assertOnce(new ActionListener<>() {
+                @Override
+                public void onResponse(DiscoveryNode remoteNode) {
+                    // success means (amongst other things) that the cluster names match
+                    logger.trace("[{}] handshake successful: {}", transportAddress, remoteNode);
+                    IOUtils.closeWhileHandlingException(connection);
+                    listener.onResponse(remoteNode);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // We opened a connection and successfully performed a low-level handshake, so we were definitely talking to an
+                    // Elasticsearch node, but the high-level handshake failed indicating some kind of mismatched configurations (e.g.
+                    // cluster name) that the user should address.
+                    logger.warn(() -> "handshake to [" + transportAddress + "] failed", e);
+                    IOUtils.closeWhileHandlingException(connection);
+                    listener.onFailure(e);
+                }
+            }));
+        }
+
+        private void openFullConnection(ActionListener<ProbeConnectionResult> listener, DiscoveryNode remoteNode) {
+            if (remoteNode.equals(transportService.getLocalNode())) {
+                throw new ConnectTransportException(
+                    remoteNode,
+                    String.format(
+                        Locale.ROOT,
+                        "successfully discovered local node %s at [%s]",
+                        remoteNode.descriptionWithoutAttributes(),
+                        transportAddress
+                    )
+                );
+            }
+
+            if (remoteNode.isMasterNode() == false) {
+                throw new ConnectTransportException(
+                    remoteNode,
+                    String.format(
+                        Locale.ROOT,
+                        """
+                            successfully discovered master-ineligible node %s at [%s]; to suppress this message, remove address [%s] from \
+                            your discovery configuration or ensure that traffic to this address is routed only to master-eligible nodes""",
+                        remoteNode.descriptionWithoutAttributes(),
+                        transportAddress,
+                        transportAddress
+                    )
+                );
+            }
+
+            transportService.connectToNode(remoteNode, ActionListener.assertOnce(new ActionListener<>() {
+                @Override
+                public void onResponse(Releasable connectionReleasable) {
+                    logger.trace("[{}] completed full connection with [{}]", transportAddress, remoteNode);
+                    listener.onResponse(new ProbeConnectionResult(remoteNode, connectionReleasable));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // We opened a connection and successfully performed a handshake, so we're definitely talking to a master-eligible node
+                    // with a matching cluster name and a good version, but the attempt to open a full connection to its publish address
+                    // failed; a common reason is that the remote node is listening on 0.0.0.0 but has made an inappropriate choice for its
+                    // publish address.
+                    logger.warn(
+                        () -> format(
+                            "completed handshake with [%s] at [%s] but followup connection to [%s] failed",
+                            remoteNode.descriptionWithoutAttributes(),
+                            transportAddress,
+                            remoteNode.getAddress()
+                        ),
+                        e
+                    );
+                    listener.onFailure(e);
+                }
+            }));
         }
     }
 }


### PR DESCRIPTION
Replaces the deeply-nested listener stack with a `SubscribableListener`
sequence to clarify the process, particularly its failure handling. Also
adds assertions that each step does not double-complete its listener.