### PR TITLE
ESQL: Document the `profile` option

### DIFF
--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -77,9 +77,8 @@ For syntax, refer to <<esql-locale-param>>.
 
 `profile`::
 (Optional, boolean) If provided and `true` the response will include an extra `profile` object
-with information on how the query was executed. This information is for human debugging
-and its format can change at any time but it can give some insight into the performance
-of each part of the query.
+with information about how the query was executed. It provides insight into the performance
+of each part of the query. This is for human debugging as the object's format might change at any time.
 
 `query`::
 (Required, string) {esql} query to run. For syntax, refer to <<esql-syntax>>.
@@ -110,4 +109,4 @@ Values for the search results.
 `profile`::
 (object)
 Profile describing the execution of the query. Only returned if `profile` was sent in the body.
-The object itself is for human debugging can change at any time.
+The object itself is for human debugging and can change at any time.

--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -75,6 +75,12 @@ For syntax, refer to <<esql-locale-param>>.
 (Optional, array) Values for parameters in the `query`. For syntax, refer to
 <<esql-rest-params>>.
 
+`profile`::
+(Optional, boolean) If provided and `true` the response will include an extra `profile` object
+with information on how the query was executed. This information is for human debugging
+and its format can change at any time but it can give some insight into the performance
+of each part of the query.
+
 `query`::
 (Required, string) {esql} query to run. For syntax, refer to <<esql-syntax>>.
 
@@ -100,3 +106,8 @@ returned if `drop_null_columns` is sent with the request.
 `rows`::
 (array of arrays)
 Values for the search results.
+
+`profile`::
+(object)
+Profile describing the execution of the query. Only returned if `profile` was sent in the body.
+The object itself is for human debugging can change at any time.


### PR DESCRIPTION
This adds some basic documentation for the `profile` option in ESQL but doesn't really explain the results beyond "this is for human debugging." We're not ready for any kind of specification for this thing, but it is useful to look at.
