### PR TITLE
[8.15] Fix ExactKnnQueryBuilderTests testToQuery (#110357) (#110589)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -88,9 +88,6 @@ tests:
 - class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
   method: testMinVersionAsOldVersion
   issue: https://github.com/elastic/elasticsearch/issues/109454
-- class: org.elasticsearch.search.vectors.ExactKnnQueryBuilderTests
-  method: testToQuery
-  issue: https://github.com/elastic/elasticsearch/issues/110357
 - class: org.elasticsearch.search.aggregations.bucket.terms.RareTermsIT
   method: testSingleValuedString
   issue: https://github.com/elastic/elasticsearch/issues/110388

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -98,7 +98,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
     public static final String COSINE_MAGNITUDE_FIELD_SUFFIX = "._magnitude";
     private static final float EPS = 1e-3f;
 
-    static boolean isNotUnitVector(float magnitude) {
+    public static boolean isNotUnitVector(float magnitude) {
         return Math.abs(magnitude - 1.0f) > EPS;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/ExactKnnQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/ExactKnnQueryBuilderTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -87,7 +88,9 @@ public class ExactKnnQueryBuilderTests extends AbstractQueryTestCase<ExactKnnQue
         DenseVectorQuery.Floats denseVectorQuery = (DenseVectorQuery.Floats) query;
         assertEquals(VECTOR_FIELD, denseVectorQuery.field);
         float[] expected = Arrays.copyOf(queryBuilder.getQuery().asFloatVector(), queryBuilder.getQuery().asFloatVector().length);
-        if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(IndexVersions.NORMALIZED_VECTOR_COSINE)) {
+        float magnitude = VectorUtil.dotProduct(expected, expected);
+        if (context.getIndexSettings().getIndexVersionCreated().onOrAfter(IndexVersions.NORMALIZED_VECTOR_COSINE)
+            && DenseVectorFieldMapper.isNotUnitVector(magnitude)) {
             VectorUtil.l2normalize(expected);
             assertArrayEquals(expected, denseVectorQuery.getQuery(), 0.0f);
         } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Fix ExactKnnQueryBuilderTests testToQuery (#110357) (#110589)](https://github.com/elastic/elasticsearch/pull/110589)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)