### PR TITLE
Add CCSUsage and CCSUsageTelemetry to UsageService

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.core.TimeValue;
+
+import java.util.Map;
+
+/**
+ * This is a snapshot of telemetry from an individual cross-cluster search for _search or _async_search (or
+ * other search endpoints that use the TransportSearchAction such as _msearch).
+ */
+public class CCSUsage {
+    private final long took;
+    private final String failureType;  // TODO: enum?
+    private final boolean minimizeRoundTrips;
+    private final boolean async;
+    private final int skippedRemotes;
+    private final Map<String, PerClusterUsage> perClusterUsage;
+
+    public static class Builder {
+        private long took;
+        private String failureType;  // TODO: enum?
+        private boolean minimizeRoundTrips;
+        private boolean async;
+        private int skippedRemotes;
+        private Map<String, PerClusterUsage> perClusterUsage;
+
+        public Builder took(long took) {
+            this.took = took;
+            return this;
+        }
+
+        public Builder failureType(String failureType) {
+            this.failureType = failureType;
+            return this;
+        }
+
+        public Builder minimizeRoundTrips(boolean minimizeRoundTrips) {
+            this.minimizeRoundTrips = minimizeRoundTrips;
+            return this;
+        }
+
+        public Builder async(boolean async) {
+            this.async = async;
+            return this;
+        }
+
+        public Builder numSkippedRemotes(int skippedRemotes) {
+            this.skippedRemotes = skippedRemotes;
+            return this;
+        }
+
+        // TODO: this should probably be a per cluster "add", not a setter that takes map - change later
+        public Builder perClusterUsage(Map<String, PerClusterUsage> perClusterUsage) {
+            this.perClusterUsage = perClusterUsage;
+            return this;
+        }
+
+        public CCSUsage build() {
+            return new CCSUsage(minimizeRoundTrips, async, took, skippedRemotes, failureType, perClusterUsage);
+        }
+    }
+
+    private CCSUsage(
+        boolean minimizeRoundTrips,
+        boolean async,
+        long took,
+        int skippedRemotes,
+        String failureType,
+        Map<String, PerClusterUsage> perClusterUsage
+    ) {
+        this.minimizeRoundTrips = minimizeRoundTrips;
+        this.async = async;
+        this.took = took;
+        this.skippedRemotes = skippedRemotes;
+        this.failureType = failureType;
+        this.perClusterUsage = perClusterUsage;
+    }
+
+    public Map<String, PerClusterUsage> getPerClusterUsage() {
+        return perClusterUsage;
+    }
+
+    public int getSkippedRemotes() {
+        return skippedRemotes;
+    }
+
+    public long getTook() {
+        return took;
+    }
+
+    public String getFailureType() {
+        return failureType;
+    }
+
+    public boolean isMinimizeRoundTrips() {
+        return minimizeRoundTrips;
+    }
+
+    public boolean isAsync() {
+        return async;
+    }
+
+    public static class PerClusterUsage {
+
+        // if MRT=true, the took time on the remote cluster (if MRT=true), otherwise the overall took time
+        private long took;
+
+        public PerClusterUsage(TimeValue took) {
+            if (took != null) {
+                this.took = took.millis();
+            }
+        }
+
+        public long getTook() {
+            return took;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.HdrHistogram.DoubleHistogram;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Service holding accumulated CCS search usage statistics. Individual cross-cluster searches will pass
+ * CCSUsage data here to have it collated and aggregated. Snapshots of the current CCS Telemetry Usage
+ * can be obtained by getting CCSTelemetrySnapshot objects (TODO: create that class (and determine the best name)).
+ */
+public class CCSUsageTelemetry {
+
+    private final LongAdder totalCCSCount;  // TODO: need this? or just sum the successfulSearchTelem and failedSearchTelem ?
+    private final SuccessfulCCSTelemetry successfulSearchTelem;
+    private final FailedCCSTelemetry failedSearchTelem;
+    private final Map<String, PerClusterCCSTelemetry> byRemoteCluster;
+
+    public CCSUsageTelemetry() {
+        this.totalCCSCount = new LongAdder();
+        this.successfulSearchTelem = new SuccessfulCCSTelemetry();
+        this.failedSearchTelem = new FailedCCSTelemetry();
+        this.byRemoteCluster = new ConcurrentHashMap<>();
+    }
+
+    public void updateUsage(CCSUsage ccsUsage) {
+        // TODO: fork this to a background thread? if yes, could just pass in the SearchResponse to parse it off the response thread
+        doUpdate(ccsUsage);
+    }
+
+    // TODO: what is the best thread-safety model here? Start with locking model in order to get the functionality working.
+    private synchronized void doUpdate(CCSUsage ccsUsage) {
+        totalCCSCount.increment();
+        if (ccsUsage.getFailureType() == null) {
+            // handle successful (or partially successful query)
+            successfulSearchTelem.update(ccsUsage);
+            for (Map.Entry<String, CCSUsage.PerClusterUsage> entry : ccsUsage.getPerClusterUsage().entrySet()) {
+                PerClusterCCSTelemetry perClusterCCSTelemetry = byRemoteCluster.get(entry.getKey());
+                if (perClusterCCSTelemetry == null) {
+                    perClusterCCSTelemetry = new PerClusterCCSTelemetry(entry.getKey());
+                    byRemoteCluster.put(entry.getKey(), perClusterCCSTelemetry);
+                }
+                // TODO: add more fields/data to the perClusterCCSTelemetry
+                perClusterCCSTelemetry.update(entry.getValue());
+            }
+
+        } else {
+            // handle failed query
+            failedSearchTelem.update(ccsUsage);
+        }
+    }
+
+    public long getTotalCCSCount() {
+        return totalCCSCount.sum();
+    }
+
+    // TODO: the getters below need to create an immutable snapshot of CCS Telemetry and return that - see SearchUsageStats as example
+    public SuccessfulCCSTelemetry getSuccessfulSearchTelemetry() {
+        return successfulSearchTelem;
+    }
+
+    public FailedCCSTelemetry getFailedSearchTelemetry() {
+        return failedSearchTelem;
+    }
+
+    public Map<String, PerClusterCCSTelemetry> getTelemetryByCluster() {
+        return byRemoteCluster;
+    }
+
+    /**
+     * Telemetry metrics for successful searches (includes searches with partial failures)
+     */
+    static class SuccessfulCCSTelemetry {
+        private long count; // total number of searches
+        private long countMinimizeRoundtrips;
+        private long countSearchesWithSkippedRemotes;
+        private long countAsync;
+        private DoubleHistogram latency;
+
+        SuccessfulCCSTelemetry() {
+            this.count = 0;
+            this.countMinimizeRoundtrips = 0;
+            this.countSearchesWithSkippedRemotes = 0;
+            this.countAsync = 0;
+            this.latency = new DoubleHistogram(2);
+        }
+
+        void update(CCSUsage ccsUsage) {
+            count++;
+            countMinimizeRoundtrips += ccsUsage.isMinimizeRoundTrips() ? 1 : 0;
+            countSearchesWithSkippedRemotes += ccsUsage.getSkippedRemotes() > 0 ? 1 : 0;
+            countAsync += ccsUsage.isAsync() ? 1 : 0;
+            latency.recordValue(ccsUsage.getTook());
+        }
+
+        // TODO: remove these getters and replace with a toSuccessfulCCSUsageSnapshot method?
+        public long getCount() {
+            return count;
+        }
+
+        public long getCountMinimizeRoundtrips() {
+            return countMinimizeRoundtrips;
+        }
+
+        public long getCountSearchesWithSkippedRemotes() {
+            return countSearchesWithSkippedRemotes;
+        }
+
+        public long getCountAsync() {
+            return countAsync;
+        }
+
+        public double getMeanLatency() {
+            return latency.getMean();
+        }
+    }
+
+    /**
+     * Telemetry metrics for failed searches (no data returned)
+     */
+    static class FailedCCSTelemetry {
+        private long count;
+        private Map<String, Integer> causes;
+
+        FailedCCSTelemetry() {
+            causes = new HashMap<>();
+        }
+
+        void update(CCSUsage ccsUsage) {
+            count++;
+            causes.compute(ccsUsage.getFailureType(), (k, v) -> (v == null) ? 1 : v + 1);
+        }
+
+        public long getCount() {
+            return count;
+        }
+    }
+
+    /**
+     * Telemetry of each remote involved in cross cluster searches
+     */
+    static class PerClusterCCSTelemetry {
+        private String clusterAlias;
+        private long count;
+        private DoubleHistogram latency;
+
+        PerClusterCCSTelemetry(String clusterAlias) {
+            this.clusterAlias = clusterAlias;
+            this.count = 0;
+            // TODO: what should we use for num significant value digits?
+            latency = new DoubleHistogram(2);
+        }
+
+        void update(CCSUsage.PerClusterUsage remoteUsage) {
+            count++;
+            latency.recordValue(remoteUsage.getTook()); // TODO: do we need to add count as well using recordValueWithCount?
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        // TODO: add additional getters around latency (max, p90)
+        public double getMeanLatency() {
+            return latency.getMean();
+        }
+
+        @Override
+        public String toString() {
+            return "PerClusterCCSTelemetry{"
+                + "clusterAlias='"
+                + clusterAlias
+                + '\''
+                + ", count="
+                + count
+                + ", latency(mean)="
+                + latency.getMean()
+                + '}';
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -702,6 +703,13 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         }
 
         /**
+         * @return collection of cluster aliases in the search response (including "(local)" if was searched).
+         */
+        public Set<String> getClusterAliases() {
+            return clusterInfo.keySet();
+        }
+
+        /**
          * Utility to swap a Cluster object. Guidelines for the remapping function:
          * <ul>
          * <li> The remapping function should return a new Cluster object to swap it for
@@ -803,6 +811,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         public boolean hasRemoteClusters() {
             return total > 1 || clusterInfo.keySet().stream().anyMatch(alias -> alias != RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
         }
+
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsage;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -81,6 +82,7 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentFactory;
 
@@ -155,6 +157,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     private final boolean ccsCheckCompatibility;
     private final SearchResponseMetrics searchResponseMetrics;
     private final Client client;
+    private final UsageService usageService;
 
     @Inject
     public TransportSearchAction(
@@ -171,7 +174,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         ExecutorSelector executorSelector,
         SearchTransportAPMMetrics searchTransportMetrics,
         SearchResponseMetrics searchResponseMetrics,
-        Client client
+        Client client,
+        UsageService usageService
     ) {
         super(TYPE.name(), transportService, actionFilters, SearchRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.threadPool = threadPool;
@@ -190,6 +194,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         this.ccsCheckCompatibility = SearchService.CCS_VERSION_CHECK_SETTING.get(clusterService.getSettings());
         this.searchResponseMetrics = searchResponseMetrics;
         this.client = client;
+        this.usageService = usageService;
     }
 
     private Map<String, OriginalIndices> buildPerIndexOriginalIndices(
@@ -317,10 +322,15 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             }
                         }
                     }
-                    listener.onResponse(searchResponse);
                     // increment after the delegated onResponse to ensure we don't
                     // record both a success and a failure if there is an exception
                     searchResponseMetrics.incrementResponseCount(responseCountTotalStatus);
+
+                    if (CCS_TELEMETRY_FEATURE_FLAG.isEnabled() && searchResponse.getClusters().hasRemoteClusters()) {
+                        extractCCSTelemetry(searchResponse, (SearchTask) task);
+                    }
+                    // TODO: should this be last?
+                    listener.onResponse(searchResponse);
                 } catch (Exception e) {
                     onFailure(e);
                 }
@@ -1427,6 +1437,51 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 }
             }
         }
+    }
+
+    private void extractCCSTelemetry(SearchResponse searchResponse, SearchTask searchTask) {
+        Map<String, CCSUsage.PerClusterUsage> clusterUsageMap = new HashMap<>();
+        for (String clusterAlias : searchResponse.getClusters().getClusterAliases()) {
+            SearchResponse.Cluster cluster = searchResponse.getClusters().getCluster(clusterAlias);
+            CCSUsage.PerClusterUsage clusterUsageInfo = new CCSUsage.PerClusterUsage(cluster.getTook());
+            clusterUsageMap.put(clusterAlias, clusterUsageInfo);
+        }
+
+        CCSUsage ccsUsage = new CCSUsage.Builder().took(searchResponse.getTookInMillis())
+            .async(isAsyncSearchTask(searchTask))
+            .minimizeRoundTrips(searchResponse.getClusters().isCcsMinimizeRoundtrips())
+            .numSkippedRemotes(searchResponse.getClusters().getClusterStateCount(SearchResponse.Cluster.Status.SKIPPED))
+            .perClusterUsage(clusterUsageMap)
+            .build();
+        usageService.getCcsUsageHolder().updateUsage(ccsUsage);
+    }
+
+    /**
+     * TransportSearchAction cannot access async-search code, so can't check whether this the Task
+     * is an instance of AsyncSearchTask, so this roundabout method is used
+     * @param searchTask SearchTask to analyze
+     * @return true if this is an async search task; false if a synchronous search task
+     */
+    private boolean isAsyncSearchTask(SearchTask searchTask) {
+        assert assertAsyncSearchTaskListener(searchTask) : "AsyncSearchTask SearchProgressListener name has ";
+        // AsyncSearchTask will not return SearchProgressListener.NOOP, since it uses its own progress listener
+        // which delegates to CCSSingleCoordinatorSearchProgressListener when minimizing roundtrips.
+        // Only synchronous SearchTask uses SearchProgressListener.NOOP or CCSSingleCoordinatorSearchProgressListener directly
+        return searchTask.getProgressListener() != SearchProgressListener.NOOP
+            && searchTask.getProgressListener() instanceof CCSSingleCoordinatorSearchProgressListener == false;
+    }
+
+    /**
+     * @param searchTask SearchTask to analyze
+     * @return true if AsyncSearchTask still uses its own special listener, not one of the two that synchronous SearchTask uses
+     */
+    private boolean assertAsyncSearchTaskListener(SearchTask searchTask) {
+        if (searchTask.getClass().getSimpleName().contains("AsyncSearchTask")) {
+            SearchProgressListener progressListener = searchTask.getProgressListener();
+            return progressListener != SearchProgressListener.NOOP
+                && progressListener instanceof CCSSingleCoordinatorSearchProgressListener == false;
+        }
+        return true;
     }
 
     private static void validateAndResolveWaitForCheckpoint(

--- a/server/src/main/java/org/elasticsearch/usage/UsageService.java
+++ b/server/src/main/java/org/elasticsearch/usage/UsageService.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.usage;
 
 import org.elasticsearch.action.admin.cluster.node.usage.NodeUsage;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry;
 import org.elasticsearch.rest.BaseRestHandler;
 
 import java.util.HashMap;
@@ -23,10 +24,12 @@ public class UsageService {
 
     private final Map<String, BaseRestHandler> handlers;
     private final SearchUsageHolder searchUsageHolder;
+    private final CCSUsageTelemetry ccsUsageHolder;
 
     public UsageService() {
         this.handlers = new HashMap<>();
         this.searchUsageHolder = new SearchUsageHolder();
+        this.ccsUsageHolder = new CCSUsageTelemetry();
     }
 
     /**
@@ -80,5 +83,9 @@ public class UsageService {
      */
     public SearchUsageHolder getSearchUsageHolder() {
         return searchUsageHolder;
+    }
+
+    public CCSUsageTelemetry getCcsUsageHolder() {
+        return ccsUsageHolder;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class CCSUsageTelemetryTests extends ESTestCase {
+
+    public void testSuccessfulSearchResults() {
+        CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
+
+        long expectedAsyncCount = 0L;
+        long expectedMinRTCount = 0L;
+        long expectedSearchesWithSkippedRemotes = 0L;
+        long took1 = 0L;
+        long took1Remote1 = 0L;
+
+        // first search
+        {
+            boolean minimizeRoundTrips = randomBoolean();
+            boolean async = randomBoolean();
+            took1 = randomLongBetween(5, 10000);
+            int numSkippedRemotes = randomIntBetween(0, 3);
+            expectedSearchesWithSkippedRemotes = numSkippedRemotes > 0 ? 1 : 0;
+            expectedAsyncCount = async ? 1 : 0;
+            expectedMinRTCount = minimizeRoundTrips ? 1 : 0;
+
+            // per cluster telemetry
+            long tookLocal = randomLongBetween(2, 8000);
+            took1Remote1 = randomLongBetween(2, 8000);
+            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
+                "(local)",
+                new CCSUsage.PerClusterUsage(new TimeValue(tookLocal)),
+                "remote1",
+                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
+            );
+
+            CCSUsage ccsUsage = new CCSUsage.Builder().took(took1)
+                .async(async)
+                .minimizeRoundTrips(minimizeRoundTrips)
+                .numSkippedRemotes(numSkippedRemotes)
+                .perClusterUsage(perClusterUsage)
+                .build();
+
+            ccsUsageHolder.updateUsage(ccsUsage);
+
+            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(1L));
+            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
+            assertThat(successfulCCSTelemetry.getCount(), equalTo(1L));
+            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
+            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
+            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1));
+
+            // per cluster telemetry asserts
+            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+            assertThat(telemetryByCluster.size(), equalTo(2));
+            var localClusterTelemetry = telemetryByCluster.get("(local)");
+            assertNotNull(localClusterTelemetry);
+            assertThat(localClusterTelemetry.getCount(), equalTo(1L));
+            assertThat(localClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(localClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) tookLocal));
+
+            var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
+            assertNotNull(remote1ClusterTelemetry);
+            assertThat(remote1ClusterTelemetry.getCount(), equalTo(1L));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1Remote1));
+        }
+
+        // second search
+        {
+            boolean minimizeRoundTrips = randomBoolean();
+            boolean async = randomBoolean();
+            expectedAsyncCount += async ? 1 : 0;
+            expectedMinRTCount += minimizeRoundTrips ? 1 : 0;
+            long took2 = randomLongBetween(5, 10000);
+            int numSkippedRemotes = randomIntBetween(0, 3);
+            expectedSearchesWithSkippedRemotes += numSkippedRemotes > 0 ? 1 : 0;
+
+            long took2Remote1 = randomLongBetween(2, 8000);
+            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
+                "remote1",
+                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
+            );
+
+            CCSUsage ccsUsage = new CCSUsage.Builder().took(took2)
+                .async(async)
+                .minimizeRoundTrips(minimizeRoundTrips)
+                .numSkippedRemotes(numSkippedRemotes)
+                .perClusterUsage(perClusterUsage)
+                .build();
+
+            ccsUsageHolder.updateUsage(ccsUsage);
+
+            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(2L));
+            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
+            assertThat(successfulCCSTelemetry.getCount(), equalTo(2L));
+            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
+            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
+            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1, took2)));
+
+            // per cluster telemetry asserts
+            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+            assertThat(telemetryByCluster.size(), equalTo(2));
+            var localClusterTelemetry = telemetryByCluster.get("(local)");
+            assertNotNull(localClusterTelemetry);
+            assertThat(localClusterTelemetry.getCount(), equalTo(1L));  // not part of second search
+
+            var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
+            assertNotNull(remote1ClusterTelemetry);
+            assertThat(remote1ClusterTelemetry.getCount(), equalTo(2L));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1Remote1, took2Remote1)));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -98,6 +98,7 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1764,7 +1765,8 @@ public class TransportSearchActionTests extends ESTestCase {
                 null,
                 new SearchTransportAPMMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
                 new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
-                client
+                client,
+                new UsageService()
             );
 
             CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -195,6 +195,7 @@ import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.junit.After;
 import org.junit.Before;
@@ -2061,6 +2062,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
             private final BigArrays bigArrays;
 
+            private final UsageService usageService;
+
             private Coordinator coordinator;
 
             TestClusterNode(DiscoveryNode node, TransportInterceptorFactory transportInterceptorFactory) throws IOException {
@@ -2071,6 +2074,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 masterService = new FakeThreadPoolMasterService(node.getName(), threadPool, deterministicTaskQueue::scheduleNow);
                 final Settings settings = environment.settings();
                 client = new NodeClient(settings, threadPool);
+                this.usageService = new UsageService();
                 final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
                 clusterService = new ClusterService(
                     settings,
@@ -2486,7 +2490,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                         EmptySystemIndices.INSTANCE.getExecutorSelector(),
                         new SearchTransportAPMMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
                         new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
-                        client
+                        client,
+                        usageService
                     )
                 );
                 actions.put(


### PR DESCRIPTION
This creates the use CCSUsage and CCSUsageTelemetry classes and wires them up
to the UsageService. UsageService is now injected into the TransportSearchAction constructor.

An initial set of telemetry metrics are now being gathered in TransportSearchAction.
Many more will be added later to meet all the requirements for the CCS Telemetry epic of work.
