### PR TITLE
Add in format nanos function

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -72,6 +72,14 @@ public interface DateFormatter {
     }
 
     /**
+     * Return the given nanoseconds-since-epoch formatted with this format.
+     */
+    default String formatNanos(long nanos) {
+        ZoneId zone = zone() != null ? zone() : ZoneOffset.UTC;
+        return format(Instant.ofEpochMilli(nanos / 1_000_000).plusNanos(nanos % 1_000_000).atZone(zone));
+    }
+
+    /**
      * A name based format for this formatter. Can be one of the registered formatters like <code>epoch_millis</code> or
      * a configured format like <code>HH:mm:ss</code>
      *

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -699,7 +699,7 @@ public class DateFormattersTests extends ESTestCase {
         String javaFormatted = DateFormatter.forPattern("strict_date_optional_time").formatNanos(Long.MIN_VALUE);
         assertThat(javaFormatted, equalTo("1677-09-21T00:12:43.145Z"));
 
-        // It is deeply unclear to me why the last 6 digits of this aren't 775808, which are the last 6 digits of Long.MIN_VALUE
+        // Note - since this is a negative value, the nanoseconds are being subtracted, which is why we get this value.
         javaFormatted = DateFormatter.forPattern("strict_date_optional_time_nanos").formatNanos(Long.MIN_VALUE);
         assertThat(javaFormatted, equalTo("1677-09-21T00:12:43.145224192Z"));
     }

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -695,6 +695,23 @@ public class DateFormattersTests extends ESTestCase {
         assertThat(javaFormatted, equalTo("-292275055-05-16T16:47:04.192Z"));
     }
 
+    public void testMinNanos() {
+        String javaFormatted = DateFormatter.forPattern("strict_date_optional_time").formatNanos(Long.MIN_VALUE);
+        assertThat(javaFormatted, equalTo("1677-09-21T00:12:43.145Z"));
+
+        // It is deeply unclear to me why the last 6 digits of this aren't 775808, which are the last 6 digits of Long.MIN_VALUE
+        javaFormatted = DateFormatter.forPattern("strict_date_optional_time_nanos").formatNanos(Long.MIN_VALUE);
+        assertThat(javaFormatted, equalTo("1677-09-21T00:12:43.145224192Z"));
+    }
+
+    public void testMaxNanos() {
+        String javaFormatted = DateFormatter.forPattern("strict_date_optional_time").formatNanos(Long.MAX_VALUE);
+        assertThat(javaFormatted, equalTo("2262-04-11T23:47:16.854Z"));
+
+        javaFormatted = DateFormatter.forPattern("strict_date_optional_time_nanos").formatNanos(Long.MAX_VALUE);
+        assertThat(javaFormatted, equalTo("2262-04-11T23:47:16.854775807Z"));
+    }
+
     public void testYearParsing() {
         // this one is considered a year
         assertParses("1234", "strict_date_optional_time||epoch_millis");


### PR DESCRIPTION
Adds a helper function to format a single long representing nanoseconds since epoch.  I found myself writing this in a few places while working on https://github.com/elastic/elasticsearch/issues/109987 and decided it would be a good helper method.