### PR TITLE
[8.14] Add known-issues for all affected releases for the feature upgrade issue (#110523)

### DIFF
--- a/docs/reference/release-notes/8.13.0.asciidoc
+++ b/docs/reference/release-notes/8.13.0.asciidoc
@@ -21,6 +21,13 @@ This affects clusters running version 8.10 or later, with an active downsampling
 https://www.elastic.co/guide/en/elasticsearch/reference/current/downsampling-ilm.html[configuration]
 or a configuration that was activated at some point since upgrading to version 8.10 or later.
 
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[breaking-8.13.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.13.1.asciidoc
+++ b/docs/reference/release-notes/8.13.1.asciidoc
@@ -3,6 +3,16 @@
 
 Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 
+[[known-issues-8.13.1]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.13.1]]
 [float]
 

--- a/docs/reference/release-notes/8.13.2.asciidoc
+++ b/docs/reference/release-notes/8.13.2.asciidoc
@@ -3,6 +3,16 @@
 
 Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 
+[[known-issues-8.13.2]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.13.2]]
 [float]
 

--- a/docs/reference/release-notes/8.13.3.asciidoc
+++ b/docs/reference/release-notes/8.13.3.asciidoc
@@ -10,6 +10,16 @@ Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 SQL::
 * Limit how much space some string functions can use {es-pull}107333[#107333]
 
+[[known-issues-8.13.3]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.13.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.13.4.asciidoc
+++ b/docs/reference/release-notes/8.13.4.asciidoc
@@ -3,6 +3,16 @@
 
 Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 
+[[known-issues-8.13.4]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.13.4]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.14.0.asciidoc
+++ b/docs/reference/release-notes/8.14.0.asciidoc
@@ -23,6 +23,16 @@ Security::
 * Apply stricter Document Level Security (DLS) rules for the validate query API with the rewrite parameter {es-pull}105709[#105709]
 * Apply stricter Document Level Security (DLS) rules for terms aggregations when min_doc_count is set to 0 {es-pull}105714[#105714]
 
+[[known-issues-8.14.0]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.14.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.14.0.asciidoc
+++ b/docs/reference/release-notes/8.14.0.asciidoc
@@ -13,6 +13,12 @@ Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
   The workaround is to grant Elasticsearch read access to the directory mentioned in the `java.nio.file.AccessDeniedException` as observed in the logs
   and repeat this until the process starts up properly, see https://support.elastic.co/knowledge/5979309d[here] for further details.
   With 8.14.1 the workaround won't be necessary anymore and original permissions can be restored.
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+  information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+  This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+  If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+  To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+  are upgraded.
 
 [[breaking-8.14.0]]
 [float]
@@ -22,16 +28,6 @@ Security::
 * Prevent DLS/FLS if `replication` is assigned {es-pull}108600[#108600]
 * Apply stricter Document Level Security (DLS) rules for the validate query API with the rewrite parameter {es-pull}105709[#105709]
 * Apply stricter Document Level Security (DLS) rules for terms aggregations when min_doc_count is set to 0 {es-pull}105714[#105714]
-
-[[known-issues-8.14.0]]
-[float]
-=== Known issues
-* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
-information about the new functionality of these upgraded nodes may not be registered properly with the master node.
-This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
-If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
-To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
-are upgraded.
 
 [[bug-8.14.0]]
 [float]

--- a/docs/reference/release-notes/8.14.1.asciidoc
+++ b/docs/reference/release-notes/8.14.1.asciidoc
@@ -4,6 +4,16 @@
 
 Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
 
+[[known-issues-8.14.1]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.14.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.14.2.asciidoc
+++ b/docs/reference/release-notes/8.14.2.asciidoc
@@ -3,6 +3,16 @@
 
 Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
 
+[[known-issues-8.14.2]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.12.2 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.13.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded.
+
 [[bug-8.14.2]]
 [float]
 === Bug fixes
@@ -34,5 +44,3 @@ Ranking::
 Search::
 * Add hexstring support byte painless scorers {es-pull}109492[#109492]
 * Fix automatic tracking of collapse with `docvalue_fields` {es-pull}110103[#110103]
-
-


### PR DESCRIPTION
Backports the following commits to 8.14:

* Add known-issues for all affected releases for the feature upgrade issue (https://github.com/elastic/elasticsearch/pull/110523)