### PR TITLE
Avoid calling real maxmind endpoint from EnterpriseGeoIpDownloader

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/EnterpriseGeoIpDownloader.java
@@ -78,6 +78,7 @@ public class EnterpriseGeoIpDownloader extends AllocatedPersistentTask {
 
     static String downloadUrl(final String name, final String suffix) {
         String endpointPattern = DEFAULT_MAXMIND_ENDPOINT;
+        assert endpointPattern.contains("maxmind.com") == false : "Do not use maxmind.com";
         if (endpointPattern.contains("%")) {
             throw new IllegalArgumentException("Invalid endpoint [" + endpointPattern + "]");
         }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -85,9 +85,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
   method: testCacheFileCreatedAsSparseFile
   issue: https://github.com/elastic/elasticsearch/issues/110801
-- class: "org.elasticsearch.xpack.watcher.test.integration.HistoryIntegrationTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/110885"
-  method: "testPayloadInputWithDotsInFieldNameWorks"
 - class: org.elasticsearch.nativeaccess.PreallocateTests
   method: testPreallocate
   issue: https://github.com/elastic/elasticsearch/issues/110948

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -106,9 +106,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {stats.MaxOfIpGrouping}
   issue: https://github.com/elastic/elasticsearch/issues/111107
-- class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
-  method: testEnterpriseDownloaderTask
-  issue: https://github.com/elastic/elasticsearch/issues/111002
 
 # Examples:
 #


### PR DESCRIPTION
If the `geoip_use_service` system property is set to true, then the EnterpriseGeoIpHttpFixture is disabled, so EnterpriseGeoIpDownloader incorrectly calls maxmind.com without credentials, and fails.
This change makes it so that the maxmind server is never called from tests.
Closes #111002