### PR TITLE
Re-enable test after backport #11031

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -114,44 +114,44 @@ using default timestamp field mapping:
               message:
                 type: text
 
-#---
-#missing hostname field:
-#  - requires:
-#      test_runner_features: [ capabilities ]
-#      capabilities:
-#        - method: PUT
-#          path: /{index}
-#          capabilities: [ logs_index_mode ]
-#      reason: "Support for 'logs' index mode capability required"
-#
-#  - do:
-#      indices.create:
-#        index: test-hostname-missing
-#        body:
-#          settings:
-#            index:
-#              mode: logs
-#              number_of_replicas: 0
-#              number_of_shards: 2
-#          mappings:
-#            properties:
-#              "@timestamp":
-#                type: date
-#              agent_id:
-#                type: keyword
-#              process_id:
-#                type: integer
-#              http_method:
-#                type: keyword
-#              message:
-#                type: text
-#
-#  - do:
-#      indices.get_settings:
-#        index: test-hostname-missing
-#
-#  - is_true: test-hostname-missing
-#  - match: { test-hostname-missing.settings.index.mode: "logs" }
+---
+missing hostname field:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ logs_index_mode ]
+      reason: "Support for 'logs' index mode capability required"
+
+  - do:
+      indices.create:
+        index: test-hostname-missing
+        body:
+          settings:
+            index:
+              mode: logs
+              number_of_replicas: 0
+              number_of_shards: 2
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              agent_id:
+                type: keyword
+              process_id:
+                type: integer
+              http_method:
+                type: keyword
+              message:
+                type: text
+
+  - do:
+      indices.get_settings:
+        index: test-hostname-missing
+
+  - is_true: test-hostname-missing
+  - match: { test-hostname-missing.settings.index.mode: "logs" }
 
 ---
 missing sort field:


### PR DESCRIPTION
Here we just re-enable a test that we disabled to make the CI green and merge
backport #111031. The test was disabled in `main` by #110938.