### PR TITLE
Remove version barrier for synthetic version based features

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -86,19 +86,6 @@ class ESRestTestFeatureService implements TestFeatureService {
         Matcher matcher = VERSION_FEATURE_PATTERN.matcher(featureId);
         if (matcher.matches()) {
             Version extractedVersion = Version.fromString(matcher.group(1));
-            if (Version.V_8_15_0.before(extractedVersion)) {
-                // As of version 8.14.0 REST tests have been migrated to use features only.
-                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before 8.15.0
-                // allowing for some transition period.
-                throw new IllegalArgumentException(
-                    Strings.format(
-                        "Synthetic version features are only available before [%s] for migration purposes! "
-                            + "Please add a cluster feature to an appropriate FeatureSpecification; test-only historical-features  "
-                            + "can be supplied via ESRestTestCase#additionalTestOnlyHistoricalFeatures()",
-                        Version.V_8_15_0
-                    )
-                );
-            }
             return version.onOrAfter(extractedVersion);
         }
 


### PR DESCRIPTION
We previously discussed that we need a way to retrospectively skip tests on known issues. And there might not be any cluster features present to precisely define the range to skip. 

For these cases the synthetic version based features are the simplest and most flexible solution. 
This PR removes the version barrier to allow usage of synthetic version features also for more recent ES versions.