### PR TITLE
[Gradle] Only resolve latest patch version for resolveAllDependencies

### DIFF
--- a/qa/packaging/build.gradle
+++ b/qa/packaging/build.gradle
@@ -38,10 +38,7 @@ tasks.register('destructivePackagingTest') {
 }
 
 tasks.named('resolveAllDependencies') {
-  // Don't try and resolve filebeat or metricbeat snapshots as they may not always be available
-  // Also skip building Elasticsearch distributions
-  configs = configurations.matching { it.name.startsWith('es_distro_') == false }
-
+  // Don't try and resolve all distros but only the latest patch versions of each minor
   def latestBugfixVersions = org.elasticsearch.gradle.internal.info.BuildParams.getBwcVersions().getIndexCompatible()
       .groupBy { [it.major, it.minor] }
       .collectEntries { key, value -> [key, value.max()] }

--- a/qa/packaging/build.gradle
+++ b/qa/packaging/build.gradle
@@ -36,3 +36,16 @@ tasks.named("test").configure { enabled = false }
 tasks.register('destructivePackagingTest') {
   dependsOn 'destructiveDistroTest'
 }
+
+tasks.named('resolveAllDependencies') {
+  // Don't try and resolve filebeat or metricbeat snapshots as they may not always be available
+  // Also skip building Elasticsearch distributions
+  configs = configurations.matching { it.name.startsWith('es_distro_') == false }
+
+  def latestBugfixVersions = org.elasticsearch.gradle.internal.info.BuildParams.getBwcVersions().getIndexCompatible()
+      .groupBy { [it.major, it.minor] }
+      .collectEntries { key, value -> [key, value.max()] }
+      .values()
+
+  configs = configurations.matching { configName -> latestBugfixVersions.any { v -> configName.name.endsWith(v.toString()) } }
+}


### PR DESCRIPTION
This should avoid downloading to many elasticsearch distributions and
- reduce disk usage and 
- speed up image creations.
