### PR TITLE
Simplify reset-features API

### DIFF
--- a/docs/reference/features/apis/reset-features-api.asciidoc
+++ b/docs/reference/features/apis/reset-features-api.asciidoc
@@ -26,7 +26,7 @@ POST /_features/_reset
 
 Return a cluster to the same state as a new installation by resetting the feature state for all {es} features. This deletes all state information stored in system indices.
 
-The response code is `HTTP 200` if state is successfully reset for all features, `HTTP 207` if there is a mixture of successes and failures, and `HTTP 500` if the reset operation fails for all features.
+The response code is `HTTP 200` if state is successfully reset for all features, or `HTTP 500` if the reset operation failed for any feature.
 
 Note that select features might provide a way to reset particular system indices. Using this API resets _all_ features, both those that are built-in and implemented as plugins.
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
@@ -10,7 +10,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.features;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
@@ -68,21 +68,21 @@ public class TransportResetFeatureStateAction extends TransportMasterNodeAction<
         ClusterState state,
         ActionListener<ResetFeatureStateResponse> listener
     ) throws Exception {
-        if (systemIndices.getFeatures().size() == 0) {
-            listener.onResponse(new ResetFeatureStateResponse(Collections.emptyList()));
-        }
-
-        final int features = systemIndices.getFeatures().size();
-        GroupedActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> groupedActionListener = new GroupedActionListener<>(
-            systemIndices.getFeatures().size(),
-            listener.map(responses -> {
-                assert features == responses.size();
-                return new ResetFeatureStateResponse(new ArrayList<>(responses));
-            })
-        );
-
-        for (SystemIndices.Feature feature : systemIndices.getFeatures()) {
-            feature.getCleanUpFunction().apply(clusterService, client, groupedActionListener);
+        final var features = systemIndices.getFeatures();
+        final var responses = new ArrayList<ResetFeatureStateResponse.ResetFeatureStateStatus>(features.size());
+        try (
+            var listeners = new RefCountingListener(
+                listener.map(ignored -> new ResetFeatureStateResponse(Collections.unmodifiableList(responses)))
+            )
+        ) {
+            for (final var feature : features) {
+                feature.getCleanUpFunction().apply(clusterService, client, listeners.acquire(e -> {
+                    assert e != null : feature.getName();
+                    synchronized (responses) {
+                        responses.add(e);
+                    }
+                }));
+            }
         }
     }
 


### PR DESCRIPTION
Today we return HTTP code 207 if some features successfully reset and
others failed. This is not an appropriate response code, it has a _very_
precise meaning according to the HTTP specification to which we do not
adhere. Since this API is used only in tests we can be stricter and
return a 500 unless it completely succeeds.