### PR TITLE
[8.15] Backporting fix for ensuring all free context actions have been handled in ESSingleNodeTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -69,6 +69,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.action.search.SearchTransportService.FREE_CONTEXT_ACTION_NAME;
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.test.NodeRoles.dataNode;
@@ -130,6 +131,8 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         logger.trace("[{}#{}]: cleaning up after test", getTestClass().getSimpleName(), getTestName());
         awaitIndexShardCloseAsyncTasks();
         ensureNoInitializingShards();
+        ensureAllFreeContextActionsAreConsumed();
+
         SearchService searchService = getInstanceFromNode(SearchService.class);
         assertThat(searchService.getActiveContexts(), equalTo(0));
         assertThat(searchService.getOpenScrollContexts(), equalTo(0));
@@ -453,6 +456,14 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
             .actionGet();
 
         assertFalse("timed out waiting for shards to initialize", actionGet.isTimedOut());
+    }
+
+    /**
+     * waits until all free_context actions have been handled by the generic thread pool
+     */
+    protected void ensureAllFreeContextActionsAreConsumed() throws Exception {
+        logger.info("--> waiting for all free_context tasks to complete within a reasonable time");
+        safeGet(clusterAdmin().prepareListTasks().setActions(FREE_CONTEXT_ACTION_NAME + "*").setWaitForCompletion(true).execute());
     }
 
     /**


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/110595 to `8.15`