### PR TITLE
Enhance test utility for running tasks in parallel

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -59,20 +59,13 @@ public class IndexingIT extends ESRestTestCase {
      */
     private int indexDocWithConcurrentUpdates(String index, final int docId, int nUpdates) throws IOException, InterruptedException {
         indexDocs(index, docId, 1);
-        Thread[] indexThreads = new Thread[nUpdates];
-        for (int i = 0; i < nUpdates; i++) {
-            indexThreads[i] = new Thread(() -> {
-                try {
-                    indexDocs(index, docId, 1);
-                } catch (IOException e) {
-                    throw new AssertionError("failed while indexing [" + e.getMessage() + "]");
-                }
-            });
-            indexThreads[i].start();
-        }
-        for (Thread indexThread : indexThreads) {
-            indexThread.join();
-        }
+        runInParallel(nUpdates, i -> {
+            try {
+                indexDocs(index, docId, 1);
+            } catch (IOException e) {
+                throw new AssertionError("failed while indexing [" + e.getMessage() + "]");
+            }
+        });
         return nUpdates + 1;
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -39,7 +39,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CyclicBarrier;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -518,14 +517,8 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         createIndex("test");
         indexDoc("test", "1", "field", "1");
         final BulkResponse[] responses = new BulkResponse[30];
-        final CyclicBarrier cyclicBarrier = new CyclicBarrier(responses.length);
 
-        runInParallel(responses.length, threadID -> {
-            try {
-                cyclicBarrier.await();
-            } catch (Exception e) {
-                return;
-            }
+        startInParallel(responses.length, threadID -> {
             BulkRequestBuilder requestBuilder = client().prepareBulk();
             requestBuilder.add(
                 client().prepareUpdate("test", "1")

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -155,9 +154,7 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         final AtomicInteger completedRequests = new AtomicInteger();
         final AtomicInteger numSuccess = new AtomicInteger();
         final AtomicInteger numFailure = new AtomicInteger();
-        Phaser phaser = new Phaser(numThreads);
-        runInParallel(numThreads, i -> {
-            phaser.arriveAndAwaitAdvance();
+        startInParallel(numThreads, i -> {
             while (completedRequests.incrementAndGet() <= numRequests) {
                 try {
                     final DocWriteResponse resp = prepareIndex("test").setSource("{}", XContentType.JSON).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -162,12 +161,10 @@ public class DynamicMappingIT extends ESIntegTestCase {
     private Map<String, Object> indexConcurrently(int numberOfFieldsToCreate, Settings.Builder settings) throws Throwable {
         indicesAdmin().prepareCreate("index").setSettings(settings).get();
         ensureGreen("index");
-        final CyclicBarrier barrier = new CyclicBarrier(numberOfFieldsToCreate);
         final AtomicReference<Throwable> error = new AtomicReference<>();
-        runInParallel(numberOfFieldsToCreate, i -> {
+        startInParallel(numberOfFieldsToCreate, i -> {
             final String id = Integer.toString(i);
             try {
-                barrier.await();
                 assertEquals(
                     DocWriteResponse.Result.CREATED,
                     prepareIndex("index").setId(id).setSource("field" + id, "bar").get().getResult()

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -26,8 +26,6 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Collection;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -141,15 +139,9 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
         final int numberOfDocuments = randomIntBetween(0, 256);
 
         final int numberOfThreads = randomIntBetween(1, 4);
-        final CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
 
         // start concurrent indexing threads
-        runInParallel(numberOfThreads, index -> {
-            try {
-                barrier.await();
-            } catch (BrokenBarrierException | InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+        startInParallel(numberOfThreads, index -> {
             for (int j = 0; j < numberOfDocuments; j++) {
                 final String id = Integer.toString(index * numberOfDocuments + j);
                 prepareIndex("test").setId(id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -179,66 +178,53 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
 
         final AtomicReference<Exception> threadException = new AtomicReference<>();
         final AtomicBoolean stop = new AtomicBoolean(false);
-        Thread[] threads = new Thread[3];
-        final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         final ArrayList<Client> clientArray = new ArrayList<>();
         for (Client c : clients()) {
             clientArray.add(c);
         }
 
-        for (int j = 0; j < threads.length; j++) {
-            threads[j] = new Thread(() -> {
-                try {
-                    barrier.await();
-
-                    for (int i = 0; i < 100; i++) {
-                        if (stop.get()) {
-                            return;
-                        }
-
-                        Client client1 = clientArray.get(i % clientArray.size());
-                        Client client2 = clientArray.get((i + 1) % clientArray.size());
-                        String indexName = i % 2 == 0 ? "test2" : "test1";
-                        String fieldName = Thread.currentThread().getName() + "_" + i;
-
-                        AcknowledgedResponse response = client1.admin()
-                            .indices()
-                            .preparePutMapping(indexName)
-                            .setSource(
-                                JsonXContent.contentBuilder()
-                                    .startObject()
-                                    .startObject("_doc")
-                                    .startObject("properties")
-                                    .startObject(fieldName)
-                                    .field("type", "text")
-                                    .endObject()
-                                    .endObject()
-                                    .endObject()
-                                    .endObject()
-                            )
-                            .setMasterNodeTimeout(TimeValue.timeValueMinutes(5))
-                            .get();
-
-                        assertThat(response.isAcknowledged(), equalTo(true));
-                        GetMappingsResponse getMappingResponse = client2.admin().indices().prepareGetMappings(indexName).get();
-                        MappingMetadata mappings = getMappingResponse.getMappings().get(indexName);
-                        @SuppressWarnings("unchecked")
-                        Map<String, Object> properties = (Map<String, Object>) mappings.getSourceAsMap().get("properties");
-                        assertThat(properties.keySet(), Matchers.hasItem(fieldName));
+        startInParallel(3, j -> {
+            try {
+                for (int i = 0; i < 100; i++) {
+                    if (stop.get()) {
+                        return;
                     }
-                } catch (Exception e) {
-                    threadException.set(e);
-                    stop.set(true);
+
+                    Client client1 = clientArray.get(i % clientArray.size());
+                    Client client2 = clientArray.get((i + 1) % clientArray.size());
+                    String indexName = i % 2 == 0 ? "test2" : "test1";
+                    String fieldName = "t_" + j + "_" + i;
+
+                    AcknowledgedResponse response = client1.admin()
+                        .indices()
+                        .preparePutMapping(indexName)
+                        .setSource(
+                            JsonXContent.contentBuilder()
+                                .startObject()
+                                .startObject("_doc")
+                                .startObject("properties")
+                                .startObject(fieldName)
+                                .field("type", "text")
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                        )
+                        .setMasterNodeTimeout(TimeValue.timeValueMinutes(5))
+                        .get();
+
+                    assertThat(response.isAcknowledged(), equalTo(true));
+                    GetMappingsResponse getMappingResponse = client2.admin().indices().prepareGetMappings(indexName).get();
+                    MappingMetadata mappings = getMappingResponse.getMappings().get(indexName);
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> properties = (Map<String, Object>) mappings.getSourceAsMap().get("properties");
+                    assertThat(properties.keySet(), Matchers.hasItem(fieldName));
                 }
-            });
-
-            threads[j].setName("t_" + j);
-            threads[j].start();
-        }
-
-        for (Thread t : threads) {
-            t.join();
-        }
+            } catch (Exception e) {
+                threadException.set(e);
+                stop.set(true);
+            }
+        });
 
         if (threadException.get() != null) {
             throw threadException.get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -197,9 +197,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().get(indexName).getStatus().value(), lessThanOrEqualTo(ClusterHealthStatus.YELLOW.value()));
 
         final int tasks = randomIntBetween(2, 5);
-        final CyclicBarrier barrier = new CyclicBarrier(tasks);
-        runInParallel(tasks, i -> {
-            safeAwait(barrier);
+        startInParallel(tasks, i -> {
             try {
                 indicesAdmin().prepareClose(indexName).get();
             } catch (final Exception e) {
@@ -247,9 +245,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         }
         assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
 
-        final CyclicBarrier barrier = new CyclicBarrier(indices.length * 2);
-        runInParallel(indices.length * 2, i -> {
-            safeAwait(barrier);
+        startInParallel(indices.length * 2, i -> {
             final String index = indices[i % indices.length];
             try {
                 if (i < indices.length) {
@@ -275,9 +271,8 @@ public class CloseIndexIT extends ESIntegTestCase {
         final int opens = randomIntBetween(1, 3);
         final CyclicBarrier barrier = new CyclicBarrier(opens + closes);
 
-        runInParallel(opens + closes, i -> {
+        startInParallel(opens + closes, i -> {
             try {
-                safeAwait(barrier);
                 if (i < closes) {
                     indicesAdmin().prepareClose(indexName).get();
                 } else {

--- a/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.profile;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -107,35 +106,21 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
 
     public void testMultiThreaded() throws InterruptedException {
         TestProfileBreakdown testBreakdown = new TestProfileBreakdown();
-        Thread[] threads = new Thread[200];
-        final CountDownLatch latch = new CountDownLatch(1);
+        final int threads = 200;
         int startsPerThread = between(1, 5);
-        for (int t = 0; t < threads.length; t++) {
-            final TestTimingTypes timingType = randomFrom(TestTimingTypes.values());
-            threads[t] = new Thread(() -> {
-                try {
-                    latch.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                Timer timer = testBreakdown.getNewTimer(timingType);
-                for (int runs = 0; runs < startsPerThread; runs++) {
-                    timer.start();
-                    timer.stop();
-                }
-            });
-            threads[t].start();
-        }
         // starting all threads simultaneously increases the likelihood of failure in case we don't synchronize timer access properly
-        latch.countDown();
-        for (Thread t : threads) {
-            t.join();
-        }
+        startInParallel(threads, t -> {
+            final TestTimingTypes timingType = randomFrom(TestTimingTypes.values());
+            Timer timer = testBreakdown.getNewTimer(timingType);
+            for (int runs = 0; runs < startsPerThread; runs++) {
+                timer.start();
+                timer.stop();
+            }
+        });
         Map<String, Long> breakdownMap = testBreakdown.toBreakdownMap();
         long totalCounter = breakdownMap.get(TestTimingTypes.ONE + "_count") + breakdownMap.get(TestTimingTypes.TWO + "_count")
             + breakdownMap.get(TestTimingTypes.THREE + "_count");
-        assertEquals(threads.length * startsPerThread, totalCounter);
-
+        assertEquals(threads * startsPerThread, totalCounter);
     }
 
     private void runTimerNTimes(Timer t, int n) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -173,7 +173,6 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -2442,11 +2441,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     public static void startInParallel(int numberOfTasks, IntConsumer taskFactory) throws InterruptedException {
         final CyclicBarrier barrier = new CyclicBarrier(numberOfTasks);
         runInParallel(numberOfTasks, i -> {
-            try {
-                barrier.await();
-            } catch (InterruptedException | BrokenBarrierException e) {
-                throw new AssertionError(e);
-            }
+            safeAwait(barrier);
             taskFactory.accept(i);
         });
     }


### PR DESCRIPTION
Follow up to #110552, add utility for starting tasks at the same time via a barrier as discussed there. Also, make use of the new tooling in a couple more spots to save LoC and thread creation.
