### PR TITLE
Use valid documentation url for capabilities in rest specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/capabilities.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/capabilities.json
@@ -1,7 +1,7 @@
 {
   "capabilities": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/capabilities.html",
+      "url": "https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc#require-or-skip-api-capabilities",
       "description": "Checks if the specified combination of method, API, parameters, and arbitrary capabilities are supported"
     },
     "stability": "experimental",


### PR DESCRIPTION
Using valid url to fix https://github.com/elastic/elasticsearch-js/pull/2306 