### PR TITLE
Make FieldInfos dedup run for all codecs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch814Codec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch814Codec.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.index.codec;
 
 import org.apache.lucene.codecs.DocValuesFormat;
-import org.apache.lucene.codecs.FieldInfosFormat;
-import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
@@ -27,11 +25,9 @@ import org.elasticsearch.index.codec.zstd.Zstd814StoredFieldsFormat;
  * Elasticsearch codec as of 8.14. This extends the Lucene 9.9 codec to compressed stored fields with ZSTD instead of LZ4/DEFLATE. See
  * {@link Zstd814StoredFieldsFormat}.
  */
-public class Elasticsearch814Codec extends FilterCodec {
+public class Elasticsearch814Codec extends CodecService.DeduplicateFieldInfosCodec {
 
     private final StoredFieldsFormat storedFieldsFormat;
-
-    private final FieldInfosFormat fieldInfosFormat;
 
     private final PostingsFormat defaultPostingsFormat;
     private final PostingsFormat postingsFormat = new PerFieldPostingsFormat() {
@@ -72,7 +68,6 @@ public class Elasticsearch814Codec extends FilterCodec {
         this.defaultPostingsFormat = new Lucene99PostingsFormat();
         this.defaultDVFormat = new Lucene90DocValuesFormat();
         this.defaultKnnVectorsFormat = new Lucene99HnswVectorsFormat();
-        this.fieldInfosFormat = new DeduplicatingFieldInfosFormat(delegate.fieldInfosFormat());
     }
 
     @Override
@@ -132,8 +127,4 @@ public class Elasticsearch814Codec extends FilterCodec {
         return defaultKnnVectorsFormat;
     }
 
-    @Override
-    public FieldInfosFormat fieldInfosFormat() {
-        return fieldInfosFormat;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.codec;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
-import org.apache.lucene.codecs.lucene99.Lucene99Codec;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntField;
@@ -73,7 +72,6 @@ public class CodecTests extends ESTestCase {
 
     public void testLegacyDefault() throws Exception {
         Codec codec = createCodecService().codec("legacy_default");
-        assertThat(codec, Matchers.instanceOf(Lucene99Codec.class));
         assertThat(codec.storedFieldsFormat(), Matchers.instanceOf(Lucene90StoredFieldsFormat.class));
         // Make sure the legacy codec is writable
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setCodec(codec))) {
@@ -87,7 +85,6 @@ public class CodecTests extends ESTestCase {
 
     public void testLegacyBestCompression() throws Exception {
         Codec codec = createCodecService().codec("legacy_best_compression");
-        assertThat(codec, Matchers.instanceOf(Lucene99Codec.class));
         assertThat(codec.storedFieldsFormat(), Matchers.instanceOf(Lucene90StoredFieldsFormat.class));
         // Make sure the legacy codec is writable
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setCodec(codec))) {


### PR DESCRIPTION
The initial fix here didn't properly apply to all situations, lets do this a little more robust to cover all codecs.
