### PR TITLE
Do not include root level `_type` field if it is not a metadata field

### DIFF
--- a/docs/changelog/110825.yaml
+++ b/docs/changelog/110825.yaml
@@ -1,0 +1,6 @@
+pr: 110825
+summary: Do not include root level `_type` field if it is not a metadata field
+area: Mapping
+type: bug
+issues:
+ - 110438

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
@@ -184,7 +184,7 @@ teardown:
         refresh: true
         body:
           - '{ "index": {"_id": "1"}}'
-          - '{ "text": "What species does chewbacca belong to", "_type": { "name": "question" }}'
+          - '{ "text": "What species does chewbacca belong to?", "_type": { "name": "question" }}'
           - '{ "index": {"_id": "2"}}'
           - '{ "text": "How did Yoda die?", "_type": { "name": "question" }}'
 
@@ -208,7 +208,7 @@ teardown:
   - match: { hits.hits.0._id: "1" }
   - match: { hits.hits.0._type: null }
   - match: { hits.hits.0._source._type.name: "question" }
-  - match: { hits.hits.0._source.text: "What species does chewbacca belong to"}
+  - match: { hits.hits.0._source.text: "What species does chewbacca belong to?"}
 
   - match: { hits.hits.1._id: "2" }
   - match: { hits.hits.1._type: null }

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/20_parent_join.yml
@@ -161,3 +161,56 @@ teardown:
           mappings:
             properties:
               join_field: { "type": "join", "relations": { "parent": "child", "child": "grand_child" }, "fields": {"keyword": {"type": "keyword"}} }
+
+
+---
+"join on field named _type":
+  - requires:
+      cluster_features: [ "gte_v8.14.0" ]
+      reason: "deprecation added in 8.14"
+
+  - do:
+      indices.create:
+        index: type-join
+        body:
+          mappings:
+            properties:
+              text: { "type": "keyword" }
+              _type: { "type": "join", "relations": { "question": "answer" }}
+
+  - do:
+      bulk:
+        index: type-join
+        refresh: true
+        body:
+          - '{ "index": {"_id": "1"}}'
+          - '{ "text": "What species does chewbacca belong to", "_type": { "name": "question" }}'
+          - '{ "index": {"_id": "2"}}'
+          - '{ "text": "How did Yoda die?", "_type": { "name": "question" }}'
+
+  - do:
+      bulk:
+        index: type-join
+        refresh: true
+        body:
+          - '{ "index": {"_id": "3"}}'
+          - '{ "text": "Wookie", "_type": { "name": "answer", "parent": "1" }}'
+          - '{ "index": {"_id": "4"}}'
+          - '{ "text": "Old age", "_type": { "name": "answer", "parent": "2" }}'
+
+  - do:
+      search:
+        index: type-join
+        body: { query: { match_all: { } } }
+
+  - length: { hits.hits: 2 }
+
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0._type: null }
+  - match: { hits.hits.0._source._type.name: "question" }
+  - match: { hits.hits.0._source.text: "What species does chewbacca belong to"}
+
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.1._type: null }
+  - match: { hits.hits.1._source._type.name: "question" }
+  - match: { hits.hits.1._source.text: "How did Yoda die?" }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.fetch.subphase;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.mapper.LegacyTypeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedValueFetcher;
 import org.elasticsearch.index.mapper.ValueFetcher;
@@ -56,6 +57,11 @@ public class FieldFetcher {
                 MappedFieldType ft = context.getFieldType(field);
                 // we want to skip metadata fields if we have a wildcard pattern
                 if (context.isMetadataField(field) && matchingPattern != null) {
+                    continue;
+                }
+                // Include the `_type` field only if it is a metadata field .
+                // Above we already skip metadata fields in case of wildcard patterns.
+                if (context.isMetadataField(field) == false && LegacyTypeFieldMapper.NAME.equals(field)) {
                     continue;
                 }
                 resolvedFields.add(new ResolvedField(field, matchingPattern, ft, fieldAndFormat.format));


### PR DESCRIPTION
`_type` is a (deprecated) metadata field. When a non-metadata field is created whose name
is `type`, it must be included in the `_source` field but not as a root-level field, as done
for `type` when it is a metadata field. For Elasticsearch using version 7 of the REST api the
`type` field is, indeed, a metadata field which is included at the root level of the response.

Resolves #110438 