### PR TITLE
Always allow rebalancing by default

### DIFF
--- a/docs/changelog/111015.yaml
+++ b/docs/changelog/111015.yaml
@@ -1,0 +1,15 @@
+pr: 111015
+summary: Always allow rebalancing by default
+area: Allocation
+type: enhancement
+issues: []
+highlight:
+  title: Always allow rebalancing by default
+  body: |-
+    In earlier versions of {es} the `cluster.routing.allocation.allow_rebalance` setting defaults to
+    `indices_all_active` which blocks all rebalancing moves while the cluster is in `yellow` or `red` health. This was
+    appropriate for the legacy allocator which might do too many rebalancing moves otherwise. Today's allocator has
+    better support for rebalancing a cluster that is not in `green` health, and expects to be able to rebalance some
+    shards away from over-full nodes to avoid allocating shards to undesirable locations in the first place. From
+    version 8.16 `allow_rebalance` setting defaults to `always` unless the legacy allocator is explicitly enabled.
+  notable: true

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -98,9 +98,9 @@ the cluster:
 Specify when shard rebalancing is allowed:
 
 
-* `always` -                    Always allow rebalancing.
+* `always` -                    (default) Always allow rebalancing.
 * `indices_primaries_active` -  Only when all primaries in the cluster are allocated.
-* `indices_all_active` -        (default) Only when all shards (primaries and replicas) in the cluster are allocated.
+* `indices_all_active` -        Only when all shards (primaries and replicas) in the cluster are allocated.
 --
 
 `cluster.routing.rebalance.enable`::

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDeciderIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.decider;
+
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 0)
+public class ClusterRebalanceAllocationDeciderIT extends ESIntegTestCase {
+    public void testDefault() {
+        internalCluster().startNode();
+        assertEquals(
+            ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS,
+            ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.get(
+                internalCluster().getInstance(ClusterService.class).getSettings()
+            )
+        );
+    }
+
+    public void testDefaultLegacyAllocator() {
+        internalCluster().startNode(
+            Settings.builder().put(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.getKey(), ClusterModule.BALANCED_ALLOCATOR)
+        );
+        assertEquals(
+            ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_ALL_ACTIVE,
+            ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.get(
+                internalCluster().getInstance(ClusterService.class).getSettings()
+            )
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -44,7 +45,9 @@ public class ClusterRebalanceAllocationDecider extends AllocationDecider {
     private static final String CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE = "cluster.routing.allocation.allow_rebalance";
     public static final Setting<ClusterRebalanceType> CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING = new Setting<>(
         CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE,
-        ClusterRebalanceType.INDICES_ALL_ACTIVE.toString(),
+        settings -> ClusterModule.DESIRED_BALANCE_ALLOCATOR.equals(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.get(settings))
+            ? ClusterRebalanceType.ALWAYS.toString()
+            : ClusterRebalanceType.INDICES_ALL_ACTIVE.toString(),
         ClusterRebalanceType::parseString,
         Property.Dynamic,
         Property.NodeScope


### PR DESCRIPTION
Today `cluster.routing.allocation.allow_rebalance` defaults to
`indices_all_active` which blocks all rebalancing moves while the
cluster is in `yellow` or `red` health. This was appropriate for the
legacy allocator which might do too many rebalancing moves otherwise.
The desired-balance allocator has better support for rebalancing a
cluster that is not in `green` health, and expects to be able to
rebalance some shards away from over-full nodes to avoid allocating
shards to undesirable locations in the first place. This commit changes
the default `allow_rebalance` setting to `always`.