### PR TITLE
ES|QL search: add restrictions for rank expressions and match usage

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -261,10 +261,9 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             if (filterExec.child() instanceof EsQueryExec queryExec) {
                 List<Expression> pushable = new ArrayList<>();
                 List<Expression> nonPushable = new ArrayList<>();
-                var filterIncludesMatch = includesMatchExpression(filterExec.condition());
                 for (Expression exp : splitAnd(filterExec.condition())) {
                     var canPushExp = canPushToSource(exp, x -> hasIdenticalDelegate(x, ctx.searchStats()));
-                    if (canPushExp == false && filterIncludesMatch) {
+                    if (canPushExp == false && includesMatchExpression(exp)) {
                         throw new VerificationException("Unsupported expression using MATCH: [{}]", exp.source().text());
                     }
                     (canPushExp ? pushable : nonPushable).add(exp);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -62,8 +62,8 @@ import static java.util.Arrays.asList;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.DOC_VALUES;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.NONE;
 import static org.elasticsearch.xpack.esql.core.util.Queries.Clause.FILTER;
-import static org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer.PushFiltersToSource.canPushToSource;
 import static org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer.TRANSLATOR_HANDLER;
+import static org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer.canPushToSource;
 
 public class PlannerUtils {
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -839,21 +839,14 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
     public void testSearchWithUnsupportedMatchFilters() {
         var error = expectThrows(VerificationException.class, () -> plannerOptimizer.plan("""
             search test [
-                | where match(first_name, "Meg") and ends_with(last_name, "Ryan")
+                | where match(first_name, "Meg") or ends_with(last_name, "Ryan")
             ]
             """));
         assertThat(error.getMessage(), containsString("Unsupported expression using MATCH"));
 
         error = expectThrows(VerificationException.class, () -> plannerOptimizer.plan("""
             search test [
-               | where not match(first_name, "Goldie") and ends_with(last_name, "Hawn")
-            ]
-            """));
-        assertThat(error.getMessage(), containsString("Unsupported expression using MATCH"));
-
-        error = expectThrows(VerificationException.class, () -> plannerOptimizer.plan("""
-            search test [
-               | where match(first_name, "Meryl") or concat(first_name, " ", last_name) == "Meryl Streep"
+               | where not match(first_name, "Goldie") or ends_with(last_name, "Hawn")
             ]
             """));
         assertThat(error.getMessage(), containsString("Unsupported expression using MATCH"));


### PR DESCRIPTION
**We want to ensure that `RANK` conditions can always be pushed to source** - previously when using `RANK` with an expression that cannot be pushed to source we would return a 500.

**Inside the search context, we want to ensure that `WHERE` expressions can always be pushed to source.** However we don't currently have a way to differentiate whether a `FilterExec` is coming from the search context or not. Until we add that we can at least ensure that if `WHERE` uses `match` it should always be pushed to source.
There is a caveat though - we would still allow boolean `AND` expressions that use `match` inside `WHERE`
For example this would still be allowed:
```
SEARCH search-movies [
  | RANK MATCH(actors, "Meryl Streep")
  | WHERE MATCH(plot, "story") AND log(imdbrating) > 1
]
```
This query will execute successfully - the expression is split on `AND` with `MATCH(plot, "story")` being pushed to source.
We are allowing this case for now, because the `LogicalPlanOptimizer` has a rule to combine filters into a single one.
For the next example example, by the time we apply `PushFiltersToSource` in `LocalPhysicalPlanOptimizer` the two where conditions are already merged into a single `FilterExec`:
```
SEARCH search-movies [
  | RANK MATCH(actors, "Meryl Streep")
  | WHERE MATCH(plot, "story") // this will become WHERE MATCH(plot, "story") AND WHERE MATCH(plot, "story")
]
| WHERE log(imdbrating) > 1  // this will be dropped
```
For the next example we will correctly return an error saying that the `WHERE` expression uses an invalid combination with `MATCH`:
```
SEARCH search-movies [
  | RANK MATCH(actors, "Meryl Streep")
  | WHERE MATCH(plot, "story") OR log(imdbrating) > 1
]
```