### PR TITLE
GET _cluster/settings with include_defaults returns the expected fallback value if defined in elasticsearch.yml

### DIFF
--- a/docs/changelog/110816.yaml
+++ b/docs/changelog/110816.yaml
@@ -1,0 +1,6 @@
+pr: 110816
+summary: GET _cluster/settings with include_defaults returns the expected fallback value if defined in elasticsearch.yml
+area: Infra/Settings
+type: bug
+issues:
+ - 110815

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -584,7 +584,7 @@ public class Setting<T> implements ToXContentObject {
      */
     public void diff(Settings.Builder builder, Settings source, Settings defaultSettings) {
         if (exists(source) == false) {
-            if (exists(defaultSettings)) {
+            if (existsOrFallbackExists(defaultSettings)) {
                 // If the setting is only in the defaults, use the value from the defaults
                 builder.put(getKey(), getRaw(defaultSettings));
             } else {


### PR DESCRIPTION
Fixes #110815

- **test: add unit test that reproduces #110815**
- **fix: consider the fallback setting when getting the default value of a setting**

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
