### PR TITLE
[8.15] [CI] Do not cache any es distros when creating ci images (#110742)

### DIFF
--- a/qa/packaging/build.gradle
+++ b/qa/packaging/build.gradle
@@ -36,3 +36,8 @@ tasks.named("test").configure { enabled = false }
 tasks.register('destructivePackagingTest') {
   dependsOn 'destructiveDistroTest'
 }
+
+tasks.named('resolveAllDependencies') {
+  // avoid resolving all elasticsearch distros
+  enabled = false
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[CI] Do not cache any es distros when creating ci images (#110742)](https://github.com/elastic/elasticsearch/pull/110742)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)