### PR TITLE
[8.15] Remove `default_field: message` from metrics index templates (#110651)

### DIFF
--- a/docs/changelog/110651.yaml
+++ b/docs/changelog/110651.yaml
@@ -1,0 +1,5 @@
+pr: 110651
+summary: "Remove `default_field: message` from metrics index templates"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/metrics@settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/metrics@settings.json
@@ -10,9 +10,6 @@
           "total_fields": {
             "ignore_dynamic_beyond_limit": true
           }
-        },
-        "query": {
-          "default_field": ["message"]
         }
       }
     }

--- a/x-pack/plugin/core/template-resources/src/main/resources/metrics@tsdb-settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/metrics@tsdb-settings.json
@@ -9,9 +9,6 @@
           "total_fields": {
             "ignore_dynamic_beyond_limit": true
           }
-        },
-        "query": {
-          "default_field": ["message"]
         }
       }
     }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -47,7 +47,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 11;
+    public static final int REGISTRY_VERSION = 12;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Remove `default_field: message` from metrics index templates (#110651)