### PR TITLE
Fix issue with returning incomplete fragment for plain highlighter.

### DIFF
--- a/docs/changelog/110707.yaml
+++ b/docs/changelog/110707.yaml
@@ -1,0 +1,5 @@
+pr: 110707
+summary: Fix issue with returning incomplete fragment for plain highlighter
+area: Highlighting
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -2177,6 +2177,15 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         field.highlighterType("unified");
         assertNotHighlighted(prepareSearch("test").highlighter(new HighlightBuilder().field(field)), 0, "text");
+
+        // Check when the requested fragment size equals the size of the string
+        var anotherText = "I am unusual and don't end with your regular )token)";
+        indexDoc("test", "1", "text", anotherText);
+        refresh();
+        for (String type : new String[] { "plain", "unified", "fvh" }) {
+            field.highlighterType(type).noMatchSize(anotherText.length()).numOfFragments(0);
+            assertHighlight(prepareSearch("test").highlighter(new HighlightBuilder().field(field)), 0, "text", 0, 1, equalTo(anotherText));
+        }
     }
 
     public void testHighlightNoMatchSizeWithMultivaluedFields() throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -218,6 +218,9 @@ public class PlainHighlighter implements Highlighter {
                 // Can't split on term boundaries without offsets
                 return -1;
             }
+            if (contents.length() <= noMatchSize) {
+                return contents.length();
+            }
             int end = -1;
             tokenStream.reset();
             while (tokenStream.incrementToken()) {


### PR DESCRIPTION
This is a bug that was noticed in the context of App Search which uses the plain highlighter.
It seems that when the text field value is ending in special characters and `no_match_size` is equal or greater than the size of the text, we are not returning the full text.
This is because in `findGoodEndForNoHighlightExcerpt` we are consuming the token stream and we just return the position of where the last token ends, thus ignoring any special characters the original text might end with that are not part of a token.

Steps to replicate:

```

POST my-index/_doc/1?refresh=true
{
  "my_text_field": ")hey)"
}

GET my-index/_search
{
  "query": {
    "bool": {
      "must": {
        "match_all": {}
      }
    }
  },
  "highlight": {
    "type": "plain",
    "fields": {
      "my_text_field": {
        "fragment_size": 100,
        "no_match_size": 100
      }
    },
    "highlight_query": {
      "match_all": {}
    }
  }
}
```

response - the highlight is `)hey` instead of `)hey)`:
```
{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "my-index",
        "_id": "1",
        "_score": 1,
        "_source": {
          "my_text_field": ")hey)"
        },
        "highlight": {
          "my_text_field": [
            ")hey"
          ]
        }
      }
    ]
  }
}
```
