### PR TITLE
Add Java 21 to archive toolchain resolver

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/ArchivedOracleJdkToolchainResolver.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/ArchivedOracleJdkToolchainResolver.java
@@ -25,7 +25,18 @@ import java.util.Optional;
 
 public abstract class ArchivedOracleJdkToolchainResolver extends AbstractCustomJavaToolchainResolver {
 
-    private static final Map<Integer, String> ARCHIVED_BASE_VERSIONS = Maps.of(20, "20.0.2", 19, "19.0.2", 18, "18.0.2.1", 17, "17.0.7");
+    private static final Map<Integer, String> ARCHIVED_BASE_VERSIONS = Maps.of(
+        21,
+        "21.0.4",
+        20,
+        "20.0.2",
+        19,
+        "19.0.2",
+        18,
+        "18.0.2.1",
+        17,
+        "17.0.7"
+    );
 
     @Override
     public Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request) {


### PR DESCRIPTION
Since the bundled JDK is now Java 22, the archive resolver needs to support resolving Java 21. This commit updates the resolver to know which version of Java 21 to download.