### PR TITLE
Add a transport action to get the features of a node

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -66,6 +66,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.action.admin.cluster.health;
     exports org.elasticsearch.action.admin.cluster.migration;
     exports org.elasticsearch.action.admin.cluster.node.capabilities;
+    exports org.elasticsearch.action.admin.cluster.node.features;
     exports org.elasticsearch.action.admin.cluster.node.hotthreads;
     exports org.elasticsearch.action.admin.cluster.node.info;
     exports org.elasticsearch.action.admin.cluster.node.reload;

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.admin.cluster.migration.PostFeatureUpgradeAction
 import org.elasticsearch.action.admin.cluster.migration.TransportGetFeatureUpgradeStatusAction;
 import org.elasticsearch.action.admin.cluster.migration.TransportPostFeatureUpgradeAction;
 import org.elasticsearch.action.admin.cluster.node.capabilities.TransportNodesCapabilitiesAction;
+import org.elasticsearch.action.admin.cluster.node.features.TransportNodesFeaturesAction;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.TransportNodesHotThreadsAction;
 import org.elasticsearch.action.admin.cluster.node.info.TransportNodesInfoAction;
 import org.elasticsearch.action.admin.cluster.node.reload.TransportNodesReloadSecureSettingsAction;
@@ -621,6 +622,7 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportNodesInfoAction.TYPE, TransportNodesInfoAction.class);
         actions.register(TransportRemoteInfoAction.TYPE, TransportRemoteInfoAction.class);
         actions.register(TransportNodesCapabilitiesAction.TYPE, TransportNodesCapabilitiesAction.class);
+        actions.register(TransportNodesFeaturesAction.TYPE, TransportNodesFeaturesAction.class);
         actions.register(RemoteClusterNodesAction.TYPE, RemoteClusterNodesAction.TransportAction.class);
         actions.register(TransportNodesStatsAction.TYPE, TransportNodesStatsAction.class);
         actions.register(TransportNodesUsageAction.TYPE, TransportNodesUsageAction.class);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodeFeatures.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodeFeatures.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class NodeFeatures extends BaseNodeResponse {
+
+    private final Set<String> features;
+
+    public NodeFeatures(StreamInput in) throws IOException {
+        super(in);
+        features = in.readCollectionAsImmutableSet(StreamInput::readString);
+    }
+
+    public NodeFeatures(Set<String> features, DiscoveryNode node) {
+        super(node);
+        this.features = features;
+    }
+
+    public Set<String> nodeFeatures() {
+        return features;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeCollection(features, StreamOutput::writeString);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesRequest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+
+public class NodesFeaturesRequest extends BaseNodesRequest<NodesFeaturesRequest> {
+    public NodesFeaturesRequest(String... nodes) {
+        super(nodes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class NodesFeaturesResponse extends BaseNodesResponse<NodeFeatures> implements ToXContentFragment {
+    protected NodesFeaturesResponse(ClusterName clusterName, List<NodeFeatures> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<NodeFeatures> readNodesFrom(StreamInput in) throws IOException {
+        return TransportAction.localOnly();
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<NodeFeatures> nodes) throws IOException {
+        TransportAction.localOnly();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("features");
+        for (var nf : getNodesMap().entrySet()) {
+            builder.array(nf.getKey(), nf.getValue().nodeFeatures().toArray(String[]::new));
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/TransportNodesFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/TransportNodesFeaturesAction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.UpdateForV9;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+@UpdateForV9    // this is not needed in v9+, all applicable versions support features
+public class TransportNodesFeaturesAction extends TransportNodesAction<
+    NodesFeaturesRequest,
+    NodesFeaturesResponse,
+    TransportNodesFeaturesAction.NodeFeaturesRequest,
+    NodeFeatures> {
+
+    public static final ActionType<NodesFeaturesResponse> TYPE = new ActionType<>("cluster:monitor/nodes/features");
+
+    private final FeatureService featureService;
+
+    @Inject
+    public TransportNodesFeaturesAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        FeatureService featureService
+    ) {
+        super(
+            TYPE.name(),
+            clusterService,
+            transportService,
+            actionFilters,
+            NodeFeaturesRequest::new,
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+        );
+        this.featureService = featureService;
+    }
+
+    @Override
+    protected NodesFeaturesResponse newResponse(
+        NodesFeaturesRequest request,
+        List<NodeFeatures> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new NodesFeaturesResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected NodeFeaturesRequest newNodeRequest(NodesFeaturesRequest request) {
+        return new NodeFeaturesRequest();
+    }
+
+    @Override
+    protected NodeFeatures newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new NodeFeatures(in);
+    }
+
+    @Override
+    protected NodeFeatures nodeOperation(NodeFeaturesRequest request, Task task) {
+        return new NodeFeatures(featureService.getNodeFeatures().keySet(), transportService.getLocalNode());
+    }
+
+    public static class NodeFeaturesRequest extends TransportRequest {
+        public NodeFeaturesRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodeFeaturesRequest() {}
+    }
+}

--- a/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
@@ -20,6 +20,9 @@ import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthActio
 import org.elasticsearch.action.admin.cluster.node.capabilities.NodesCapabilitiesRequest;
 import org.elasticsearch.action.admin.cluster.node.capabilities.NodesCapabilitiesResponse;
 import org.elasticsearch.action.admin.cluster.node.capabilities.TransportNodesCapabilitiesAction;
+import org.elasticsearch.action.admin.cluster.node.features.NodesFeaturesRequest;
+import org.elasticsearch.action.admin.cluster.node.features.NodesFeaturesResponse;
+import org.elasticsearch.action.admin.cluster.node.features.TransportNodesFeaturesAction;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -240,6 +243,14 @@ public class ClusterAdminClient implements ElasticsearchClient {
 
     public void nodesCapabilities(final NodesCapabilitiesRequest request, final ActionListener<NodesCapabilitiesResponse> listener) {
         execute(TransportNodesCapabilitiesAction.TYPE, request, listener);
+    }
+
+    public ActionFuture<NodesFeaturesResponse> nodesFeatures(final NodesFeaturesRequest request) {
+        return execute(TransportNodesFeaturesAction.TYPE, request);
+    }
+
+    public void nodesFeatures(final NodesFeaturesRequest request, final ActionListener<NodesFeaturesResponse> listener) {
+        execute(TransportNodesFeaturesAction.TYPE, request, listener);
     }
 
     public void nodesUsage(final NodesUsageRequest request, final ActionListener<NodesUsageResponse> listener) {


### PR DESCRIPTION
Whilst this is not currently used for anything, it will be used by a cluster state listener to fix node features in cluster state, in a similar way to `TransportVersionsFixupListener`. This is separate to get it onto serverless before we deploy anything that uses it.

Relates to https://github.com/elastic/elasticsearch/issues/109254