### PR TITLE
Ignore bwc plugin tests on windows

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -9,16 +9,18 @@
 package org.elasticsearch.gradle.internal
 
 import org.elasticsearch.gradle.Architecture
+import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.fixtures.AbstractGitAwareGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 /*
- * Test is ignored on ARM since this test case tests the ability to build certain older BWC branches that we don't support on ARM
+ * Test is ignored on ARM since this test case tests the ability to build certain older BWC branches that we don't support on ARM.
+ * We also ignore on Windows since we don't run BWC tests on that platform anyway.
  */
 
-@IgnoreIf({ Architecture.current() == Architecture.AARCH64 })
+@IgnoreIf({ Architecture.current() == Architecture.AARCH64  || OS.current() == OS.WINDOWS })
 class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
     def setup() {


### PR DESCRIPTION
Ignore this test on Windows since we don't do explicit BWC testing on that platform anyhow. Also, the 7.17 branch doesn't do _any_ BWC snapshot testing so this functionality is actually never used anyhow.

Closes https://github.com/elastic/elasticsearch/issues/111139