### PR TITLE
[ESQL] Run SingleValueMatchQuery approximation last

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -108,8 +108,6 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   method: test {p0=data_stream/190_failure_store_redirection/Ensure failure is redirected to correct failure store after a reroute processor}
   issue: https://github.com/elastic/elasticsearch/issues/111041
-- class: org.elasticsearch.xpack.esql.querydsl.query.SingleValueQueryTests
-  issue: https://github.com/elastic/elasticsearch/issues/111042
 - class: org.elasticsearch.compute.lucene.ValueSourceReaderTypeConversionTests
   method: testLoadAllStatusAllInOnePage
   issue: https://github.com/elastic/elasticsearch/issues/111048

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -97,9 +97,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: "test {stats.Count_or_null SYNC #2}"
   issue: https://github.com/elastic/elasticsearch/issues/110950
-- class: "org.elasticsearch.xpack.esql.querydsl.query.SingleValueQueryTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/110977"
-  method: "testNotMatchSome {p0=StandardSetup[fieldType=keyword, multivaluedField=true, empty=true, count=100]}"
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/110978
 - class: org.elasticsearch.search.sort.FieldSortIT

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueMatchQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueMatchQuery.java
@@ -42,11 +42,10 @@ import java.util.Objects;
 final class SingleValueMatchQuery extends Query {
 
     /**
-     * The estimated number of comparisons to check if a {@link DocValues}
-     * has more than one value. There isn't a good way to get that number out of
-     * {@link DocValues} so this is a guess.
+     * We choose this value to big big so this approximation always run last. This avoid
+     * reporting warnings when queries are not matching multi-values
      */
-    private static final int MULTI_VALUE_MATCH_COST = 10;
+    private static final int MULTI_VALUE_MATCH_COST = 1000;
     private static final IllegalArgumentException MULTI_VALUE_EXCEPTION = new IllegalArgumentException(
         "single-value function encountered multi-value"
     );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueMatchQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueMatchQuery.java
@@ -42,8 +42,8 @@ import java.util.Objects;
 final class SingleValueMatchQuery extends Query {
 
     /**
-     * We choose this value to big big so this approximation always run last. This avoid
-     * reporting warnings when queries are not matching multi-values
+     * Choose a big enough value so this approximation never drives the iteration.
+     * This avoids reporting warnings when queries are not matching multi-values
      */
     private static final int MULTI_VALUE_MATCH_COST = 1000;
     private static final IllegalArgumentException MULTI_VALUE_EXCEPTION = new IllegalArgumentException(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
@@ -148,8 +148,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         }
         assertThat(count, equalTo(expected));
 
-        // the SingleValueQuery.TwoPhaseIteratorForSortedNumericsAndTwoPhaseQueries can scan all docs - and generate warnings - even if
-        // inner query matches none, so warn if MVs have been encountered within given range, OR if a full scan is required
+        // we should only have warnings if we have matched a multi-value
         if (mvCountInRange > 0) {
             assertWarnings(
                 "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
@@ -76,7 +76,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         int max = between(1, 100);
         testCase(
             new SingleValueQuery.Builder(new RangeQueryBuilder("i").lt(max), "foo", Source.EMPTY),
-            (fieldValues, count) -> runCase(fieldValues, count, null, max, false)
+            (fieldValues, count) -> runCase(fieldValues, count, null, max)
         );
     }
 
@@ -116,7 +116,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         int max = between(1, 100);
         testCase(
             new SingleValueQuery(new RangeQuery(Source.EMPTY, "i", null, false, max, false, null), "foo").negate(Source.EMPTY).asBuilder(),
-            (fieldValues, count) -> runCase(fieldValues, count, max, 100, true)
+            (fieldValues, count) -> runCase(fieldValues, count, max, 100)
         );
     }
 
@@ -132,10 +132,8 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
      * @param count The count of the docs the query matched.
      * @param docsStart The start of the slice in fieldValues we want to consider. If `null`, the start will be 0.
      * @param docsStop The end of the slice in fieldValues we want to consider. If `null`, the end will be the fieldValues size.
-     * @param scanForMVs Should the check for Warnings scan the entire fieldValues? This will override the docsStart:docsStop interval,
-     *                   which is needed for some cases.
      */
-    private void runCase(List<List<Object>> fieldValues, int count, Integer docsStart, Integer docsStop, boolean scanForMVs) {
+    private void runCase(List<List<Object>> fieldValues, int count, Integer docsStart, Integer docsStop) {
         int expected = 0;
         int min = docsStart != null ? docsStart : 0;
         int max = docsStop != null ? docsStop : fieldValues.size();
@@ -152,7 +150,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
 
         // the SingleValueQuery.TwoPhaseIteratorForSortedNumericsAndTwoPhaseQueries can scan all docs - and generate warnings - even if
         // inner query matches none, so warn if MVs have been encountered within given range, OR if a full scan is required
-        if (mvCountInRange > 0 || (scanForMVs && fieldValues.stream().anyMatch(x -> x.size() > 1))) {
+        if (mvCountInRange > 0) {
             assertWarnings(
                 "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
                 "Line -1:-1: java.lang.IllegalArgumentException: single-value function encountered multi-value"
@@ -161,7 +159,7 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
     }
 
     private void runCase(List<List<Object>> fieldValues, int count) {
-        runCase(fieldValues, count, null, null, false);
+        runCase(fieldValues, count, null, null);
     }
 
     private void testCase(SingleValueQuery.Builder builder, TestCase testCase) throws IOException {


### PR DESCRIPTION
Currently we run SingleValueQueries as a filter composed of the original and a doc values queries that filter multivalues. It might happen that the latter drives the iteration resulting in warnings of multivalue fields even if the query does not match any.
This PR proposes to increase the match cost for the doc values query so it always run last. This makes it easier to test and it should never give false warnings.

fixes https://github.com/elastic/elasticsearch/issues/110977