### PR TITLE
Use FileSystemProvider instead of RandomGenerator in test

### DIFF
--- a/server/src/test/java/org/elasticsearch/plugins/UberModuleClassLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/UberModuleClassLoaderTests.java
@@ -427,12 +427,12 @@ public class UberModuleClassLoaderTests extends ESTestCase {
             package p;
 
             import java.util.ServiceLoader;
-            import java.util.random.RandomGenerator;
+            import java.nio.file.spi.FileSystemProvider;
 
             public class ServiceCaller {
                 public static String demo() {
                     // check no error if we load a service from the jdk
-                    ServiceLoader<RandomGenerator> randomLoader = ServiceLoader.load(RandomGenerator.class);
+                    ServiceLoader<FileSystemProvider> fileSystemLoader = ServiceLoader.load(FileSystemProvider.class);
 
                     ServiceLoader<MyService> loader = ServiceLoader.load(MyService.class, ServiceCaller.class.getClassLoader());
                     return loader.findFirst().get().getTestString();


### PR DESCRIPTION
FileSystemProvider is no longer provided by SPI as of Java 23 EA build 24.

Fixes #109191 

See https://github.com/openjdk/jdk/commit/42e3c842ae2684265c794868fc76eb0ff2dea3d9#diff-03546451d9e4189f639e3af3dcd6a9e44318fff5ceaadce8478cbf0203ac3f45L422-L435

