### PR TITLE
Fix logsdb mapping rest tests on serverless

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
@@ -22,6 +22,8 @@ stored _source mode is not supported:
           settings:
             index:
               mode: logs
+              lossy:
+                source-mapping-parameters: true
           mappings:
             _source:
               mode: stored
@@ -59,6 +61,8 @@ disabled _source is not supported:
           settings:
             index:
               mode: logs
+              lossy:
+                source-mapping-parameters: true
           mappings:
             _source:
               enabled: false
@@ -80,6 +84,8 @@ disabled _source is not supported:
           settings:
             index:
               mode: logs
+              lossy:
+                source-mapping-parameters: true
           mappings:
             _source:
               mode: disabled

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -33,6 +33,7 @@ import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.index.store.FsDirectoryFactory;
 import org.elasticsearch.index.store.Store;
@@ -151,6 +152,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexFieldDataService.INDEX_FIELDDATA_CACHE_KEY,
         FieldMapper.IGNORE_MALFORMED_SETTING,
         FieldMapper.COERCE_SETTING,
+        SourceFieldMapper.LOSSY_PARAMETERS_ALLOWED_SETTING,
         Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING,
         MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING,
         MapperService.INDEX_MAPPING_NESTED_DOCS_LIMIT_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -17,6 +17,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
@@ -45,6 +46,13 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     public static final String CONTENT_TYPE = "_source";
 
     public static final String LOSSY_PARAMETERS_ALLOWED_SETTING_NAME = "index.lossy.source-mapping-parameters";
+
+    public static final Setting<Boolean> LOSSY_PARAMETERS_ALLOWED_SETTING = Setting.boolSetting(
+        LOSSY_PARAMETERS_ALLOWED_SETTING_NAME,
+        true,
+        Setting.Property.IndexScope,
+        Setting.Property.InternalIndex
+    );
 
     /** The source mode */
     private enum Mode {


### PR DESCRIPTION
Currently fails due to validation that is only performed in serverless:
```
java.lang.AssertionError: Failure at [logsdb/20_mapping:94]: 
Expected: "Failed to parse mapping: Indices with with index mode [logs] only support synthetic source"
     but: was "Failed to parse mapping: Parameter [mode=disabled] is not allowed in source"
```