### PR TITLE
CoordinatorRewriteContext.hasTimestampData should check for UNKNOWN ranges

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -123,10 +123,12 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
     boolean hasTimestampData(String fieldName) {
         if (DataStream.TIMESTAMP_FIELD_NAME.equals(fieldName)) {
             return dateFieldRangeInfo.getTimestampRange().isComplete()
-                && dateFieldRangeInfo.getTimestampRange() != IndexLongFieldRange.EMPTY;
+                && dateFieldRangeInfo.getTimestampRange() != IndexLongFieldRange.EMPTY
+                && dateFieldRangeInfo.getTimestampRange() != IndexLongFieldRange.UNKNOWN;
         } else if (IndexMetadata.EVENT_INGESTED_FIELD_NAME.equals(fieldName)) {
             return dateFieldRangeInfo.getEventIngestedRange().isComplete()
-                && dateFieldRangeInfo.getEventIngestedRange() != IndexLongFieldRange.EMPTY;
+                && dateFieldRangeInfo.getEventIngestedRange() != IndexLongFieldRange.EMPTY
+                && dateFieldRangeInfo.getEventIngestedRange() != IndexLongFieldRange.UNKNOWN;
         } else {
             throw new IllegalArgumentException(
                 Strings.format(


### PR DESCRIPTION
When doing a coordinator rewrite against either the @timestamp or event.ingested fields, the range must 
have legitimate values, which it will not if the range is marked as UNKNOWN. This commit changes
CoordinatorRewriteContext.hasTimestampData to check for UNKNOWN range as well as EMPTY.

In serverless we see this error.

```
java.lang.AssertionError: min is meaningless if range is unknown
	at org.elasticsearch.server@8.16.0/org.elasticsearch.index.shard.IndexLongFieldRange.getMin(IndexLongFieldRange.java:96)
	at org.elasticsearch.server@8.16.0/org.elasticsearch.index.query.CoordinatorRewriteContext.getMinTimestamp(CoordinatorRewriteContext.java:78)
	at org.elasticsearch.server@8.16.0/org.elasticsearch.index.query.RangeQueryBuilder.getRelation(RangeQueryBuilder.java:442)
	at org.elasticsearch.server@8.16.0/org.elasticsearch.index.query.RangeQueryBuilder.doCoordinatorRewrite(RangeQueryBuilder.java:488)
```

The error "min is meaningless if range is unknown" [tells us](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/shard/IndexLongFieldRange.java#L96) that the the range was in fact UNKNOWN, so this fix will prevent that error from occurring and avoid attempting a search coordinator rewrite against that field.

