### PR TITLE
Do not update dangling indices asynchronously in a test

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkAfterWriteFsyncFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkAfterWriteFsyncFailureIT.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.index.IndexSettings.INDEX_REFRESH_INTERVAL_SETTING;
+import static org.elasticsearch.indices.IndicesService.WRITE_DANGLING_INDICES_INFO_SETTING;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -48,7 +49,11 @@ public class BulkAfterWriteFsyncFailureIT extends ESSingleNodeTestCase {
         PathUtilsForTesting.teardown();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/110551")
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder().put(WRITE_DANGLING_INDICES_INFO_SETTING.getKey(), false).build();
+    }
+
     public void testFsyncFailureDoesNotAdvanceLocalCheckpoints() {
         String indexName = randomIdentifier();
         client().admin()


### PR DESCRIPTION
So that the only expected disk write at the point of the assertion is from the bulk request. And not from the asynchronous runnable of `updateDanglingIndicesInfo()`  (see stack trace in latest test failures e.g. [this one](https://gradle-enterprise.elastic.co/s/ljfx57niyqbf2)).

Fixes #110551
