### PR TITLE
Rename `logs` index mode to `logsdb`

### DIFF
--- a/docs/reference/data-streams/logs.asciidoc
+++ b/docs/reference/data-streams/logs.asciidoc
@@ -1,7 +1,7 @@
 [[logs-data-stream]]
 == Logs data stream
 
-preview::[Logs data streams and the logs index mode are in tech preview and may be changed or removed in the future. Don't use logs data streams or logs index mode in production.]
+preview::[Logs data streams and the logsdb index mode are in tech preview and may be changed or removed in the future. Don't use logs data streams or logsdb index mode in production.]
 
 A logs data stream is a data stream type that stores log data more efficiently.
 
@@ -20,7 +20,7 @@ The following features are enabled in a logs data stream:
 [[how-to-use-logsds]]
 === Create a logs data stream
 
-To create a logs data stream, set your index template  `index.mode` to `logs`:
+To create a logs data stream, set your index template  `index.mode` to `logsdb`:
 
 [source,console]
 ----
@@ -30,7 +30,7 @@ PUT _index_template/my-index-template
   "data_stream": { },
   "template": {
      "settings": {
-        "index.mode": "logs" <1>
+        "index.mode": "logsdb" <1>
      }
   },
   "priority": 101 <2>

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/LogsDataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/LogsDataStreamIT.java
@@ -165,7 +165,7 @@ public class LogsDataStreamIT extends ESSingleNodeTestCase {
             client(),
             "logs-composable-template",
             LOGS_OR_STANDARD_MAPPING,
-            Map.of("index.mode", "logs"),
+            Map.of("index.mode", "logsdb"),
             List.of("logs-*-*")
         );
         final String dataStreamName = generateDataStreamName("logs");
@@ -188,7 +188,7 @@ public class LogsDataStreamIT extends ESSingleNodeTestCase {
         );
         createDataStream(client(), dataStreamName);
         for (int i = 0; i < randomIntBetween(5, 10); i++) {
-            final IndexMode indexMode = i % 2 == 0 ? IndexMode.LOGS : IndexMode.STANDARD;
+            final IndexMode indexMode = i % 2 == 0 ? IndexMode.LOGSDB : IndexMode.STANDARD;
             indexModes.add(indexMode);
             updateComposableIndexTemplate(
                 client(),
@@ -206,7 +206,7 @@ public class LogsDataStreamIT extends ESSingleNodeTestCase {
     public void testIndexModeLogsAndTimeSeriesSwitching() throws IOException, ExecutionException, InterruptedException {
         final String dataStreamName = generateDataStreamName("custom");
         final List<String> indexPatterns = List.of("custom-*-*");
-        final Map<String, String> logsSettings = Map.of("index.mode", "logs");
+        final Map<String, String> logsSettings = Map.of("index.mode", "logsdb");
         final Map<String, String> timeSeriesSettings = Map.of("index.mode", "time_series", "index.routing_path", "host.name");
 
         putComposableIndexTemplate(client(), "custom-composable-template", LOGS_OR_STANDARD_MAPPING, logsSettings, indexPatterns);
@@ -221,13 +221,13 @@ public class LogsDataStreamIT extends ESSingleNodeTestCase {
         rolloverDataStream(dataStreamName);
         indexLogOrStandardDocuments(client(), randomIntBetween(10, 20), randomIntBetween(32, 64), dataStreamName);
 
-        assertDataStreamBackingIndicesModes(dataStreamName, List.of(IndexMode.LOGS, IndexMode.TIME_SERIES, IndexMode.LOGS));
+        assertDataStreamBackingIndicesModes(dataStreamName, List.of(IndexMode.LOGSDB, IndexMode.TIME_SERIES, IndexMode.LOGSDB));
     }
 
     public void testInvalidIndexModeTimeSeriesSwitchWithoutRoutingPath() throws IOException, ExecutionException, InterruptedException {
         final String dataStreamName = generateDataStreamName("custom");
         final List<String> indexPatterns = List.of("custom-*-*");
-        final Map<String, String> logsSettings = Map.of("index.mode", "logs");
+        final Map<String, String> logsSettings = Map.of("index.mode", "logsdb");
         final Map<String, String> timeSeriesSettings = Map.of("index.mode", "time_series");
 
         putComposableIndexTemplate(client(), "custom-composable-template", LOGS_OR_STANDARD_MAPPING, logsSettings, indexPatterns);
@@ -249,7 +249,7 @@ public class LogsDataStreamIT extends ESSingleNodeTestCase {
     public void testInvalidIndexModeTimeSeriesSwitchWithoutDimensions() throws IOException, ExecutionException, InterruptedException {
         final String dataStreamName = generateDataStreamName("custom");
         final List<String> indexPatterns = List.of("custom-*-*");
-        final Map<String, String> logsSettings = Map.of("index.mode", "logs");
+        final Map<String, String> logsSettings = Map.of("index.mode", "logsdb");
         final Map<String, String> timeSeriesSettings = Map.of("index.mode", "time_series", "index.routing_path", "host.name");
 
         putComposableIndexTemplate(client(), "custom-composable-template", LOGS_OR_STANDARD_MAPPING, logsSettings, indexPatterns);

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamRestIT.java
@@ -72,7 +72,7 @@ public class LogsDataStreamRestIT extends ESRestTestCase {
           "template": {
             "settings": {
               "index": {
-                "mode": "logs"
+                "mode": "logsdb"
               }
             },
             "mappings": {
@@ -161,7 +161,7 @@ public class LogsDataStreamRestIT extends ESRestTestCase {
                 randomIp(randomBoolean())
             )
         );
-        assertDataStreamBackingIndexMode("logs", 0);
+        assertDataStreamBackingIndexMode("logsdb", 0);
         rolloverDataStream(client, DATA_STREAM_NAME);
         indexDocument(
             client,
@@ -175,7 +175,7 @@ public class LogsDataStreamRestIT extends ESRestTestCase {
                 randomIp(randomBoolean())
             )
         );
-        assertDataStreamBackingIndexMode("logs", 1);
+        assertDataStreamBackingIndexMode("logsdb", 1);
     }
 
     public void testLogsStandardIndexModeSwitch() throws IOException {
@@ -193,7 +193,7 @@ public class LogsDataStreamRestIT extends ESRestTestCase {
                 randomIp(randomBoolean())
             )
         );
-        assertDataStreamBackingIndexMode("logs", 0);
+        assertDataStreamBackingIndexMode("logsdb", 0);
 
         putTemplate(client, "custom-template", STANDARD_TEMPLATE);
         rolloverDataStream(client, DATA_STREAM_NAME);
@@ -225,7 +225,7 @@ public class LogsDataStreamRestIT extends ESRestTestCase {
                 randomIp(randomBoolean())
             )
         );
-        assertDataStreamBackingIndexMode("logs", 2);
+        assertDataStreamBackingIndexMode("logsdb", 2);
     }
 
     private void assertDataStreamBackingIndexMode(final String indexMode, int backingIndex) throws IOException {

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeDisabledRestTestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeDisabledRestTestIT.java
@@ -50,7 +50,7 @@ public class LogsIndexModeDisabledRestTestIT extends LogsIndexModeRestTestIT {
     public void testLogsSettingsIndexModeDisabled() throws IOException {
         assertOK(createDataStream(client, "logs-custom-dev"));
         final String indexMode = (String) getSetting(client, getDataStreamBackingIndex(client, "logs-custom-dev", 0), "index.mode");
-        assertThat(indexMode, Matchers.not(equalTo(IndexMode.LOGS.getName())));
+        assertThat(indexMode, Matchers.not(equalTo(IndexMode.LOGSDB.getName())));
     }
 
 }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeEnabledRestTestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeEnabledRestTestIT.java
@@ -179,7 +179,7 @@ public class LogsIndexModeEnabledRestTestIT extends LogsIndexModeRestTestIT {
         assertOK(putComponentTemplate(client, "logs@custom", MAPPINGS));
         assertOK(createDataStream(client, "logs-custom-dev"));
         final String indexMode = (String) getSetting(client, getDataStreamBackingIndex(client, "logs-custom-dev", 0), "index.mode");
-        assertThat(indexMode, equalTo(IndexMode.LOGS.getName()));
+        assertThat(indexMode, equalTo(IndexMode.LOGSDB.getName()));
     }
 
     public void testBulkIndexing() throws IOException {

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -99,7 +99,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
 
     @Override
     public void contenderSettings(Settings.Builder builder) {
-        builder.put("index.mode", "logs");
+        builder.put("index.mode", "logsdb");
         settings(builder);
     }
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -151,7 +151,6 @@ missing hostname field:
 
   - is_true: test-hostname-missing
   - match: { test-hostname-missing.settings.index.mode: "logs" }
->>>>>>> main
 
 ---
 missing sort field:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -151,7 +151,7 @@ missing hostname field:
         index: test-hostname-missing
 
   - is_true: test-hostname-missing
-  - match: { test-hostname-missing.settings.index.mode: "logs" }
+  - match: { test-hostname-missing.settings.index.mode: "logsdb" }
 
 ---
 missing sort field:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -114,6 +114,7 @@ using default timestamp field mapping:
               message:
                 type: text
 
+---
 missing hostname field:
   - requires:
       test_runner_features: [ capabilities ]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -24,7 +24,7 @@ create logs index:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
           mappings:
@@ -75,7 +75,7 @@ create logs index:
         index: test
 
   - is_true: test
-  - match: { test.settings.index.mode: "logs" }
+  - match: { test.settings.index.mode: "logsdb" }
 
   - do:
       indices.get_mapping:
@@ -89,8 +89,8 @@ using default timestamp field mapping:
       capabilities:
         - method: PUT
           path: /{index}
-          capabilities: [ logs_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+          capabilities: [ logsdb_index_mode ]
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -98,7 +98,7 @@ using default timestamp field mapping:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
           mappings:
@@ -121,8 +121,8 @@ using default timestamp field mapping:
 #      capabilities:
 #        - method: PUT
 #          path: /{index}
-#          capabilities: [ logs_index_mode ]
-#      reason: "Support for 'logs' index mode capability required"
+#          capabilities: [ logsdb_index_mode ]
+#      reason: "Support for 'logsdb' index mode capability required"
 #
 #  - do:
 #      indices.create:
@@ -130,7 +130,7 @@ using default timestamp field mapping:
 #        body:
 #          settings:
 #            index:
-#              mode: logs
+#              mode: logsdb
 #              number_of_replicas: 0
 #              number_of_shards: 2
 #          mappings:
@@ -151,7 +151,7 @@ using default timestamp field mapping:
 #        index: test-hostname-missing
 #
 #  - is_true: test-hostname-missing
-#  - match: { test-hostname-missing.settings.index.mode: "logs" }
+#  - match: { test-hostname-missing.settings.index.mode: "logsdb" }
 
 ---
 missing sort field:
@@ -160,8 +160,8 @@ missing sort field:
       capabilities:
         - method: PUT
           path: /{index}
-          capabilities: [ logs_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+          capabilities: [ logsdb_index_mode ]
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       catch: bad_request
@@ -237,7 +237,7 @@ non-default sort settings:
         index: test-sort
 
   - is_true: test-sort
-  - match: { test-sort.settings.index.mode: "logs" }
+  - match: { test-sort.settings.index.mode: "logsdb" }
   - match: { test-sort.settings.index.sort.field.0: "agent_id" }
   - match: { test-sort.settings.index.sort.field.1: "@timestamp" }
   - match: { test-sort.settings.index.sort.order.0: "asc" }
@@ -289,7 +289,7 @@ override sort order settings:
         index: test-sort-order
 
   - is_true: test-sort-order
-  - match: { test-sort-order.settings.index.mode: "logs" }
+  - match: { test-sort-order.settings.index.mode: "logsdb" }
   - match: { test-sort-order.settings.index.sort.field.0: null }
   - match: { test-sort-order.settings.index.sort.field.1: null }
   - match: { test-sort-order.settings.index.sort.order.0: "asc" }
@@ -337,7 +337,7 @@ override sort missing settings:
         index: test-sort-missing
 
   - is_true: test-sort-missing
-  - match: { test-sort-missing.settings.index.mode: "logs" }
+  - match: { test-sort-missing.settings.index.mode: "logsdb" }
   - match: { test-sort-missing.settings.index.sort.field.0: null }
   - match: { test-sort-missing.settings.index.sort.field.1: null }
   - match: { test-sort-missing.settings.index.sort.missing.0: "_last" }
@@ -385,7 +385,7 @@ override sort mode settings:
         index: test-sort-mode
 
   - is_true: test-sort-mode
-  - match: { test-sort-mode.settings.index.mode: "logs" }
+  - match: { test-sort-mode.settings.index.mode: "logsdb" }
   - match: { test-sort-mode.settings.index.sort.field.0: null }
   - match: { test-sort-mode.settings.index.sort.field.1: null }
   - match: { test-sort-mode.settings.index.sort.mode.0: "max" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -130,7 +130,7 @@ missing hostname field:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
           mappings:
@@ -170,7 +170,7 @@ missing sort field:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
               sort:
@@ -211,7 +211,7 @@ non-default sort settings:
           settings:
 
             index:
-              mode: logs
+              mode: logsdb
               number_of_shards: 2
               number_of_replicas: 0
               sort:
@@ -264,7 +264,7 @@ override sort order settings:
           settings:
 
             index:
-              mode: logs
+              mode: logsdb
               number_of_shards: 2
               number_of_replicas: 0
               sort:
@@ -312,7 +312,7 @@ override sort missing settings:
           settings:
 
             index:
-              mode: logs
+              mode: logsdb
               number_of_shards: 2
               number_of_replicas: 0
               sort:
@@ -360,7 +360,7 @@ override sort mode settings:
           settings:
 
             index:
-              mode: logs
+              mode: logsdb
               number_of_shards: 2
               number_of_replicas: 0
               sort:
@@ -409,7 +409,7 @@ override sort field using nested field type in sorting:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
               sort:
@@ -455,7 +455,7 @@ override sort field using nested field type:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
           mappings:
@@ -496,7 +496,7 @@ routing path not allowed in logs mode:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
               routing_path: [ "host.name", "agent_id" ]
@@ -536,7 +536,7 @@ start time not allowed in logs mode:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
               time_series:
@@ -577,7 +577,7 @@ end time not allowed in logs mode:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
               number_of_replicas: 0
               number_of_shards: 2
               time_series:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -6,7 +6,7 @@ setup:
         - method: PUT
           path: /{index}
           capabilities: [logsdb_index_mode]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
 ---
 create logs index:
@@ -16,7 +16,7 @@ create logs index:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -122,7 +122,7 @@ missing hostname field:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -202,7 +202,7 @@ non-default sort settings:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -255,7 +255,7 @@ override sort order settings:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -303,7 +303,7 @@ override sort missing settings:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -351,7 +351,7 @@ override sort mode settings:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -400,7 +400,7 @@ override sort field using nested field type in sorting:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       catch: bad_request
@@ -447,7 +447,7 @@ override sort field using nested field type:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       indices.create:
@@ -487,7 +487,7 @@ routing path not allowed in logs mode:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       catch: bad_request
@@ -527,7 +527,7 @@ start time not allowed in logs mode:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       catch: bad_request
@@ -568,7 +568,7 @@ end time not allowed in logs mode:
         - method: PUT
           path: /{index}
           capabilities: [ logsdb_index_mode ]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
@@ -5,7 +5,7 @@ stored _source mode is not supported:
       capabilities:
         - method: PUT
           path: /{index}
-          capabilities: [logs_index_mode]
+          capabilities: [logsdb_index_mode]
       reason: "Support for 'logs' index mode capability required"
 
   - skip:
@@ -42,7 +42,7 @@ disabled _source is not supported:
       capabilities:
         - method: PUT
           path: /{index}
-          capabilities: [logs_index_mode]
+          capabilities: [logsdb_index_mode]
       reason: "Support for 'logs' index mode capability required"
 
   - skip:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
@@ -70,7 +70,7 @@ disabled _source is not supported:
 
   - match: { error.type: "mapper_parsing_exception" }
   - match: { error.root_cause.0.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: Indices with with index mode [logs] only support synthetic source" }
+  - match: { error.reason: "Failed to parse mapping: Indices with with index mode [logsdb] only support synthetic source" }
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
@@ -6,7 +6,7 @@ stored _source mode is not supported:
         - method: PUT
           path: /{index}
           capabilities: [logsdb_index_mode]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - skip:
       known_issues:
@@ -43,7 +43,7 @@ disabled _source is not supported:
         - method: PUT
           path: /{index}
           capabilities: [logsdb_index_mode]
-      reason: "Support for 'logs' index mode capability required"
+      reason: "Support for 'logsdb' index mode capability required"
 
   - skip:
       known_issues:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
@@ -21,7 +21,7 @@ stored _source mode is not supported:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
           mappings:
             _source:
               mode: stored
@@ -58,7 +58,7 @@ disabled _source is not supported:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
           mappings:
             _source:
               enabled: false
@@ -79,7 +79,7 @@ disabled _source is not supported:
         body:
           settings:
             index:
-              mode: logs
+              mode: logsdb
           mappings:
             _source:
               mode: disabled

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -473,8 +473,7 @@ public enum IndexMode {
         return switch (value) {
             case "standard" -> IndexMode.STANDARD;
             case "time_series" -> IndexMode.TIME_SERIES;
-            // NOTE: temporarily leave "logs" here just to be on the safe side
-            case "logs", "logsdb" -> IndexMode.LOGSDB;
+            case "logsdb" -> IndexMode.LOGSDB;
             default -> throw new IllegalArgumentException(
                 "["
                     + value

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -473,7 +473,8 @@ public enum IndexMode {
         return switch (value) {
             case "standard" -> IndexMode.STANDARD;
             case "time_series" -> IndexMode.TIME_SERIES;
-            case "logsdb" -> IndexMode.LOGSDB;
+            // NOTE: temporarily leave "logs" here just to be on the safe side
+            case "logs", "logsdb" -> IndexMode.LOGSDB;
             default -> throw new IllegalArgumentException(
                 "["
                     + value

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -223,7 +223,7 @@ public enum IndexMode {
             return true;
         }
     },
-    LOGS("logs") {
+    LOGSDB("logsdb") {
         @Override
         void validateWithOtherSettings(Map<Setting<?>, Object> settings) {
             IndexMode.validateTimeSeriesSettings(settings);
@@ -473,7 +473,7 @@ public enum IndexMode {
         return switch (value) {
             case "standard" -> IndexMode.STANDARD;
             case "time_series" -> IndexMode.TIME_SERIES;
-            case "logs" -> IndexMode.LOGS;
+            case "logsdb" -> IndexMode.LOGSDB;
             default -> throw new IllegalArgumentException(
                 "["
                     + value

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -153,14 +153,14 @@ public final class IndexSortConfig {
         }
 
         List<String> fields = INDEX_SORT_FIELD_SETTING.get(settings);
-        if (this.indexMode == IndexMode.LOGS && fields.isEmpty()) {
+        if (this.indexMode == IndexMode.LOGSDB && fields.isEmpty()) {
             fields = List.of("host.name", DataStream.TIMESTAMP_FIELD_NAME);
         }
         this.sortSpecs = fields.stream().map(FieldSortSpec::new).toArray(FieldSortSpec[]::new);
 
         if (INDEX_SORT_ORDER_SETTING.exists(settings)) {
             List<SortOrder> orders = INDEX_SORT_ORDER_SETTING.get(settings);
-            if (this.indexMode == IndexMode.LOGS && orders.isEmpty()) {
+            if (this.indexMode == IndexMode.LOGSDB && orders.isEmpty()) {
                 orders = List.of(SortOrder.DESC, SortOrder.DESC);
             }
             if (orders.size() != sortSpecs.length) {
@@ -175,7 +175,7 @@ public final class IndexSortConfig {
 
         if (INDEX_SORT_MODE_SETTING.exists(settings)) {
             List<MultiValueMode> modes = INDEX_SORT_MODE_SETTING.get(settings);
-            if (this.indexMode == IndexMode.LOGS && modes.isEmpty()) {
+            if (this.indexMode == IndexMode.LOGSDB && modes.isEmpty()) {
                 modes = List.of(MultiValueMode.MIN, MultiValueMode.MIN);
             }
             if (modes.size() != sortSpecs.length) {
@@ -188,7 +188,7 @@ public final class IndexSortConfig {
 
         if (INDEX_SORT_MISSING_SETTING.exists(settings)) {
             List<String> missingValues = INDEX_SORT_MISSING_SETTING.get(settings);
-            if (this.indexMode == IndexMode.LOGS && missingValues.isEmpty()) {
+            if (this.indexMode == IndexMode.LOGSDB && missingValues.isEmpty()) {
                 missingValues = List.of("_first", "_first");
             }
             if (missingValues.size() != sortSpecs.length) {

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -123,7 +123,7 @@ public class PerFieldFormatSupplier {
     }
 
     private boolean isLogsModeIndex() {
-        return mapperService != null && IndexMode.LOGS == mapperService.getIndexSettings().getMode();
+        return mapperService != null && IndexMode.LOGSDB == mapperService.getIndexSettings().getMode();
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -69,12 +69,12 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         IndexMode.TIME_SERIES
     );
 
-    private static final SourceFieldMapper LOGS_DEFAULT = new SourceFieldMapper(
+    private static final SourceFieldMapper LOGSDB_DEFAULT = new SourceFieldMapper(
         Mode.SYNTHETIC,
         Explicit.IMPLICIT_TRUE,
         Strings.EMPTY_ARRAY,
         Strings.EMPTY_ARRAY,
-        IndexMode.LOGS
+        IndexMode.LOGSDB
     );
 
     /*
@@ -184,7 +184,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
             if (isDefault()) {
                 return switch (indexMode) {
                     case TIME_SERIES -> TSDB_DEFAULT;
-                    case LOGS -> LOGS_DEFAULT;
+                    case LOGSDB -> LOGSDB_DEFAULT;
                     default -> DEFAULT;
                 };
             }
@@ -234,8 +234,8 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                 } else {
                     return TSDB_LEGACY_DEFAULT;
                 }
-            } else if (indexMode == IndexMode.LOGS) {
-                return LOGS_DEFAULT;
+            } else if (indexMode == IndexMode.LOGSDB) {
+                return LOGSDB_DEFAULT;
             }
         }
         return DEFAULT;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/CreateIndexCapabilities.java
@@ -18,7 +18,7 @@ public class CreateIndexCapabilities {
     /**
      * Support for using the 'logs' index mode.
      */
-    private static final String LOGS_INDEX_MODE_CAPABILITY = "logs_index_mode";
+    private static final String LOGSDB_INDEX_MODE_CAPABILITY = "logsdb_index_mode";
 
-    public static Set<String> CAPABILITIES = Set.of(LOGS_INDEX_MODE_CAPABILITY);
+    public static Set<String> CAPABILITIES = Set.of(LOGSDB_INDEX_MODE_CAPABILITY);
 }

--- a/server/src/test/java/org/elasticsearch/index/LogsIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/LogsIndexModeTests.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class LogsIndexModeTests extends ESTestCase {
     public void testLogsIndexModeSetting() {
-        assertThat(IndexSettings.MODE.get(buildSettings()), equalTo(IndexMode.LOGS));
+        assertThat(IndexSettings.MODE.get(buildSettings()), equalTo(IndexMode.LOGSDB));
     }
 
     public void testSortField() {
@@ -25,9 +25,9 @@ public class LogsIndexModeTests extends ESTestCase {
             .put(IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey(), "agent_id")
             .build();
         final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", sortSettings);
-        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGS));
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        assertThat(settings.getMode(), equalTo(IndexMode.LOGS));
+        assertThat(settings.getMode(), equalTo(IndexMode.LOGSDB));
         assertThat("agent_id", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey())));
     }
 
@@ -38,9 +38,9 @@ public class LogsIndexModeTests extends ESTestCase {
             .put(IndexSortConfig.INDEX_SORT_MODE_SETTING.getKey(), "max")
             .build();
         final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", sortSettings);
-        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGS));
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        assertThat(settings.getMode(), equalTo(IndexMode.LOGS));
+        assertThat(settings.getMode(), equalTo(IndexMode.LOGSDB));
         assertThat("agent_id", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey())));
         assertThat("max", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_MODE_SETTING.getKey())));
     }
@@ -52,9 +52,9 @@ public class LogsIndexModeTests extends ESTestCase {
             .put(IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey(), "desc")
             .build();
         final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", sortSettings);
-        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGS));
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        assertThat(settings.getMode(), equalTo(IndexMode.LOGS));
+        assertThat(settings.getMode(), equalTo(IndexMode.LOGSDB));
         assertThat("agent_id", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey())));
         assertThat("desc", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_ORDER_SETTING.getKey())));
     }
@@ -66,15 +66,15 @@ public class LogsIndexModeTests extends ESTestCase {
             .put(IndexSortConfig.INDEX_SORT_MISSING_SETTING.getKey(), "_last")
             .build();
         final IndexMetadata metadata = IndexSettingsTests.newIndexMeta("test", sortSettings);
-        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGS));
+        assertThat(metadata.getIndexMode(), equalTo(IndexMode.LOGSDB));
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-        assertThat(settings.getMode(), equalTo(IndexMode.LOGS));
+        assertThat(settings.getMode(), equalTo(IndexMode.LOGSDB));
         assertThat("agent_id", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_FIELD_SETTING.getKey())));
         assertThat("_last", equalTo(getIndexSetting(settings, IndexSortConfig.INDEX_SORT_MISSING_SETTING.getKey())));
     }
 
     private Settings buildSettings() {
-        return Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGS.getName()).build();
+        return Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName()).build();
     }
 
     private String getIndexSetting(final IndexSettings settings, final String name) {

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -188,7 +188,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
     }
 
     public void testLogsIndexMode() throws IOException {
-        PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(true, IndexMode.LOGS, MAPPING_3);
+        PerFieldFormatSupplier perFieldMapperCodec = createFormatSupplier(true, IndexMode.LOGSDB, MAPPING_3);
         assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("@timestamp")), is(true));
         assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("hostname")), is(true));
         assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("response_size")), is(true));

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexModeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexModeFieldTypeTests.java
@@ -44,15 +44,15 @@ public class IndexModeFieldTypeTests extends ConstantFieldTypeTestCase {
 
         assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("stand*", null, createContext(IndexMode.STANDARD)));
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("stand*", null, createContext(IndexMode.TIME_SERIES)));
-        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("stand*", null, createContext(IndexMode.LOGS)));
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("stand*", null, createContext(IndexMode.LOGSDB)));
 
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("time*", null, createContext(IndexMode.STANDARD)));
         assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("time*", null, createContext(IndexMode.TIME_SERIES)));
-        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("time*", null, createContext(IndexMode.LOGS)));
+        assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("time*", null, createContext(IndexMode.LOGSDB)));
 
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("logs*", null, createContext(IndexMode.STANDARD)));
         assertEquals(new MatchNoDocsQuery(), ft.wildcardQuery("logs*", null, createContext(IndexMode.TIME_SERIES)));
-        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("logs*", null, createContext(IndexMode.LOGS)));
+        assertEquals(new MatchAllDocsQuery(), ft.wildcardQuery("logs*", null, createContext(IndexMode.LOGSDB)));
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -151,7 +152,7 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
     }
 
     protected final DocumentMapper createLogsModeDocumentMapper(XContentBuilder mappings) throws IOException {
-        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "logs").build();
+        Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName()).build();
         return createMapperService(settings, mappings).documentMapper();
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -697,8 +697,8 @@ public class FollowingEngineTests extends ESTestCase {
             case TIME_SERIES:
                 settingsBuilder.put("index.mode", "time_series").put("index.routing_path", "foo");
                 break;
-            case LOGS:
-                settingsBuilder.put("index.mode", "logs");
+            case LOGSDB:
+                settingsBuilder.put("index.mode", IndexMode.LOGSDB.getName());
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown index mode [" + indexMode + "]");

--- a/x-pack/plugin/core/src/javaRestTest/java/org/elasticsearch/xpack/core/DataStreamRestIT.java
+++ b/x-pack/plugin/core/src/javaRestTest/java/org/elasticsearch/xpack/core/DataStreamRestIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -56,7 +57,7 @@ public class DataStreamRestIT extends ESRestTestCase {
         assertBusy(() -> {
             Map<?, ?> logsTemplate = (Map<?, ?>) ((List<?>) getLocation("/_index_template/logs").get("index_templates")).get(0);
             assertThat(logsTemplate, notNullValue());
-            assertThat(logsTemplate.get("name"), equalTo("logs"));
+            assertThat(logsTemplate.get("name"), equalTo(IndexMode.LOGSDB.getName()));
             assertThat(((Map<?, ?>) logsTemplate.get("index_template")).get("data_stream"), notNullValue());
         });
         putFailureStoreTemplate();

--- a/x-pack/plugin/core/src/javaRestTest/java/org/elasticsearch/xpack/core/DataStreamRestIT.java
+++ b/x-pack/plugin/core/src/javaRestTest/java/org/elasticsearch/xpack/core/DataStreamRestIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -57,7 +56,7 @@ public class DataStreamRestIT extends ESRestTestCase {
         assertBusy(() -> {
             Map<?, ?> logsTemplate = (Map<?, ?>) ((List<?>) getLocation("/_index_template/logs").get("index_templates")).get(0);
             assertThat(logsTemplate, notNullValue());
-            assertThat(logsTemplate.get("name"), equalTo(IndexMode.LOGSDB.getName()));
+            assertThat(logsTemplate.get("name"), equalTo("logs"));
             assertThat(((Map<?, ?>) logsTemplate.get("index_template")).get("data_stream"), notNullValue());
         });
         putFailureStoreTemplate();

--- a/x-pack/plugin/core/template-resources/src/main/resources/logs@settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/logs@settings.json
@@ -3,7 +3,7 @@
     "settings": {
       "index": {
         "lifecycle": {
-          "name": "logs"
+          "name": "logsdb"
         },
         "mode": "${xpack.stack.template.logs.index.mode}",
         "codec": "best_compression",

--- a/x-pack/plugin/core/template-resources/src/main/resources/logs@settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/logs@settings.json
@@ -3,9 +3,9 @@
     "settings": {
       "index": {
         "lifecycle": {
-          "name": "logsdb"
+          "name": "logs"
         },
-        "mode": "${xpack.stack.template.logs.index.mode}",
+        "mode": "${xpack.stack.template.logsdb.index.mode}",
         "codec": "best_compression",
         "mapping": {
           "ignore_malformed": true,

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
@@ -54,7 +54,7 @@ public class LegacyStackTemplateRegistry extends IndexTemplateRegistry {
     private static final Map<String, String> ADDITIONAL_TEMPLATE_VARIABLES = Map.of(
         "xpack.stack.template.deprecated",
         "true",
-        "xpack.stack.template.logs.index.mode",
+        "xpack.stack.template.logsdb.index.mode",
         "standard"
     );
 

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -58,7 +58,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
     );
 
     /**
-     * if index.mode "logs" is applied by default in logs@settings for 'logs-*-*'
+     * if index.mode "logsdb" is applied by default in logs@settings for 'logs-*-*'
      */
     public static final Setting<Boolean> CLUSTER_LOGSDB_ENABLED = Setting.boolSetting(
         "cluster.logsdb.enabled",

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -166,8 +167,8 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
                 Map.of(
                     "xpack.stack.template.deprecated",
                     "false",
-                    "xpack.stack.template.logs.index.mode",
-                    logsDbEnabled ? "logs" : "standard"
+                    "xpack.stack.template.logsdb.index.mode",
+                    logsDbEnabled ? IndexMode.LOGSDB.getName() : IndexMode.STANDARD.getName()
                 )
             ),
             new IndexTemplateConfig(


### PR DESCRIPTION
For consistency and to avoid multiple names for the same thing we decided to
rename the index mode to `logsdb`.

Resolves #111049 