### PR TITLE
[ML] Updated filtering in DetectionRulesIt.testCondition()

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -47,9 +47,6 @@ import static org.hamcrest.Matchers.oneOf;
  */
 public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
 
-    // logger
-    public static final Logger logger = LogManager.getLogger(DetectionRulesIT.class);
-
     @After
     public void cleanUpTest() {
         cleanUp();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
@@ -46,6 +48,9 @@ import static org.hamcrest.Matchers.oneOf;
  * An integration test for detection rules
  */
 public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
+
+    // logger
+    public static final Logger logger = LogManager.getLogger(DetectionRulesIT.class);
 
     @After
     public void cleanUpTest() {
@@ -95,6 +100,9 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         closeJob(job.getId());
 
         List<AnomalyRecord> records = getRecords(job.getId());
+        // remove records that are not anomalies
+        records.removeIf(record -> record.getInitialRecordScore() < 1e-5);
+
         assertThat(records.size(), equalTo(1));
         assertThat(records.get(0).getByFieldValue(), equalTo("high"));
         long firstRecordTimestamp = records.get(0).getTimestamp().getTime();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -8,8 +8,6 @@ package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;


### PR DESCRIPTION
While working on elastic/ml-cpp#2677, I encountered a failure in the integration test DetectionRulesIt.testCondition(). It checks the number of return records. With the new change in ml-cpp the native code returns two more values that have no significant score. I added filtering those out in the integration test code so it continues working as expected.