### PR TITLE
[8.15] Remove typo put-lifecycle.asciidoc (#110875)

### DIFF
--- a/docs/reference/data-streams/lifecycle/apis/put-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/put-lifecycle.asciidoc
@@ -54,7 +54,7 @@ duration the document could be deleted. When empty, every document in this data 
 
 `enabled`::
 (Optional, boolean)
-If defined, it turns data streqm lifecycle on/off (`true`/`false`) for this data stream.
+If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream.
 A data stream lifecycle that's disabled (`enabled: false`) will have no effect on the
 data stream. Defaults to `true`.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.14` to `8.15`:
 - [Remove typo put-lifecycle.asciidoc (#110875)](https://github.com/elastic/elasticsearch/pull/110875)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)