### PR TITLE
Remove preview from top level query rules API page

### DIFF
--- a/docs/reference/query-rules/apis/index.asciidoc
+++ b/docs/reference/query-rules/apis/index.asciidoc
@@ -1,8 +1,6 @@
 [[query-rules-apis]]
 == Query rules APIs
 
-preview::[]
-
 ++++
 <titleabbrev>Query rules APIs</titleabbrev>
 ++++


### PR DESCRIPTION
Forgot one preview tag in https://github.com/elastic/elasticsearch/pull/110004