### PR TITLE
[8.15] Fix issue with returning incomplete fragment for plain highlighter. (#110707)

### DIFF
--- a/docs/changelog/110707.yaml
+++ b/docs/changelog/110707.yaml
@@ -1,0 +1,5 @@
+pr: 110707
+summary: Fix issue with returning incomplete fragment for plain highlighter
+area: Highlighting
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -2177,6 +2177,15 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         field.highlighterType("unified");
         assertNotHighlighted(prepareSearch("test").highlighter(new HighlightBuilder().field(field)), 0, "text");
+
+        // Check when the requested fragment size equals the size of the string
+        var anotherText = "I am unusual and don't end with your regular )token)";
+        indexDoc("test", "1", "text", anotherText);
+        refresh();
+        for (String type : new String[] { "plain", "unified", "fvh" }) {
+            field.highlighterType(type).noMatchSize(anotherText.length()).numOfFragments(0);
+            assertHighlight(prepareSearch("test").highlighter(new HighlightBuilder().field(field)), 0, "text", 0, 1, equalTo(anotherText));
+        }
     }
 
     public void testHighlightNoMatchSizeWithMultivaluedFields() throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -218,6 +218,9 @@ public class PlainHighlighter implements Highlighter {
                 // Can't split on term boundaries without offsets
                 return -1;
             }
+            if (contents.length() <= noMatchSize) {
+                return contents.length();
+            }
             int end = -1;
             tokenStream.reset();
             while (tokenStream.incrementToken()) {


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Fix issue with returning incomplete fragment for plain highlighter. (#110707)