### PR TITLE
Enforce LTR licensing to enterprise when putting a model.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfig.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.license.License;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 import java.util.Arrays;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.xpack.core.ml.MachineLearningField.ML_API_FEATURE;
 
 public interface InferenceConfig extends NamedXContentObject, VersionedNamedWriteable {
 
@@ -113,5 +115,9 @@ public interface InferenceConfig extends NamedXContentObject, VersionedNamedWrit
             getName(),
             updateName
         );
+    }
+
+    default License.OperationMode getMinLicenseSupported() {
+        return ML_API_FEATURE.getMinimumOperationMode();
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearningToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearningToRankConfig.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.license.License;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -224,6 +225,11 @@ public class LearningToRankConfig extends RegressionConfig implements Rewriteabl
     @Override
     public TransportVersion getMinimalSupportedTransportVersion() {
         return MIN_SUPPORTED_TRANSPORT_VERSION;
+    }
+
+    @Override
+    public License.OperationMode getMinLicenseSupported() {
+        return License.OperationMode.ENTERPRISE;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.TransportVersion;
@@ -188,6 +189,17 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
                     )
                 );
                 return;
+            }
+
+            if (licenseState.isAllowedByLicense(config.getInferenceConfig().getMinLicenseSupported()) == false) {
+                finalResponseListener.onFailure(
+                    new ElasticsearchSecurityException(
+                        "Model of type [{}] requires [{}] license level",
+                        RestStatus.FORBIDDEN,
+                        config.getInferenceConfig().getName(),
+                        config.getInferenceConfig().getMinLicenseSupported().description()
+                    )
+                );
             }
 
             TransportVersion minCompatibilityVersion = config.getModelDefinition().getTrainedModel().getMinimalCompatibilityVersion();


### PR DESCRIPTION
It was decided that LTR will be an enterprise feature.
This PR prevent the user to put LTR models if they are not meeting the license requirement.
