### PR TITLE
[8.13] [DOCS] Fix typo: though -> through (#110636)

### DIFF
--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -8,7 +8,7 @@ Deletes an {infer} endpoint.
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
-Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+Hugging Face. For built-in models and models uploaded through Eland, the {infer}
 APIs offer an alternative way to use and manage trained models. However, if you
 do not plan to use the {infer} APIs to use these models or if you want to use
 non-NLP models, use the <<ml-df-trained-models-apis>>.

--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -8,7 +8,7 @@ Retrieves {infer} endpoint information.
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
-Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+Hugging Face. For built-in models and models uploaded through Eland, the {infer}
 APIs offer an alternative way to use and manage trained models. However, if you
 do not plan to use the {infer} APIs to use these models or if you want to use
 non-NLP models, use the <<ml-df-trained-models-apis>>.

--- a/docs/reference/inference/inference-apis.asciidoc
+++ b/docs/reference/inference/inference-apis.asciidoc
@@ -6,7 +6,7 @@ experimental[]
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
-Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+Hugging Face. For built-in models and models uploaded through Eland, the {infer}
 APIs offer an alternative way to use and manage trained models. However, if you
 do not plan to use the {infer} APIs to use these models or if you want to use
 non-NLP models, use the <<ml-df-trained-models-apis>>.

--- a/docs/reference/inference/post-inference.asciidoc
+++ b/docs/reference/inference/post-inference.asciidoc
@@ -8,7 +8,7 @@ Performs an inference task on an input text by using an {infer} endpoint.
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
-Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+Hugging Face. For built-in models and models uploaded through Eland, the {infer}
 APIs offer an alternative way to use and manage trained models. However, if you
 do not plan to use the {infer} APIs to use these models or if you want to use
 non-NLP models, use the <<ml-df-trained-models-apis>>.

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -8,7 +8,7 @@ Creates an {infer} endpoint to perform an {infer} task.
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
-Hugging Face. For built-in models and models uploaded though
+Hugging Face. For built-in models and models uploaded through
 Eland, the {infer} APIs offer an alternative way to use and manage trained
 models. However, if you do not plan to use the {infer} APIs to use these models
 or if you want to use non-NLP models, use the <<ml-df-trained-models-apis>>.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[DOCS] Fix typo: though -&gt; through (#110636)](https://github.com/elastic/elasticsearch/pull/110636)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)