### PR TITLE
[8.1] Fix search template examples by removing params on put (#110660)

### DIFF
--- a/docs/reference/search/multi-search-template-api.asciidoc
+++ b/docs/reference/search/multi-search-template-api.asciidoc
@@ -22,9 +22,6 @@ PUT _scripts/my-search-template
       },
       "from": "{{from}}",
       "size": "{{size}}"
-    },
-    "params": {
-      "query_string": "My query string"
     }
   }
 }

--- a/docs/reference/search/render-search-template-api.asciidoc
+++ b/docs/reference/search/render-search-template-api.asciidoc
@@ -22,9 +22,6 @@ PUT _scripts/my-search-template
       },
       "from": "{{from}}",
       "size": "{{size}}"
-    },
-    "params": {
-      "query_string": "My query string"
     }
   }
 }

--- a/docs/reference/search/search-template-api.asciidoc
+++ b/docs/reference/search/search-template-api.asciidoc
@@ -21,9 +21,6 @@ PUT _scripts/my-search-template
       },
       "from": "{{from}}",
       "size": "{{size}}"
-    },
-    "params": {
-      "query_string": "My query string"
     }
   }
 }

--- a/docs/reference/search/search-your-data/search-template.asciidoc
+++ b/docs/reference/search/search-your-data/search-template.asciidoc
@@ -42,9 +42,6 @@ PUT _scripts/my-search-template
       },
       "from": "{{from}}",
       "size": "{{size}}"
-    },
-    "params": {
-      "query_string": "My query string"
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Fix search template examples by removing params on put (#110660)