### PR TITLE
[8.15] Remove preview from top level query rules API page (#110838)

### DIFF
--- a/docs/reference/query-rules/apis/index.asciidoc
+++ b/docs/reference/query-rules/apis/index.asciidoc
@@ -1,8 +1,6 @@
 [[query-rules-apis]]
 == Query rules APIs
 
-preview::[]
-
 ++++
 <titleabbrev>Query rules APIs</titleabbrev>
 ++++


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Remove preview from top level query rules API page (#110838)