### PR TITLE
Unmute DockerTests.test600Interrupt

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1231,7 +1231,6 @@ public class DockerTests extends PackagingTestCase {
         assertBusy(() -> assertTrue(readinessProbe(9399)));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99508")
     public void test600Interrupt() {
         waitForElasticsearch(installation, "elastic", PASSWORD);
         final Result containerLogs = getContainerLogs();


### PR DESCRIPTION
Investigating https://github.com/elastic/elasticsearch/issues/111132 and it seems this test has been muted on `main` for some time. Let's unmute, to see if this is specific to the 7.17 branch or not.