### PR TITLE
ESQL: Fix Double operations returning infinite

### DIFF
--- a/docs/changelog/111064.yaml
+++ b/docs/changelog/111064.yaml
@@ -1,0 +1,6 @@
+pr: 111064
+summary: "ESQL: Fix Double operations returning infinite"
+area: ES|QL
+type: bug
+issues:
+ - 111026

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Add.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Add.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -101,9 +102,9 @@ public class Add extends DateTimeArithmeticOperation implements BinaryComparison
         return unsignedLongAddExact(lhs, rhs);
     }
 
-    @Evaluator(extraName = "Doubles")
+    @Evaluator(extraName = "Doubles", warnExceptions = { ArithmeticException.class })
     static double processDoubles(double lhs, double rhs) {
-        return lhs + rhs;
+        return NumericUtils.asFiniteNumber(lhs + rhs);
     }
 
     @Evaluator(extraName = "Datetimes", warnExceptions = { ArithmeticException.class, DateTimeException.class })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Mul.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Mul.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 
 import java.io.IOException;
 
@@ -92,9 +93,9 @@ public class Mul extends EsqlArithmeticOperation implements BinaryComparisonInve
         return unsignedLongMultiplyExact(lhs, rhs);
     }
 
-    @Evaluator(extraName = "Doubles")
+    @Evaluator(extraName = "Doubles", warnExceptions = { ArithmeticException.class })
     static double processDoubles(double lhs, double rhs) {
-        return lhs * rhs;
+        return NumericUtils.asFiniteNumber(lhs * rhs);
     }
 
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Sub.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/Sub.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmeti
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 
 import java.io.IOException;
@@ -114,9 +115,9 @@ public class Sub extends DateTimeArithmeticOperation implements BinaryComparison
         return unsignedLongSubtractExact(lhs, rhs);
     }
 
-    @Evaluator(extraName = "Doubles")
+    @Evaluator(extraName = "Doubles", warnExceptions = { ArithmeticException.class })
     static double processDoubles(double lhs, double rhs) {
-        return lhs - rhs;
+        return NumericUtils.asFiniteNumber(lhs - rhs);
     }
 
     @Evaluator(extraName = "Datetimes", warnExceptions = { ArithmeticException.class, DateTimeException.class })

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -75,36 +74,36 @@ public class AddTests extends AbstractScalarFunctionTestCase {
         );
 
         // Double overflows
-        suppliers.addAll(List.of(
-            new TestCaseSupplier(
-                List.of(DataType.DOUBLE, DataType.DOUBLE),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
-                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
-                    ),
-                    "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                    DataType.DOUBLE,
-                    equalTo(null)
+        suppliers.addAll(
+            List.of(
+                new TestCaseSupplier(
+                    List.of(DataType.DOUBLE, DataType.DOUBLE),
+                    () -> new TestCaseSupplier.TestCase(
+                        List.of(
+                            new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                            new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                        ),
+                        "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                        DataType.DOUBLE,
+                        equalTo(null)
+                    ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                        .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
+                ),
+                new TestCaseSupplier(
+                    List.of(DataType.DOUBLE, DataType.DOUBLE),
+                    () -> new TestCaseSupplier.TestCase(
+                        List.of(
+                            new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                            new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                        ),
+                        "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                        DataType.DOUBLE,
+                        equalTo(null)
+                    ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                        .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
                 )
-                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
-                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
-            ),
-            new TestCaseSupplier(
-                List.of(DataType.DOUBLE, DataType.DOUBLE),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
-                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "rhs")
-                    ),
-                    "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                    DataType.DOUBLE,
-                    equalTo(null)
-                )
-                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
-                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
             )
-        ));
+        );
 
         // Unsigned Long cases
         // TODO: These should be integrated into the type cross product above, but are currently broken

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -72,6 +73,38 @@ public class AddTests extends AbstractScalarFunctionTestCase {
                 true
             )
         );
+
+        // Double overflows
+        suppliers.addAll(List.of(
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                    ),
+                    "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                )
+                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
+            ),
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                    ),
+                    "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                )
+                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
+            )
+        ));
 
         // Unsigned Long cases
         // TODO: These should be integrated into the type cross product above, but are currently broken

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/MulTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/MulTests.java
@@ -56,19 +56,53 @@ public class MulTests extends AbstractScalarFunctionTestCase {
             )
         );
 
-        suppliers.add(new TestCaseSupplier("Double * Double", List.of(DataType.DOUBLE, DataType.DOUBLE), () -> {
-            double rhs = randomDouble();
-            double lhs = randomDouble();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataType.DOUBLE, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, DataType.DOUBLE, "rhs")
-                ),
-                "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                DataType.DOUBLE,
-                equalTo(lhs * rhs)
-            );
-        }));
+        // Double
+        suppliers.addAll(List.of(
+            new TestCaseSupplier("Double * Double", List.of(DataType.DOUBLE, DataType.DOUBLE), () -> {
+                double rhs = randomDouble();
+                double lhs = randomDouble();
+                return new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(lhs, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(rhs, DataType.DOUBLE, "rhs")
+                    ),
+                    "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(lhs * rhs)
+                );
+            }),
+
+            // Overflows
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                    ),
+                    "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                )
+                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
+            ),
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                    ),
+                    "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                )
+                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
+            )
+        ));
+
         suppliers.add(
             arithmeticExceptionOverflowCase(
                 DataType.INTEGER,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/MulTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/MulTests.java
@@ -57,20 +57,19 @@ public class MulTests extends AbstractScalarFunctionTestCase {
         );
 
         // Double
-        suppliers.addAll(List.of(
-            new TestCaseSupplier("Double * Double", List.of(DataType.DOUBLE, DataType.DOUBLE), () -> {
-                double rhs = randomDouble();
-                double lhs = randomDouble();
-                return new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(lhs, DataType.DOUBLE, "lhs"),
-                        new TestCaseSupplier.TypedData(rhs, DataType.DOUBLE, "rhs")
-                    ),
-                    "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                    DataType.DOUBLE,
-                    equalTo(lhs * rhs)
-                );
-            }),
+        suppliers.addAll(List.of(new TestCaseSupplier("Double * Double", List.of(DataType.DOUBLE, DataType.DOUBLE), () -> {
+            double rhs = randomDouble();
+            double lhs = randomDouble();
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(lhs, DataType.DOUBLE, "lhs"),
+                    new TestCaseSupplier.TypedData(rhs, DataType.DOUBLE, "rhs")
+                ),
+                "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                DataType.DOUBLE,
+                equalTo(lhs * rhs)
+            );
+        }),
 
             // Overflows
             new TestCaseSupplier(
@@ -83,8 +82,7 @@ public class MulTests extends AbstractScalarFunctionTestCase {
                     "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                     DataType.DOUBLE,
                     equalTo(null)
-                )
-                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
                     .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
             ),
             new TestCaseSupplier(
@@ -97,8 +95,7 @@ public class MulTests extends AbstractScalarFunctionTestCase {
                     "MulDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                     DataType.DOUBLE,
                     equalTo(null)
-                )
-                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
                     .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
             )
         ));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/SubTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/SubTests.java
@@ -78,6 +78,38 @@ public class SubTests extends AbstractScalarFunctionTestCase {
                 equalTo(asLongUnsigned(lhsBI.subtract(rhsBI).longValue()))
             );
           }) */
+        
+        // Double overflows
+        suppliers.addAll(List.of(
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                    ),
+                    "SubDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                )
+                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
+            ),
+            new TestCaseSupplier(
+                List.of(DataType.DOUBLE, DataType.DOUBLE),
+                () -> new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                    ),
+                    "SubDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                    DataType.DOUBLE,
+                    equalTo(null)
+                )
+                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
+            )
+        ));
 
         suppliers.add(new TestCaseSupplier("Datetime - Period", () -> {
             long lhs = (Long) randomLiteral(DataType.DATETIME).value();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/SubTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/SubTests.java
@@ -78,38 +78,38 @@ public class SubTests extends AbstractScalarFunctionTestCase {
                 equalTo(asLongUnsigned(lhsBI.subtract(rhsBI).longValue()))
             );
           }) */
-        
+
         // Double overflows
-        suppliers.addAll(List.of(
-            new TestCaseSupplier(
-                List.of(DataType.DOUBLE, DataType.DOUBLE),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
-                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "rhs")
-                    ),
-                    "SubDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                    DataType.DOUBLE,
-                    equalTo(null)
+        suppliers.addAll(
+            List.of(
+                new TestCaseSupplier(
+                    List.of(DataType.DOUBLE, DataType.DOUBLE),
+                    () -> new TestCaseSupplier.TestCase(
+                        List.of(
+                            new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                            new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                        ),
+                        "SubDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                        DataType.DOUBLE,
+                        equalTo(null)
+                    ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                        .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
+                ),
+                new TestCaseSupplier(
+                    List.of(DataType.DOUBLE, DataType.DOUBLE),
+                    () -> new TestCaseSupplier.TestCase(
+                        List.of(
+                            new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
+                            new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
+                        ),
+                        "SubDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                        DataType.DOUBLE,
+                        equalTo(null)
+                    ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
+                        .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
                 )
-                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
-                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: Infinity")
-            ),
-            new TestCaseSupplier(
-                List.of(DataType.DOUBLE, DataType.DOUBLE),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(-Double.MAX_VALUE, DataType.DOUBLE, "lhs"),
-                        new TestCaseSupplier.TypedData(Double.MAX_VALUE, DataType.DOUBLE, "rhs")
-                    ),
-                    "SubDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                    DataType.DOUBLE,
-                    equalTo(null)
-                )
-                    .withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
-                    .withWarning("Line -1:-1: java.lang.ArithmeticException: not a finite double number: -Infinity")
             )
-        ));
+        );
 
         suppliers.add(new TestCaseSupplier("Datetime - Period", () -> {
             long lhs = (Long) randomLiteral(DataType.DATETIME).value();


### PR DESCRIPTION
Fixes Add, Sub and Mul to return a null and a warning (using `warnExceptions`).

Partially fixes https://github.com/elastic/elasticsearch/issues/111026