### PR TITLE
Use bundled jdk version for immutable collections patch

### DIFF
--- a/test/immutable-collections-patch/build.gradle
+++ b/test/immutable-collections-patch/build.gradle
@@ -35,7 +35,7 @@ generatePatch.configure {
     executable = "${BuildParams.runtimeJavaHome}/bin/java" + (OS.current() == OS.WINDOWS ? '.exe' : '')
   } else {
     javaLauncher = javaToolchains.launcherFor {
-      languageVersion = JavaLanguageVersion.of(BuildParams.runtimeJavaVersion.majorVersion)
+      languageVersion = JavaLanguageVersion.of(VersionProperties.bundledJdkMajorVersion)
       vendor = VersionProperties.bundledJdkVendor == "openjdk" ?
         JvmVendorSpec.ORACLE :
         JvmVendorSpec.matching(VersionProperties.bundledJdkVendor)


### PR DESCRIPTION
When building our patch for immutable collections we must find a jdk to use for the build. If runtime java is set, this is clear. But if there is no runtime java, we intend to fallback to the bundled jdk version. Yet the runtime version in this case does not itself fallback to the bundled jdk. This commit changes the immutable collections patch build to explicitly use the bundled jdk version.