### PR TITLE
Fix BWC for compute listener

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -97,8 +97,6 @@ tests:
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110591"
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -76,8 +76,9 @@ final class ComputeListener implements Releasable {
     ActionListener<ComputeResponse> acquireCompute() {
         return acquireAvoid().map(resp -> {
             responseHeaders.collect();
-            if (resp != null && resp.getProfiles().isEmpty() == false) {
-                collectedProfiles.addAll(resp.getProfiles());
+            var profiles = resp.getProfiles();
+            if (profiles != null && profiles.isEmpty() == false) {
+                collectedProfiles.addAll(profiles);
             }
             return null;
         });


### PR DESCRIPTION
ComputeResponse from old nodes may have a null value instead of an empty list for profiles.

Relates #110400
Closes #110591