### PR TITLE
Fix BWC for compute listener (#110615)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -76,8 +76,9 @@ final class ComputeListener implements Releasable {
     ActionListener<ComputeResponse> acquireCompute() {
         return acquireAvoid().map(resp -> {
             responseHeaders.collect();
-            if (resp != null && resp.getProfiles().isEmpty() == false) {
-                collectedProfiles.addAll(resp.getProfiles());
+            var profiles = resp.getProfiles();
+            if (profiles != null && profiles.isEmpty() == false) {
+                collectedProfiles.addAll(profiles);
             }
             return null;
         });


### PR DESCRIPTION
ComputeResponse from old nodes may have a null value instead of an empty list for profiles.

Relates #110400 
Closes #110591
