### PR TITLE
Remove `PlainActionFuture#get` utility

### DIFF
--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -22,8 +22,6 @@ import com.sun.net.httpserver.HttpHandler;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
-import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -121,22 +119,13 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         return settings.build();
     }
 
-    public void testDeleteSingleItem() {
+    public void testDeleteSingleItem() throws IOException {
         final String repoName = createRepository(randomRepositoryName());
         final RepositoriesService repositoriesService = internalCluster().getAnyMasterNodeInstance(RepositoriesService.class);
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repoName);
-        PlainActionFuture.get(
-            f -> repository.threadPool()
-                .generic()
-                .execute(
-                    ActionRunnable.run(
-                        f,
-                        () -> repository.blobStore()
-                            .blobContainer(repository.basePath())
-                            .deleteBlobsIgnoringIfNotExists(randomPurpose(), Iterators.single("foo"))
-                    )
-                )
-        );
+        repository.blobStore()
+            .blobContainer(repository.basePath())
+            .deleteBlobsIgnoringIfNotExists(randomPurpose(), Iterators.single("foo"));
     }
 
     public void testChunkSize() {

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -14,8 +14,6 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
-import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -418,23 +416,14 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
         final BytesReference serialized = BytesReference.bytes(
             modifiedRepositoryData.snapshotsToXContent(XContentFactory.jsonBuilder(), SnapshotsService.OLD_SNAPSHOT_FORMAT)
         );
-        PlainActionFuture.get(
-            f -> repository.threadPool()
-                .generic()
-                .execute(
-                    ActionRunnable.run(
-                        f,
-                        () -> repository.blobStore()
-                            .blobContainer(repository.basePath())
-                            .writeBlobAtomic(
-                                randomNonDataPurpose(),
-                                BlobStoreRepository.INDEX_FILE_PREFIX + modifiedRepositoryData.getGenId(),
-                                serialized,
-                                true
-                            )
-                    )
-                )
-        );
+        repository.blobStore()
+            .blobContainer(repository.basePath())
+            .writeBlobAtomic(
+                randomNonDataPurpose(),
+                BlobStoreRepository.INDEX_FILE_PREFIX + modifiedRepositoryData.getGenId(),
+                serialized,
+                true
+            );
 
         final String newSnapshotName = "snapshot-new";
         final long beforeThrottledSnapshot = repository.threadPool().relativeTimeInNanos();

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -86,16 +86,13 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
     }
 
     public void testConnectException() throws UnknownHostException {
-        try {
-            connectToNode(
-                serviceA,
-                DiscoveryNodeUtils.create("C", new TransportAddress(InetAddress.getByName("localhost"), 9876), emptyMap(), emptySet())
-            );
-            fail("Expected ConnectTransportException");
-        } catch (ConnectTransportException e) {
-            assertThat(e.getMessage(), containsString("connect_exception"));
-            assertThat(e.getMessage(), containsString("[127.0.0.1:9876]"));
-        }
+        final var e = connectToNodeExpectFailure(
+            serviceA,
+            DiscoveryNodeUtils.create("C", new TransportAddress(InetAddress.getByName("localhost"), 9876), emptyMap(), emptySet()),
+            null
+        );
+        assertThat(e.getMessage(), containsString("connect_exception"));
+        assertThat(e.getMessage(), containsString("[127.0.0.1:9876]"));
     }
 
     public void testDefaultKeepAliveSettings() throws IOException {
@@ -236,10 +233,7 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
                 final ConnectionProfile profile = builder.build();
                 // now with the 1ms timeout we got and test that is it's applied
                 long startTime = System.nanoTime();
-                ConnectTransportException ex = expectThrows(
-                    ConnectTransportException.class,
-                    () -> openConnection(service, second, profile)
-                );
+                ConnectTransportException ex = openConnectionExpectFailure(service, second, profile);
                 final long now = System.nanoTime();
                 final long timeTaken = TimeValue.nsecToMSec(now - startTime);
                 assertTrue(

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -8,12 +8,10 @@
 package org.elasticsearch.snapshots;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -34,7 +32,6 @@ import org.elasticsearch.repositories.ShardGeneration;
 import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.fs.FsRepository;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.nio.channels.SeekableByteChannel;
@@ -309,18 +306,8 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         );
 
         logger.info("--> verify that repo is assumed in old metadata format");
-        final ThreadPool threadPool = internalCluster().getCurrentMasterNodeInstance(ThreadPool.class);
         assertThat(
-            PlainActionFuture.get(
-                // any other executor than generic and management
-                f -> threadPool.executor(ThreadPool.Names.SNAPSHOT)
-                    .execute(
-                        ActionRunnable.supply(
-                            f,
-                            () -> SnapshotsService.minCompatibleVersion(IndexVersion.current(), getRepositoryData(repoName), null)
-                        )
-                    )
-            ),
+            SnapshotsService.minCompatibleVersion(IndexVersion.current(), getRepositoryData(repoName), null),
             is(SnapshotsService.OLD_SNAPSHOT_FORMAT)
         );
 
@@ -329,15 +316,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
 
         logger.info("--> verify that repository is assumed in new metadata format after removing corrupted snapshot");
         assertThat(
-            PlainActionFuture.get(
-                f -> threadPool.generic()
-                    .execute(
-                        ActionRunnable.supply(
-                            f,
-                            () -> SnapshotsService.minCompatibleVersion(IndexVersion.current(), getRepositoryData(repoName), null)
-                        )
-                    )
-            ),
+            SnapshotsService.minCompatibleVersion(IndexVersion.current(), getRepositoryData(repoName), null),
             is(IndexVersion.current())
         );
         final RepositoryData finalRepositoryData = getRepositoryData(repoName);

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -367,12 +366,6 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
             return runtimeException;
         }
         return new UncategorizedExecutionException("Failed execution", root);
-    }
-
-    public static <T, E extends Exception> T get(CheckedConsumer<PlainActionFuture<T>, E> e) throws E {
-        PlainActionFuture<T> fut = new PlainActionFuture<>();
-        e.accept(fut);
-        return fut.actionGet();
     }
 
     private boolean assertCompleteAllowed() {

--- a/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.CheckedConsumer;
 
 import java.util.Objects;
 
@@ -42,11 +41,5 @@ public class UnsafePlainActionFuture<T> extends PlainActionFuture<T> {
             || unsafeExecutor.equals(EsExecutors.executorName(thread1))
             || unsafeExecutor2 == null
             || unsafeExecutor2.equals(EsExecutors.executorName(thread1));
-    }
-
-    public static <T, E extends Exception> T get(CheckedConsumer<PlainActionFuture<T>, E> e, String allowedExecutor) throws E {
-        PlainActionFuture<T> fut = new UnsafePlainActionFuture<>(allowedExecutor);
-        e.accept(fut);
-        return fut.actionGet();
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -501,7 +501,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     @Override
     public void awaitIdle() {
         assert lifecycle.closed();
-        PlainActionFuture.<Void, RuntimeException>get(closedAndIdleListeners::addListener);
+        final var future = new PlainActionFuture<Void>();
+        closedAndIdleListeners.addListener(future);
+        future.actionGet(); // wait for as long as it takes
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here

--- a/server/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
@@ -131,16 +131,16 @@ public class ThreadedActionListenerTests extends ESTestCase {
 
         assertEquals(
             "ThreadedActionListener[DeterministicTaskQueue/forkingExecutor/NoopActionListener]/onResponse",
-            PlainActionFuture.get(future -> new ThreadedActionListener<Void>(deterministicTaskQueue.getThreadPool(s -> {
-                future.onResponse(s.toString());
+            safeAwait(listener -> new ThreadedActionListener<Void>(deterministicTaskQueue.getThreadPool(s -> {
+                listener.onResponse(s.toString());
                 return s;
             }).generic(), randomBoolean(), ActionListener.noop()).onResponse(null))
         );
 
         assertEquals(
             "ThreadedActionListener[DeterministicTaskQueue/forkingExecutor/NoopActionListener]/onFailure",
-            PlainActionFuture.get(future -> new ThreadedActionListener<Void>(deterministicTaskQueue.getThreadPool(s -> {
-                future.onResponse(s.toString());
+            safeAwait(listener -> new ThreadedActionListener<Void>(deterministicTaskQueue.getThreadPool(s -> {
+                listener.onResponse(s.toString());
                 return s;
             }).generic(), randomBoolean(), ActionListener.noop()).onFailure(new ElasticsearchException("test")))
         );

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
@@ -95,10 +94,11 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
             );
             assertEquals(
                 "fake remote-cluster client",
-                expectThrows(
+                asInstanceOf(
                     UnsupportedOperationException.class,
-                    () -> PlainActionFuture.<ClusterStateResponse, Exception>get(
-                        fut -> remoteClusterClient.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(), fut)
+                    safeAwaitFailure(
+                        ClusterStateResponse.class,
+                        listener -> remoteClusterClient.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(), listener)
                     )
                 ).getMessage()
             );

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.cluster.coordination.stateless;
 
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.core.TimeValue;
@@ -66,7 +65,7 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
 
         // Either there's no heartbeat or is stale
         if (randomBoolean()) {
-            PlainActionFuture.<Void, Exception>get(f -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), f));
+            safeAwait((ActionListener<Void> l) -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), l));
             fakeClock.set(maxTimeSinceLastHeartbeat.millis() + randomLongBetween(0, 1000));
         }
 
@@ -107,7 +106,7 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
                 }
             };
 
-            PlainActionFuture.<Void, Exception>get(f -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), f));
+            safeAwait((ActionListener<Void> l) -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), l));
             fakeClock.addAndGet(randomLongBetween(0L, maxTimeSinceLastHeartbeat.millis() - 1));
 
             var startElection = new AtomicBoolean();
@@ -141,7 +140,7 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
             }
         };
 
-        PlainActionFuture.<Void, Exception>get(f -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), f));
+        safeAwait((ActionListener<Void> l) -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), l));
 
         var startElection = new AtomicBoolean();
         var preVoteCollector = new AtomicRegisterPreVoteCollector(heartbeatService, () -> startElection.set(true));

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
@@ -66,7 +66,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         final var currentLeader = DiscoveryNodeUtils.create("master");
         heartbeatService.start(currentLeader, currentTermProvider.get(), completionListener);
 
-        Heartbeat firstHeartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+        Heartbeat firstHeartbeat = safeAwait(heartbeatStore::readLatestHeartbeat);
         assertThat(firstHeartbeat, is(notNullValue()));
         assertThat(firstHeartbeat.term(), is(equalTo(1L)));
         assertThat(firstHeartbeat.absoluteTimeInMillis(), is(lessThanOrEqualTo(threadPool.absoluteTimeInMillis())));
@@ -79,7 +79,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
 
         assertThat(completionListener.isDone(), is(false));
 
-        Heartbeat secondHeartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+        Heartbeat secondHeartbeat = safeAwait(heartbeatStore::readLatestHeartbeat);
         assertThat(secondHeartbeat, is(notNullValue()));
         assertThat(secondHeartbeat.term(), is(equalTo(1L)));
         assertThat(secondHeartbeat.absoluteTimeInMillis(), is(greaterThanOrEqualTo(firstHeartbeat.absoluteTimeInMillis())));
@@ -95,7 +95,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         // No new tasks are scheduled after stopping the heart beat service
         assertThat(threadPool.scheduledTasks.poll(), is(nullValue()));
 
-        Heartbeat heartbeatAfterStoppingTheService = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+        Heartbeat heartbeatAfterStoppingTheService = safeAwait(heartbeatStore::readLatestHeartbeat);
         assertThat(heartbeatAfterStoppingTheService, is(equalTo(secondHeartbeat)));
 
         assertThat(completionListener.isDone(), is(false));
@@ -134,7 +134,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         heartbeatService.start(currentLeader, currentTermProvider.get(), completionListener);
 
         if (failFirstHeartBeat == false) {
-            Heartbeat firstHeartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+            Heartbeat firstHeartbeat = safeAwait(heartbeatStore::readLatestHeartbeat);
             assertThat(firstHeartbeat, is(notNullValue()));
 
             var scheduledTask = threadPool.scheduledTasks.poll();
@@ -179,7 +179,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         heartbeatService.start(currentLeader, currentTerm, completionListener);
 
         if (termBumpBeforeStart == false) {
-            Heartbeat firstHeartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+            Heartbeat firstHeartbeat = safeAwait(heartbeatStore::readLatestHeartbeat);
             assertThat(firstHeartbeat, is(notNullValue()));
 
             var scheduledTask = threadPool.scheduledTasks.poll();
@@ -229,7 +229,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
 
         // Empty store
         {
-            Heartbeat heartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+            Heartbeat heartbeat = safeAwait(heartbeatStore::readLatestHeartbeat);
             assertThat(heartbeat, is(nullValue()));
 
             AtomicBoolean noRecentLeaderFound = new AtomicBoolean();
@@ -239,7 +239,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
 
         // Recent heartbeat
         {
-            PlainActionFuture.<Void, Exception>get(f -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), f));
+            safeAwait((ActionListener<Void> l) -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), l));
 
             AtomicBoolean noRecentLeaderFound = new AtomicBoolean();
             heartbeatService.checkLeaderHeartbeatAndRun(() -> noRecentLeaderFound.set(true), hb -> {});
@@ -248,7 +248,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
 
         // Stale heartbeat
         {
-            PlainActionFuture.<Void, Exception>get(f -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), f));
+            safeAwait((ActionListener<Void> l) -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), l));
             fakeClock.set(maxTimeSinceLastHeartbeat.millis() + 1);
 
             AtomicBoolean noRecentLeaderFound = new AtomicBoolean();
@@ -258,7 +258,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
 
         // Failing store
         {
-            PlainActionFuture.<Void, Exception>get(f -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), f));
+            safeAwait((ActionListener<Void> l) -> heartbeatStore.writeHeartbeat(new Heartbeat(1, fakeClock.get()), l));
             fakeClock.set(maxTimeSinceLastHeartbeat.millis() + 1);
             failReadingHeartbeat.set(true);
 
@@ -309,7 +309,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
 
         retryTask.v2().run();
 
-        Heartbeat firstHeartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
+        Heartbeat firstHeartbeat = safeAwait(heartbeatStore::readLatestHeartbeat);
         assertThat(firstHeartbeat, is(notNullValue()));
         assertThat(firstHeartbeat.term(), is(equalTo(1L)));
 

--- a/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.common.component;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -99,8 +99,8 @@ public class LifecycleTests extends ESTestCase {
 
         void testTransition(BooleanSupplier doTransition) {
             final var transitioned = new AtomicBoolean();
-            PlainActionFuture.<Void, RuntimeException>get(fut -> {
-                try (var listeners = new RefCountingListener(fut)) {
+            safeAwait((ActionListener<Void> listener) -> {
+                try (var listeners = new RefCountingListener(listener)) {
                     for (int i = 0; i < threads; i++) {
                         executor.execute(ActionRunnable.run(listeners.acquire(), () -> {
                             safeAwait(barrier);

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -706,7 +705,7 @@ public class DefaultRestChannelTests extends ESTestCase {
                 if (content.isLastPart()) {
                     return;
                 }
-                writeContent(bso, PlainActionFuture.get(content::getNextPart));
+                writeContent(bso, safeAwait(content::getNextPart));
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.repositories.blobstore;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.TestUtil;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -171,8 +170,8 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                 new SnapshotId(snapshot.getSnapshotId().getName(), "_uuid2")
             );
             final ShardGenerations shardGenerations = ShardGenerations.builder().put(indexId, 0, shardGen).build();
-            PlainActionFuture.<RepositoryData, Exception>get(
-                f -> repository.finalizeSnapshot(
+            final RepositoryData ignoredRepositoryData = safeAwait(
+                listener -> repository.finalizeSnapshot(
                     new FinalizeSnapshotContext(
                         shardGenerations,
                         RepositoryData.EMPTY_REPO_GEN,
@@ -192,7 +191,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                             Collections.emptyMap()
                         ),
                         IndexVersion.current(),
-                        f,
+                        listener,
                         info -> {}
                     )
                 )

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -119,7 +119,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
             validatedConnectionRef.set(c);
             l.onResponse(null);
         };
-        PlainActionFuture.get(fut -> connectionManager.connectToNode(node, connectionProfile, validator, fut.map(x -> null)));
+        safeAwait(listener -> connectionManager.connectToNode(node, connectionProfile, validator, listener.map(x -> null)));
 
         assertFalse(connection.isClosed());
         assertTrue(connectionManager.nodeConnected(node));
@@ -166,9 +166,9 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         final ConnectionManager.ConnectionValidator validator = (c, p, l) -> l.onResponse(null);
         final AtomicReference<Releasable> toClose = new AtomicReference<>();
 
-        PlainActionFuture.get(f -> connectionManager.connectToNode(remoteClose, connectionProfile, validator, f.map(x -> null)));
-        PlainActionFuture.get(f -> connectionManager.connectToNode(shutdownClose, connectionProfile, validator, f.map(x -> null)));
-        PlainActionFuture.get(f -> connectionManager.connectToNode(localClose, connectionProfile, validator, f.map(toClose::getAndSet)));
+        safeAwait(l -> connectionManager.connectToNode(remoteClose, connectionProfile, validator, l.map(x -> null)));
+        safeAwait(l -> connectionManager.connectToNode(shutdownClose, connectionProfile, validator, l.map(x -> null)));
+        safeAwait(l -> connectionManager.connectToNode(localClose, connectionProfile, validator, l.map(toClose::getAndSet)));
 
         final Releasable localConnectionRef = toClose.getAndSet(null);
         assertThat(localConnectionRef, notNullValue());

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -922,7 +922,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                         RemoteClusterCredentialsManager.EMPTY
                     )
                 ) {
-                    PlainActionFuture.get(fut -> connection.ensureConnected(fut.map(x -> null)));
+                    safeAwait(listener -> connection.ensureConnected(listener.map(x -> null)));
                     for (int i = 0; i < 10; i++) {
                         // always a direct connection as the remote node is already connected
                         Transport.Connection remoteConnection = connection.getConnection(seedNode);

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.VersionInformation;
@@ -21,6 +20,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
@@ -147,7 +147,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
                 TestProfiles.LIGHT_PROFILE
             )
         ) {
-            DiscoveryNode connectedNode = PlainActionFuture.get(fut -> transportServiceA.handshake(connection, timeout, fut));
+            DiscoveryNode connectedNode = safeAwait(listener -> transportServiceA.handshake(connection, timeout, listener));
             assertNotNull(connectedNode);
             // the name and version should be updated
             assertEquals(connectedNode.getName(), "TS_B");
@@ -177,21 +177,23 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             .roles(emptySet())
             .version(Version.CURRENT.minimumCompatibilityVersion(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
             .build();
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> {
-            try (
-                Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
-                    transportServiceA,
-                    discoveryNode,
-                    TestProfiles.LIGHT_PROFILE
+        try (
+            Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
+                transportServiceA,
+                discoveryNode,
+                TestProfiles.LIGHT_PROFILE
+            )
+        ) {
+            assertThat(
+                asInstanceOf(
+                    IllegalStateException.class,
+                    safeAwaitFailure(DiscoveryNode.class, listener -> transportServiceA.handshake(connection, timeout, listener))
+                ).getMessage(),
+                containsString(
+                    "handshake with [" + discoveryNode + "] failed: remote cluster name [b] does not match local cluster name [a]"
                 )
-            ) {
-                PlainActionFuture.get(fut -> transportServiceA.handshake(connection, timeout, fut.map(x -> null)));
-            }
-        });
-        assertThat(
-            ex.getMessage(),
-            containsString("handshake with [" + discoveryNode + "] failed: remote cluster name [b] does not match local cluster name [a]")
-        );
+            );
+        }
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
     }
 
@@ -220,29 +222,29 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             .roles(emptySet())
             .version(Version.CURRENT.minimumCompatibilityVersion(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
             .build();
-        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> {
-            try (
-                Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
-                    transportServiceA,
-                    discoveryNode,
-                    TestProfiles.LIGHT_PROFILE
-                )
-            ) {
-                PlainActionFuture.get(fut -> transportServiceA.handshake(connection, timeout, fut.map(x -> null)));
-            }
-        });
-        assertThat(
-            ex.getMessage(),
-            containsString(
-                "handshake with ["
-                    + discoveryNode
-                    + "] failed: remote node version ["
-                    + transportServiceB.getLocalNode().getVersion()
-                    + "] is incompatible with local node version ["
-                    + Version.CURRENT
-                    + "]"
+        try (
+            Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
+                transportServiceA,
+                discoveryNode,
+                TestProfiles.LIGHT_PROFILE
             )
-        );
+        ) {
+            assertThat(
+                asInstanceOf(
+                    IllegalStateException.class,
+                    safeAwaitFailure(DiscoveryNode.class, listener -> transportServiceA.handshake(connection, timeout, listener))
+                ).getMessage(),
+                containsString(
+                    "handshake with ["
+                        + discoveryNode
+                        + "] failed: remote node version ["
+                        + transportServiceB.getLocalNode().getVersion()
+                        + "] is incompatible with local node version ["
+                        + Version.CURRENT
+                        + "]"
+                )
+            );
+        }
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
     }
 
@@ -267,17 +269,13 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             .roles(emptySet())
             .version(Version.CURRENT.minimumCompatibilityVersion(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
             .build();
-        expectThrows(ConnectTransportException.class, () -> {
-            try (
-                Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
-                    transportServiceA,
-                    discoveryNode,
-                    TestProfiles.LIGHT_PROFILE
-                )
-            ) {
-                PlainActionFuture.get(fut -> transportServiceA.handshake(connection, timeout, fut.map(x -> null)));
-            }
-        });
+        assertThat(
+            safeAwaitFailure(
+                Transport.Connection.class,
+                listener -> transportServiceA.openConnection(discoveryNode, TestProfiles.LIGHT_PROFILE, listener)
+            ),
+            instanceOf(ConnectTransportException.class)
+        );
         // the error is exposed as a general connection exception, the actual message is in the logs
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
     }
@@ -303,12 +301,14 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             .roles(emptySet())
             .version(transportServiceB.getLocalNode().getVersionInformation())
             .build();
-        ConnectTransportException ex = expectThrows(
-            ConnectTransportException.class,
-            () -> AbstractSimpleTransportTestCase.connectToNode(transportServiceA, discoveryNode, TestProfiles.LIGHT_PROFILE)
-        );
         assertThat(
-            ex.getMessage(),
+            asInstanceOf(
+                ConnectTransportException.class,
+                safeAwaitFailure(
+                    Releasable.class,
+                    listener -> transportServiceA.connectToNode(discoveryNode, TestProfiles.LIGHT_PROFILE, listener)
+                )
+            ).getMessage(),
             allOf(
                 containsString("Connecting to [" + discoveryNode.getAddress() + "] failed"),
                 containsString("expected to connect to [" + discoveryNode.descriptionWithoutAttributes() + "]"),
@@ -350,21 +350,24 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             .roles(emptySet())
             .version(Version.CURRENT.minimumCompatibilityVersion(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current())
             .build();
-        TransportSerializationException ex = expectThrows(TransportSerializationException.class, () -> {
-            try (
-                Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
-                    transportServiceA,
-                    discoveryNode,
-                    TestProfiles.LIGHT_PROFILE
-                )
-            ) {
-                PlainActionFuture.get(fut -> transportServiceA.handshake(connection, timeout, fut.map(x -> null)));
-            }
-        });
-        assertThat(
-            ExceptionsHelper.unwrap(ex, IllegalArgumentException.class).getMessage(),
-            containsString("which has an incompatible wire format")
-        );
+        try (
+            Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
+                transportServiceA,
+                discoveryNode,
+                TestProfiles.LIGHT_PROFILE
+            )
+        ) {
+            assertThat(
+                ExceptionsHelper.unwrap(
+                    asInstanceOf(
+                        TransportSerializationException.class,
+                        safeAwaitFailure(DiscoveryNode.class, listener -> transportServiceA.handshake(connection, timeout, listener))
+                    ),
+                    IllegalArgumentException.class
+                ).getMessage(),
+                containsString("which has an incompatible wire format")
+            );
+        }
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/action/support/TestPlainActionFuture.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/TestPlainActionFuture.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+/**
+ * A {@link PlainActionFuture} which bypasses the deadlock-detection checks since we're only using this in tests.
+ */
+public class TestPlainActionFuture<T> extends PlainActionFuture<T> {
+    @Override
+    boolean allowedExecutors(Thread thread1, Thread thread2) {
+        return true;
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -11,7 +11,6 @@ import org.apache.lucene.tests.mockfile.ExtrasFS;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequestBuilder;
@@ -292,12 +291,10 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
     }
 
     protected BlobStore newBlobStore(String repository) {
-        final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) internalCluster().getAnyMasterNodeInstance(
-            RepositoriesService.class
-        ).repository(repository);
-        return PlainActionFuture.get(
-            f -> blobStoreRepository.threadPool().generic().execute(ActionRunnable.supply(f, blobStoreRepository::blobStore))
-        );
+        return asInstanceOf(
+            BlobStoreRepository.class,
+            internalCluster().getAnyMasterNodeInstance(RepositoriesService.class).repository(repository)
+        ).blobStore();
     }
 
     public void testSnapshotAndRestore() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -44,8 +44,8 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.support.ActionTestUtils;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.bootstrap.BootstrapForTesting;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.cluster.ClusterModule;
@@ -2287,7 +2287,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * @return The value with which the {@code listener} was completed.
      */
     public static <T> T safeAwait(SubscribableListener<T> listener) {
-        final var future = new PlainActionFuture<T>();
+        final var future = new TestPlainActionFuture<T>();
         listener.addListener(future);
         return safeGet(future);
     }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1868,8 +1868,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         assertBusy(() -> assertFalse(serviceB.nodeConnected(nodeA)));
 
         // now try to connect again and see that it fails
-        expectThrows(ConnectTransportException.class, () -> connectToNode(serviceB, nodeA));
-        expectThrows(ConnectTransportException.class, () -> openConnection(serviceB, nodeA, TestProfiles.LIGHT_PROFILE));
+        assertNotNull(connectToNodeExpectFailure(serviceB, nodeA, null));
+        assertNotNull(openConnectionExpectFailure(serviceB, nodeA, TestProfiles.LIGHT_PROFILE));
     }
 
     public void testMockUnresponsiveRule() throws InterruptedException {
@@ -1916,11 +1916,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         );
 
         assertThat(expectThrows(ExecutionException.class, res::get).getCause(), instanceOf(ReceiveTimeoutTransportException.class));
-        expectThrows(ConnectTransportException.class, () -> {
-            serviceB.disconnectFromNode(nodeA);
-            connectToNode(serviceB, nodeA);
-        });
-        expectThrows(ConnectTransportException.class, () -> openConnection(serviceB, nodeA, TestProfiles.LIGHT_PROFILE));
+        serviceB.disconnectFromNode(nodeA);
+        assertNotNull(connectToNodeExpectFailure(serviceB, nodeA, null));
+        assertNotNull(openConnectionExpectFailure(serviceB, nodeA, TestProfiles.LIGHT_PROFILE));
     }
 
     public void testHostOnMessages() throws InterruptedException {
@@ -2342,7 +2340,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportRequestOptions.Type.REG,
                 TransportRequestOptions.Type.STATE
             );
-            expectThrows(ConnectTransportException.class, () -> openConnection(serviceA, node, builder.build()));
+            assertNotNull(openConnectionExpectFailure(serviceA, node, builder.build()));
         }
     }
 
@@ -2448,10 +2446,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportRequestOptions.Type.STATE
             );
             builder.setHandshakeTimeout(TimeValue.timeValueMillis(1));
-            ConnectTransportException ex = expectThrows(
-                ConnectTransportException.class,
-                () -> connectToNode(serviceA, dummy, builder.build())
-            );
+            ConnectTransportException ex = connectToNodeExpectFailure(serviceA, dummy, builder.build());
             assertEquals("[][" + dummy.getAddress() + "] handshake_timeout[1ms]", ex.getMessage());
         }
     }
@@ -2488,10 +2483,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportRequestOptions.Type.STATE
             );
             builder.setHandshakeTimeout(TimeValue.timeValueHours(1));
-            ConnectTransportException ex = expectThrows(
-                ConnectTransportException.class,
-                () -> connectToNode(serviceA, dummy, builder.build())
-            );
+            ConnectTransportException ex = connectToNodeExpectFailure(serviceA, dummy, builder.build());
             assertEquals("[][" + dummy.getAddress() + "] general node connection failure", ex.getMessage());
             assertThat(ex.getCause().getMessage(), startsWith("handshake failed"));
             t.join();
@@ -3160,10 +3152,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 TransportRequestOptions.Type.REG,
                 TransportRequestOptions.Type.STATE
             );
-            final ConnectTransportException e = expectThrows(
-                ConnectTransportException.class,
-                () -> openConnection(service, nodeA, builder.build())
-            );
+            final ConnectTransportException e = openConnectionExpectFailure(service, nodeA, builder.build());
             assertThat(e, hasToString(containsString(("a channel closed while connecting"))));
             assertTrue(connectionClosedListenerCalled.get());
         }
@@ -3506,7 +3495,21 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
      * @param connectionProfile the connection profile to use when connecting to this node
      */
     public static void connectToNode(TransportService service, DiscoveryNode node, ConnectionProfile connectionProfile) {
-        UnsafePlainActionFuture.get(fut -> service.connectToNode(node, connectionProfile, fut.map(x -> null)), ThreadPool.Names.GENERIC);
+        safeAwait(listener -> service.connectToNode(node, connectionProfile, listener.map(ignored -> null)));
+    }
+
+    /**
+     * Attempt to connect to the specified node, but assert that this fails and return the resulting exception.
+     */
+    public static ConnectTransportException connectToNodeExpectFailure(
+        TransportService service,
+        DiscoveryNode node,
+        ConnectionProfile connectionProfile
+    ) {
+        return asInstanceOf(
+            ConnectTransportException.class,
+            safeAwaitFailure(Releasable.class, listener -> service.connectToNode(node, connectionProfile, listener))
+        );
     }
 
     /**
@@ -3517,7 +3520,21 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
      * @param connectionProfile the connection profile to use
      */
     public static Transport.Connection openConnection(TransportService service, DiscoveryNode node, ConnectionProfile connectionProfile) {
-        return PlainActionFuture.get(fut -> service.openConnection(node, connectionProfile, fut));
+        return safeAwait(listener -> service.openConnection(node, connectionProfile, listener));
+    }
+
+    /**
+     * Attempt to connect to the specified node, but assert that this fails and return the resulting exception.
+     */
+    public static ConnectTransportException openConnectionExpectFailure(
+        TransportService service,
+        DiscoveryNode node,
+        ConnectionProfile connectionProfile
+    ) {
+        return asInstanceOf(
+            ConnectTransportException.class,
+            safeAwaitFailure(Transport.Connection.class, listener -> service.openConnection(node, connectionProfile, listener))
+        );
     }
 
     public static <T extends TransportResponse> Future<T> submitRequest(

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -593,32 +593,28 @@ public class DisruptableMockTransportTests extends ESTestCase {
 
         disconnectedLinks.add(Tuple.tuple(node1, node2));
         assertThat(
-            expectThrows(ConnectTransportException.class, () -> AbstractSimpleTransportTestCase.connectToNode(service1, node2))
-                .getMessage(),
+            AbstractSimpleTransportTestCase.connectToNodeExpectFailure(service1, node2, null).getMessage(),
             endsWith("is [DISCONNECTED] not [CONNECTED]")
         );
         disconnectedLinks.clear();
 
         blackholedLinks.add(Tuple.tuple(node1, node2));
         assertThat(
-            expectThrows(ConnectTransportException.class, () -> AbstractSimpleTransportTestCase.connectToNode(service1, node2))
-                .getMessage(),
+            AbstractSimpleTransportTestCase.connectToNodeExpectFailure(service1, node2, null).getMessage(),
             endsWith("is [BLACK_HOLE] not [CONNECTED]")
         );
         blackholedLinks.clear();
 
         blackholedRequestLinks.add(Tuple.tuple(node1, node2));
         assertThat(
-            expectThrows(ConnectTransportException.class, () -> AbstractSimpleTransportTestCase.connectToNode(service1, node2))
-                .getMessage(),
+            AbstractSimpleTransportTestCase.connectToNodeExpectFailure(service1, node2, null).getMessage(),
             endsWith("is [BLACK_HOLE_REQUESTS_ONLY] not [CONNECTED]")
         );
         blackholedRequestLinks.clear();
 
         final DiscoveryNode node3 = DiscoveryNodeUtils.create("node3");
         assertThat(
-            expectThrows(ConnectTransportException.class, () -> AbstractSimpleTransportTestCase.connectToNode(service1, node3))
-                .getMessage(),
+            AbstractSimpleTransportTestCase.connectToNodeExpectFailure(service1, node3, null).getMessage(),
             endsWith("does not exist")
         );
     }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -591,19 +591,15 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 threads[i] = new Thread(() -> {
                     for (int j = 0; j < 1000; j++) {
                         final var cacheKey = generateCacheKey();
-                        try {
-                            PlainActionFuture.<Void, Exception>get(
-                                f -> cacheService.maybeFetchFullEntry(
-                                    cacheKey,
-                                    size,
-                                    (channel, channelPos, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
-                                    bulkExecutor,
-                                    f
-                                )
-                            );
-                        } catch (Exception e) {
-                            throw new AssertionError(e);
-                        }
+                        safeAwait(
+                            (ActionListener<Void> listener) -> cacheService.maybeFetchFullEntry(
+                                cacheKey,
+                                size,
+                                (channel, channelPos, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
+                                bulkExecutor,
+                                listener
+                            )
+                        );
                     }
                 });
             }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -834,12 +834,12 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
         @Override
         protected void performOnReplica(BulkShardOperationsRequest request, IndexShard replica) throws Exception {
             try (
-                Releasable ignored = PlainActionFuture.get(
-                    f -> replica.acquireReplicaOperationPermit(
+                Releasable ignored = safeAwait(
+                    listener -> replica.acquireReplicaOperationPermit(
                         getPrimaryShard().getPendingPrimaryTerm(),
                         getPrimaryShard().getLastKnownGlobalCheckpoint(),
                         getPrimaryShard().getMaxSeqNoOfUpdatesOrDeletes(),
-                        f,
+                        ActionListener.assertOnce(listener),
                         EsExecutors.DIRECT_EXECUTOR_SERVICE
                     )
                 )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -363,13 +363,11 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                 indexId
             )
         ).build();
-        IndexMetadata metadata = runAsSnapshot(
-            threadPool,
-            () -> repository.getSnapshotIndexMetaData(
-                PlainActionFuture.get(listener -> repository.getRepositoryData(EsExecutors.DIRECT_EXECUTOR_SERVICE, listener)),
-                snapshotId,
-                indexId
-            )
+
+        IndexMetadata metadata = repository.getSnapshotIndexMetaData(
+            safeAwait(listener -> repository.getRepositoryData(EsExecutors.DIRECT_EXECUTOR_SERVICE, listener)),
+            snapshotId,
+            indexId
         );
         IndexShard restoredShard = newShard(
             shardRouting,


### PR DESCRIPTION
This utility is almost entirely used in tests where an infinite wait is
inappropriate, and the exception-mangling behaviour is unhelpful, so
this commit replaces it with safer alternatives. There should be no need
for an easy way to block production threads forever.