### PR TITLE
Correct force merge disk space requirements

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -88,9 +88,9 @@ Each targeted shard is force-merged separately using <<modules-threadpool,the
 one at a time. If you expand the `force_merge` threadpool on a node then it
 will force merge its shards in parallel.
 
-Force merge makes the storage for the shard being merged temporarily
-increase, up to double its size in case `max_num_segments` parameter is set to
-`1`, as all segments need to be rewritten into a new one.
+Force merge may temporarily require free space for the shard being merged up
+to triple its size in case `max_num_segments` parameter is set to `1`, as all
+segments need to be rewritten into a new one.
 
 [[forcemerge-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -88,9 +88,10 @@ Each targeted shard is force-merged separately using <<modules-threadpool,the
 one at a time. If you expand the `force_merge` threadpool on a node then it
 will force merge its shards in parallel.
 
-Force merge may temporarily require free space for the shard being merged up
-to triple its size in case `max_num_segments` parameter is set to `1`, as all
-segments need to be rewritten into a new one.
+Force merge makes the storage for the shard being merged temporarily
+increase, as it may require free space up to triple its size in case
+`max_num_segments` parameter is set to `1`, to rewrite all segments into a new
+one.
 
 [[forcemerge-api-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
According to [Lucene documentation](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/index/IndexWriter.html#forceMerge%28int%29) around force merges:

> Note that this requires free space that is proportional to the size of the index in your Directory: 2X if you are not using compound file format, and 3X if you are.

So we should clarify this documentation part better. I was not sure it's a good idea to mention the distinction between the compound file format, so just kept the upper number (3x).