### PR TITLE
Backport bugfixes for union-types to 8.15

### DIFF
--- a/docs/changelog/110476.yaml
+++ b/docs/changelog/110476.yaml
@@ -1,0 +1,7 @@
+pr: 110476
+summary: Fix bug in union-types with type-casting in grouping key of STATS
+area: ES|QL
+type: bug
+issues:
+ - 109922
+ - 110477

--- a/docs/changelog/110793.yaml
+++ b/docs/changelog/110793.yaml
@@ -1,0 +1,7 @@
+pr: 110793
+summary: Fix for union-types for multiple columns with the same name
+area: ES|QL
+type: bug
+issues:
+ - 110490
+ - 109916

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValueSourceReaderTypeConversionTests.java
@@ -1687,12 +1687,13 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
 
         @Override
         public boolean supportsOrdinals() {
-            return delegate.supportsOrdinals();
+            // Fields with mismatching types cannot use ordinals for uniqueness determination, but must convert the values first
+            return false;
         }
 
         @Override
-        public SortedSetDocValues ordinals(LeafReaderContext context) throws IOException {
-            return delegate.ordinals(context);
+        public SortedSetDocValues ordinals(LeafReaderContext context) {
+            throw new IllegalArgumentException("Ordinals are not supported for type conversion");
         }
 
         @Override

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatters;
@@ -332,15 +331,15 @@ public final class CsvTestUtils {
             columnTypes = new ArrayList<>(header.length);
 
             for (String c : header) {
-                String[] nameWithType = Strings.split(c, ":");
-                if (nameWithType == null || nameWithType.length != 2) {
+                String[] nameWithType = escapeTypecast(c).split(":");
+                if (nameWithType.length != 2) {
                     throw new IllegalArgumentException("Invalid CSV header " + c);
                 }
-                String typeName = nameWithType[1].trim();
-                if (typeName.length() == 0) {
-                    throw new IllegalArgumentException("A type is always expected in the csv file; found " + nameWithType);
+                String typeName = unescapeTypecast(nameWithType[1]).trim();
+                if (typeName.isEmpty()) {
+                    throw new IllegalArgumentException("A type is always expected in the csv file; found " + Arrays.toString(nameWithType));
                 }
-                String name = nameWithType[0].trim();
+                String name = unescapeTypecast(nameWithType[0]).trim();
                 columnNames.add(name);
                 Type type = Type.asType(typeName);
                 if (type == null) {
@@ -396,6 +395,16 @@ public final class CsvTestUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static final String TYPECAST_SPACER = "__TYPECAST__";
+
+    private static String escapeTypecast(String typecast) {
+        return typecast.replace("::", TYPECAST_SPACER);
+    }
+
+    private static String unescapeTypecast(String typecast) {
+        return typecast.replace(TYPECAST_SPACER, "::");
     }
 
     public enum Type {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -45,8 +45,10 @@ FROM sample_data_ts_long
 ;
 
 singleIndexIpStats
+required_capability: casting_operator
+
 FROM sample_data
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
 | SORT count DESC, client_ip ASC
 | KEEP count, client_ip
@@ -60,8 +62,10 @@ count:long  |  client_ip:ip
 ;
 
 singleIndexIpStringStats
+required_capability: casting_operator
+
 FROM sample_data_str
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
 | SORT count DESC, client_ip ASC
 | KEEP count, client_ip
@@ -74,12 +78,28 @@ count:long  |  client_ip:ip
 1           |  172.21.2.162
 ;
 
+singleIndexIpStringStatsInline
+required_capability: casting_operator
+
+FROM sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| STATS mc=count(count) BY count
+| SORT mc DESC, count ASC
+| KEEP mc, count
+;
+
+mc:l | count:l
+3    | 1
+1    | 4
+;
+
 multiIndexIpString
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str METADATA _index
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | KEEP _index, @timestamp, client_ip, event_duration, message
 | SORT _index ASC, @timestamp DESC
 ;
@@ -104,9 +124,10 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233         
 multiIndexIpStringRename
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str METADATA _index
-| EVAL host_ip = TO_IP(client_ip)
+| EVAL host_ip = client_ip::ip
 | KEEP _index, @timestamp, host_ip, event_duration, message
 | SORT _index ASC, @timestamp DESC
 ;
@@ -191,9 +212,10 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  3450233              |  Connected
 
 multiIndexIpStringStats
 required_capability: union_types
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
 | SORT count DESC, client_ip ASC
 | KEEP count, client_ip
@@ -208,9 +230,10 @@ count:long  |  client_ip:ip
 
 multiIndexIpStringRenameStats
 required_capability: union_types
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str
-| EVAL host_ip = TO_IP(client_ip)
+| EVAL host_ip = client_ip::ip
 | STATS count=count(*) BY host_ip
 | SORT count DESC, host_ip ASC
 | KEEP count, host_ip
@@ -240,6 +263,24 @@ count:long  |  host_ip:keyword
 2           |  172.21.2.162
 ;
 
+multiIndexIpStringStatsDrop
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| KEEP count
+| SORT count DESC
+;
+
+count:long
+8
+2
+2
+2
+;
+
 multiIndexIpStringStatsInline
 required_capability: union_types
 required_capability: union_types_inline_fix
@@ -255,6 +296,39 @@ count:long  |  client_ip:ip
 2           |  172.21.0.5
 2           |  172.21.2.113
 2           |  172.21.2.162
+;
+
+multiIndexIpStringStatsInline2
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| SORT count DESC, `client_ip::ip` ASC
+;
+
+count:long  |  client_ip::ip:ip
+8           |  172.21.3.15
+2           |  172.21.0.5
+2           |  172.21.2.113
+2           |  172.21.2.162
+;
+
+multiIndexIpStringStatsInline3
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| STATS mc=count(count) BY count
+| SORT mc DESC, count ASC
+;
+
+mc:l | count:l
+3    | 2
+1    | 8
 ;
 
 multiIndexWhereIpStringStats
@@ -383,6 +457,61 @@ FROM sample_data, sample_data_ts_long
 count:long  |  @timestamp:date
 10          |  2023-10-23T13:00:00.000Z
 4           |  2023-10-23T12:00:00.000Z
+;
+
+multiIndexTsLongStatsDrop
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_long
+| STATS count=count(*) BY @timestamp::datetime
+| KEEP count
+;
+
+count:long
+2
+2
+2
+2
+2
+2
+2
+;
+
+multiIndexTsLongStatsInline2
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_long
+| STATS count=count(*) BY @timestamp::datetime
+| SORT count DESC, `@timestamp::datetime` DESC
+;
+
+count:long  |  @timestamp::datetime:datetime
+2           |  2023-10-23T13:55:01.543Z
+2           |  2023-10-23T13:53:55.832Z
+2           |  2023-10-23T13:52:55.015Z
+2           |  2023-10-23T13:51:54.732Z
+2           |  2023-10-23T13:33:34.937Z
+2           |  2023-10-23T12:27:28.948Z
+2           |  2023-10-23T12:15:03.360Z
+;
+
+multiIndexTsLongStatsInline3
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_long
+| STATS count=count(*) BY @timestamp::datetime
+| STATS mc=count(count) BY count
+| SORT mc DESC, count ASC
+;
+
+mc:l | count:l
+7    | 2
 ;
 
 multiIndexTsLongRenameStats
@@ -716,4 +845,38 @@ FROM sample_data* METADATA _index
 null            | null           |  8268153            | Connection error | sample_data         | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
 null            | null           |  8268153            | Connection error | sample_data_str     | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
 null            | null           |  8268153            | Connection error | sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 1698069175015  |  172.21.3.15   |  172.21.3.15
+;
+
+multiIndexMultiColumnTypesRenameAndKeep
+required_capability: union_types
+required_capability: metadata_fields
+
+FROM sample_data* METADATA _index
+| WHERE event_duration > 8000000
+| EVAL ts = TO_DATETIME(@timestamp), ts_str = TO_STRING(@timestamp), ts_l = TO_LONG(@timestamp), ip = TO_IP(client_ip), ip_str = TO_STRING(client_ip) 
+| KEEP _index, ts, ts_str, ts_l, ip, ip_str, event_duration
+| SORT _index ASC, ts DESC
+;
+
+_index:keyword      | ts:date                   | ts_str:keyword            | ts_l:long      |  ip:ip         |  ip_str:k      |  event_duration:long
+sample_data         | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15   |  8268153
+sample_data_str     | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15   |  8268153
+sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 1698069175015  |  172.21.3.15   |  172.21.3.15   |  8268153
+;
+
+multiIndexMultiColumnTypesRenameAndDrop
+required_capability: union_types
+required_capability: metadata_fields
+
+FROM sample_data* METADATA _index
+| WHERE event_duration > 8000000
+| EVAL ts = TO_DATETIME(@timestamp), ts_str = TO_STRING(@timestamp), ts_l = TO_LONG(@timestamp), ip = TO_IP(client_ip), ip_str = TO_STRING(client_ip) 
+| DROP @timestamp, client_ip, message
+| SORT _index ASC, ts DESC
+;
+
+event_duration:long | _index:keyword      | ts:date                   | ts_str:keyword            | ts_l:long      |  ip:ip         |  ip_str:k  
+8268153             | sample_data         | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
+8268153             | sample_data_str     | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
+8268153             | sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 1698069175015  |  172.21.3.15   |  172.21.3.15
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -514,6 +514,21 @@ mc:l | count:l
 7    | 2
 ;
 
+multiIndexTsLongStatsStats
+required_capability: union_types
+required_capability: union_types_agg_cast
+
+FROM sample_data, sample_data_ts_long
+| EVAL ts = TO_STRING(@timestamp)
+| STATS count = COUNT(*) BY ts
+| STATS mc = COUNT(count) BY count
+| SORT mc DESC, count ASC
+;
+
+mc:l | count:l
+14   | 1
+;
+
 multiIndexTsLongRenameStats
 required_capability: union_types
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -97,6 +97,7 @@ multiIndexIpString
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: casting_operator
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str METADATA _index
 | EVAL client_ip = client_ip::ip
@@ -125,6 +126,7 @@ multiIndexIpStringRename
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: casting_operator
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str METADATA _index
 | EVAL host_ip = client_ip::ip
@@ -152,6 +154,7 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233         
 multiIndexIpStringRenameToString
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str METADATA _index
 | EVAL host_ip = TO_STRING(TO_IP(client_ip))
@@ -179,6 +182,7 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  172.21.2.162     |  3450233      
 multiIndexWhereIpString
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str METADATA _index
 | WHERE STARTS_WITH(TO_STRING(client_ip), "172.21.2")
@@ -196,6 +200,7 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  3450233              |  Connected
 multiIndexWhereIpStringLike
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str METADATA _index
 | WHERE TO_STRING(client_ip) LIKE "172.21.2.*"
@@ -210,9 +215,39 @@ sample_data_str | 2023-10-23T12:27:28.948Z  |  2764889              |  Connected
 sample_data_str | 2023-10-23T12:15:03.360Z  |  3450233              |  Connected to 10.1.0.3
 ;
 
+multiIndexSortIpString
+required_capability: union_types
+required_capability: casting_operator
+required_capability: union_types_remove_fields
+
+FROM sample_data, sample_data_str
+| SORT client_ip::ip
+| LIMIT 1
+;
+
+@timestamp:date           |  client_ip:null  |  event_duration:long  |  message:keyword
+2023-10-23T13:33:34.937Z  |  null            |  1232382              |  Disconnected
+;
+
+multiIndexSortIpStringEval
+required_capability: union_types
+required_capability: casting_operator
+required_capability: union_types_remove_fields
+
+FROM sample_data, sample_data_str
+| SORT client_ip::ip, @timestamp ASC
+| EVAL client_ip_as_ip = client_ip::ip
+| LIMIT 1
+;
+
+@timestamp:date           |  client_ip:null  |  event_duration:long  |  message:keyword | client_ip_as_ip:ip
+2023-10-23T13:33:34.937Z  |  null            |  1232382              |  Disconnected    | 172.21.0.5
+;
+
 multiIndexIpStringStats
 required_capability: union_types
 required_capability: casting_operator
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str
 | EVAL client_ip = client_ip::ip
@@ -231,6 +266,7 @@ count:long  |  client_ip:ip
 multiIndexIpStringRenameStats
 required_capability: union_types
 required_capability: casting_operator
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str
 | EVAL host_ip = client_ip::ip
@@ -248,6 +284,7 @@ count:long  |  host_ip:ip
 
 multiIndexIpStringRenameToStringStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str
 | EVAL host_ip = TO_STRING(TO_IP(client_ip))
@@ -333,6 +370,7 @@ mc:l | count:l
 
 multiIndexWhereIpStringStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_str
 | WHERE STARTS_WITH(TO_STRING(client_ip), "172.21.2")
@@ -349,6 +387,7 @@ count:long  |  message:keyword
 multiIndexTsLong
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long METADATA _index
 | EVAL @timestamp = TO_DATETIME(@timestamp)
@@ -376,6 +415,7 @@ sample_data_ts_long | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233     
 multiIndexTsLongRename
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long METADATA _index
 | EVAL ts = TO_DATETIME(@timestamp)
@@ -403,6 +443,7 @@ sample_data_ts_long | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233     
 multiIndexTsLongRenameToString
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long METADATA _index
 | EVAL ts = TO_STRING(TO_DATETIME(@timestamp))
@@ -430,6 +471,7 @@ sample_data_ts_long | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233     
 multiIndexWhereTsLong
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long METADATA _index
 | WHERE TO_LONG(@timestamp) < 1698068014937
@@ -446,6 +488,7 @@ sample_data_ts_long  | 172.21.2.162  |  3450233              |  Connected to 10.
 
 multiIndexTsLongStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | EVAL @timestamp = DATE_TRUNC(1 hour, TO_DATETIME(@timestamp))
@@ -517,6 +560,7 @@ mc:l | count:l
 multiIndexTsLongStatsStats
 required_capability: union_types
 required_capability: union_types_agg_cast
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | EVAL ts = TO_STRING(@timestamp)
@@ -531,6 +575,7 @@ mc:l | count:l
 
 multiIndexTsLongRenameStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | EVAL hour = DATE_TRUNC(1 hour, TO_DATETIME(@timestamp))
@@ -546,6 +591,7 @@ count:long  |  hour:date
 
 multiIndexTsLongRenameToDatetimeToStringStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | EVAL hour = LEFT(TO_STRING(TO_DATETIME(@timestamp)), 13)
@@ -561,6 +607,7 @@ count:long  |  hour:keyword
 
 multiIndexTsLongRenameToStringStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | EVAL mess = LEFT(TO_STRING(@timestamp), 7)
@@ -579,6 +626,7 @@ count:long  |  mess:keyword
 
 multiIndexTsLongStatsInline
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | STATS count=COUNT(*), max=MAX(TO_DATETIME(@timestamp))
@@ -603,6 +651,7 @@ count:long
 
 multiIndexWhereTsLongStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data, sample_data_ts_long
 | WHERE TO_LONG(@timestamp) < 1698068014937
@@ -619,6 +668,7 @@ count:long  |  message:keyword
 multiIndexIpStringTsLong
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | EVAL @timestamp = TO_DATETIME(@timestamp), client_ip = TO_IP(client_ip)
@@ -687,6 +737,7 @@ sample_data_ts_long |  8268153              |  Connection error
 multiIndexIpStringTsLongRename
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | EVAL ts = TO_DATETIME(@timestamp), host_ip = TO_IP(client_ip)
@@ -755,6 +806,7 @@ sample_data_ts_long |  8268153              |  Connection error
 multiIndexIpStringTsLongRenameToString
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | EVAL ts = TO_STRING(TO_DATETIME(@timestamp)), host_ip = TO_STRING(TO_IP(client_ip))
@@ -789,6 +841,7 @@ sample_data_ts_long | 2023-10-23T12:15:03.360Z  |  172.21.2.162     |  3450233  
 multiIndexWhereIpStringTsLong
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) == "172.21.2.162"
@@ -804,6 +857,7 @@ sample_data_ts_long  |  3450233              |  Connected to 10.1.0.3
 
 multiIndexWhereIpStringTsLongStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data*
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) == "172.21.2.162"
@@ -819,6 +873,7 @@ count:long  |  message:keyword
 multiIndexWhereIpStringLikeTsLong
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) LIKE "172.21.2.16?"
@@ -834,6 +889,7 @@ sample_data_ts_long  |  3450233              |  Connected to 10.1.0.3
 
 multiIndexWhereIpStringLikeTsLongStats
 required_capability: union_types
+required_capability: union_types_remove_fields
 
 FROM sample_data*
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) LIKE "172.21.2.16?"
@@ -849,6 +905,7 @@ count:long  |  message:keyword
 multiIndexMultiColumnTypesRename
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | WHERE event_duration > 8000000
@@ -865,6 +922,7 @@ null            | null           |  8268153            | Connection error | samp
 multiIndexMultiColumnTypesRenameAndKeep
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | WHERE event_duration > 8000000
@@ -882,6 +940,7 @@ sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 16
 multiIndexMultiColumnTypesRenameAndDrop
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: union_types_remove_fields
 
 FROM sample_data* METADATA _index
 | WHERE event_duration > 8000000

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -109,12 +109,6 @@ public class EsqlCapabilities {
         AGG_WEIGHTED_AVG,
 
         /**
-         * Fix a parsing issue where numbers below Long.MIN_VALUE threw an exception instead of parsing as doubles.
-         * see <a href="https://github.com/elastic/elasticsearch/issues/104323"> Parsing large numbers is inconsistent #104323 </a>
-         */
-        FIX_PARSING_LARGE_NEGATIVE_NUMBERS,
-
-        /**
          * Fix for union-types when aggregating over an inline conversion with casting operator. Done in #110476.
          */
         UNION_TYPES_AGG_CAST,
@@ -122,7 +116,24 @@ public class EsqlCapabilities {
         /**
          * Fix for union-types when aggregating over an inline conversion with conversion function. Done in #110652.
          */
-        UNION_TYPES_INLINE_FIX;
+        UNION_TYPES_INLINE_FIX,
+
+        /**
+         * Fix for union-types when sorting a type-casted field. We changed how we remove synthetic union-types fields.
+         */
+        UNION_TYPES_REMOVE_FIELDS,
+
+        /**
+         * Fix a parsing issue where numbers below Long.MIN_VALUE threw an exception instead of parsing as doubles.
+         * see <a href="https://github.com/elastic/elasticsearch/issues/104323"> Parsing large numbers is inconsistent #104323 </a>
+         */
+        FIX_PARSING_LARGE_NEGATIVE_NUMBERS,
+
+        /**
+         * Fix the status code returned when trying to run count_distinct on the _source type (which is not supported).
+         * see <a href="https://github.com/elastic/elasticsearch/issues/105240">count_distinct(_source) returns a 500 response</a>
+         */
+        FIX_COUNT_DISTINCT_SOURCE_ERROR;
 
         private final boolean snapshotOnly;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -112,7 +112,12 @@ public class EsqlCapabilities {
          * Fix a parsing issue where numbers below Long.MIN_VALUE threw an exception instead of parsing as doubles.
          * see <a href="https://github.com/elastic/elasticsearch/issues/104323"> Parsing large numbers is inconsistent #104323 </a>
          */
-        FIX_PARSING_LARGE_NEGATIVE_NUMBERS;
+        FIX_PARSING_LARGE_NEGATIVE_NUMBERS,
+
+        /**
+         * Fix for union-types when aggregating over an inline conversion with casting operator. Done in #110476.
+         */
+        UNION_TYPES_AGG_CAST;
 
         private final boolean snapshotOnly;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -117,7 +117,12 @@ public class EsqlCapabilities {
         /**
          * Fix for union-types when aggregating over an inline conversion with casting operator. Done in #110476.
          */
-        UNION_TYPES_AGG_CAST;
+        UNION_TYPES_AGG_CAST,
+
+        /**
+         * Fix for union-types when aggregating over an inline conversion with conversion function. Done in #110652.
+         */
+        UNION_TYPES_INLINE_FIX;
 
         private final boolean snapshotOnly;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1089,7 +1089,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
             // In ResolveRefs the aggregates are resolved from the groupings, which might have an unresolved MultiTypeEsField.
             // Now that we have resolved those, we need to re-resolve the aggregates.
-            if (plan instanceof EsqlAggregate agg && agg.expressionsResolved() == false) {
+            if (plan instanceof EsqlAggregate agg) {
+                // If the union-types resolution occurred in a child of the aggregate, we need to check the groupings
+                plan = agg.transformExpressionsOnly(FieldAttribute.class, UnresolveUnionTypes::checkUnresolved);
+
+                // Aggregates where the grouping key comes from a union-type field need to be resolved against the grouping key
                 Map<Attribute, Expression> resolved = new HashMap<>();
                 for (Expression e : agg.groupings()) {
                     Attribute attr = Expressions.attribute(e);
@@ -1097,7 +1101,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         resolved.put(attr, e);
                     }
                 }
-                plan = agg.transformExpressionsOnly(UnresolvedAttribute.class, ua -> resolveAttribute(ua, resolved));
+                plan = plan.transformExpressionsOnly(UnresolvedAttribute.class, ua -> resolveAttribute(ua, resolved));
             }
 
             // Otherwise drop the converted attributes after the alias function, as they are only needed for this function, and
@@ -1223,9 +1227,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             return plan.transformExpressionsOnly(FieldAttribute.class, UnresolveUnionTypes::checkUnresolved);
         }
 
-        private static Attribute checkUnresolved(FieldAttribute fa) {
-            var field = fa.field();
-            if (field instanceof InvalidMappedField imf) {
+        static Attribute checkUnresolved(FieldAttribute fa) {
+            if (fa.field() instanceof InvalidMappedField imf) {
                 String unresolvedMessage = "Cannot use field [" + fa.name() + "] due to ambiguities being " + imf.errorMessage();
                 return new UnresolvedAttribute(fa.source(), fa.name(), fa.qualifier(), fa.id(), unresolvedMessage, null);
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.core.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.core.rule.ParameterizedRule;
 import org.elasticsearch.xpack.esql.core.rule.ParameterizedRuleExecutor;
+import org.elasticsearch.xpack.esql.core.rule.Rule;
 import org.elasticsearch.xpack.esql.core.rule.RuleExecutor;
 import org.elasticsearch.xpack.esql.core.session.Configuration;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -63,6 +64,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractC
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.DateTimeArithmeticOperation;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.EsqlArithmeticOperation;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.optimizer.rules.SubstituteSurrogates;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Drop;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
@@ -141,7 +143,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             new ResolveUnionTypes(),  // Must be after ResolveRefs, so union types can be found
             new ImplicitCasting()
         );
-        var finish = new Batch<>("Finish Analysis", Limiter.ONCE, new AddImplicitLimit(), new UnresolveUnionTypes());
+        var finish = new Batch<>("Finish Analysis", Limiter.ONCE, new AddImplicitLimit(), new UnionTypesCleanup());
         rules = List.of(init, resolution, finish);
     }
 
@@ -217,13 +219,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         return list;
     }
 
-    private static void mappingAsAttributes(List<Attribute> list, Source source, String parentName, Map<String, EsField> mapping) {
+    private static void mappingAsAttributes(List<Attribute> list, Source source, FieldAttribute parent, Map<String, EsField> mapping) {
         for (Map.Entry<String, EsField> entry : mapping.entrySet()) {
             String name = entry.getKey();
             EsField t = entry.getValue();
 
             if (t != null) {
-                name = parentName == null ? name : parentName + "." + name;
+                name = parent == null ? name : parent.fieldName() + "." + name;
                 var fieldProperties = t.getProperties();
                 var type = t.getDataType().widenSmallNumeric();
                 // due to a bug also copy the field since the Attribute hierarchy extracts the data type
@@ -232,19 +234,16 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     t = new EsField(t.getName(), type, t.getProperties(), t.isAggregatable(), t.isAlias());
                 }
 
+                FieldAttribute attribute = t instanceof UnsupportedEsField uef
+                    ? new UnsupportedAttribute(source, name, uef)
+                    : new FieldAttribute(source, parent, name, t);
                 // primitive branch
                 if (EsqlDataTypes.isPrimitive(type)) {
-                    Attribute attribute;
-                    if (t instanceof UnsupportedEsField uef) {
-                        attribute = new UnsupportedAttribute(source, name, uef);
-                    } else {
-                        attribute = new FieldAttribute(source, null, name, t);
-                    }
                     list.add(attribute);
                 }
                 // allow compound object even if they are unknown (but not NESTED)
                 if (type != NESTED && fieldProperties.isEmpty() == false) {
-                    mappingAsAttributes(list, source, name, fieldProperties);
+                    mappingAsAttributes(list, source, attribute, fieldProperties);
                 }
             }
         }
@@ -1091,7 +1090,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // Now that we have resolved those, we need to re-resolve the aggregates.
             if (plan instanceof EsqlAggregate agg) {
                 // If the union-types resolution occurred in a child of the aggregate, we need to check the groupings
-                plan = agg.transformExpressionsOnly(FieldAttribute.class, UnresolveUnionTypes::checkUnresolved);
+                plan = agg.transformExpressionsOnly(FieldAttribute.class, UnionTypesCleanup::checkUnresolved);
 
                 // Aggregates where the grouping key comes from a union-type field need to be resolved against the grouping key
                 Map<Attribute, Expression> resolved = new HashMap<>();
@@ -1104,23 +1103,21 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 plan = plan.transformExpressionsOnly(UnresolvedAttribute.class, ua -> resolveAttribute(ua, resolved));
             }
 
-            // Otherwise drop the converted attributes after the alias function, as they are only needed for this function, and
-            // the original version of the attribute should still be seen as unconverted.
-            plan = dropConvertedAttributes(plan, unionFieldAttributes);
-
             // And add generated fields to EsRelation, so these new attributes will appear in the OutputExec of the Fragment
             // and thereby get used in FieldExtractExec
             plan = plan.transformDown(EsRelation.class, esr -> {
-                List<Attribute> output = esr.output();
                 List<Attribute> missing = new ArrayList<>();
                 for (FieldAttribute fa : unionFieldAttributes) {
-                    if (output.stream().noneMatch(a -> a.id().equals(fa.id()))) {
+                    // Using outputSet().contains looks by NameId, resp. uses semanticEquals.
+                    if (esr.outputSet().contains(fa) == false) {
                         missing.add(fa);
                     }
                 }
+
                 if (missing.isEmpty() == false) {
-                    output.addAll(missing);
-                    return new EsRelation(esr.source(), esr.index(), output, esr.indexMode(), esr.frozen());
+                    List<Attribute> newOutput = new ArrayList<>(esr.output());
+                    newOutput.addAll(missing);
+                    return new EsRelation(esr.source(), esr.index(), newOutput, esr.indexMode(), esr.frozen());
                 }
                 return esr;
             });
@@ -1134,17 +1131,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 case 1 -> named.get(0).equals(ua) ? ua : resolved.get(named.get(0));
                 default -> ua.withUnresolvedMessage("Resolved [" + ua + "] unexpectedly to multiple attributes " + named);
             };
-        }
-
-        private LogicalPlan dropConvertedAttributes(LogicalPlan plan, List<FieldAttribute> unionFieldAttributes) {
-            List<NamedExpression> projections = new ArrayList<>(plan.output());
-            for (var e : unionFieldAttributes) {
-                projections.removeIf(p -> p.id().equals(e.id()));
-            }
-            if (projections.size() != plan.output().size()) {
-                return new EsqlProject(plan.source(), plan, projections);
-            }
-            return plan;
         }
 
         private Expression resolveConvertFunction(AbstractConvertFunction convert, List<FieldAttribute> unionFieldAttributes) {
@@ -1175,7 +1161,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             MultiTypeEsField resolvedField,
             List<FieldAttribute> unionFieldAttributes
         ) {
-            var unionFieldAttribute = new FieldAttribute(fa.source(), fa.name(), resolvedField);  // Generates new ID for the field
+            // Generate new ID for the field and suffix it with the data type to maintain unique attribute names.
+            String unionTypedFieldName = SubstituteSurrogates.rawTemporaryName(
+                fa.name(),
+                "converted_to",
+                resolvedField.getDataType().typeName()
+            );
+            FieldAttribute unionFieldAttribute = new FieldAttribute(fa.source(), fa.parent(), unionTypedFieldName, resolvedField);
             int existingIndex = unionFieldAttributes.indexOf(unionFieldAttribute);
             if (existingIndex >= 0) {
                 // Do not generate multiple name/type combinations with different IDs
@@ -1208,23 +1200,30 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
     }
 
     /**
-     * If there was no AbstractConvertFunction that resolved multi-type fields in the ResolveUnionTypes rules,
-     * then there could still be some FieldAttributes that contain unresolved MultiTypeEsFields.
-     * These need to be converted back to actual UnresolvedAttribute in order for validation to generate appropriate failures.
+     * {@link ResolveUnionTypes} creates new, synthetic attributes for union types:
+     * If there was no {@code AbstractConvertFunction} that resolved multi-type fields in the {@link ResolveUnionTypes} rule,
+     * then there could still be some {@code FieldAttribute}s that contain unresolved {@link MultiTypeEsField}s.
+     * These need to be converted back to actual {@code UnresolvedAttribute} in order for validation to generate appropriate failures.
+     * <p>
+     * Finally, if {@code client_ip} is present in 2 indices, once with type {@code ip} and once with type {@code keyword},
+     * using {@code EVAL x = to_ip(client_ip)} will create a single attribute @{code $$client_ip$converted_to$ip}.
+     * This should not spill into the query output, so we drop such attributes at the end.
      */
-    private static class UnresolveUnionTypes extends AnalyzerRules.AnalyzerRule<LogicalPlan> {
-        @Override
-        protected boolean skipResolved() {
-            return false;
-        }
+    private static class UnionTypesCleanup extends Rule<LogicalPlan, LogicalPlan> {
+        public LogicalPlan apply(LogicalPlan plan) {
+            LogicalPlan planWithCheckedUnionTypes = plan.transformUp(LogicalPlan.class, p -> {
+                if (p instanceof EsRelation esRelation) {
+                    // Leave esRelation as InvalidMappedField so that UNSUPPORTED fields can still pass through
+                    return esRelation;
+                }
+                return p.transformExpressionsOnly(FieldAttribute.class, UnionTypesCleanup::checkUnresolved);
+            });
 
-        @Override
-        protected LogicalPlan rule(LogicalPlan plan) {
-            if (plan instanceof EsRelation esRelation) {
-                // Leave esRelation as InvalidMappedField so that UNSUPPORTED fields can still pass through
-                return esRelation;
-            }
-            return plan.transformExpressionsOnly(FieldAttribute.class, UnresolveUnionTypes::checkUnresolved);
+            // To drop synthetic attributes at the end, we need to compute the plan's output.
+            // This is only legal to do if the plan is resolved.
+            return planWithCheckedUnionTypes.resolved()
+                ? planWithoutSyntheticAttributes(planWithCheckedUnionTypes)
+                : planWithCheckedUnionTypes;
         }
 
         static Attribute checkUnresolved(FieldAttribute fa) {
@@ -1233,6 +1232,21 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return new UnresolvedAttribute(fa.source(), fa.name(), fa.qualifier(), fa.id(), unresolvedMessage, null);
             }
             return fa;
+        }
+
+        private static LogicalPlan planWithoutSyntheticAttributes(LogicalPlan plan) {
+            List<Attribute> output = plan.output();
+            List<Attribute> newOutput = new ArrayList<>(output.size());
+
+            for (Attribute attr : output) {
+                // TODO: this should really use .synthetic()
+                // https://github.com/elastic/elasticsearch/issues/105821
+                if (attr.name().startsWith(FieldAttribute.SYNTHETIC_ATTRIBUTE_NAME_PREFIX) == false) {
+                    newOutput.add(attr);
+                }
+            }
+
+            return newOutput.size() == output.size() ? plan : new Project(Source.EMPTY, plan, newOutput);
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1087,6 +1087,19 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return plan;
             }
 
+            // In ResolveRefs the aggregates are resolved from the groupings, which might have an unresolved MultiTypeEsField.
+            // Now that we have resolved those, we need to re-resolve the aggregates.
+            if (plan instanceof EsqlAggregate agg && agg.expressionsResolved() == false) {
+                Map<Attribute, Expression> resolved = new HashMap<>();
+                for (Expression e : agg.groupings()) {
+                    Attribute attr = Expressions.attribute(e);
+                    if (attr != null && attr.resolved()) {
+                        resolved.put(attr, e);
+                    }
+                }
+                plan = agg.transformExpressionsOnly(UnresolvedAttribute.class, ua -> resolveAttribute(ua, resolved));
+            }
+
             // Otherwise drop the converted attributes after the alias function, as they are only needed for this function, and
             // the original version of the attribute should still be seen as unconverted.
             plan = dropConvertedAttributes(plan, unionFieldAttributes);
@@ -1108,6 +1121,15 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return esr;
             });
             return plan;
+        }
+
+        private Expression resolveAttribute(UnresolvedAttribute ua, Map<Attribute, Expression> resolved) {
+            var named = resolveAgainstList(ua, resolved.keySet());
+            return switch (named.size()) {
+                case 0 -> ua;
+                case 1 -> named.get(0).equals(ua) ? ua : resolved.get(named.get(0));
+                default -> ua.withUnresolvedMessage("Resolved [" + ua + "] unexpectedly to multiple attributes " + named);
+            };
         }
 
         private LogicalPlan dropConvertedAttributes(LogicalPlan plan, List<FieldAttribute> unionFieldAttributes) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
@@ -105,6 +105,13 @@ public final class UnsupportedAttribute extends FieldAttribute implements Unreso
     }
 
     @Override
+    public String fieldName() {
+        // The super fieldName uses parents to compute the path; this class ignores parents, so we need to rely on the name instead.
+        // Using field().getName() would be wrong: for subfields like parent.subfield that would return only the last part, subfield.
+        return name();
+    }
+
+    @Override
     protected NodeInfo<FieldAttribute> info() {
         return NodeInfo.create(this, UnsupportedAttribute::new, name(), field(), hasCustomMessage ? message : null, id());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -140,7 +140,8 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
                 Map<DataType, Alias> nullLiteral = Maps.newLinkedHashMapWithExpectedSize(DataType.types().size());
 
                 for (NamedExpression projection : projections) {
-                    if (projection instanceof FieldAttribute f && stats.exists(f.qualifiedName()) == false) {
+                    // Do not use the attribute name, this can deviate from the field name for union types.
+                    if (projection instanceof FieldAttribute f && stats.exists(f.fieldName()) == false) {
                         DataType dt = f.dataType();
                         Alias nullAlias = nullLiteral.get(f.dataType());
                         // save the first field as null (per datatype)
@@ -170,7 +171,8 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
                 || plan instanceof TopN) {
                     plan = plan.transformExpressionsOnlyUp(
                         FieldAttribute.class,
-                        f -> stats.exists(f.qualifiedName()) ? f : Literal.of(f, null)
+                        // Do not use the attribute name, this can deviate from the field name for union types.
+                        f -> stats.exists(f.fieldName()) ? f : Literal.of(f, null)
                     );
                 }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -77,7 +77,6 @@ import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.planner.EsqlTranslatorHandler;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
-import org.elasticsearch.xpack.esql.type.MultiTypeEsField;
 
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -194,10 +193,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                  * it loads the field lazily. If we have more than one field we need to
                  * make sure the fields are loaded for the standard hash aggregator.
                  */
-                if (p instanceof AggregateExec agg
-                    && agg.groupings().size() == 1
-                    && (isMultiTypeFieldAttribute(agg.groupings().get(0)) == false) // Union types rely on field extraction.
-                ) {
+                if (p instanceof AggregateExec agg && agg.groupings().size() == 1) {
                     var leaves = new LinkedList<>();
                     // TODO: this seems out of place
                     agg.aggregates()
@@ -219,10 +215,6 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             });
 
             return plan;
-        }
-
-        private static boolean isMultiTypeFieldAttribute(Expression attribute) {
-            return attribute instanceof FieldAttribute fa && fa.field() instanceof MultiTypeEsField;
         }
 
         private static Set<Attribute> missingAttributes(PhysicalPlan p) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -77,6 +77,7 @@ import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
 import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.planner.EsqlTranslatorHandler;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
+import org.elasticsearch.xpack.esql.type.MultiTypeEsField;
 
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -193,7 +194,10 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                  * it loads the field lazily. If we have more than one field we need to
                  * make sure the fields are loaded for the standard hash aggregator.
                  */
-                if (p instanceof AggregateExec agg && agg.groupings().size() == 1) {
+                if (p instanceof AggregateExec agg
+                    && agg.groupings().size() == 1
+                    && (isMultiTypeFieldAttribute(agg.groupings().get(0)) == false) // Union types rely on field extraction.
+                ) {
                     var leaves = new LinkedList<>();
                     // TODO: this seems out of place
                     agg.aggregates()
@@ -215,6 +219,10 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             });
 
             return plan;
+        }
+
+        private static boolean isMultiTypeFieldAttribute(Expression attribute) {
+            return attribute instanceof FieldAttribute fa && fa.field() instanceof MultiTypeEsField;
         }
 
         private static Set<Attribute> missingAttributes(PhysicalPlan p) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SubstituteSurrogates.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SubstituteSurrogates.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.EmptyAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
@@ -141,7 +142,7 @@ public final class SubstituteSurrogates extends OptimizerRules.OptimizerRule<Agg
     }
 
     public static String rawTemporaryName(String inner, String outer, String suffix) {
-        return "$$" + inner + "$" + outer + "$" + suffix;
+        return FieldAttribute.SYNTHETIC_ATTRIBUTE_NAME_PREFIX + inner + "$" + outer + "$" + suffix;
     }
 
     static int TO_STRING_LIMIT = 16;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -99,7 +99,7 @@ public class EsRelation extends LeafPlan {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, indexMode, frozen);
+        return Objects.hash(index, indexMode, frozen, attrs);
     }
 
     @Override
@@ -113,7 +113,10 @@ public class EsRelation extends LeafPlan {
         }
 
         EsRelation other = (EsRelation) obj;
-        return Objects.equals(index, other.index) && indexMode == other.indexMode() && frozen == other.frozen;
+        return Objects.equals(index, other.index)
+            && indexMode == other.indexMode()
+            && frozen == other.frozen
+            && Objects.equals(attrs, other.attrs);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -116,7 +116,8 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             DataType dataType = attr.dataType();
             MappedFieldType.FieldExtractPreference fieldExtractPreference = PlannerUtils.extractPreference(docValuesAttrs.contains(attr));
             ElementType elementType = PlannerUtils.toElementType(dataType, fieldExtractPreference);
-            String fieldName = attr.name();
+            // Do not use the field attribute name, this can deviate from the field name for union types.
+            String fieldName = attr instanceof FieldAttribute fa ? fa.fieldName() : attr.name();
             boolean isUnsupported = dataType == DataType.UNSUPPORTED;
             IntFunction<BlockLoader> loader = s -> getBlockLoaderFor(s, fieldName, isUnsupported, fieldExtractPreference, unionTypes);
             fields.add(new ValuesSourceReaderOperator.FieldInfo(fieldName, elementType, loader));
@@ -234,8 +235,10 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         // Costin: why are they ready and not already exposed in the layout?
         boolean isUnsupported = attrSource.dataType() == DataType.UNSUPPORTED;
         var unionTypes = findUnionTypes(attrSource);
+        // Do not use the field attribute name, this can deviate from the field name for union types.
+        String fieldName = attrSource instanceof FieldAttribute fa ? fa.fieldName() : attrSource.name();
         return new OrdinalsGroupingOperator.OrdinalsGroupingOperatorFactory(
-            shardIdx -> getBlockLoaderFor(shardIdx, attrSource.name(), isUnsupported, NONE, unionTypes),
+            shardIdx -> getBlockLoaderFor(shardIdx, fieldName, isUnsupported, NONE, unionTypes),
             vsShardContexts,
             groupElementType,
             docChannel,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -5507,9 +5507,11 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             EsRelation relation = as(eval.child(), EsRelation.class);
             assertThat(relation.indexMode(), equalTo(IndexMode.STANDARD));
         }
-        for (int i = 1; i < plans.size(); i++) {
-            assertThat(plans.get(i), equalTo(plans.get(0)));
-        }
+        // TODO: Unmute this part
+        // https://github.com/elastic/elasticsearch/issues/110827
+        // for (int i = 1; i < plans.size(); i++) {
+        // assertThat(plans.get(i), equalTo(plans.get(0)));
+        // }
     }
 
     public void testRateInStats() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -4,8 +4,8 @@ setup:
         - method: POST
           path: /_query
           parameters: [method, path, parameters, capabilities]
-          capabilities: [union_types]
-      reason: "Union types introduced in 8.15.0"
+          capabilities: [union_types, union_types_remove_fields, casting_operator]
+      reason: "Union types and casting operator introduced in 8.15.0"
       test_runner_features: [capabilities, allowed_warnings_regex]
 
   - do:
@@ -204,13 +204,6 @@ load single index keyword_keyword:
 
 ---
 load single index ip_long and aggregate by client_ip:
-  - requires:
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: [method, path, parameters, capabilities]
-          capabilities: [casting_operator]
-      reason: "Casting operator and introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -234,13 +227,6 @@ load single index ip_long and aggregate by client_ip:
 
 ---
 load single index ip_long and aggregate client_ip my message:
-  - requires:
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: [method, path, parameters, capabilities]
-          capabilities: [casting_operator]
-      reason: "Casting operator and introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -266,13 +252,6 @@ load single index ip_long and aggregate client_ip my message:
 
 ---
 load single index ip_long stats invalid grouping:
-  - requires:
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: [method, path, parameters, capabilities]
-          capabilities: [casting_operator]
-      reason: "Casting operator and introduced in 8.15.0"
   - do:
       catch: '/Unknown column \[x\]/'
       esql.query:
@@ -591,13 +570,6 @@ load two indices, convert, rename but not drop ambiguous field client_ip:
 
 ---
 load two indexes and group by converted client_ip:
-  - requires:
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: [method, path, parameters, capabilities]
-          capabilities: [casting_operator, union_types_agg_cast]
-      reason: "Casting operator and Union types introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -621,13 +593,6 @@ load two indexes and group by converted client_ip:
 
 ---
 load two indexes and aggregate converted client_ip:
-  - requires:
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: [method, path, parameters, capabilities]
-          capabilities: [casting_operator, union_types_agg_cast]
-      reason: "Casting operator and Union types introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -653,13 +618,6 @@ load two indexes and aggregate converted client_ip:
 
 ---
 load two indexes, convert client_ip and group by something invalid:
-  - requires:
-      capabilities:
-        - method: POST
-          path: /_query
-          parameters: [method, path, parameters, capabilities]
-          capabilities: [casting_operator, union_types_agg_cast]
-      reason: "Casting operator and Union types introduced in 8.15.0"
   - do:
       catch: '/Unknown column \[x\]/'
       esql.query:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -147,6 +147,9 @@ setup:
           - '{"index": {}}'
           - '{"@timestamp": "2023-10-23T12:15:03.360Z", "client_ip": "172.21.2.162", "event_duration": "3450233", "message": "Connected to 10.1.0.3"}'
 
+############################################################################################################
+# Test a single index as a control of the expected results
+
 ---
 load single index ip_long:
   - do:
@@ -173,9 +176,6 @@ load single index ip_long:
   - match: { values.0.3: 1756467 }
   - match: { values.0.4: "Connected to 10.1.0.1" }
 
-############################################################################################################
-# Test a single index as a control of the expected results
-
 ---
 load single index keyword_keyword:
   - do:
@@ -201,6 +201,83 @@ load single index keyword_keyword:
   - match: { values.0.2: "172.21.3.15" }
   - match: { values.0.3: "1756467" }
   - match: { values.0.4: "Connected to 10.1.0.1" }
+
+---
+load single index ip_long and aggregate by client_ip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator]
+      reason: "Casting operator and introduced in 8.15.0"
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_ip_long | STATS count = COUNT(*) BY client_ip::ip | SORT count DESC, `client_ip::ip` ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "client_ip::ip" }
+  - match: { columns.1.type: "ip" }
+  - length: { values: 4 }
+  - match: { values.0.0: 4 }
+  - match: { values.0.1: "172.21.3.15" }
+  - match: { values.1.0: 1 }
+  - match: { values.1.1: "172.21.0.5" }
+  - match: { values.2.0: 1 }
+  - match: { values.2.1: "172.21.2.113" }
+  - match: { values.3.0: 1 }
+  - match: { values.3.1: "172.21.2.162" }
+
+---
+load single index ip_long and aggregate client_ip my message:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator]
+      reason: "Casting operator and introduced in 8.15.0"
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_ip_long | STATS count = COUNT(client_ip::ip) BY message | SORT count DESC, message ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "message" }
+  - match: { columns.1.type: "keyword" }
+  - length: { values: 5 }
+  - match: { values.0.0: 3 }
+  - match: { values.0.1: "Connection error" }
+  - match: { values.1.0: 1 }
+  - match: { values.1.1: "Connected to 10.1.0.1" }
+  - match: { values.2.0: 1 }
+  - match: { values.2.1: "Connected to 10.1.0.2" }
+  - match: { values.3.0: 1 }
+  - match: { values.3.1: "Connected to 10.1.0.3" }
+  - match: { values.4.0: 1 }
+  - match: { values.4.1: "Disconnected" }
+
+---
+load single index ip_long stats invalid grouping:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator]
+      reason: "Casting operator and introduced in 8.15.0"
+  - do:
+      catch: '/Unknown column \[x\]/'
+      esql.query:
+        body:
+          query: 'FROM events_ip_long | STATS count = COUNT(client_ip::ip) BY x'
 
 ############################################################################################################
 # Test two indices where the event_duration is mapped as a LONG and as a KEYWORD
@@ -511,6 +588,83 @@ load two indices, convert, rename but not drop ambiguous field client_ip:
   - match: { values.1.4: "172.21.3.15" }
   - match: { values.1.5: "172.21.3.15" }
   - match: { values.1.6: "172.21.3.15" }
+
+---
+load two indexes and group by converted client_ip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator, union_types_agg_cast]
+      reason: "Casting operator and Union types introduced in 8.15.0"
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_*_long | STATS count = COUNT(*) BY client_ip::ip | SORT count DESC, `client_ip::ip` ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "client_ip::ip" }
+  - match: { columns.1.type: "ip" }
+  - length: { values: 4 }
+  - match: { values.0.0: 8 }
+  - match: { values.0.1: "172.21.3.15" }
+  - match: { values.1.0: 2 }
+  - match: { values.1.1: "172.21.0.5" }
+  - match: { values.2.0: 2 }
+  - match: { values.2.1: "172.21.2.113" }
+  - match: { values.3.0: 2 }
+  - match: { values.3.1: "172.21.2.162" }
+
+---
+load two indexes and aggregate converted client_ip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator, union_types_agg_cast]
+      reason: "Casting operator and Union types introduced in 8.15.0"
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_*_long | STATS count = COUNT(client_ip::ip) BY message | SORT count DESC, message ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "message" }
+  - match: { columns.1.type: "keyword" }
+  - length: { values: 5 }
+  - match: { values.0.0: 6 }
+  - match: { values.0.1: "Connection error" }
+  - match: { values.1.0: 2 }
+  - match: { values.1.1: "Connected to 10.1.0.1" }
+  - match: { values.2.0: 2 }
+  - match: { values.2.1: "Connected to 10.1.0.2" }
+  - match: { values.3.0: 2 }
+  - match: { values.3.1: "Connected to 10.1.0.3" }
+  - match: { values.4.0: 2 }
+  - match: { values.4.1: "Disconnected" }
+
+---
+load two indexes, convert client_ip and group by something invalid:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator, union_types_agg_cast]
+      reason: "Casting operator and Union types introduced in 8.15.0"
+  - do:
+      catch: '/Unknown column \[x\]/'
+      esql.query:
+        body:
+          query: 'FROM events_*_long | STATS count = COUNT(client_ip::ip) BY x'
 
 ############################################################################################################
 # Test four indices with both the client_IP (IP and KEYWORD) and event_duration (LONG and KEYWORD) mappings

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/161_union_types_subfields.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/161_union_types_subfields.yml
@@ -4,7 +4,7 @@ setup:
         - method: POST
           path: /_query
           parameters: [ method, path, parameters, capabilities ]
-          capabilities: [ union_types ]
+          capabilities: [ union_types, union_types_remove_fields ]
       reason: "Union types introduced in 8.15.0"
       test_runner_features: [ capabilities, allowed_warnings_regex ]
 


### PR DESCRIPTION
Since 8.15 feature freeze, there have been a series of important bugfixes to the union-types feature that need to go into 8.15. These have been done as a series of PRs to main (8.16), and are being back-ported as a single PR to 8.15.

See the following PRs in main for the details:

* https://github.com/elastic/elasticsearch/pull/110476
* https://github.com/elastic/elasticsearch/pull/110600
* https://github.com/elastic/elasticsearch/pull/110652
* https://github.com/elastic/elasticsearch/pull/110793
