### PR TITLE
Removing the use of Stream::peek from GeoIpDownloader::cleanDatabases

### DIFF
--- a/docs/changelog/110666.yaml
+++ b/docs/changelog/110666.yaml
@@ -1,5 +1,5 @@
 pr: 110666
-summary: Removing the use of Stream::peak from `GeoIpDownloader::cleanDatabases`
+summary: Removing the use of Stream::peek from `GeoIpDownloader::cleanDatabases`
 area: Ingest Node
 type: bug
 issues: []

--- a/docs/changelog/110666.yaml
+++ b/docs/changelog/110666.yaml
@@ -1,0 +1,5 @@
+pr: 110666
+summary: Removing the use of Stream::peak from `GeoIpDownloader::cleanDatabases`
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
@@ -580,7 +580,6 @@ public class GeoIpDownloaderTests extends ESTestCase {
         client.addHandler(
             UpdatePersistentTaskStatusAction.INSTANCE,
             (UpdatePersistentTaskStatusAction.Request request, ActionListener<PersistentTaskResponse> taskResponseListener) -> {
-
                 PersistentTasksCustomMetadata.Assignment assignment = mock(PersistentTasksCustomMetadata.Assignment.class);
                 PersistentTasksCustomMetadata.PersistentTask<?> persistentTask = new PersistentTasksCustomMetadata.PersistentTask<>(
                     GeoIpDownloader.GEOIP_DOWNLOADER,
@@ -589,8 +588,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
                     request.getAllocationId(),
                     assignment
                 );
-                taskResponseListener.onResponse(new PersistentTaskResponse(new PersistentTask<>(persistentTask, request.getState())));
                 updatePersistentTaskStateCount.incrementAndGet();
+                taskResponseListener.onResponse(new PersistentTaskResponse(new PersistentTask<>(persistentTask, request.getState())));
             }
         );
         client.addHandler(


### PR DESCRIPTION
The [Stream::peek documentation](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#peek-java.util.function.Consumer-) says that it mainly exists to support debugging. There is a chance, however unlikely, that it will not be called if the terminal operation (count) can be calculated without going through each element. This PR removes the use of peek. No functional behavior is changed.
Test coverage is provided by #110650.