### PR TITLE
ESQL: Fix Max not working with negative or zero doubles

### DIFF
--- a/docs/changelog/110586.yaml
+++ b/docs/changelog/110586.yaml
@@ -1,0 +1,5 @@
+pr: 110586
+summary: "ESQL: Fix Max doubles bug with negatives and add tests for Max and Min"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregator.java
@@ -16,7 +16,7 @@ import org.elasticsearch.compute.ann.IntermediateState;
 class MaxDoubleAggregator {
 
     public static double init() {
-        return Double.MIN_VALUE;
+        return -Double.MAX_VALUE;
     }
 
     public static double combine(double current, double v) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionTests.java
@@ -22,7 +22,10 @@ import static org.hamcrest.Matchers.equalTo;
 public class MaxDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
     protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
-        return new SequenceDoubleBlockSourceOperator(blockFactory, LongStream.range(0, size).mapToDouble(l -> ESTestCase.randomDouble()));
+        return new SequenceDoubleBlockSourceOperator(
+            blockFactory,
+            LongStream.range(0, size).mapToDouble(l -> ESTestCase.randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true))
+        );
     }
 
     @Override


### PR DESCRIPTION
Partial backport from https://github.com/elastic/elasticsearch/pull/110586

Just the Max fix and an extra test for it.