### PR TITLE
[8.15] Fix flaky test #109978 (#110245)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -94,9 +94,8 @@ tests:
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_half_byte_quantized/Test create, merge, and search cosine}
-  issue: https://github.com/elastic/elasticsearch/issues/109978
+- class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
+  issue: "https://github.com/elastic/elasticsearch/issues/110591"
 
 # Examples:
 #

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_half_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_half_byte_quantized.yml
@@ -428,7 +428,7 @@ setup:
         index: hnsw_byte_quantized_merge_cosine
         id: "1"
         body:
-          embedding: [1.0, 1.0, 1.0, 1.0]
+          embedding: [0.5, 0.5, 0.5, 0.5, 0.5, 1.0]
 
   # Flush in order to provoke a merge later
   - do:
@@ -439,7 +439,7 @@ setup:
         index: hnsw_byte_quantized_merge_cosine
         id: "2"
         body:
-          embedding: [1.0, 1.0, 1.0, 2.0]
+          embedding: [0.0, 0.0, 0.0, 1.0, 1.0, 0.5]
 
   # Flush in order to provoke a merge later
   - do:
@@ -450,7 +450,7 @@ setup:
         index: hnsw_byte_quantized_merge_cosine
         id: "3"
         body:
-          embedding: [1.0, 1.0, 1.0, 3.0]
+          embedding: [0.0, 0.0, 0.0, 0.0, 0.0, 10.5]
 
   - do:
       indices.forcemerge:
@@ -468,7 +468,7 @@ setup:
           query:
             knn:
               field: embedding
-              query_vector: [1.0, 1.0, 1.0, 1.0]
+              query_vector: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
               num_candidates: 10
 
   - length: { hits.hits: 3 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Fix flaky test #109978 (#110245)](https://github.com/elastic/elasticsearch/pull/110245)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)