### PR TITLE
[CI] Do not cache any es distros when creating ci images

### DIFF
--- a/qa/packaging/build.gradle
+++ b/qa/packaging/build.gradle
@@ -38,11 +38,6 @@ tasks.register('destructivePackagingTest') {
 }
 
 tasks.named('resolveAllDependencies') {
-  // Don't try and resolve all distros but only the latest patch versions of each minor
-  def latestBugfixVersions = org.elasticsearch.gradle.internal.info.BuildParams.getBwcVersions().getIndexCompatible()
-      .groupBy { [it.major, it.minor] }
-      .collectEntries { key, value -> [key, value.max()] }
-      .values()
-
-  configs = configurations.matching { configName -> latestBugfixVersions.any { v -> configName.name.endsWith(v.toString()) } }
+  // avoid resolving all elasticsearch distros
+  enabled = false
 }


### PR DESCRIPTION
This should make our ci image creation more reliable and faster (cache less)