### PR TITLE
[7.17] [CI] Do not cache any es distros when creating ci images (#110742)

### DIFF
--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -36,6 +36,15 @@ tasks.register('destructivePackagingTest') {
   dependsOn 'destructiveDistroTest'
 }
 
+subprojects { Project platformProject ->
+  tasks.register('packagingTest') {
+    dependsOn 'distroTest'
+  }
+
+  vagrant {
+    hostEnv 'VAGRANT_PROJECT_DIR', platformProject.projectDir.absolutePath
+  }
+}
 tasks.named('resolveAllDependencies') {
   // avoid resolving all elasticsearch distros
   enabled = false

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -36,12 +36,7 @@ tasks.register('destructivePackagingTest') {
   dependsOn 'destructiveDistroTest'
 }
 
-subprojects { Project platformProject ->
-  tasks.register('packagingTest') {
-    dependsOn 'distroTest'
-  }
-
-  vagrant {
-    hostEnv 'VAGRANT_PROJECT_DIR', platformProject.projectDir.absolutePath
-  }
+tasks.named('resolveAllDependencies') {
+  // avoid resolving all elasticsearch distros
+  enabled = false
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[CI] Do not cache any es distros when creating ci images (#110742)](https://github.com/elastic/elasticsearch/pull/110742)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)