### PR TITLE
[DOCS] Fix rendering bug in service-amazon-bedrock.asciidoc

### DIFF
--- a/docs/reference/inference/service-amazon-bedrock.asciidoc
+++ b/docs/reference/inference/service-amazon-bedrock.asciidoc
@@ -125,12 +125,7 @@ Should not be used if `temperature` is specified.
 =====
 +
 .`task_settings` for the `text_embedding` task type
-[%collapsible%closed]
-=====
-
 There are no `task_settings` available for the `text_embedding` task type.
-
-=====
 
 [discrete]
 [[inference-example-amazonbedrock]]


### PR DESCRIPTION
Screenshot of rendering bug:

<img width="635" alt="Screenshot 2024-07-18 at 16 40 28" src="https://github.com/user-attachments/assets/50e7ffc5-afde-4a51-8e82-8ad98ebdc63f">
