### PR TITLE
[8.15] Add a cluster listener to fix missing cluster features after upgrade (#110710)

### DIFF
--- a/docs/changelog/110710.yaml
+++ b/docs/changelog/110710.yaml
@@ -1,0 +1,6 @@
+pr: 110710
+summary: Add a cluster listener to fix missing node features after upgrading from a version prior to 8.13
+area: Infra/Core
+type: bug
+issues:
+ - 109254

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.admin.cluster.migration.PostFeatureUpgradeAction
 import org.elasticsearch.action.admin.cluster.migration.TransportGetFeatureUpgradeStatusAction;
 import org.elasticsearch.action.admin.cluster.migration.TransportPostFeatureUpgradeAction;
 import org.elasticsearch.action.admin.cluster.node.capabilities.TransportNodesCapabilitiesAction;
+import org.elasticsearch.action.admin.cluster.node.features.TransportNodesFeaturesAction;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.TransportNodesHotThreadsAction;
 import org.elasticsearch.action.admin.cluster.node.info.TransportNodesInfoAction;
 import org.elasticsearch.action.admin.cluster.node.reload.TransportNodesReloadSecureSettingsAction;
@@ -621,6 +622,7 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportNodesInfoAction.TYPE, TransportNodesInfoAction.class);
         actions.register(TransportRemoteInfoAction.TYPE, TransportRemoteInfoAction.class);
         actions.register(TransportNodesCapabilitiesAction.TYPE, TransportNodesCapabilitiesAction.class);
+        actions.register(TransportNodesFeaturesAction.TYPE, TransportNodesFeaturesAction.class);
         actions.register(RemoteClusterNodesAction.TYPE, RemoteClusterNodesAction.TransportAction.class);
         actions.register(TransportNodesStatsAction.TYPE, TransportNodesStatsAction.class);
         actions.register(TransportNodesUsageAction.TYPE, TransportNodesUsageAction.class);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodeFeatures.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodeFeatures.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class NodeFeatures extends BaseNodeResponse {
+
+    private final Set<String> features;
+
+    public NodeFeatures(StreamInput in) throws IOException {
+        super(in);
+        features = in.readCollectionAsImmutableSet(StreamInput::readString);
+    }
+
+    public NodeFeatures(Set<String> features, DiscoveryNode node) {
+        super(node);
+        this.features = Set.copyOf(features);
+    }
+
+    public Set<String> nodeFeatures() {
+        return features;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeCollection(features, StreamOutput::writeString);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesRequest.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+
+public class NodesFeaturesRequest extends BaseNodesRequest<NodesFeaturesRequest> {
+    public NodesFeaturesRequest(String... nodes) {
+        super(nodes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/NodesFeaturesResponse.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+public class NodesFeaturesResponse extends BaseNodesResponse<NodeFeatures> {
+    public NodesFeaturesResponse(ClusterName clusterName, List<NodeFeatures> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<NodeFeatures> readNodesFrom(StreamInput in) throws IOException {
+        return TransportAction.localOnly();
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<NodeFeatures> nodes) throws IOException {
+        TransportAction.localOnly();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/TransportNodesFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/TransportNodesFeaturesAction.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.node.features;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.UpdateForV9;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+@UpdateForV9
+// @UpdateForV10 // this can be removed in v10. It may be called by v8 nodes to v9 nodes.
+public class TransportNodesFeaturesAction extends TransportNodesAction<
+    NodesFeaturesRequest,
+    NodesFeaturesResponse,
+    TransportNodesFeaturesAction.NodeFeaturesRequest,
+    NodeFeatures> {
+
+    public static final ActionType<NodesFeaturesResponse> TYPE = new ActionType<>("cluster:monitor/nodes/features");
+
+    private final FeatureService featureService;
+
+    @Inject
+    public TransportNodesFeaturesAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        FeatureService featureService
+    ) {
+        super(
+            TYPE.name(),
+            clusterService,
+            transportService,
+            actionFilters,
+            NodeFeaturesRequest::new,
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+        );
+        this.featureService = featureService;
+    }
+
+    @Override
+    protected NodesFeaturesResponse newResponse(
+        NodesFeaturesRequest request,
+        List<NodeFeatures> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new NodesFeaturesResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected NodeFeaturesRequest newNodeRequest(NodesFeaturesRequest request) {
+        return new NodeFeaturesRequest();
+    }
+
+    @Override
+    protected NodeFeatures newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new NodeFeatures(in);
+    }
+
+    @Override
+    protected NodeFeatures nodeOperation(NodeFeaturesRequest request, Task task) {
+        return new NodeFeatures(featureService.getNodeFeatures().keySet(), transportService.getLocalNode());
+    }
+
+    public static class NodeFeaturesRequest extends TransportRequest {
+        public NodeFeaturesRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodeFeaturesRequest() {}
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -884,6 +884,11 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
             return Collections.unmodifiableMap(this.nodeFeatures);
         }
 
+        public Builder putNodeFeatures(String node, Set<String> features) {
+            this.nodeFeatures.put(node, features);
+            return this;
+        }
+
         public Builder routingTable(RoutingTable.Builder routingTableBuilder) {
             return routingTable(routingTableBuilder.build());
         }

--- a/server/src/main/java/org/elasticsearch/cluster/features/NodeFeaturesFixupListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/features/NodeFeaturesFixupListener.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.features;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.admin.cluster.node.features.NodeFeatures;
+import org.elasticsearch.action.admin.cluster.node.features.NodesFeaturesRequest;
+import org.elasticsearch.action.admin.cluster.node.features.NodesFeaturesResponse;
+import org.elasticsearch.action.admin.cluster.node.features.TransportNodesFeaturesAction;
+import org.elasticsearch.client.internal.ClusterAdminClient;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterFeatures;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.UpdateForV9;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+@UpdateForV9    // this can be removed in v9
+public class NodeFeaturesFixupListener implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(NodeFeaturesFixupListener.class);
+
+    private static final TimeValue RETRY_TIME = TimeValue.timeValueSeconds(30);
+
+    private final MasterServiceTaskQueue<NodesFeaturesTask> taskQueue;
+    private final ClusterAdminClient client;
+    private final Scheduler scheduler;
+    private final Executor executor;
+    private final Set<String> pendingNodes = Collections.synchronizedSet(new HashSet<>());
+
+    public NodeFeaturesFixupListener(ClusterService service, ClusterAdminClient client, ThreadPool threadPool) {
+        // there tends to be a lot of state operations on an upgrade - this one is not time-critical,
+        // so use LOW priority. It just needs to be run at some point after upgrade.
+        this(
+            service.createTaskQueue("fix-node-features", Priority.LOW, new NodesFeaturesUpdater()),
+            client,
+            threadPool,
+            threadPool.executor(ThreadPool.Names.CLUSTER_COORDINATION)
+        );
+    }
+
+    NodeFeaturesFixupListener(
+        MasterServiceTaskQueue<NodesFeaturesTask> taskQueue,
+        ClusterAdminClient client,
+        Scheduler scheduler,
+        Executor executor
+    ) {
+        this.taskQueue = taskQueue;
+        this.client = client;
+        this.scheduler = scheduler;
+        this.executor = executor;
+    }
+
+    class NodesFeaturesTask implements ClusterStateTaskListener {
+        private final Map<String, Set<String>> results;
+        private final int retryNum;
+
+        NodesFeaturesTask(Map<String, Set<String>> results, int retryNum) {
+            this.results = results;
+            this.retryNum = retryNum;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            logger.error("Could not apply features for nodes {} to cluster state", results.keySet(), e);
+            scheduleRetry(results.keySet(), retryNum);
+        }
+
+        public Map<String, Set<String>> results() {
+            return results;
+        }
+    }
+
+    static class NodesFeaturesUpdater implements ClusterStateTaskExecutor<NodesFeaturesTask> {
+        @Override
+        public ClusterState execute(BatchExecutionContext<NodesFeaturesTask> context) {
+            ClusterState.Builder builder = ClusterState.builder(context.initialState());
+            var existingFeatures = builder.nodeFeatures();
+
+            boolean modified = false;
+            for (var c : context.taskContexts()) {
+                for (var e : c.getTask().results().entrySet()) {
+                    // double check there are still no features for the node
+                    if (existingFeatures.getOrDefault(e.getKey(), Set.of()).isEmpty()) {
+                        builder.putNodeFeatures(e.getKey(), e.getValue());
+                        modified = true;
+                    }
+                }
+                c.success(() -> {});
+            }
+            return modified ? builder.build() : context.initialState();
+        }
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.nodesDelta().masterNodeChanged() && event.localNodeMaster()) {
+            /*
+             * Execute this if we have just become master.
+             * Check if there are any nodes that should have features in cluster state, but don't.
+             * This can happen if the master was upgraded from before 8.13, and one or more non-master nodes
+             * were already upgraded. They don't re-join the cluster with the new master, so never get their features
+             * (which the master now understands) added to cluster state.
+             * So we need to do a separate transport call to get the node features and add them to cluster state.
+             * We can't use features to determine when this should happen, as the features are incorrect.
+             * We also can't use transport version, as that is unreliable for upgrades
+             * from versions before 8.8 (see TransportVersionFixupListener).
+             * So the only thing we can use is release version.
+             * This is ok here, as Serverless will never hit this case, so the node feature fetch action will never be called on Serverless.
+             * This whole class will be removed in ES v9.
+             */
+            ClusterFeatures nodeFeatures = event.state().clusterFeatures();
+            Set<String> queryNodes = event.state()
+                .nodes()
+                .stream()
+                .filter(n -> n.getVersion().onOrAfter(Version.V_8_15_0))
+                .map(DiscoveryNode::getId)
+                .filter(n -> getNodeFeatures(nodeFeatures, n).isEmpty())
+                .collect(Collectors.toSet());
+
+            if (queryNodes.isEmpty() == false) {
+                logger.debug("Fetching actual node features for nodes {}", queryNodes);
+                queryNodesFeatures(queryNodes, 0);
+            }
+        }
+    }
+
+    @SuppressForbidden(reason = "Need to access a specific node's features")
+    private static Set<String> getNodeFeatures(ClusterFeatures features, String nodeId) {
+        return features.nodeFeatures().getOrDefault(nodeId, Set.of());
+    }
+
+    private void scheduleRetry(Set<String> nodes, int thisRetryNum) {
+        // just keep retrying until this succeeds
+        logger.debug("Scheduling retry {} for nodes {}", thisRetryNum + 1, nodes);
+        scheduler.schedule(() -> queryNodesFeatures(nodes, thisRetryNum + 1), RETRY_TIME, executor);
+    }
+
+    private void queryNodesFeatures(Set<String> nodes, int retryNum) {
+        // some might already be in-progress
+        Set<String> outstandingNodes = Sets.newHashSetWithExpectedSize(nodes.size());
+        synchronized (pendingNodes) {
+            for (String n : nodes) {
+                if (pendingNodes.add(n)) {
+                    outstandingNodes.add(n);
+                }
+            }
+        }
+        if (outstandingNodes.isEmpty()) {
+            // all nodes already have in-progress requests
+            return;
+        }
+
+        NodesFeaturesRequest request = new NodesFeaturesRequest(outstandingNodes.toArray(String[]::new));
+        client.execute(TransportNodesFeaturesAction.TYPE, request, new ActionListener<>() {
+            @Override
+            public void onResponse(NodesFeaturesResponse response) {
+                pendingNodes.removeAll(outstandingNodes);
+                handleResponse(response, retryNum);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                pendingNodes.removeAll(outstandingNodes);
+                logger.warn("Could not read features for nodes {}", outstandingNodes, e);
+                scheduleRetry(outstandingNodes, retryNum);
+            }
+        });
+    }
+
+    private void handleResponse(NodesFeaturesResponse response, int retryNum) {
+        if (response.hasFailures()) {
+            Set<String> failedNodes = new HashSet<>();
+            for (FailedNodeException fne : response.failures()) {
+                logger.warn("Failed to read features from node {}", fne.nodeId(), fne);
+                failedNodes.add(fne.nodeId());
+            }
+            scheduleRetry(failedNodes, retryNum);
+        }
+        // carry on and read what we can
+
+        Map<String, Set<String>> results = response.getNodes()
+            .stream()
+            .collect(Collectors.toUnmodifiableMap(n -> n.getNode().getId(), NodeFeatures::nodeFeatures));
+
+        if (results.isEmpty() == false) {
+            taskQueue.submitTask("fix-node-features", new NodesFeaturesTask(results, retryNum), null);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.cluster.coordination.CoordinationDiagnosticsService;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.coordination.MasterHistoryService;
 import org.elasticsearch.cluster.coordination.StableMasterHealthIndicatorService;
+import org.elasticsearch.cluster.features.NodeFeaturesFixupListener;
 import org.elasticsearch.cluster.metadata.DataStreamFactoryRetention;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetentionResolver;
 import org.elasticsearch.cluster.metadata.IndexMetadataVerifier;
@@ -752,6 +753,7 @@ class NodeConstruction {
             clusterService.addListener(
                 new TransportVersionsFixupListener(clusterService, client.admin().cluster(), featureService, threadPool)
             );
+            clusterService.addListener(new NodeFeaturesFixupListener(clusterService, client.admin().cluster(), threadPool));
         }
 
         SourceFieldMetrics sourceFieldMetrics = new SourceFieldMetrics(

--- a/server/src/test/java/org/elasticsearch/cluster/features/NodeFeaturesFixupListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/features/NodeFeaturesFixupListenerTests.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.features;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.node.features.NodeFeatures;
+import org.elasticsearch.action.admin.cluster.node.features.NodesFeaturesRequest;
+import org.elasticsearch.action.admin.cluster.node.features.NodesFeaturesResponse;
+import org.elasticsearch.action.admin.cluster.node.features.TransportNodesFeaturesAction;
+import org.elasticsearch.client.internal.ClusterAdminClient;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.features.NodeFeaturesFixupListener.NodesFeaturesTask;
+import org.elasticsearch.cluster.features.NodeFeaturesFixupListener.NodesFeaturesUpdater;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+
+public class NodeFeaturesFixupListenerTests extends ESTestCase {
+
+    @SuppressWarnings("unchecked")
+    private static MasterServiceTaskQueue<NodesFeaturesTask> newMockTaskQueue() {
+        return mock(MasterServiceTaskQueue.class);
+    }
+
+    private static DiscoveryNodes nodes(Version... versions) {
+        var builder = DiscoveryNodes.builder();
+        for (int i = 0; i < versions.length; i++) {
+            builder.add(DiscoveryNodeUtils.create("node" + i, new TransportAddress(TransportAddress.META_ADDRESS, 9200 + i), versions[i]));
+        }
+        builder.localNodeId("node0").masterNodeId("node0");
+        return builder.build();
+    }
+
+    private static DiscoveryNodes nodes(VersionInformation... versions) {
+        var builder = DiscoveryNodes.builder();
+        for (int i = 0; i < versions.length; i++) {
+            builder.add(
+                DiscoveryNodeUtils.builder("node" + i)
+                    .address(new TransportAddress(TransportAddress.META_ADDRESS, 9200 + i))
+                    .version(versions[i])
+                    .build()
+            );
+        }
+        builder.localNodeId("node0").masterNodeId("node0");
+        return builder.build();
+    }
+
+    @SafeVarargs
+    private static Map<String, Set<String>> features(Set<String>... nodeFeatures) {
+        Map<String, Set<String>> features = new HashMap<>();
+        for (int i = 0; i < nodeFeatures.length; i++) {
+            features.put("node" + i, nodeFeatures[i]);
+        }
+        return features;
+    }
+
+    private static NodesFeaturesResponse getResponse(Map<String, Set<String>> responseData) {
+        return new NodesFeaturesResponse(
+            ClusterName.DEFAULT,
+            responseData.entrySet()
+                .stream()
+                .map(
+                    e -> new NodeFeatures(
+                        e.getValue(),
+                        DiscoveryNodeUtils.create(e.getKey(), new TransportAddress(TransportAddress.META_ADDRESS, 9200))
+                    )
+                )
+                .toList(),
+            List.of()
+        );
+    }
+
+    public void testNothingDoneWhenNothingToFix() {
+        MasterServiceTaskQueue<NodesFeaturesTask> taskQueue = newMockTaskQueue();
+        ClusterAdminClient client = mock(ClusterAdminClient.class);
+
+        ClusterState testState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(nodes(Version.CURRENT, Version.CURRENT))
+            .nodeFeatures(features(Set.of("f1", "f2"), Set.of("f1", "f2")))
+            .build();
+
+        NodeFeaturesFixupListener listener = new NodeFeaturesFixupListener(taskQueue, client, null, null);
+        listener.clusterChanged(new ClusterChangedEvent("test", testState, ClusterState.EMPTY_STATE));
+
+        verify(taskQueue, never()).submitTask(anyString(), any(), any());
+    }
+
+    public void testFeaturesFixedAfterNewMaster() throws Exception {
+        MasterServiceTaskQueue<NodesFeaturesTask> taskQueue = newMockTaskQueue();
+        ClusterAdminClient client = mock(ClusterAdminClient.class);
+        Set<String> features = Set.of("f1", "f2");
+
+        ClusterState testState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(nodes(Version.CURRENT, Version.CURRENT, Version.CURRENT))
+            .nodeFeatures(features(features, Set.of(), Set.of()))
+            .build();
+
+        ArgumentCaptor<ActionListener<NodesFeaturesResponse>> action = ArgumentCaptor.captor();
+        ArgumentCaptor<NodesFeaturesTask> task = ArgumentCaptor.captor();
+
+        NodeFeaturesFixupListener listener = new NodeFeaturesFixupListener(taskQueue, client, null, null);
+        listener.clusterChanged(new ClusterChangedEvent("test", testState, ClusterState.EMPTY_STATE));
+        verify(client).execute(
+            eq(TransportNodesFeaturesAction.TYPE),
+            argThat(transformedMatch(NodesFeaturesRequest::nodesIds, arrayContainingInAnyOrder("node1", "node2"))),
+            action.capture()
+        );
+
+        action.getValue().onResponse(getResponse(Map.of("node1", features, "node2", features)));
+        verify(taskQueue).submitTask(anyString(), task.capture(), any());
+
+        ClusterState newState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
+            testState,
+            new NodesFeaturesUpdater(),
+            List.of(task.getValue())
+        );
+
+        assertThat(newState.clusterFeatures().allNodeFeatures(), containsInAnyOrder("f1", "f2"));
+    }
+
+    public void testFeaturesFetchedOnlyForUpdatedNodes() {
+        MasterServiceTaskQueue<NodesFeaturesTask> taskQueue = newMockTaskQueue();
+        ClusterAdminClient client = mock(ClusterAdminClient.class);
+
+        ClusterState testState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(
+                nodes(
+                    VersionInformation.CURRENT,
+                    VersionInformation.CURRENT,
+                    new VersionInformation(Version.V_8_12_0, IndexVersion.current(), IndexVersion.current())
+                )
+            )
+            .nodeFeatures(features(Set.of("f1", "f2"), Set.of(), Set.of()))
+            .build();
+
+        ArgumentCaptor<ActionListener<NodesFeaturesResponse>> action = ArgumentCaptor.captor();
+
+        NodeFeaturesFixupListener listener = new NodeFeaturesFixupListener(taskQueue, client, null, null);
+        listener.clusterChanged(new ClusterChangedEvent("test", testState, ClusterState.EMPTY_STATE));
+        verify(client).execute(
+            eq(TransportNodesFeaturesAction.TYPE),
+            argThat(transformedMatch(NodesFeaturesRequest::nodesIds, arrayContainingInAnyOrder("node1"))),
+            action.capture()
+        );
+    }
+
+    public void testConcurrentChangesDoNotOverlap() {
+        MasterServiceTaskQueue<NodesFeaturesTask> taskQueue = newMockTaskQueue();
+        ClusterAdminClient client = mock(ClusterAdminClient.class);
+        Set<String> features = Set.of("f1", "f2");
+
+        ClusterState testState1 = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(nodes(Version.CURRENT, Version.CURRENT, Version.CURRENT))
+            .nodeFeatures(features(features, Set.of(), Set.of()))
+            .build();
+
+        NodeFeaturesFixupListener listeners = new NodeFeaturesFixupListener(taskQueue, client, null, null);
+        listeners.clusterChanged(new ClusterChangedEvent("test", testState1, ClusterState.EMPTY_STATE));
+        verify(client).execute(
+            eq(TransportNodesFeaturesAction.TYPE),
+            argThat(transformedMatch(NodesFeaturesRequest::nodesIds, arrayContainingInAnyOrder("node1", "node2"))),
+            any()
+        );
+        // don't send back the response yet
+
+        ClusterState testState2 = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(nodes(Version.CURRENT, Version.CURRENT, Version.CURRENT))
+            .nodeFeatures(features(features, features, Set.of()))
+            .build();
+        // should not send any requests
+        listeners.clusterChanged(new ClusterChangedEvent("test", testState2, testState1));
+        verifyNoMoreInteractions(client);
+    }
+
+    public void testFailedRequestsAreRetried() {
+        MasterServiceTaskQueue<NodesFeaturesTask> taskQueue = newMockTaskQueue();
+        ClusterAdminClient client = mock(ClusterAdminClient.class);
+        Scheduler scheduler = mock(Scheduler.class);
+        Executor executor = mock(Executor.class);
+        Set<String> features = Set.of("f1", "f2");
+
+        ClusterState testState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .nodes(nodes(Version.CURRENT, Version.CURRENT, Version.CURRENT))
+            .nodeFeatures(features(features, Set.of(), Set.of()))
+            .build();
+
+        ArgumentCaptor<ActionListener<NodesFeaturesResponse>> action = ArgumentCaptor.captor();
+        ArgumentCaptor<Runnable> retry = ArgumentCaptor.forClass(Runnable.class);
+
+        NodeFeaturesFixupListener listener = new NodeFeaturesFixupListener(taskQueue, client, scheduler, executor);
+        listener.clusterChanged(new ClusterChangedEvent("test", testState, ClusterState.EMPTY_STATE));
+        verify(client).execute(
+            eq(TransportNodesFeaturesAction.TYPE),
+            argThat(transformedMatch(NodesFeaturesRequest::nodesIds, arrayContainingInAnyOrder("node1", "node2"))),
+            action.capture()
+        );
+
+        action.getValue().onFailure(new RuntimeException("failure"));
+        verify(scheduler).schedule(retry.capture(), any(), same(executor));
+
+        // running the retry should cause another call
+        retry.getValue().run();
+        verify(client, times(2)).execute(
+            eq(TransportNodesFeaturesAction.TYPE),
+            argThat(transformedMatch(NodesFeaturesRequest::nodesIds, arrayContainingInAnyOrder("node1", "node2"))),
+            action.capture()
+        );
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -353,6 +353,7 @@ public class Constants {
         "cluster:monitor/main",
         "cluster:monitor/nodes/capabilities",
         "cluster:monitor/nodes/data_tier_usage",
+        "cluster:monitor/nodes/features",
         "cluster:monitor/nodes/hot_threads",
         "cluster:monitor/nodes/info",
         "cluster:monitor/nodes/stats",


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Add a cluster listener to fix missing cluster features after upgrade (#110710)