### PR TITLE
[8.15] Fix RollupIndexerStateTests

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -556,22 +557,22 @@ public class RollupIndexerStateTests extends ESTestCase {
                 assertThat(indexer.getState(), equalTo(IndexerState.STARTED));
                 // This may take more than one attempt due to a cleanup/transition phase
                 // that happens after state change to STARTED (`isJobFinishing`).
-                assertBusy(() -> indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+                assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
                 assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
                 assertFalse(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
                 assertThat(indexer.getState(), equalTo(IndexerState.INDEXING));
                 latch.countDown();
                 assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)));
-                assertThat(indexer.getStats().getNumInvocations(), equalTo((long) i + 1));
                 assertThat(indexer.getStats().getNumPages(), equalTo((long) i + 1));
             }
             final CountDownLatch latch = indexer.newLatch();
-            assertBusy(() -> indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+            assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
             assertThat(indexer.stop(), equalTo(IndexerState.STOPPING));
             assertThat(indexer.getState(), Matchers.either(Matchers.is(IndexerState.STOPPING)).or(Matchers.is(IndexerState.STOPPED)));
             latch.countDown();
             assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STOPPED)));
             assertTrue(indexer.abort());
+            assertThat(indexer.getStats().getNumInvocations(), greaterThanOrEqualTo(6L));
         } finally {
             ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
This PR backports fixes to this test to 8.15.