### PR TITLE
Generalize min number of replicas concept

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -153,6 +153,7 @@ public record AutoExpandReplicas(int minReplicas, int maxReplicas, boolean enabl
                     indexMetadata.getSettings().get(ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING.getKey()),
                     "stateless"
                 )) {
+                    // TODO Replace this with new logic that leverages IndexMetadata.MIN_NUM_REPLICAS
                     if (indexMetadata.getNumberOfReplicas() == 0) {
                         nrReplicasChanged.computeIfAbsent(1, ArrayList::new).add(indexMetadata.getIndex().getName());
                     } else {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -266,6 +266,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String SETTING_AUTO_EXPAND_REPLICAS = "index.auto_expand_replicas";
     public static final Setting<AutoExpandReplicas> INDEX_AUTO_EXPAND_REPLICAS_SETTING = AutoExpandReplicas.SETTING;
 
+    // This setting is not registered by default, but can be registered to provide a minimum number of replicas that is higher than 0
+    public static final String MIN_NUMBER_OF_REPLICAS = "index.min_number_of_replicas";
+
+    public static int getMinNumReplicas(Settings settings) {
+        return settings.getAsInt(MIN_NUMBER_OF_REPLICAS, 0);
+    }
+
     public enum APIBlock implements Writeable {
         READ_ONLY("read_only", INDEX_READ_ONLY_BLOCK, Property.ServerlessPublic),
         READ("read", INDEX_READ_BLOCK, Property.ServerlessPublic),

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
@@ -48,6 +48,7 @@ public class Downsample extends Plugin implements ActionPlugin, PersistentTaskPl
 
     public static final String DOWNSAMPLE_TASK_THREAD_POOL_NAME = "downsample_indexing";
     private static final int DOWNSAMPLE_TASK_THREAD_POOL_QUEUE_SIZE = 256;
+    // TODO remove this in favour of IndexMetadata.MIN_NUMBER_OF_REPLICAS
     public static final String DOWNSAMPLE_MIN_NUMBER_OF_REPLICAS_NAME = "downsample.min_number_of_replicas";
 
     @Override

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -85,8 +85,6 @@ public class EnrichPolicyRunner implements Runnable {
     static final String ENRICH_MATCH_FIELD_NAME = "enrich_match_field";
     static final String ENRICH_README_FIELD_NAME = "enrich_readme";
 
-    public static final String ENRICH_MIN_NUMBER_OF_REPLICAS_NAME = "enrich.min_number_of_replicas";
-
     static final String ENRICH_INDEX_README_TEXT = "This index is managed by Elasticsearch and should not be modified in any way.";
 
     private final String policyName;
@@ -437,10 +435,9 @@ public class EnrichPolicyRunner implements Runnable {
     }
 
     private void prepareAndCreateEnrichIndex(List<Map<String, Object>> mappings, Settings settings) {
-        int numberOfReplicas = settings.getAsInt(ENRICH_MIN_NUMBER_OF_REPLICAS_NAME, 0);
         Settings enrichIndexSettings = Settings.builder()
             .put("index.number_of_shards", 1)
-            .put("index.number_of_replicas", numberOfReplicas)
+            .put("index.number_of_replicas", IndexMetadata.getMinNumReplicas(settings))
             // No changes will be made to an enrich index after policy execution, so need to enable automatic refresh interval:
             .put("index.refresh_interval", -1)
             // This disables eager global ordinals loading for all fields:


### PR DESCRIPTION
Downsampling currently offers a way to override the minimum number of replicas used for its internal index via plugin. The goal is to index data agaist a minimum number of replicas, which defaults to 0, and later increase that number of replicas via update index settings API. There are though situations in which we want to create the index with 1 replica instead of 0, that is made possible by a plugin that registers the setting with a default value set to 1 instead of 0.

Enrich has the exact same problem, and we initially addressed it by replicating the same logic as downsampling. That though requires an additional enrich plugin to override the specific enrich setting. We could instead have a single global setting that controls the minimum number of replicas and leverage it in different places. A single plugin would then be required to override behavior for both enrich and downsampling. AutoExpandReplicas could also leverage the same setting, as it currently has stateless related logic.
