### PR TITLE
Cleanup some ActionListener use in SearchTransportService

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -319,7 +319,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
             Runnable r = () -> {
                 final Thread thread = Thread.currentThread();
                 try {
-                    executePhaseOnShard(shardIt, shard, new SearchActionListener<Result>(shard, shardIndex) {
+                    executePhaseOnShard(shardIt, shard, new SearchActionListener<>(shard, shardIndex) {
                         @Override
                         public void innerOnResponse(Result result) {
                             try {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchExecutionStatsCollector.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchExecutionStatsCollector.java
@@ -38,7 +38,7 @@ public final class SearchExecutionStatsCollector extends DelegatingActionListene
 
     @SuppressWarnings("unchecked")
     public static
-        BiFunction<Transport.Connection, SearchActionListener<? super SearchPhaseResult>, ActionListener<? super SearchPhaseResult>>
+        BiFunction<Transport.Connection, ActionListener<? super SearchPhaseResult>, ActionListener<? super SearchPhaseResult>>
         makeWrapper(ResponseCollectorService service) {
         return (connection, originalListener) -> new SearchExecutionStatsCollector(
             (ActionListener<SearchPhaseResult>) originalListener,

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -147,7 +147,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
             // we can't create a SearchShardTarget here since we don't know the index and shard ID we are talking to
             // we only know the node and the search context ID. Yet, the response will contain the SearchShardTarget
             // from the target node instead...that's why we pass null here
-            SearchActionListener<T> searchActionListener = new SearchActionListener<T>(null, shardIndex) {
+            SearchActionListener<T> searchActionListener = new SearchActionListener<>(null, shardIndex) {
 
                 @Override
                 protected void setSearchShardTarget(T response) {
@@ -215,7 +215,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
     protected abstract void executeInitialPhase(
         Transport.Connection connection,
         InternalScrollSearchRequest internalRequest,
-        SearchActionListener<T> searchActionListener
+        ActionListener<T> searchActionListener
     );
 
     protected abstract SearchPhase moveToNextPhase(BiFunction<String, String, DiscoveryNode> clusterNodeLookup);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryAndFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryAndFetchAsyncAction.java
@@ -43,7 +43,7 @@ final class SearchScrollQueryAndFetchAsyncAction extends SearchScrollAsyncAction
     protected void executeInitialPhase(
         Transport.Connection connection,
         InternalScrollSearchRequest internalRequest,
-        SearchActionListener<ScrollQueryFetchSearchResult> searchActionListener
+        ActionListener<ScrollQueryFetchSearchResult> searchActionListener
     ) {
         searchTransportService.sendExecuteScrollFetch(connection, internalRequest, task, searchActionListener);
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollQueryThenFetchAsyncAction.java
@@ -55,7 +55,7 @@ final class SearchScrollQueryThenFetchAsyncAction extends SearchScrollAsyncActio
     protected void executeInitialPhase(
         Transport.Connection connection,
         InternalScrollSearchRequest internalRequest,
-        SearchActionListener<ScrollQuerySearchResult> searchActionListener
+        ActionListener<ScrollQuerySearchResult> searchActionListener
     ) {
         searchTransportService.sendExecuteScrollQuery(connection, internalRequest, task, searchActionListener);
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -116,7 +116,7 @@ public class SearchTransportService {
     private final NodeClient client;
     private final BiFunction<
         Transport.Connection,
-        SearchActionListener<? super SearchPhaseResult>,
+        ActionListener<? super SearchPhaseResult>,
         ActionListener<? super SearchPhaseResult>> responseWrapper;
     private final Map<String, Long> clientConnections = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
@@ -125,13 +125,20 @@ public class SearchTransportService {
         NodeClient client,
         BiFunction<
             Transport.Connection,
-            SearchActionListener<? super SearchPhaseResult>,
+            ActionListener<? super SearchPhaseResult>,
             ActionListener<? super SearchPhaseResult>> responseWrapper
     ) {
         this.transportService = transportService;
         this.client = client;
         this.responseWrapper = responseWrapper;
     }
+
+    private static final ActionListenerResponseHandler<SearchFreeContextResponse> SEND_FREE_CONTEXT_LISTENER =
+        new ActionListenerResponseHandler<>(
+            ActionListener.noop(),
+            SearchFreeContextResponse::readFrom,
+            TransportResponseHandler.TRANSPORT_WORKER
+        );
 
     public void sendFreeContext(Transport.Connection connection, final ShardSearchContextId contextId, OriginalIndices originalIndices) {
         transportService.sendRequest(
@@ -140,11 +147,7 @@ public class SearchTransportService {
             new SearchFreeContextRequest(originalIndices, contextId),
             TransportRequestOptions.EMPTY,
             // no need to respond if it was freed or not
-            new ActionListenerResponseHandler<>(
-                ActionListener.noop(),
-                SearchFreeContextResponse::new,
-                TransportResponseHandler.TRANSPORT_WORKER
-            )
+            SEND_FREE_CONTEXT_LISTENER
         );
     }
 
@@ -158,7 +161,7 @@ public class SearchTransportService {
             FREE_CONTEXT_SCROLL_ACTION_NAME,
             new ScrollFreeContextRequest(contextId),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(listener, SearchFreeContextResponse::new, TransportResponseHandler.TRANSPORT_WORKER)
+            new ActionListenerResponseHandler<>(listener, SearchFreeContextResponse::readFrom, TransportResponseHandler.TRANSPORT_WORKER)
         );
     }
 
@@ -173,7 +176,6 @@ public class SearchTransportService {
             QUERY_CAN_MATCH_NODE_NAME,
             request,
             task,
-            TransportRequestOptions.EMPTY,
             new ActionListenerResponseHandler<>(listener, CanMatchNodeResponse::new, TransportResponseHandler.TRANSPORT_WORKER)
         );
     }
@@ -184,11 +186,7 @@ public class SearchTransportService {
             CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
             new ClearScrollContextsRequest(),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(
-                listener,
-                (in) -> TransportResponse.Empty.INSTANCE,
-                TransportResponseHandler.TRANSPORT_WORKER
-            )
+            new ActionListenerResponseHandler<>(listener, in -> TransportResponse.Empty.INSTANCE, TransportResponseHandler.TRANSPORT_WORKER)
         );
     }
 
@@ -196,7 +194,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final ShardSearchRequest request,
         SearchTask task,
-        final SearchActionListener<DfsSearchResult> listener
+        final ActionListener<DfsSearchResult> listener
     ) {
         transportService.sendChildRequest(
             connection,
@@ -211,7 +209,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final ShardSearchRequest request,
         SearchTask task,
-        final SearchActionListener<? super SearchPhaseResult> listener
+        final ActionListener<SearchPhaseResult> listener
     ) {
         // we optimize this and expect a QueryFetchSearchResult if we only have a single shard in the search request
         // this used to be the QUERY_AND_FETCH which doesn't exist anymore.
@@ -233,7 +231,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final QuerySearchRequest request,
         SearchTask task,
-        final SearchActionListener<QuerySearchResult> listener
+        final ActionListener<QuerySearchResult> listener
     ) {
         transportService.sendChildRequest(
             connection,
@@ -248,7 +246,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final InternalScrollSearchRequest request,
         SearchTask task,
-        final SearchActionListener<ScrollQuerySearchResult> listener
+        final ActionListener<ScrollQuerySearchResult> listener
     ) {
         transportService.sendChildRequest(
             connection,
@@ -263,7 +261,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final RankFeatureShardRequest request,
         SearchTask task,
-        final SearchActionListener<RankFeatureResult> listener
+        final ActionListener<RankFeatureResult> listener
     ) {
         transportService.sendChildRequest(
             connection,
@@ -278,7 +276,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final InternalScrollSearchRequest request,
         SearchTask task,
-        final SearchActionListener<ScrollQueryFetchSearchResult> listener
+        final ActionListener<ScrollQueryFetchSearchResult> listener
     ) {
         transportService.sendChildRequest(
             connection,
@@ -293,7 +291,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final ShardFetchSearchRequest request,
         SearchTask task,
-        final SearchActionListener<FetchSearchResult> listener
+        final ActionListener<FetchSearchResult> listener
     ) {
         sendExecuteFetch(connection, FETCH_ID_ACTION_NAME, request, task, listener);
     }
@@ -302,7 +300,7 @@ public class SearchTransportService {
         Transport.Connection connection,
         final ShardFetchRequest request,
         SearchTask task,
-        final SearchActionListener<FetchSearchResult> listener
+        final ActionListener<FetchSearchResult> listener
     ) {
         sendExecuteFetch(connection, FETCH_ID_SCROLL_ACTION_NAME, request, task, listener);
     }
@@ -312,7 +310,7 @@ public class SearchTransportService {
         String action,
         final ShardFetchRequest request,
         SearchTask task,
-        final SearchActionListener<FetchSearchResult> listener
+        final ActionListener<FetchSearchResult> listener
     ) {
         transportService.sendChildRequest(
             connection,
@@ -420,13 +418,20 @@ public class SearchTransportService {
 
     public static class SearchFreeContextResponse extends TransportResponse {
 
+        private static final SearchFreeContextResponse FREED = new SearchFreeContextResponse(true);
+        private static final SearchFreeContextResponse NOT_FREED = new SearchFreeContextResponse(false);
+
         private final boolean freed;
 
-        SearchFreeContextResponse(StreamInput in) throws IOException {
-            freed = in.readBoolean();
+        static SearchFreeContextResponse readFrom(StreamInput in) throws IOException {
+            return of(in.readBoolean());
         }
 
-        SearchFreeContextResponse(boolean freed) {
+        static SearchFreeContextResponse of(boolean freed) {
+            return freed ? FREED : NOT_FREED;
+        }
+
+        private SearchFreeContextResponse(boolean freed) {
             this.freed = freed;
         }
 
@@ -448,7 +453,7 @@ public class SearchTransportService {
         final TransportRequestHandler<ScrollFreeContextRequest> freeContextHandler = (request, channel, task) -> {
             logger.trace("releasing search context [{}]", request.id());
             boolean freed = searchService.freeReaderContext(request.id());
-            channel.sendResponse(new SearchFreeContextResponse(freed));
+            channel.sendResponse(SearchFreeContextResponse.of(freed));
         };
         transportService.registerRequestHandler(
             FREE_CONTEXT_SCROLL_ACTION_NAME,
@@ -456,7 +461,12 @@ public class SearchTransportService {
             ScrollFreeContextRequest::new,
             instrumentedHandler(FREE_CONTEXT_SCROLL_ACTION_METRIC, transportService, searchTransportMetrics, freeContextHandler)
         );
-        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_SCROLL_ACTION_NAME, false, SearchFreeContextResponse::new);
+        TransportActionProxy.registerProxyAction(
+            transportService,
+            FREE_CONTEXT_SCROLL_ACTION_NAME,
+            false,
+            SearchFreeContextResponse::readFrom
+        );
 
         transportService.registerRequestHandler(
             FREE_CONTEXT_ACTION_NAME,
@@ -464,7 +474,7 @@ public class SearchTransportService {
             SearchFreeContextRequest::new,
             instrumentedHandler(FREE_CONTEXT_ACTION_METRIC, transportService, searchTransportMetrics, freeContextHandler)
         );
-        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, false, SearchFreeContextResponse::new);
+        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, false, SearchFreeContextResponse::readFrom);
 
         transportService.registerRequestHandler(
             CLEAR_SCROLL_CONTEXTS_ACTION_NAME,

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.inject.Inject;
@@ -63,7 +62,6 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
     private final NamedWriteableRegistry namedWriteableRegistry;
     private final TransportService transportService;
     private final SearchService searchService;
-    private final Client client;
 
     @Inject
     public TransportOpenPointInTimeAction(
@@ -72,8 +70,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
         ActionFilters actionFilters,
         TransportSearchAction transportSearchAction,
         SearchTransportService searchTransportService,
-        NamedWriteableRegistry namedWriteableRegistry,
-        Client client
+        NamedWriteableRegistry namedWriteableRegistry
     ) {
         super(TYPE.name(), transportService, actionFilters, OpenPointInTimeRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.transportService = transportService;
@@ -81,7 +78,6 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
         this.searchService = searchService;
         this.searchTransportService = searchTransportService;
         this.namedWriteableRegistry = namedWriteableRegistry;
-        this.client = client;
         transportService.registerRequestHandler(
             OPEN_SHARD_READER_CONTEXT_NAME,
             EsExecutors.DIRECT_EXECUTOR_SERVICE,

--- a/server/src/test/java/org/elasticsearch/action/search/ClearScrollControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ClearScrollControllerTests.java
@@ -120,7 +120,7 @@ public class ClearScrollControllerTests extends ESTestCase {
                 if (freed) {
                     numFreed.incrementAndGet();
                 }
-                Thread t = new Thread(() -> listener.onResponse(new SearchFreeContextResponse(freed)));
+                Thread t = new Thread(() -> listener.onResponse(SearchFreeContextResponse.of(freed)));
                 t.start();
             }
 
@@ -200,7 +200,7 @@ public class ClearScrollControllerTests extends ESTestCase {
                         if (freed) {
                             numFreed.incrementAndGet();
                         }
-                        listener.onResponse(new SearchFreeContextResponse(freed));
+                        listener.onResponse(SearchFreeContextResponse.of(freed));
                     }
                 });
                 t.start();

--- a/server/src/test/java/org/elasticsearch/action/search/DfsQueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/DfsQueryPhaseTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
@@ -78,7 +79,7 @@ public class DfsQueryPhaseTests extends ESTestCase {
                 Transport.Connection connection,
                 QuerySearchRequest request,
                 SearchTask task,
-                SearchActionListener<QuerySearchResult> listener
+                ActionListener<QuerySearchResult> listener
             ) {
                 if (request.contextId().getId() == 1) {
                     QuerySearchResult queryResult = new QuerySearchResult(
@@ -180,7 +181,7 @@ public class DfsQueryPhaseTests extends ESTestCase {
                 Transport.Connection connection,
                 QuerySearchRequest request,
                 SearchTask task,
-                SearchActionListener<QuerySearchResult> listener
+                ActionListener<QuerySearchResult> listener
             ) {
                 if (request.contextId().getId() == 1) {
                     QuerySearchResult queryResult = new QuerySearchResult(
@@ -267,7 +268,7 @@ public class DfsQueryPhaseTests extends ESTestCase {
                 Transport.Connection connection,
                 QuerySearchRequest request,
                 SearchTask task,
-                SearchActionListener<QuerySearchResult> listener
+                ActionListener<QuerySearchResult> listener
             ) {
                 if (request.contextId().getId() == 1) {
                     QuerySearchResult queryResult = new QuerySearchResult(

--- a/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.tests.store.MockDirectoryWrapper;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
@@ -201,7 +202,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
                     Transport.Connection connection,
                     ShardFetchSearchRequest request,
                     SearchTask task,
-                    SearchActionListener<FetchSearchResult> listener
+                    ActionListener<FetchSearchResult> listener
                 ) {
                     FetchSearchResult fetchResult = new FetchSearchResult();
                     try {
@@ -317,7 +318,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
                     Transport.Connection connection,
                     ShardFetchSearchRequest request,
                     SearchTask task,
-                    SearchActionListener<FetchSearchResult> listener
+                    ActionListener<FetchSearchResult> listener
                 ) {
                     if (request.contextId().getId() == 321) {
                         FetchSearchResult fetchResult = new FetchSearchResult();
@@ -426,7 +427,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
                     Transport.Connection connection,
                     ShardFetchSearchRequest request,
                     SearchTask task,
-                    SearchActionListener<FetchSearchResult> listener
+                    ActionListener<FetchSearchResult> listener
                 ) {
                     new Thread(() -> {
                         FetchSearchResult fetchResult = new FetchSearchResult();
@@ -562,7 +563,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
                     Transport.Connection connection,
                     ShardFetchSearchRequest request,
                     SearchTask task,
-                    SearchActionListener<FetchSearchResult> listener
+                    ActionListener<FetchSearchResult> listener
                 ) {
                     FetchSearchResult fetchResult = new FetchSearchResult();
                     try {
@@ -667,7 +668,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
                     Transport.Connection connection,
                     ShardFetchSearchRequest request,
                     SearchTask task,
-                    SearchActionListener<FetchSearchResult> listener
+                    ActionListener<FetchSearchResult> listener
                 ) {
                     FetchSearchResult fetchResult = new FetchSearchResult();
                     try {

--- a/server/src/test/java/org/elasticsearch/action/search/RankFeaturePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/RankFeaturePhaseTests.java
@@ -106,7 +106,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
                         // make sure to match the context id generated above, otherwise we throw
                         if (request.contextId().getId() == 123 && Arrays.equals(request.getDocIds(), new int[] { 1, 2 })) {
@@ -212,7 +212,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
                         // make sure to match the context id generated above, otherwise we throw
                         // first shard
@@ -327,7 +327,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
                         // make sure to match the context id generated above, otherwise we throw
                         if (request.contextId().getId() == 123 && Arrays.equals(request.getDocIds(), new int[] { 1, 2 })) {
@@ -419,7 +419,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
                         // make sure to match the context id generated above, otherwise we throw
                         // first shard
@@ -511,7 +511,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
                         // make sure to match the context id generated above, otherwise we throw
                         if (request.contextId().getId() == 123 && Arrays.equals(request.getDocIds(), new int[] { 1, 2 })) {
@@ -637,7 +637,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
 
                         RankFeatureResult rankFeatureResult = new RankFeatureResult();
@@ -779,7 +779,7 @@ public class RankFeaturePhaseTests extends ESTestCase {
                         Transport.Connection connection,
                         final RankFeatureShardRequest request,
                         SearchTask task,
-                        final SearchActionListener<RankFeatureResult> listener
+                        final ActionListener<RankFeatureResult> listener
                     ) {
                         RankFeatureResult rankFeatureResult = new RankFeatureResult();
                         // make sure to match the context id generated above, otherwise we throw

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -103,7 +103,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                 Transport.Connection connection,
                 ShardSearchRequest request,
                 SearchTask task,
-                SearchActionListener<? super SearchPhaseResult> listener
+                ActionListener<SearchPhaseResult> listener
             ) {
                 int shardId = request.shardId().id();
                 if (request.canReturnNullResponseIfMatchNoDocs()) {
@@ -447,7 +447,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                 Transport.Connection connection,
                 ShardSearchRequest request,
                 SearchTask task,
-                SearchActionListener<? super SearchPhaseResult> listener
+                ActionListener<SearchPhaseResult> listener
             ) {
                 int shardId = request.shardId().id();
                 QuerySearchResult queryResult = new QuerySearchResult(
@@ -598,7 +598,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                 Transport.Connection connection,
                 ShardSearchRequest request,
                 SearchTask task,
-                SearchActionListener<? super SearchPhaseResult> listener
+                ActionListener<SearchPhaseResult> listener
             ) {
                 int shardId = request.shardId().id();
                 QuerySearchResult queryResult = new QuerySearchResult(

--- a/server/src/test/java/org/elasticsearch/action/search/SearchScrollAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchScrollAsyncActionTests.java
@@ -62,7 +62,7 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             protected void executeInitialPhase(
                 Transport.Connection connection,
                 InternalScrollSearchRequest internalRequest,
-                SearchActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
+                ActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
             ) {
                 new Thread(() -> {
                     SearchAsyncActionTests.TestSearchPhaseResult testSearchPhaseResult = new SearchAsyncActionTests.TestSearchPhaseResult(
@@ -159,7 +159,7 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             protected void executeInitialPhase(
                 Transport.Connection connection,
                 InternalScrollSearchRequest internalRequest,
-                SearchActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
+                ActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
             ) {
                 new Thread(() -> {
                     SearchAsyncActionTests.TestSearchPhaseResult testSearchPhaseResult = new SearchAsyncActionTests.TestSearchPhaseResult(
@@ -232,7 +232,7 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             protected void executeInitialPhase(
                 Transport.Connection connection,
                 InternalScrollSearchRequest internalRequest,
-                SearchActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
+                ActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
             ) {
                 try {
                     assertNotEquals("node2 is not available", "node2", connection.getNode().getId());
@@ -317,7 +317,7 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             protected void executeInitialPhase(
                 Transport.Connection connection,
                 InternalScrollSearchRequest internalRequest,
-                SearchActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
+                ActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
             ) {
                 new Thread(() -> {
                     if (internalRequest.contextId().getId() == 17) {
@@ -420,7 +420,7 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             protected void executeInitialPhase(
                 Transport.Connection connection,
                 InternalScrollSearchRequest internalRequest,
-                SearchActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
+                ActionListener<SearchAsyncActionTests.TestSearchPhaseResult> searchActionListener
             ) {
                 new Thread(() -> searchActionListener.onFailure(new IllegalArgumentException("BOOM on shard"))).start();
             }


### PR DESCRIPTION
Small cleanup and allocation saving:

* remove publicly exposing the `SearchActionListener` outside of its module scope
* use constants for the free response and the noop transport listener to remove some pointless transport thread allocations
