### PR TITLE
Do not run TickerScheduleTriggerEngine watches if the schedule trigger engine is paused (#110061)

### DIFF
--- a/docs/changelog/110061.yaml
+++ b/docs/changelog/110061.yaml
@@ -1,0 +1,6 @@
+pr: 110061
+summary: Avoiding running watch jobs in TickerScheduleTriggerEngine if it is paused
+area: Watcher
+type: bug
+issues:
+ - 105933


### PR DESCRIPTION
This changes watcher to bail out of executing triggered watches if the watcher engine is paused. It fixes the problem described in https://github.com/elastic/elasticsearch/issues/105933#issuecomment-2093624251
Closes https://github.com/elastic/elasticsearch/issues/105933