### PR TITLE
Make min num replicas for enrich index configurable

### DIFF
--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -85,6 +85,8 @@ public class EnrichPolicyRunner implements Runnable {
     static final String ENRICH_MATCH_FIELD_NAME = "enrich_match_field";
     static final String ENRICH_README_FIELD_NAME = "enrich_readme";
 
+    public static final String ENRICH_MIN_NUMBER_OF_REPLICAS_NAME = "enrich.min_number_of_replicas";
+
     static final String ENRICH_INDEX_README_TEXT = "This index is managed by Elasticsearch and should not be modified in any way.";
 
     private final String policyName;
@@ -137,7 +139,7 @@ public class EnrichPolicyRunner implements Runnable {
             // This call does not set the origin to ensure that the user executing the policy has permission to access the source index
             client.admin().indices().getIndex(getIndexRequest, listener.delegateFailureAndWrap((l, getIndexResponse) -> {
                 validateMappings(getIndexResponse);
-                prepareAndCreateEnrichIndex(toMappings(getIndexResponse));
+                prepareAndCreateEnrichIndex(toMappings(getIndexResponse), clusterService.getSettings());
             }));
         } catch (Exception e) {
             listener.onFailure(e);
@@ -434,10 +436,11 @@ public class EnrichPolicyRunner implements Runnable {
         }
     }
 
-    private void prepareAndCreateEnrichIndex(List<Map<String, Object>> mappings) {
+    private void prepareAndCreateEnrichIndex(List<Map<String, Object>> mappings, Settings settings) {
+        int numberOfReplicas = settings.getAsInt(ENRICH_MIN_NUMBER_OF_REPLICAS_NAME, 0);
         Settings enrichIndexSettings = Settings.builder()
             .put("index.number_of_shards", 1)
-            .put("index.number_of_replicas", 0)
+            .put("index.number_of_replicas", numberOfReplicas)
             // No changes will be made to an enrich index after policy execution, so need to enable automatic refresh interval:
             .put("index.refresh_interval", -1)
             // This disables eager global ordinals loading for all fields:


### PR DESCRIPTION
The min num replicas for the enrich index is currenty hardcoded to 0. We'd like to be able to override that value via a setting (currently not registered), like we already do for the downsample index.