### PR TITLE
[8.15] [DOCS] Add note about ML model 502 timeout when using `Create inference API` (#110835)

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -11,7 +11,6 @@ IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 For built-in models and models uploaded through Eland, the {infer} APIs offer an alternative way to use and manage trained models.
 However, if you do not plan to use the {infer} APIs to use these models or if you want to use non-NLP models, use the <<ml-df-trained-models-apis>>.
 
-
 [discrete]
 [[put-inference-api-request]]
 ==== {api-request-title}
@@ -24,7 +23,6 @@ However, if you do not plan to use the {infer} APIs to use these models or if yo
 
 * Requires the `manage_inference` <<privileges-list-cluster,cluster privilege>>
 (the built-in `inference_admin` role grants this privilege)
-
 
 [discrete]
 [[put-inference-api-desc]]
@@ -45,3 +43,11 @@ The following services are available through the {infer} API, click the links to
 * <<infer-service-hugging-face,Hugging Face>>
 * <<infer-service-mistral,Mistral>>
 * <<infer-service-openai,OpenAI>>
+
+[NOTE]
+====
+You might see a 502 bad gateway error in the response when using the {kib} Console.
+This error usually just reflects a timeout, while the model downloads in the background.
+You can check the download progress in the {ml-app} UI.
+If using the Python client, you can set the `timeout` parameter to a higher value.
+====

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -24,7 +24,6 @@ This tutorial uses the <<inference-example-elser,`elser` service>> for demonstra
 To use the `semantic_text` field type, you must have an {infer} endpoint deployed in
 your cluster using the <<put-inference-api>>.
 
-
 [discrete]
 [[semantic-text-infer-endpoint]]
 ==== Create the {infer} endpoint
@@ -48,6 +47,13 @@ be used and ELSER creates sparse vectors. The `inference_id` is
 `my-elser-endpoint`.
 <2> The `elser` service is used in this example.
 
+[NOTE]
+====
+You might see a 502 bad gateway error in the response when using the {kib} Console.
+This error usually just reflects a timeout, while the model downloads in the background.
+You can check the download progress in the {ml-app} UI.
+If using the Python client, you can set the `timeout` parameter to a higher value.
+====
 
 [discrete]
 [[semantic-text-index-mapping]]


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [DOCS] Add note about ML model 502 timeout when using `Create inference API` (#110835)