### PR TITLE
Capture StatusLogger warn/error events

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -128,6 +128,21 @@ public class LogConfigurator {
         configureESLogging();
         configure(environment.settings(), environment.configFile(), environment.logsFile(), useConsole);
         initializeStatics();
+        // creates a permanent status logger that can watch for StatusLogger events and forward to a real logger
+        configureStatusLoggerForwarder();
+    }
+
+    private static void configureStatusLoggerForwarder() {
+        // the real logger is lazily retrieved here since logging won't yet be setup during clinit of this class
+        var logger = LogManager.getLogger("StatusLogger");
+        var listener = new StatusConsoleListener(Level.WARN) {
+            @Override
+            public void log(StatusData data) {
+                logger.log(data.getLevel(), data.getMessage(), data.getThrowable());
+                super.log(data);
+            }
+        };
+        StatusLogger.getLogger().registerListener(listener);
     }
 
     public static void configureESLogging() {


### PR DESCRIPTION
When errors occur inside log4j while logging, they are sent to the StatusLogger. We use a StatusLogger listener to check for errors during startup before logging is configured, but remove that listener once configured. This commit adds another status logger that listens for the lifetime of the ES process for StatusLogger warn and error messages. Any messages received are forwarded to the ES log.