### PR TITLE
[8.15] ESQL: Skip retrofitted tests (#111019)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -69,7 +69,7 @@ ROW left = "left", foo = "foo", client_ip = "172.21.0.5", env = "env", right = "
 left:keyword | client_ip:keyword | env:keyword | right:keyword | foo:keyword
 ;
 
-shadowingSubfields
+shadowingSubfields#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
 required_capability: enrich_load
 FROM addresses
 | KEEP city.country.continent.planet.name, city.country.name, city.name
@@ -84,8 +84,7 @@ United States of America  | South San Francisco | San Francisco Int'l
 Japan                     | Tokyo               | null
 ;
 
-shadowingSubfieldsLimit0
-required_capability: enrich_load
+shadowingSubfieldsLimit0#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
 FROM addresses
 | KEEP city.country.continent.planet.name, city.country.name, city.name
 | EVAL city.name = REPLACE(city.name, "San Francisco", "South San Francisco")
@@ -135,7 +134,7 @@ ROW left = "left", airport = "Zurich Airport ZRH", city = "Zürich", middle = "m
 left:keyword | city:keyword | middle:keyword | right:keyword | airport:text | region:text | city_boundary:geo_shape
 ;
 
-shadowingInternal
+shadowingInternal#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
 required_capability: enrich_load
 ROW city = "Zürich"
 | ENRICH city_names ON city WITH x = airport, x = region
@@ -145,7 +144,7 @@ city:keyword | x:text
 Zürich       | Bezirk Zürich
 ;
 
-shadowingInternalImplicit
+shadowingInternalImplicit#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
 required_capability: enrich_load
 ROW city = "Zürich"
 | ENRICH city_names ON city WITH airport = region
@@ -155,7 +154,7 @@ city:keyword | airport:text
 Zürich       | Bezirk Zürich
 ;
 
-shadowingInternalImplicit2
+shadowingInternalImplicit2#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
 required_capability: enrich_load
 ROW city = "Zürich"
 | ENRICH city_names ON city WITH airport, airport = region
@@ -165,7 +164,7 @@ city:keyword | airport:text
 Zürich       | Bezirk Zürich
 ;
 
-shadowingInternalImplicit3
+shadowingInternalImplicit3#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
 required_capability: enrich_load
 ROW city = "Zürich"
 | ENRICH city_names ON city WITH airport = region, airport

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -15,7 +15,7 @@ left:keyword | right:keyword | x:integer
 left         | right         | 1
 ;
 
-shadowingSubfields
+shadowingSubfields#[skip:-8.13.3,reason:fixed in 8.13]
 FROM addresses
 | KEEP city.country.continent.planet.name, city.country.name, city.name
 | EVAL city.country.continent.planet.name = to_upper(city.country.continent.planet.name)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -540,7 +540,7 @@ c:i
 1
 ;
 
-shadowingInternal
+shadowingInternal#[skip:-8.13.3,reason:fixed in 8.13]
 FROM employees
 | SORT emp_no ASC
 | KEEP last_name, emp_no, last_name
@@ -552,7 +552,7 @@ emp_no:integer | last_name:keyword
          10002 | Simmel
 ;
 
-shadowingInternalWildcard
+shadowingInternalWildcard#[skip:-8.13.3,reason:fixed in 8.13]
 FROM employees
 | SORT emp_no ASC
 | KEEP last*name, emp_no, last*name, first_name, last*, gender, last*
@@ -564,7 +564,7 @@ emp_no:integer | first_name:keyword | gender:keyword | last_name:keyword
          10002 | Bezalel            | F              | Simmel
 ;
 
-shadowingInternalWildcardAndExplicit
+shadowingInternalWildcardAndExplicit#[skip:-8.13.3,reason:fixed in 8.13]
 FROM employees
 | SORT emp_no ASC
 | KEEP last*name, emp_no, last_name, first_name, last*, languages, last_name, gender, last*name
@@ -576,7 +576,7 @@ emp_no:integer | first_name:keyword | languages:integer | last_name:keyword | ge
          10002 | Bezalel            | 5                 | Simmel            | F
 ;
 
-shadowingSubfields
+shadowingSubfields#[skip:-8.13.3,reason:fixed in 8.13]
 FROM addresses
 | KEEP city.country.continent.planet.name, city.country.continent.name, city.country.name, city.name, city.country.continent.planet.name
 | SORT city.name
@@ -588,7 +588,7 @@ North America                       | United States of America  | San Francisco 
 Asia                                | Japan                     | Tokyo             | Earth
 ;
 
-shadowingSubfieldsWildcard
+shadowingSubfieldsWildcard#[skip:-8.13.3,reason:fixed in 8.13]
 FROM addresses
 | KEEP *name, city.country.continent.planet.name
 | SORT city.name

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1829,7 +1829,7 @@ x:integer
 10001
 ;
 
-shadowingInternalWithGroup
+shadowingInternalWithGroup#[skip:-8.14.1,reason:implemented in 8.14]
 FROM employees
 | STATS x = MAX(emp_no), x = MIN(emp_no) BY x = gender
 | SORT x ASC


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [ESQL: Skip retrofitted tests (#111019)](https://github.com/elastic/elasticsearch/pull/111019)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)