### PR TITLE
Short-circuit single slice searches in ContextIndexSearcher

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -2842,8 +2842,8 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     searcher.search(termQuery, new TotalHitCountCollectorManager());
                     assertBusy(
                         () -> assertEquals(
-                            "The number of slices should be 1 as FETCH does not support parallel collection.",
-                            1,
+                            "The number of slices should be 0 as FETCH does not support parallel collection.",
+                            0,
                             executor.getCompletedTaskCount() - priorExecutorTaskCount
                         )
                     );
@@ -2857,8 +2857,8 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     searcher.search(termQuery, new TotalHitCountCollectorManager());
                     assertBusy(
                         () -> assertEquals(
-                            "The number of slices should be 1 as NONE does not support parallel collection.",
-                            1,
+                            "The number of slices should be 0 as NONE does not support parallel collection.",
+                            0,
                             executor.getCompletedTaskCount() - priorExecutorTaskCount
                         )
                     );
@@ -2880,8 +2880,8 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         searcher.search(termQuery, new TotalHitCountCollectorManager());
                         assertBusy(
                             () -> assertEquals(
-                                "The number of slices should be 1 when QUERY parallel collection is disabled.",
-                                1,
+                                "The number of slices should be 0 when QUERY parallel collection is disabled.",
+                                0,
                                 executor.getCompletedTaskCount() - priorExecutorTaskCount
                             )
                         );


### PR DESCRIPTION
Even with the recent Lucene improvements in
https://github.com/apache/lucene/pull/13472 there is no need to go through all the Lucene machinery for a single slice here. The task executor allocates a bunch of objects and runs into some memory barriers that the JVM can't necessarily compile away. Let's save that overhead for the single slice case and get some of that Lucene 9.12.0 fork-saving behaviour right away. (I am aware this changes the load distribution across search and search_worker a little, but I think it's irrelevant practically because forking and joining a task will probably as expensive as executing it outright in a lot of cases anyway)

Also this PR removes the pointless list of collectors that we were building.
Lastly, a neat side-effect of this change is that it makes whether or not forking has happened a little easier to spot in profiling in the current ES version.