### PR TITLE
Fix broken "How to reproduce" lines in CSV tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -67,7 +67,7 @@ public class ReproduceInfoPrinter extends RunListener {
         boolean isBwcTest = Boolean.parseBoolean(System.getProperty("tests.bwc", "false"));
 
         // append Gradle test runner test filter string
-        b.append("'" + task + "'");
+        b.append("\"" + task + "\"");
         if (isBwcTest) {
             // Use "legacy" method for bwc tests so that it applies globally to all upstream bwc test tasks
             b.append(" -Dtests.class=\"");

--- a/x-pack/plugin/esql-core/test-fixtures/src/main/java/org/elasticsearch/xpack/esql/core/SpecReader.java
+++ b/x-pack/plugin/esql-core/test-fixtures/src/main/java/org/elasticsearch/xpack/esql/core/SpecReader.java
@@ -79,7 +79,7 @@ public final class SpecReader {
                         Object result = parser.parse(line);
                         // only if the parser is ready, add the object - otherwise keep on serving it lines
                         if (result != null) {
-                            testCases.add(new Object[] { fileName, groupName, testName, Integer.valueOf(lineNumber), result });
+                            testCases.add(makeTestCase(fileName, groupName, testName, lineNumber, result));
                             testName = null;
                         }
                     }
@@ -101,5 +101,14 @@ public final class SpecReader {
 
     public static boolean shouldSkipLine(String line) {
         return line.isEmpty() || line.startsWith("//") || line.startsWith("#");
+    }
+
+    private static Object[] makeTestCase(String fileName, String groupName, String testName, int lineNumber, Object result) {
+        var testNameParts = testName.split("#", 2);
+
+        testName = testNameParts[0];
+        var instructions = testNameParts.length == 2 ? testNameParts[1] : "";
+
+        return new Object[] { fileName, groupName, testName, lineNumber, result, instructions };
     }
 }

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
@@ -56,14 +56,22 @@ public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
         oldClusterTestFeatureService = null;
     }
 
-    public MixedClusterEsqlSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
-        super(fileName, groupName, testName, lineNumber, testCase, mode);
+    public MixedClusterEsqlSpecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        Mode mode
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, mode);
     }
 
     @Override
     protected void shouldSkipTest(String testName) throws IOException {
         super.shouldSkipTest(testName);
-        assumeTrue("Test " + testName + " is skipped on " + bwcVersion, isEnabled(testName, bwcVersion));
+        assumeTrue("Test " + testName + " is skipped on " + bwcVersion, isEnabled(testName, instructions, bwcVersion));
         if (mode == ASYNC) {
             assumeTrue("Async is not supported on " + bwcVersion, supportsAsync());
         }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -88,8 +88,16 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
         return testcases;
     }
 
-    public MultiClusterSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
-        super(fileName, groupName, testName, lineNumber, convertToRemoteIndices(testCase), mode);
+    public MultiClusterSpecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        Mode mode
+    ) {
+        super(fileName, groupName, testName, lineNumber, convertToRemoteIndices(testCase), instructions, mode);
     }
 
     @Override
@@ -97,7 +105,10 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
         super.shouldSkipTest(testName);
         checkCapabilities(remoteClusterClient(), remoteFeaturesService(), testName, testCase);
         assumeFalse("can't test with _index metadata", hasIndexMetadata(testCase.query));
-        assumeTrue("Test " + testName + " is skipped on " + Clusters.oldVersion(), isEnabled(testName, Clusters.oldVersion()));
+        assumeTrue(
+            "Test " + testName + " is skipped on " + Clusters.oldVersion(),
+            isEnabled(testName, instructions, Clusters.oldVersion())
+        );
     }
 
     private TestFeatureService remoteFeaturesService() throws IOException {

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
@@ -21,8 +21,16 @@ public class EsqlSpecIT extends EsqlSpecTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EsqlSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
-        super(fileName, groupName, testName, lineNumber, testCase, mode);
+    public EsqlSpecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        Mode mode
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, mode);
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
@@ -25,8 +25,16 @@ public class EsqlSpecIT extends EsqlSpecTestCase {
         return cluster.getHttpAddresses();
     }
 
-    public EsqlSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
-        super(fileName, groupName, testName, lineNumber, testCase, mode);
+    public EsqlSpecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        Mode mode
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, mode);
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -109,7 +109,15 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         return testcases;
     }
 
-    protected EsqlSpecTestCase(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, String instructions, Mode mode) {
+    protected EsqlSpecTestCase(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        Mode mode
+    ) {
         this.fileName = fileName;
         this.groupName = groupName;
         this.testName = testName;

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -82,6 +82,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     private final String testName;
     private final Integer lineNumber;
     protected final CsvTestCase testCase;
+    protected final String instructions;
     protected final Mode mode;
 
     public enum Mode {
@@ -108,12 +109,13 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         return testcases;
     }
 
-    protected EsqlSpecTestCase(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
+    protected EsqlSpecTestCase(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, String instructions, Mode mode) {
         this.fileName = fileName;
         this.groupName = groupName;
         this.testName = testName;
         this.lineNumber = lineNumber;
         this.testCase = testCase;
+        this.instructions = instructions;
         this.mode = mode;
     }
 
@@ -155,7 +157,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     protected void shouldSkipTest(String testName) throws IOException {
         checkCapabilities(adminClient(), testFeatureService, testName, testCase);
-        assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
+        assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, instructions, Version.CURRENT));
     }
 
     protected static void checkCapabilities(RestClient client, TestFeatureService testFeatureService, String testName, CsvTestCase testCase)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -69,21 +69,21 @@ public final class CsvTestUtils {
 
     private CsvTestUtils() {}
 
-    public static boolean isEnabled(String testName, Version version) {
+    public static boolean isEnabled(String testName, String instructions, Version version) {
         if (testName.endsWith("-Ignore")) {
             return false;
         }
-        Tuple<Version, Version> skipRange = skipVersionRange(testName);
+        Tuple<Version, Version> skipRange = skipVersionRange(testName, instructions);
         if (skipRange != null && version.onOrAfter(skipRange.v1()) && version.onOrBefore(skipRange.v2())) {
             return false;
         }
         return true;
     }
 
-    private static final Pattern INSTRUCTION_PATTERN = Pattern.compile("#\\[(.*?)]");
+    private static final Pattern INSTRUCTION_PATTERN = Pattern.compile("\\[(.*?)]");
 
-    public static Map<String, String> extractInstructions(String testName) {
-        Matcher matcher = INSTRUCTION_PATTERN.matcher(testName);
+    public static Map<String, String> parseInstructions(String instructions) {
+        Matcher matcher = INSTRUCTION_PATTERN.matcher(instructions);
         Map<String, String> pairs = new HashMap<>();
         if (matcher.find()) {
             String[] groups = matcher.group(1).split(",");
@@ -98,8 +98,8 @@ public final class CsvTestUtils {
         return pairs;
     }
 
-    public static Tuple<Version, Version> skipVersionRange(String testName) {
-        Map<String, String> pairs = extractInstructions(testName);
+    public static Tuple<Version, Version> skipVersionRange(String testName, String instructions) {
+        Map<String, String> pairs = parseInstructions(instructions);
         String versionRange = pairs.get("skip");
         if (versionRange != null) {
             String[] skipVersions = versionRange.split("-", Integer.MAX_VALUE);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -157,6 +157,7 @@ public class CsvTests extends ESTestCase {
     private final String testName;
     private final Integer lineNumber;
     private final CsvSpecReader.CsvTestCase testCase;
+    private final String instructions;
 
     private final EsqlConfiguration configuration = EsqlTestUtils.configuration(
         new QueryPragmas(Settings.builder().put("page_size", randomPageSize()).build())
@@ -211,17 +212,18 @@ public class CsvTests extends ESTestCase {
         }
     }
 
-    public CsvTests(String fileName, String groupName, String testName, Integer lineNumber, CsvSpecReader.CsvTestCase testCase) {
+    public CsvTests(String fileName, String groupName, String testName, Integer lineNumber, CsvSpecReader.CsvTestCase testCase, String instructions) {
         this.fileName = fileName;
         this.groupName = groupName;
         this.testName = testName;
         this.lineNumber = lineNumber;
         this.testCase = testCase;
+        this.instructions = instructions;
     }
 
     public final void test() throws Throwable {
         try {
-            assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
+            assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, instructions, Version.CURRENT));
             /*
              * The csv tests support all but a few features. The unsupported features
              * are tested in integration tests.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -212,7 +212,14 @@ public class CsvTests extends ESTestCase {
         }
     }
 
-    public CsvTests(String fileName, String groupName, String testName, Integer lineNumber, CsvSpecReader.CsvTestCase testCase, String instructions) {
+    public CsvTests(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvSpecReader.CsvTestCase testCase,
+        String instructions
+    ) {
         this.fileName = fileName;
         this.groupName = groupName;
         this.testName = testName;


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/105017

A quick summary:
- `randomizedtesting` library doesn't handle "+" chars in test names
- We currently have the "...#[skip:..., ...]" instructions as part of the test name

As removing the instructions from the name fixes both issues (And makes launching a single test in CLI far easier), the instructions have been moved out of the test name to another parameter.

Before:
```
gradlew ':x-pack:plugin:esql:test' --tests "org.elasticsearch.xpack.esql.CsvTests" -Dtests.method="test {stats.GroupByNull#[skip:-8.12.99,reason:bug fixed in 8.13+]}"
```

After:
```
gradlew ":x-pack:plugin:esql:test" --tests "org.elasticsearch.xpack.esql.CsvTests" -Dtests.method="test {stats.GroupByNull}"
```