### PR TITLE
[8.15] Ignore configs from DistributionDownload plugin and bwc for resolveAllDependencies (#110828)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -42,8 +42,10 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
     private static final String FAKE_SNAPSHOT_IVY_GROUP = "elasticsearch-distribution-snapshot";
     private static final String DOWNLOAD_REPO_NAME = "elasticsearch-downloads";
     private static final String SNAPSHOT_REPO_NAME = "elasticsearch-snapshots";
-    public static final String DISTRO_EXTRACTED_CONFIG_PREFIX = "es_distro_extracted_";
-    public static final String DISTRO_CONFIG_PREFIX = "es_distro_file_";
+
+    public static final String ES_DISTRO_CONFIG_PREFIX = "es_distro_";
+    public static final String DISTRO_EXTRACTED_CONFIG_PREFIX = ES_DISTRO_CONFIG_PREFIX + "extracted_";
+    public static final String DISTRO_CONFIG_PREFIX = ES_DISTRO_CONFIG_PREFIX + "file_";
 
     private final ObjectFactory objectFactory;
     private NamedDomainObjectContainer<ElasticsearchDistribution> distributionsContainer;

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.util.GradleUtils
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency
+import org.elasticsearch.gradle.DistributionDownloadPlugin
 
 import java.nio.file.Files
 
@@ -284,11 +285,16 @@ allprojects {
   }
 
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
-    configs = project.configurations
+    def ignoredPrefixes = [DistributionDownloadPlugin.ES_DISTRO_CONFIG_PREFIX, "jdbcDriver"]
+    configs = project.configurations.matching { config -> ignoredPrefixes.any { config.name.startsWith(it) } == false }
     resolveJavaToolChain = true
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }
+    if (project.path.contains(":distribution:docker")) {
+      enabled = false
+    }
+
   }
 
   plugins.withId('lifecycle-base') {

--- a/qa/packaging/build.gradle
+++ b/qa/packaging/build.gradle
@@ -36,8 +36,3 @@ tasks.named("test").configure { enabled = false }
 tasks.register('destructivePackagingTest') {
   dependsOn 'destructiveDistroTest'
 }
-
-tasks.named('resolveAllDependencies') {
-  // avoid resolving all elasticsearch distros
-  enabled = false
-}


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Ignore configs from DistributionDownload plugin and bwc for resolveAllDependencies (#110828)