### PR TITLE
Add an 8.15 backport version for the ENTERPRISE_GEOIP_DOWNLOADER

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
@@ -42,10 +42,10 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 
 class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
 
-    // for clarity inside this file, it's useful to have an alias that reads like what we're using it for
-    // rather than what the version is -- previously this was two separate conceptual versions, but it's not
-    // especially useful to make that distinction in the TransportVersions class itself
-    private static final TransportVersion INCLUDE_SHA256 = TransportVersions.ENTERPRISE_GEOIP_DOWNLOADER;
+    private static boolean includeSha256(TransportVersion version) {
+        return version.isPatchFrom(TransportVersions.ENTERPRISE_GEOIP_DOWNLOADER_BACKPORT_8_15)
+            || version.onOrAfter(TransportVersions.ENTERPRISE_GEOIP_DOWNLOADER);
+    }
 
     private static final ParseField DATABASES = new ParseField("databases");
 
@@ -83,7 +83,7 @@ class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
                 in.readVInt(),
                 in.readString(),
                 in.readLong(),
-                in.getTransportVersion().onOrAfter(INCLUDE_SHA256) ? input.readOptionalString() : null
+                includeSha256(in.getTransportVersion()) ? input.readOptionalString() : null
             )
         );
     }
@@ -143,7 +143,7 @@ class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
             o.writeVInt(v.lastChunk);
             o.writeString(v.md5);
             o.writeLong(v.lastCheck);
-            if (o.getTransportVersion().onOrAfter(INCLUDE_SHA256)) {
+            if (includeSha256(o.getTransportVersion())) {
                 o.writeOptionalString(v.sha256);
             }
         });

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -209,6 +209,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_GOOGLE_VERTEX_AI_RERANKING_ADDED = def(8_700_00_0);
     public static final TransportVersion VERSIONED_MASTER_NODE_REQUESTS = def(8_701_00_0);
     public static final TransportVersion ML_INFERENCE_AMAZON_BEDROCK_ADDED = def(8_702_00_0);
+    public static final TransportVersion ENTERPRISE_GEOIP_DOWNLOADER_BACKPORT_8_15 = def(8_702_00_1);
     public static final TransportVersion ML_INFERENCE_DONT_DELETE_WHEN_SEMANTIC_TEXT_EXISTS = def(8_703_00_0);
     public static final TransportVersion INFERENCE_ADAPTIVE_ALLOCATIONS = def(8_704_00_0);
     public static final TransportVersion INDEX_REQUEST_UPDATE_BY_SCRIPT_ORIGIN = def(8_705_00_0);


### PR DESCRIPTION
Adding a TransportVersion on `main` for the backport of #110844 to `8.15`. Actual backport of #110844 to `8.15` to follow.