### PR TITLE
[7.17] Ignore configs from DistributionDownload plugin and bwc for resolveAllDependencies (#110828)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -42,8 +42,10 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
     private static final String FAKE_SNAPSHOT_IVY_GROUP = "elasticsearch-distribution-snapshot";
     private static final String DOWNLOAD_REPO_NAME = "elasticsearch-downloads";
     private static final String SNAPSHOT_REPO_NAME = "elasticsearch-snapshots";
-    public static final String DISTRO_EXTRACTED_CONFIG_PREFIX = "es_distro_extracted_";
-    public static final String DISTRO_CONFIG_PREFIX = "es_distro_file_";
+
+    public static final String ES_DISTRO_CONFIG_PREFIX = "es_distro_";
+    public static final String DISTRO_EXTRACTED_CONFIG_PREFIX = ES_DISTRO_CONFIG_PREFIX + "extracted_";
+    public static final String DISTRO_CONFIG_PREFIX = ES_DISTRO_CONFIG_PREFIX + "file_";
 
     private final ObjectFactory objectFactory;
     private NamedDomainObjectContainer<ElasticsearchDistribution> distributionsContainer;

--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,6 @@ allprojects {
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     def ignoredPrefixes = [DistributionDownloadPlugin.ES_DISTRO_CONFIG_PREFIX, "jdbcDriver"]
     configs = project.configurations.matching { config -> ignoredPrefixes.any { config.name.startsWith(it) } == false }
-    resolveJavaToolChain = true
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency
 import org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin
 import org.elasticsearch.gradle.internal.ResolveAllDependencies
+import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.util.GradleUtils
+import org.gradle.plugins.ide.eclipse.model.AccessRule
+import org.gradle.plugins.ide.eclipse.model.ProjectDependency
+import org.elasticsearch.gradle.DistributionDownloadPlugin
+
 import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
@@ -273,10 +279,16 @@ allprojects {
   }
 
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
-    configs = project.configurations
+    def ignoredPrefixes = [DistributionDownloadPlugin.ES_DISTRO_CONFIG_PREFIX, "jdbcDriver"]
+    configs = project.configurations.matching { config -> ignoredPrefixes.any { config.name.startsWith(it) } == false }
+    resolveJavaToolChain = true
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }
+    if (project.path.contains(":distribution:docker")) {
+      enabled = false
+    }
+
   }
 
   def checkPart1 = tasks.register('checkPart1')

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -45,7 +45,3 @@ subprojects { Project platformProject ->
     hostEnv 'VAGRANT_PROJECT_DIR', platformProject.projectDir.absolutePath
   }
 }
-tasks.named('resolveAllDependencies') {
-  // avoid resolving all elasticsearch distros
-  enabled = false
-}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Ignore configs from DistributionDownload plugin and bwc for resolveAllDependencies (#110828)](https://github.com/elastic/elasticsearch/pull/110828)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)