### PR TITLE
Fix FileSettingsUpgradeIT to not create irrelevant clusters at all

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -85,8 +85,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
   method: testCacheFileCreatedAsSparseFile
   issue: https://github.com/elastic/elasticsearch/issues/110801
-- class: org.elasticsearch.upgrades.FileSettingsUpgradeIT
-  issue: https://github.com/elastic/elasticsearch/issues/110884
 - class: "org.elasticsearch.xpack.watcher.test.integration.HistoryIntegrationTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110885"
   method: "testPayloadInputWithDotsInFieldNameWorks"

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsUpgradeIT.java
@@ -15,11 +15,10 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
-import org.elasticsearch.test.cluster.local.DefaultLocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
-import org.junit.BeforeClass;
+import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -33,10 +32,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class FileSettingsUpgradeIT extends ParameterizedRollingUpgradeTestCase {
 
-    @BeforeClass
-    public static void checkVersion() {
-        assumeTrue("Only valid when upgrading from pre-file settings", getOldClusterTestVersion().before(new Version(8, 4, 0)));
-    }
+    private static final RunnableTestRuleAdapter versionLimit = new RunnableTestRuleAdapter(
+        () -> assumeTrue("Only valid when upgrading from pre-file settings", getOldClusterTestVersion().before(new Version(8, 4, 0))));
 
     private static final String settingsJSON = """
         {
@@ -53,7 +50,7 @@ public class FileSettingsUpgradeIT extends ParameterizedRollingUpgradeTestCase {
 
     private static final TemporaryFolder repoDirectory = new TemporaryFolder();
 
-    private static final ElasticsearchCluster cluster = new DefaultLocalClusterSpecBuilder().distribution(DistributionType.DEFAULT)
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local().distribution(DistributionType.DEFAULT)
         .version(getOldClusterTestVersion())
         .nodes(NODE_NUM)
         .setting("path.repo", new Supplier<>() {
@@ -69,7 +66,7 @@ public class FileSettingsUpgradeIT extends ParameterizedRollingUpgradeTestCase {
         .build();
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
+    public static TestRule ruleChain = RuleChain.outerRule(versionLimit).around(repoDirectory).around(cluster);
 
     public FileSettingsUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsUpgradeIT.java
@@ -33,7 +33,8 @@ import static org.hamcrest.Matchers.equalTo;
 public class FileSettingsUpgradeIT extends ParameterizedRollingUpgradeTestCase {
 
     private static final RunnableTestRuleAdapter versionLimit = new RunnableTestRuleAdapter(
-        () -> assumeTrue("Only valid when upgrading from pre-file settings", getOldClusterTestVersion().before(new Version(8, 4, 0))));
+        () -> assumeTrue("Only valid when upgrading from pre-file settings", getOldClusterTestVersion().before(new Version(8, 4, 0)))
+    );
 
     private static final String settingsJSON = """
         {
@@ -50,7 +51,8 @@ public class FileSettingsUpgradeIT extends ParameterizedRollingUpgradeTestCase {
 
     private static final TemporaryFolder repoDirectory = new TemporaryFolder();
 
-    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local().distribution(DistributionType.DEFAULT)
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
         .version(getOldClusterTestVersion())
         .nodes(NODE_NUM)
         .setting("path.repo", new Supplier<>() {


### PR DESCRIPTION
@BeforeClass is executed after the test rules. This means it creates the clusters for all the invalid versions, which sometimes doesnt work.

Change it to a rule which definitely evaluates before the clusters are created. This will also speed up this test in CI

Fixes #110884