### PR TITLE
(Doc+) Link Gateway Settings to Full Restart

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -4,11 +4,11 @@
 The local gateway stores the cluster state and shard data across full
 cluster restarts.
 
-The following _static_ settings, which must be set on every master node,
+The following _static_ settings, which must be set on every <<master-node,master-eligible node>>,
 control how long a freshly elected master should wait before it tries to
-recover the cluster state and the cluster's data.
+recover the <<cluster-state,cluster state>> and the cluster's data.
 
-NOTE: These settings only take effect on a full cluster restart.
+NOTE: These settings only take effect during a <<restart-cluster-full,full cluster restart>>.
 
 `gateway.expected_data_nodes`::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -11,7 +11,7 @@ time, so the service remains uninterrupted.
 [WARNING]
 ====
 Nodes exceeding the low watermark threshold will be slow to restart. Reduce the disk
-usage below the <<cluster-routing-watermark-low,low watermark>> before to restarting nodes.
+usage below the <<cluster-routing-watermark-low,low watermark>> before restarting nodes.
 ====
 
 [discrete]

--- a/docs/reference/upgrade/disable-shard-alloc.asciidoc
+++ b/docs/reference/upgrade/disable-shard-alloc.asciidoc
@@ -18,6 +18,6 @@ PUT _cluster/settings
 --------------------------------------------------
 // TEST[skip:indexes don't assign]
 
-You may also consider <<modules-gateway,gateway settings>> when restarting 
+You can also consider <<modules-gateway,gateway settings>> when restarting 
 large clusters to reduce initial strain while nodes are processing 
 <<modules-discovery,through discovery>>. 

--- a/docs/reference/upgrade/disable-shard-alloc.asciidoc
+++ b/docs/reference/upgrade/disable-shard-alloc.asciidoc
@@ -18,4 +18,6 @@ PUT _cluster/settings
 --------------------------------------------------
 // TEST[skip:indexes don't assign]
 
-You may also consider <<modules-gateway,gateway settings>>. 
+You may also consider <<modules-gateway,gateway settings>> when restarting 
+large clusters to reduce initial strain while nodes are processing 
+<<modules-discovery,through discovery>>. 

--- a/docs/reference/upgrade/disable-shard-alloc.asciidoc
+++ b/docs/reference/upgrade/disable-shard-alloc.asciidoc
@@ -17,3 +17,5 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // TEST[skip:indexes don't assign]
+
+You may also consider <<modules-gateway,gateway settings>>. 


### PR DESCRIPTION
👋🏽 howdy, team! Mini update to cross-link the [Gateway Settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html) to the [Full Cluster Restart](https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-cluster.html#restart-cluster-full) docs. 