### PR TITLE
Remove PUT /_connector path in connector.put

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json
@@ -27,12 +27,6 @@
               "description": "The unique identifier of the connector to be created or updated."
             }
           }
-        },
-        {
-          "path": "/_connector",
-          "methods": [
-            "PUT"
-          ]
         }
       ]
     },


### PR DESCRIPTION
This PR fixes the [connector.put](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json) rest-api-spec removing the `PUT /_connector` path.

I tested and it seems not possible to send `PUT /_connector` without the `connector_id` parameter.
See https://github.com/elastic/elasticsearch-specification/issues/2715 for more details.