### PR TITLE
[8.14] Remove version barrier for synthetic version based features in tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -81,18 +81,6 @@ class ESRestTestFeatureService implements TestFeatureService {
         Matcher matcher = VERSION_FEATURE_PATTERN.matcher(featureId);
         if (matcher.matches()) {
             Version extractedVersion = Version.fromString(matcher.group(1));
-            if (Version.CURRENT.before(extractedVersion)) {
-                // As of version 8.14.0 REST tests have been migrated to use features only.
-                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before CURRENT (8.14.x).
-                throw new IllegalArgumentException(
-                    Strings.format(
-                        "Synthetic version features are only available before [%s] for migration purposes! "
-                            + "Please add a cluster feature to an appropriate FeatureSpecification; test-only historical-features  "
-                            + "can be supplied via ESRestTestCase#createAdditionalFeatureSpecifications()",
-                        Version.CURRENT
-                    )
-                );
-            }
             return version.onOrAfter(extractedVersion);
         }
 


### PR DESCRIPTION
Remove version barrier for synthetic version based features in tests.
Backport of https://github.com/elastic/elasticsearch/pull/110656