### PR TITLE
Skip preallocate tests on windows (#110998)

### DIFF
--- a/libs/preallocate/src/test/java/org/elasticsearch/preallocate/PreallocateTests.java
+++ b/libs/preallocate/src/test/java/org/elasticsearch/preallocate/PreallocateTests.java
@@ -18,13 +18,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class PreallocateTests extends ESTestCase {
     public void testPreallocate() throws Exception {
+        assumeFalse("no preallocate on windows", System.getProperty("os.name").startsWith("Windows"));
         Path cacheFile = createTempFile();
         long size = 1024 * 1024; // 1 MB
         Preallocate.preallocate(cacheFile, size);
         OptionalLong foundSize = FileSystemNatives.allocatedSizeInBytes(cacheFile);
         assertTrue(foundSize.isPresent());
-        // Note that on Windows the fallback setLength is used. Although that creates a sparse
-        // file on Linux/MacOS, it full allocates the file on Windows
         assertThat(foundSize.getAsLong(), equalTo(size));
     }
 }


### PR DESCRIPTION
The preallocate tests assumed that preallocation was using the fallback implementation which calls setLength on Windows. However, that fallback only happens inside the SharedBytes class, so windows doesn't actually do anything when tryPreallocate is called. This commit skips the test on windows.

closes #110948