### PR TITLE
Fix references to incorrect query rule criteria type

### DIFF
--- a/docs/reference/query-rules/apis/put-query-rule.asciidoc
+++ b/docs/reference/query-rules/apis/put-query-rule.asciidoc
@@ -70,10 +70,10 @@ Matches all queries, regardless of input.
 --
 - `metadata` (Optional, string) The metadata field to match against.
 This metadata will be used to match against `match_criteria` sent in the <<query-dsl-rule-query>>.
-Required for all criteria types except `global`.
+Required for all criteria types except `always`.
 - `values` (Optional, array of strings) The values to match against the metadata field.
 Only one value must match for the criteria to be met.
-Required for all criteria types except `global`.
+Required for all criteria types except `always`.
 
 `actions`::
 (Required, object) The actions to take when the rule is matched.

--- a/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
@@ -78,10 +78,10 @@ Matches all queries, regardless of input.
 --
 - `metadata` (Optional, string) The metadata field to match against.
 This metadata will be used to match against `match_criteria` sent in the <<query-dsl-rule-query>>.
-Required for all criteria types except `global`.
+Required for all criteria types except `always`.
 - `values` (Optional, array of strings) The values to match against the metadata field.
 Only one value must match for the criteria to be met.
-Required for all criteria types except `global`.
+Required for all criteria types except `always`.
 
 Actions depend on the rule type.
 For `pinned` rules, actions follow the format specified by the <<query-dsl-pinned-query,Pinned Query>>.


### PR DESCRIPTION
`global` was renamed to `always` before launch, but not all documentation changes were caught at the time. 