### PR TITLE
Speedup CanMatchPreFilterSearchPhase constructor

### DIFF
--- a/docs/changelog/110860.yaml
+++ b/docs/changelog/110860.yaml
@@ -1,0 +1,5 @@
+pr: 110860
+summary: Speedup `CanMatchPreFilterSearchPhase` constructor
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
@@ -19,7 +19,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -174,14 +173,24 @@ public final class SearchShardIterator implements Comparable<SearchShardIterator
 
     @Override
     public int hashCode() {
-        return Objects.hash(clusterAlias, shardId);
+        var clusterAlias = this.clusterAlias;
+        return 31 * (31 + (clusterAlias == null ? 0 : clusterAlias.hashCode())) + shardId.hashCode();
     }
-
-    private static final Comparator<SearchShardIterator> COMPARATOR = Comparator.comparing(SearchShardIterator::shardId)
-        .thenComparing(SearchShardIterator::getClusterAlias, Comparator.nullsFirst(String::compareTo));
 
     @Override
     public int compareTo(SearchShardIterator o) {
-        return COMPARATOR.compare(this, o);
+        int res = shardId.compareTo(o.shardId);
+        if (res != 0) {
+            return res;
+        }
+        var thisClusterAlias = clusterAlias;
+        var otherClusterAlias = o.clusterAlias;
+        if (thisClusterAlias == null) {
+            return otherClusterAlias == null ? 0 : -1;
+        } else if (otherClusterAlias == null) {
+            return 1;
+        } else {
+            return thisClusterAlias.compareTo(otherClusterAlias);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
@@ -108,14 +108,17 @@ public class ShardId implements Comparable<ShardId>, ToXContentFragment, Writeab
 
     @Override
     public int compareTo(ShardId o) {
-        if (o.getId() == shardId) {
-            int compare = index.getName().compareTo(o.getIndex().getName());
-            if (compare != 0) {
-                return compare;
-            }
-            return index.getUUID().compareTo(o.getIndex().getUUID());
+        final int res = Integer.compare(shardId, o.shardId);
+        if (res != 0) {
+            return res;
         }
-        return Integer.compare(shardId, o.getId());
+        final Index index = this.index;
+        final Index otherIndex = o.index;
+        int compare = index.getName().compareTo(otherIndex.getName());
+        if (compare != 0) {
+            return compare;
+        }
+        return index.getUUID().compareTo(otherIndex.getUUID());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -82,7 +82,9 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
             null,
             request,
             listener,
-            new GroupShardsIterator<>(Collections.singletonList(new SearchShardIterator(null, null, Collections.emptyList(), null))),
+            new GroupShardsIterator<>(
+                Collections.singletonList(new SearchShardIterator(null, new ShardId("index", "_na", 0), Collections.emptyList(), null))
+            ),
             timeProvider,
             ClusterState.EMPTY_STATE,
             null,


### PR DESCRIPTION
This constructor is needlessly inefficient, this change speeds it up by up to an order of magnitude for crude benchmarks of O(1k) shards scenarios:
* Sorting an array is quite a bit faster than sorting an `ArrayList` the way we did it here (could do it faster via List.sort but array ist still better).
* Pre-size the hashmap of positions
* Faster `ShardId.compareTo`
* Much faster `SearchShardIterator.compareTo` (the comparator constant didn't inline at all, so the cost of this thing was almost all function calls!

relates #109527 (lets not call it fixed quite yet, I have a second round of equally impactful but orthogonal fixes incoming in another PR)