### PR TITLE
Making sure that watcher-history index is green in HistoryIntegrationTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -85,9 +85,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
   method: testCacheFileCreatedAsSparseFile
   issue: https://github.com/elastic/elasticsearch/issues/110801
-- class: "org.elasticsearch.xpack.watcher.test.integration.HistoryIntegrationTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/110885"
-  method: "testPayloadInputWithDotsInFieldNameWorks"
 - class: org.elasticsearch.nativeaccess.PreallocateTests
   method: testPreallocate
   issue: https://github.com/elastic/elasticsearch/issues/110948


### PR DESCRIPTION
Since the .watcher-history index is written asynchronously, it is possible that this test can query it when it is not yet ready. This adds a call to ensureGreen() before doing a search request so that we don't run into a NoShardAvailableActionException. This change also moves all of the search requests into a shared method so that we can more easily modify this behavior in the future if we need to.
Closes #110885
Relates #98014