### PR TITLE
Fix leak in collapsing search results

### DIFF
--- a/docs/changelog/110927.yaml
+++ b/docs/changelog/110927.yaml
@@ -1,0 +1,5 @@
+pr: 110927
+summary: Fix leak in collapsing search results
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -100,6 +100,10 @@ final class ExpandSearchPhase extends SearchPhase {
                     if (hit.getInnerHits() == null) {
                         hit.setInnerHits(Maps.newMapWithExpectedSize(innerHitBuilders.size()));
                     }
+                    if (hit.isPooled() == false) {
+                        // TODO: make this work pooled by forcing the hit itself to become pooled as needed here
+                        innerHits = innerHits.asUnpooled();
+                    }
                     hit.getInnerHits().put(innerHitBuilder.getName(), innerHits);
                     assert innerHits.isPooled() == false || hit.isPooled() : "pooled inner hits can only be added to a pooled hit";
                     innerHits.mustIncRef();


### PR DESCRIPTION
Fixing this case for now by enforcing unpooled to plug the leak, this needs a little more work to function well pooled.
