### PR TITLE
Prevent blocking loops on `PlainActionFuture`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -1167,7 +1167,14 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
                             threadPool.executor(NODE_RESTARTER).execute(mustSucceed(() -> {
                                 logger.info("--> restarting [{}]", nodeName);
-                                cluster.restartNode(nodeName);
+                                final var threadName = Thread.currentThread().getName();
+                                try {
+                                    // bypass deadlock detection on this thread
+                                    Thread.currentThread().setName("restarting " + nodeName);
+                                    cluster.restartNode(nodeName);
+                                } finally {
+                                    Thread.currentThread().setName(threadName);
+                                }
                                 logger.info("--> finished restarting [{}]", nodeName);
                                 shuffleNodes();
                                 Releasables.close(releaseAll);

--- a/server/src/main/java/org/elasticsearch/action/support/AllowedExecutors.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AllowedExecutors.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.set.Sets;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A digraph of the executors that are allowed to block while waiting for a future to be completed on a different threadpool. To avoid
+ * deadlocks there must be no cycles in this digraph.
+ */
+class AllowedExecutors {
+    static class AllowedExecutorsEntry implements Map.Entry<String, Set<String>> {
+        private final String key;
+        private final Set<String> value;
+
+        AllowedExecutorsEntry(String key, Set<String> value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public Set<String> getValue() {
+            return value;
+        }
+
+        @Override
+        public Set<String> setValue(Set<String> value) {
+            assert false : "unexpected";
+            return null;
+        }
+    }
+
+    /**
+     * @return a digraph of the executors which are permitted to block each other in production.
+     */
+    static Map<String, Set<String>> getProductionAllowedExecutors() {
+        return getAllowedExecutors(
+            newEntry("ccr" /* does not block */),
+            newEntry("clusterApplierService#updateTask" /* does not block */),
+            newEntry("get" /* does not block */),
+            newEntry("masterService#updateTask" /* does not block */),
+            newEntry("searchable_snapshots_cache_fetch_async" /* does not block */),
+            newEntry("system_read" /* does not block */),
+            newEntry("system_write" /* does not block */),
+            newEntry("transport_worker" /* does not block */),
+            newEntry("write" /* does not block */),
+            newEntry(
+                "file-watcher",
+                /* blocks on futures completed by: */
+                "masterService#updateTask"
+            ),
+            newEntry(
+                "management",
+                /* blocks on futures completed by: */
+                "system_read"
+            ),
+            newEntry(
+                "cluster_coordination",
+                /* blocks on futures completed by: */
+                "transport_worker"
+            ),
+            newEntry(
+                "watcher",
+                /* blocks on futures completed by: */
+                "get",
+                "system_read"
+            ),
+            newEntry(
+                "watcher-lifecycle",
+                /* blocks on futures completed by: */
+                "system_read",
+                "get"
+            ),
+            newEntry(
+                "search",
+                /* blocks on futures completed by: */
+                "searchable_snapshots_cache_fetch_async"
+            ),
+            newEntry(
+                "search_worker",
+                /* blocks on futures completed by: */
+                "searchable_snapshots_cache_fetch_async"
+            ),
+            newEntry(
+                "searchable_snapshots_cache_prewarming",
+                /* blocks on futures completed by: */
+                "searchable_snapshots_cache_fetch_async"
+            ),
+            newEntry(
+                "ml_job_comms",
+                /* blocks on futures completed by: */
+                "clusterApplierService#updateTask",
+                "masterService#updateTask",
+                "search",
+                "transport_worker",
+                "write"
+            ),
+            newEntry(
+                "ml_utility",
+                /* blocks on futures completed by: */
+                "clusterApplierService#updateTask",
+                "management",
+                "masterService#updateTask",
+                "system_read",
+                "system_write",
+                "transport_worker",
+                "write"
+            ),
+            newEntry(
+                "snapshot_meta",
+                /* blocks on futures completed by: */
+                "ccr"
+            ),
+            newEntry(
+                "generic",
+                /* blocks on futures completed by: */
+                "ccr",
+                "management",
+                "masterService#updateTask",
+                "searchable_snapshots_cache_fetch_async",
+                "system_read",
+                "transport_worker"
+            ),
+            newEntry(
+                "snapshot",
+                /* blocks on futures completed by: */
+                "generic",
+                "searchable_snapshots_cache_fetch_async",
+                "system_read",
+                "transport_worker"
+            )
+        );
+    }
+
+    /**
+     * @return a digraph of the executors which are permitted to block each other according to the given entries.
+     * @throws IllegalStateException if the input entries are not topologically sorted.
+     */
+    static Map<String, Set<String>> getAllowedExecutors(AllowedExecutorsEntry... entries) {
+        final var keys = Sets.newHashSetWithExpectedSize(entries.length);
+        for (final var entry : entries) {
+            if (keys.contains(entry.key)) {
+                throw new IllegalStateException(Strings.format("duplicate key %s", entry.getKey()));
+            }
+            if (keys.containsAll(entry.getValue()) == false) {
+                throw new IllegalStateException(
+                    Strings.format(
+                        "input is not topologically sorted: threadpool [%s] may only block on a subset of %s, saw %s",
+                        entry.getKey(),
+                        keys,
+                        entry.getValue()
+                    )
+                );
+            }
+            keys.add(entry.getKey());
+        }
+        return Map.ofEntries(entries);
+    }
+
+    static AllowedExecutorsEntry newEntry(String waitingThread, String... completingThreads) {
+        return new AllowedExecutorsEntry(waitingThread, Set.of(completingThreads));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -22,7 +22,9 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transports;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -387,6 +389,10 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
         assert thread1 != thread2 : "only call this for different threads";
         String thread1Name = EsExecutors.executorName(thread1);
         String thread2Name = EsExecutors.executorName(thread2);
-        return thread1Name == null || thread2Name == null || thread1Name.equals(thread2Name) == false;
+        return thread1Name == null
+            || thread2Name == null
+            || ALLOWED_EXECUTORS_GRAPH.getOrDefault(thread1Name, Set.of()).contains(thread2Name);
     }
+
+    private static final Map<String, Set<String>> ALLOWED_EXECUTORS_GRAPH = AllowedExecutors.getProductionAllowedExecutors();
 }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -308,13 +308,18 @@ public class EsExecutors {
     }
 
     public static String executorName(String threadName) {
+        if (threadName.startsWith("TEST-") || threadName.startsWith("SUITE-") || threadName.startsWith("LuceneTestCase")) {
+            return null;
+        }
+
+        if (threadName.startsWith("elasticsearch[file-watcher[")) {
+            return "file-watcher";
+        }
+
         // subtract 2 to avoid the `]` of the thread number part.
         int executorNameEnd = threadName.lastIndexOf(']', threadName.length() - 2);
         int executorNameStart = threadName.lastIndexOf('[', executorNameEnd);
-        if (executorNameStart == -1
-            || executorNameEnd - executorNameStart <= 1
-            || threadName.startsWith("TEST-")
-            || threadName.startsWith("LuceneTestCase")) {
+        if (executorNameStart == -1 || executorNameEnd - executorNameStart <= 1) {
             return null;
         }
         return threadName.substring(executorNameStart + 1, executorNameEnd);

--- a/server/src/test/java/org/elasticsearch/action/support/AllowedExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/AllowedExecutorsTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.action.support.AllowedExecutors.getAllowedExecutors;
+import static org.elasticsearch.action.support.AllowedExecutors.newEntry;
+
+public class AllowedExecutorsTests extends ESTestCase {
+    public void test() {
+        assertEquals(Map.of(), getAllowedExecutors());
+        assertEquals(Map.of("p1", Set.of()), getAllowedExecutors(newEntry("p1")));
+        assertEquals(Map.of("p1", Set.of(), "p2", Set.of()), getAllowedExecutors(newEntry("p1"), newEntry("p2")));
+        assertEquals(Map.of("p1", Set.of(), "p2", Set.of("p1")), getAllowedExecutors(newEntry("p1"), newEntry("p2", "p1")));
+        expectThrows(IllegalStateException.class, () -> getAllowedExecutors(newEntry("p1", "p2")));
+        expectThrows(IllegalStateException.class, () -> getAllowedExecutors(newEntry("p2", "p1"), newEntry("p1")));
+        expectThrows(IllegalStateException.class, () -> getAllowedExecutors(newEntry("p1"), newEntry("p2", "p2")));
+        expectThrows(IllegalStateException.class, () -> getAllowedExecutors(newEntry("p1"), newEntry("p1")));
+        AllowedExecutors.getProductionAllowedExecutors(); // must not throw
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ClusterInfoServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ClusterInfoServiceUtils.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 
 import java.util.concurrent.TimeUnit;
@@ -21,7 +22,7 @@ public class ClusterInfoServiceUtils {
 
     public static ClusterInfo refresh(InternalClusterInfoService internalClusterInfoService) {
         logger.trace("refreshing cluster info");
-        final PlainActionFuture<ClusterInfo> future = new PlainActionFuture<>() {
+        final PlainActionFuture<ClusterInfo> future = new TestPlainActionFuture<>() {
             @Override
             protected boolean blockingAllowed() {
                 // In tests we permit blocking the applier thread here so that we know a followup reroute isn't working with stale data.


### PR DESCRIPTION
Extending the work of #108934, this commit adds a check that there are
no loops of executors that might block on each other, causing a
harder-to-detect possible deadlock than one that only involves a single
executor.