### PR TITLE
Unmuting #110999 after #111029

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -102,9 +102,6 @@ tests:
   method: "testNotMatchSome {p0=StandardSetup[fieldType=keyword, multivaluedField=true, empty=true, count=100]}"
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/110978
-- class: org.elasticsearch.search.sort.FieldSortIT
-  method: testIssue6614
-  issue: https://github.com/elastic/elasticsearch/issues/110999
 - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
   method: testEnterpriseDownloaderTask
   issue: https://github.com/elastic/elasticsearch/issues/111002


### PR DESCRIPTION
this is now fixed after #111029 

closes https://github.com/elastic/elasticsearch/issues/110999