### PR TITLE
Optimize transport_thread exectures search logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -279,9 +279,14 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
     }
 
     private static void checkIndexBlocks(ClusterState clusterState, String[] concreteIndices) {
-        clusterState.blocks().globalBlockedRaiseException(ClusterBlockLevel.READ);
+        var blocks = clusterState.blocks();
+        if (blocks.global().isEmpty() && blocks.indices().isEmpty()) {
+            // short circuit optimization because block check below is relatively expensive for many indices
+            return;
+        }
+        blocks.globalBlockedRaiseException(ClusterBlockLevel.READ);
         for (String index : concreteIndices) {
-            clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index);
+            blocks.indexBlockedRaiseException(ClusterBlockLevel.READ, index);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -50,6 +50,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
@@ -543,10 +544,11 @@ public final class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * is an instance of this class, null otherwise.
      */
     public static FieldSortBuilder getPrimaryFieldSortOrNull(SearchSourceBuilder source) {
-        if (source == null || source.sorts() == null || source.sorts().isEmpty()) {
+        final List<SortBuilder<?>> sorts;
+        if (source == null || (sorts = source.sorts()) == null || sorts.isEmpty()) {
             return null;
         }
-        return source.sorts().get(0) instanceof FieldSortBuilder ? (FieldSortBuilder) source.sorts().get(0) : null;
+        return sorts.get(0) instanceof FieldSortBuilder fieldSortBuilder ? fieldSortBuilder : null;
     }
 
     /**


### PR DESCRIPTION
We can save a bunch of allocations and cycles in a few spots, the blocks checks in particular are very heavy if done in a loop over many indices. Also, presizing some collections, avoiding temporary collections where not necessary etc. helps a bit as well. None of this is very relevant for searches over few indices but all of it becomes quite visible in profiling once you target a larger number of indices/shards.