### PR TITLE
Add test for native preallocation

### DIFF
--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
@@ -118,7 +118,7 @@ class JnaPosixCLibrary implements PosixCLibrary {
 
         int mlockall(int flags);
 
-        int fcntl(int fd, int cmd, Pointer fst);
+        int fcntl(int fd, int cmd, Object... args);
 
         int ftruncate(int fd, NativeLong length);
 

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -49,8 +49,12 @@ class JdkPosixCLibrary implements PosixCLibrary {
         FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS)
     );
     private static final MethodHandle mlockall$mh = downcallHandleWithErrno("mlockall", FunctionDescriptor.of(JAVA_INT, JAVA_INT));
-    private static final MethodHandle fcntl$mh = downcallHandle("fcntl", FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, ADDRESS));
-    private static final MethodHandle ftruncate$mh = downcallHandle("ftruncate", FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_LONG));
+    private static final MethodHandle fcntl$mh = downcallHandle(
+        "fcntl",
+        FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, ADDRESS),
+        CAPTURE_ERRNO_OPTION,
+        Linker.Option.firstVariadicArg(2));
+    private static final MethodHandle ftruncate$mh = downcallHandleWithErrno("ftruncate", FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_LONG));
     private static final MethodHandle open$mh = downcallHandle(
         "open",
         FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT),
@@ -281,17 +285,16 @@ class JdkPosixCLibrary implements PosixCLibrary {
 
     private static class JdkFStore implements FStore {
         private static final MemoryLayout layout = MemoryLayout.structLayout(JAVA_INT, JAVA_INT, JAVA_LONG, JAVA_LONG, JAVA_LONG);
-        private static final VarHandle st_flags$vh = layout.varHandle(groupElement(0));
-        private static final VarHandle st_posmode$vh = layout.varHandle(groupElement(1));
-        private static final VarHandle st_offset$vh = layout.varHandle(groupElement(2));
-        private static final VarHandle st_length$vh = layout.varHandle(groupElement(3));
-        private static final VarHandle st_bytesalloc$vh = layout.varHandle(groupElement(4));
+        private static final VarHandle st_flags$vh = varHandleWithoutOffset(layout, groupElement(0));
+        private static final VarHandle st_posmode$vh = varHandleWithoutOffset(layout, groupElement(1));
+        private static final VarHandle st_offset$vh = varHandleWithoutOffset(layout, groupElement(2));
+        private static final VarHandle st_length$vh = varHandleWithoutOffset(layout, groupElement(3));
+        private static final VarHandle st_bytesalloc$vh = varHandleWithoutOffset(layout, groupElement(4));
 
         private final MemorySegment segment;
 
         JdkFStore() {
-            var arena = Arena.ofAuto();
-            this.segment = arena.allocate(layout);
+            this.segment = Arena.ofAuto().allocate(layout);
         }
 
         @Override
@@ -306,7 +309,7 @@ class JdkPosixCLibrary implements PosixCLibrary {
 
         @Override
         public void set_offset(long offset) {
-            st_offset$vh.get(segment, offset);
+            st_offset$vh.set(segment, offset);
         }
 
         @Override

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -53,8 +53,12 @@ class JdkPosixCLibrary implements PosixCLibrary {
         "fcntl",
         FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_INT, ADDRESS),
         CAPTURE_ERRNO_OPTION,
-        Linker.Option.firstVariadicArg(2));
-    private static final MethodHandle ftruncate$mh = downcallHandleWithErrno("ftruncate", FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_LONG));
+        Linker.Option.firstVariadicArg(2)
+    );
+    private static final MethodHandle ftruncate$mh = downcallHandleWithErrno(
+        "ftruncate",
+        FunctionDescriptor.of(JAVA_INT, JAVA_INT, JAVA_LONG)
+    );
     private static final MethodHandle open$mh = downcallHandle(
         "open",
         FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT),

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/PreallocateTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/PreallocateTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.OptionalLong;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class PreallocateTests extends ESTestCase {
+    public void testPreallocate() throws IOException {
+        Path file = createTempFile();
+        long size = 1024 * 1024; // 1 MB
+        var nativeAccess = NativeAccess.instance();
+        nativeAccess.tryPreallocate(file, size);
+        OptionalLong foundSize = nativeAccess.allocatedSizeInBytes(file);
+        assertTrue(foundSize.isPresent());
+        // Note that on Windows the fallback setLength is used. Although that creates a sparse
+        // file on Linux/MacOS, it full allocates the file on Windows
+        assertThat(foundSize.getAsLong(), equalTo(size));
+    }
+}


### PR DESCRIPTION
This commit forward ports a test for native preallocation from #110851. It also fixes fcntl and ftruncate bindings used by MacOS for preallocation.