### PR TITLE
[8.15] Remove version barrier for synthetic version based features in tests (#110656)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -86,19 +86,6 @@ class ESRestTestFeatureService implements TestFeatureService {
         Matcher matcher = VERSION_FEATURE_PATTERN.matcher(featureId);
         if (matcher.matches()) {
             Version extractedVersion = Version.fromString(matcher.group(1));
-            if (Version.V_8_15_0.before(extractedVersion)) {
-                // As of version 8.14.0 REST tests have been migrated to use features only.
-                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before 8.15.0
-                // allowing for some transition period.
-                throw new IllegalArgumentException(
-                    Strings.format(
-                        "Synthetic version features are only available before [%s] for migration purposes! "
-                            + "Please add a cluster feature to an appropriate FeatureSpecification; test-only historical-features  "
-                            + "can be supplied via ESRestTestCase#additionalTestOnlyHistoricalFeatures()",
-                        Version.V_8_15_0
-                    )
-                );
-            }
             return version.onOrAfter(extractedVersion);
         }
 


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Remove version barrier for synthetic version based features in tests (#110656)