### PR TITLE
[Backport] 110824 to 8.15

### DIFF
--- a/docs/changelog/110824.yaml
+++ b/docs/changelog/110824.yaml
@@ -1,0 +1,5 @@
+pr: 110824
+summary: "[ESQL] Count_distinct(_source) should return a 400"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -50,6 +50,11 @@ public class EsqlCapabilities {
         AGG_TOP,
 
         /**
+         * Support for booleans in aggregations {@code MAX} and {@code MIN}.
+         */
+        AGG_MAX_MIN_BOOLEAN_SUPPORT,
+
+        /**
          * Optimization for ST_CENTROID changed some results in cartesian data. #108713
          */
         ST_CENTROID_AGG_OPTIMIZED,
@@ -109,10 +114,32 @@ public class EsqlCapabilities {
         AGG_WEIGHTED_AVG,
 
         /**
+         * Fix for union-types when aggregating over an inline conversion with casting operator. Done in #110476.
+         */
+        UNION_TYPES_AGG_CAST,
+
+        /**
+         * Fix to GROK validation in case of multiple fields with same name and different types
+         * https://github.com/elastic/elasticsearch/issues/110533
+         */
+        GROK_VALIDATION,
+
+        /**
+         * Fix for union-types when aggregating over an inline conversion with conversion function. Done in #110652.
+         */
+        UNION_TYPES_INLINE_FIX,
+
+        /**
          * Fix a parsing issue where numbers below Long.MIN_VALUE threw an exception instead of parsing as doubles.
          * see <a href="https://github.com/elastic/elasticsearch/issues/104323"> Parsing large numbers is inconsistent #104323 </a>
          */
-        FIX_PARSING_LARGE_NEGATIVE_NUMBERS;
+        FIX_PARSING_LARGE_NEGATIVE_NUMBERS,
+
+        /**
+         * Fix the status code returned when trying to run count_distinct on the _source type (which is not supported).
+         * see <a href="https://github.com/elastic/elasticsearch/issues/105240">count_distinct(_source) returns a 500 response</a>
+         */
+        FIX_COUNT_DISTINCT_SOURCE_ERROR;
 
         private final boolean snapshotOnly;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -114,22 +114,6 @@ public class EsqlCapabilities {
         AGG_WEIGHTED_AVG,
 
         /**
-         * Fix for union-types when aggregating over an inline conversion with casting operator. Done in #110476.
-         */
-        UNION_TYPES_AGG_CAST,
-
-        /**
-         * Fix to GROK validation in case of multiple fields with same name and different types
-         * https://github.com/elastic/elasticsearch/issues/110533
-         */
-        GROK_VALIDATION,
-
-        /**
-         * Fix for union-types when aggregating over an inline conversion with conversion function. Done in #110652.
-         */
-        UNION_TYPES_INLINE_FIX,
-
-        /**
          * Fix a parsing issue where numbers below Long.MIN_VALUE threw an exception instead of parsing as doubles.
          * see <a href="https://github.com/elastic/elasticsearch/issues/104323"> Parsing large numbers is inconsistent #104323 </a>
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -50,11 +50,6 @@ public class EsqlCapabilities {
         AGG_TOP,
 
         /**
-         * Support for booleans in aggregations {@code MAX} and {@code MIN}.
-         */
-        AGG_MAX_MIN_BOOLEAN_SUPPORT,
-
-        /**
          * Optimization for ST_CENTROID changed some results in cartesian data. #108713
          */
         ST_CENTROID_AGG_OPTIMIZED,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -116,10 +116,10 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
         boolean resolved = resolution.resolved();
         resolution = isType(
             field(),
-            dt -> resolved && dt != DataType.UNSIGNED_LONG,
+            dt -> resolved && dt != DataType.UNSIGNED_LONG && dt != DataType.SOURCE,
             sourceText(),
             DEFAULT,
-            "any exact type except unsigned_long or counter types"
+            "any exact type except unsigned_long, _source, or counter types"
         );
         if (resolution.unresolved() || precision == null) {
             return resolution;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -264,7 +264,7 @@ final class AggregateMapper {
             case INT -> DataType.INTEGER;
             case LONG -> DataType.LONG;
             case DOUBLE -> DataType.DOUBLE;
-            default -> throw new EsqlIllegalArgumentException("unsupported agg type: " + elementType);
+            case FLOAT, NULL, DOC, COMPOSITE, UNKNOWN -> throw new EsqlIllegalArgumentException("unsupported agg type: " + elementType);
         };
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1830,7 +1830,7 @@ public class AnalyzerTests extends ESTestCase {
             Found 8 problems
             line 2:12: argument of [avg(x)] must be [numeric except unsigned_long or counter types],\
              found value [x] type [unsigned_long]
-            line 2:20: argument of [count_distinct(x)] must be [any exact type except unsigned_long or counter types],\
+            line 2:20: argument of [count_distinct(x)] must be [any exact type except unsigned_long, _source, or counter types],\
              found value [x] type [unsigned_long]
             line 2:39: argument of [max(x)] must be [datetime or numeric except unsigned_long or counter types],\
              found value [max(x)] type [unsigned_long]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/140_metadata.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/140_metadata.yml
@@ -5,7 +5,7 @@ setup:
         - method: POST
           path: /_query
           parameters: [method, path, parameters, capabilities]
-          capabilities: [metadata_fields, metadata_field_ignored]
+          capabilities: [metadata_fields, metadata_ignored_field]
       reason: "Ignored metadata field capability required"
 
   - do:
@@ -140,3 +140,18 @@ setup:
   - match: {columns.0.name: "count_distinct(_ignored)"}
   - match: {columns.0.type: "long"}
   - match: {values.0.0: 2}
+
+---
+"Count_distinct on _source is a 400 error":
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [fix_count_distinct_source_error]
+      reason: "Capability marks fixing this bug"
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'FROM test [metadata _source] | STATS COUNT_DISTINCT(_source)'


### PR DESCRIPTION
Resolves
[#105240](https://github.com/elastic/elasticsearch/issues/105240)

Count_distinct doesn't work on source, but the type resolution was allowing that through.  This resulted in a 500 layer deeper in the aggregations code.  This PR fixes the 500 error by correctly failing during type resolution.