### PR TITLE
Fix remaining references to logs index mode

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeCustomSettingsIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeCustomSettingsIT.java
@@ -111,7 +111,7 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
             e.getMessage(),
             containsString("updating component template [logs@custom] results in invalid composable template [logs]")
         );
-        assertThat(e.getMessage(), containsString("Indices with with index mode [logs] only support synthetic source"));
+        assertThat(e.getMessage(), containsString("Indices with with index mode [logsdb] only support synthetic source"));
 
         assertOK(createDataStream(client, "logs-custom-dev"));
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_mapping.yml
@@ -33,7 +33,7 @@ stored _source mode is not supported:
 
   - match: { error.type: "mapper_parsing_exception" }
   - match: { error.root_cause.0.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: Indices with with index mode [logs] only support synthetic source" }
+  - match: { error.reason: "Failed to parse mapping: Indices with with index mode [logsdb] only support synthetic source" }
 
 ---
 disabled _source is not supported:
@@ -91,4 +91,4 @@ disabled _source is not supported:
 
   - match: { error.type: "mapper_parsing_exception" }
   - match: { error.root_cause.0.type: "mapper_parsing_exception" }
-  - match: { error.reason: "Failed to parse mapping: Indices with with index mode [logs] only support synthetic source" }
+  - match: { error.reason: "Failed to parse mapping: Indices with with index mode [logsdb] only support synthetic source" }

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -289,7 +289,7 @@ public enum IndexMode {
         @Override
         public void validateSourceFieldMapper(SourceFieldMapper sourceFieldMapper) {
             if (sourceFieldMapper.isSynthetic() == false) {
-                throw new IllegalArgumentException("Indices with with index mode [logs] only support synthetic source");
+                throw new IllegalArgumentException("Indices with with index mode [" + IndexMode.LOGSDB + "] only support synthetic source");
             }
         }
 


### PR DESCRIPTION
This fixes remaining references (all that i am aware of) to `logs` index mode which is now called `logsdb`.

#111049