### PR TITLE
An alternative approach to supporting union-types on stats grouping field

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValueSourceReaderTypeConversionTests.java
@@ -1687,12 +1687,13 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
 
         @Override
         public boolean supportsOrdinals() {
-            return delegate.supportsOrdinals();
+            // Fields with mismatching types cannot use ordinals for uniqueness determination, but must convert the values first
+            return false;
         }
 
         @Override
-        public SortedSetDocValues ordinals(LeafReaderContext context) throws IOException {
-            return delegate.ordinals(context);
+        public SortedSetDocValues ordinals(LeafReaderContext context) {
+            throw new IllegalArgumentException("Ordinals are not supported for type conversion");
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -77,7 +77,6 @@ import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.planner.EsqlTranslatorHandler;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
-import org.elasticsearch.xpack.esql.type.MultiTypeEsField;
 
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -194,10 +193,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                  * it loads the field lazily. If we have more than one field we need to
                  * make sure the fields are loaded for the standard hash aggregator.
                  */
-                if (p instanceof AggregateExec agg
-                    && agg.groupings().size() == 1
-                    && (isMultiTypeFieldAttribute(agg.groupings().get(0)) == false) // Union types rely on field extraction.
-                ) {
+                if (p instanceof AggregateExec agg && agg.groupings().size() == 1) {
                     var leaves = new LinkedList<>();
                     // TODO: this seems out of place
                     agg.aggregates()
@@ -219,10 +215,6 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             });
 
             return plan;
-        }
-
-        private static boolean isMultiTypeFieldAttribute(Expression attribute) {
-            return attribute instanceof FieldAttribute fa && fa.field() instanceof MultiTypeEsField;
         }
 
         private static Set<Attribute> missingAttributes(PhysicalPlan p) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -233,8 +233,9 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         // The grouping-by values are ready, let's group on them directly.
         // Costin: why are they ready and not already exposed in the layout?
         boolean isUnsupported = attrSource.dataType() == DataType.UNSUPPORTED;
+        var unionTypes = findUnionTypes(attrSource);
         return new OrdinalsGroupingOperator.OrdinalsGroupingOperatorFactory(
-            shardIdx -> shardContexts.get(shardIdx).blockLoader(attrSource.name(), isUnsupported, NONE),
+            shardIdx -> getBlockLoaderFor(shardIdx, attrSource.name(), isUnsupported, NONE, unionTypes),
             vsShardContexts,
             groupElementType,
             docChannel,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -435,12 +435,13 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
         @Override
         public boolean supportsOrdinals() {
-            return delegate.supportsOrdinals();
+            // Fields with mismatching types cannot use ordinals for uniqueness determination, but must convert the values first
+            return false;
         }
 
         @Override
-        public SortedSetDocValues ordinals(LeafReaderContext context) throws IOException {
-            return delegate.ordinals(context);
+        public SortedSetDocValues ordinals(LeafReaderContext context) {
+            throw new IllegalArgumentException("Ordinals are not supported for type conversion");
         }
 
         @Override


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/110476 fixed errors with cases where we have STATS grouping on a field with union-types, but it did so by disabling the ordinals aggregation code path (by blocking the removal of the missing field from FieldExtraction, which had the knockon effect of disabling ordinals aggregation). The new approach re-enables that code path, adds the union-types BlockLoader to the ordinals aggregation so that it is able to convert types for the grouping key, but also makes sure this Blockloader returns `false` to the `supportsOrdinals` method, since that will not be true for union-types. Without this `false`, two fields that are not identical before conversion will not be understood to be identical after conversion. We want, for example `IP("192.168.0.1")` to be identical to `STRING("192.168.0.1")` if the grouping key includes the conversion function (eg. `STATS count(*) BY client_ip::ip`).
