### PR TITLE
[8.14] Add runtime classpath as input to ThirdPartyAuditTask (#110882)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -193,6 +193,11 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
     @SkipWhenEmpty
     public abstract ConfigurableFileCollection getJarsToScan();
 
+    @Classpath
+    public FileCollection getClasspath() {
+        return classpath;
+    }
+
     @TaskAction
     public void runThirdPartyAudit() throws IOException {
         Set<File> jars = getJarsToScan().getFiles();


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Add runtime classpath as input to ThirdPartyAuditTask (#110882)