### PR TITLE
Improvement of CCS usage stats collection

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.action.admin.cluster.stats.LongMetric.LongMetricValue;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Holds a snapshot of the CCS telemetry statistics.
+ * Used to hold the stats for a single node that's part of a {@link ClusterStatsNodeResponse}, as well as to
+ * accumulate stats for the entire cluster and return them as part of the {@link ClusterStatsResponse}.
+ */
+public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment {
+    private long totalCount;
+    private long successCount;
+    private final Map<String, Long> failureReasons;
+
+    private final LongMetricValue took;
+    private final LongMetricValue tookMrtTrue;
+    private final LongMetricValue tookMrtFalse;
+    private long remotesPerSearchMax;
+    private double remotesPerSearchAvg;
+    private long skippedRemotes;
+
+    private final Map<String, Long> featureCounts;
+
+    private final Map<String, Long> clientCounts;
+    private final Map<String, PerClusterCCSTelemetry> byRemoteCluster;
+
+    public long getTotalCount() {
+        return totalCount;
+    }
+
+    public long getSuccessCount() {
+        return successCount;
+    }
+
+    public Map<String, Long> getFailureReasons() {
+        return failureReasons;
+    }
+
+    public LongMetricValue getTook() {
+        return took;
+    }
+
+    public LongMetricValue getTookMrtTrue() {
+        return tookMrtTrue;
+    }
+
+    public LongMetricValue getTookMrtFalse() {
+        return tookMrtFalse;
+    }
+
+    public long getRemotesPerSearchMax() {
+        return remotesPerSearchMax;
+    }
+
+    public double getRemotesPerSearchAvg() {
+        return remotesPerSearchAvg;
+    }
+
+    public long getSkippedRemotes() {
+        return skippedRemotes;
+    }
+
+    public Map<String, Long> getFeatureCounts() {
+        return featureCounts;
+    }
+
+    public Map<String, Long> getClientCounts() {
+        return clientCounts;
+    }
+
+    public Map<String, PerClusterCCSTelemetry> getByRemoteCluster() {
+        return byRemoteCluster;
+    }
+
+    public static class PerClusterCCSTelemetry implements Writeable, ToXContentFragment {
+        private long count;
+        private long skippedCount;
+        private final LongMetricValue took;
+
+        public PerClusterCCSTelemetry() {
+            took = new LongMetricValue();
+        }
+
+        public PerClusterCCSTelemetry(long count, long skippedCount, LongMetricValue took) {
+            this.took = took;
+            this.skippedCount = skippedCount;
+            this.count = count;
+        }
+
+        public PerClusterCCSTelemetry(StreamInput in) throws IOException {
+            this.count = in.readVLong();
+            this.skippedCount = in.readVLong();
+            this.took = LongMetricValue.fromStream(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(count);
+            out.writeVLong(skippedCount);
+            took.writeTo(out);
+        }
+
+        public PerClusterCCSTelemetry add(PerClusterCCSTelemetry v) {
+            count += v.count;
+            skippedCount += v.skippedCount;
+            took.add(v.took);
+            return this;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("total", count);
+            builder.field("skipped", skippedCount);
+            publishLatency(builder, took, "took");
+            return builder;
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        public long getSkippedCount() {
+            return skippedCount;
+        }
+
+        public LongMetricValue getTook() {
+            return took;
+        }
+    }
+
+    /**
+    * Creates a new stats instance with the provided info.
+    */
+    public CCSTelemetrySnapshot(
+        long totalCount,
+        long successCount,
+        Map<String, Long> failureReasons,
+        LongMetricValue took,
+        LongMetricValue tookMrtTrue,
+        LongMetricValue tookMrtFalse,
+        long remotesPerSearchMax,
+        double remotesPerSearchAvg,
+        long skippedRemotes,
+        Map<String, Long> featureCounts,
+        Map<String, Long> clientCounts,
+        Map<String, PerClusterCCSTelemetry> byRemoteCluster
+    ) {
+        this.totalCount = totalCount;
+        this.successCount = successCount;
+        this.failureReasons = failureReasons;
+        this.took = took;
+        this.tookMrtTrue = tookMrtTrue;
+        this.tookMrtFalse = tookMrtFalse;
+        this.remotesPerSearchMax = remotesPerSearchMax;
+        this.remotesPerSearchAvg = remotesPerSearchAvg;
+        this.skippedRemotes = skippedRemotes;
+        this.featureCounts = featureCounts;
+        this.clientCounts = clientCounts;
+        this.byRemoteCluster = byRemoteCluster;
+    }
+
+    /**
+     * Creates a new empty stats instance, that will get additional stats added through {@link #add(CCSTelemetrySnapshot)}
+     */
+    public CCSTelemetrySnapshot() {
+        failureReasons = new HashMap<>();
+        featureCounts = new HashMap<>();
+        clientCounts = new HashMap<>();
+        byRemoteCluster = new HashMap<>();
+        took = new LongMetricValue();
+        tookMrtTrue = new LongMetricValue();
+        tookMrtFalse = new LongMetricValue();
+    }
+
+    public CCSTelemetrySnapshot(StreamInput in) throws IOException {
+        this.totalCount = in.readVLong();
+        this.successCount = in.readVLong();
+        this.failureReasons = in.readMap(StreamInput::readLong);
+        this.took = LongMetricValue.fromStream(in);
+        this.tookMrtTrue = LongMetricValue.fromStream(in);
+        this.tookMrtFalse = LongMetricValue.fromStream(in);
+        this.remotesPerSearchMax = in.readVLong();
+        this.remotesPerSearchAvg = in.readDouble();
+        this.skippedRemotes = in.readVLong();
+        this.featureCounts = in.readMap(StreamInput::readLong);
+        this.clientCounts = in.readMap(StreamInput::readLong);
+        this.byRemoteCluster = in.readMap(PerClusterCCSTelemetry::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(totalCount);
+        out.writeVLong(successCount);
+        out.writeMap(failureReasons, StreamOutput::writeLong);
+        took.writeTo(out);
+        tookMrtTrue.writeTo(out);
+        tookMrtFalse.writeTo(out);
+        out.writeVLong(remotesPerSearchMax);
+        out.writeDouble(remotesPerSearchAvg);
+        out.writeVLong(skippedRemotes);
+        out.writeMap(featureCounts, StreamOutput::writeLong);
+        out.writeMap(clientCounts, StreamOutput::writeLong);
+        out.writeMap(byRemoteCluster, StreamOutput::writeWriteable);
+    }
+
+    /**
+     * Add the provided stats to the ones held by the current instance, effectively merging the two
+     */
+    public void add(CCSTelemetrySnapshot stats) {
+        long oldCount = totalCount;
+        totalCount += stats.totalCount;
+        successCount += stats.successCount;
+        skippedRemotes += stats.skippedRemotes;
+        stats.failureReasons.forEach((k, v) -> failureReasons.merge(k, v, Long::sum));
+        stats.featureCounts.forEach((k, v) -> featureCounts.merge(k, v, Long::sum));
+        stats.clientCounts.forEach((k, v) -> clientCounts.merge(k, v, Long::sum));
+        took.add(stats.took);
+        tookMrtTrue.add(stats.tookMrtTrue);
+        tookMrtFalse.add(stats.tookMrtFalse);
+        remotesPerSearchMax = Math.max(remotesPerSearchMax, stats.remotesPerSearchMax);
+        // Weighted average
+        remotesPerSearchAvg = (double) (remotesPerSearchMax * oldCount + stats.remotesPerSearchMax * stats.totalCount) / totalCount;
+        stats.byRemoteCluster.forEach((r, v) -> byRemoteCluster.merge(r, v, PerClusterCCSTelemetry::add));
+    }
+
+    /**
+     * Publishes the latency statistics to the provided {@link XContentBuilder}.
+     * Example:
+     * "took": {
+     *      "max": 345032,
+     *      "avg": 1620,
+     *      "p90": 2570
+     * }
+     */
+    public static void publishLatency(XContentBuilder builder, LongMetricValue took, String name) throws IOException {
+        builder.startObject(name);
+        {
+            builder.field("max", took.max());
+            builder.field("avg", took.avg());
+            builder.field("p90", took.p90());
+        }
+        builder.endObject();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("ccs_telemetry");
+        {
+            builder.field("total", totalCount);
+            builder.field("success", successCount);
+            builder.field("skipped", skippedRemotes);
+            publishLatency(builder, took, "took");
+            publishLatency(builder, tookMrtTrue, "took_mrt_true");
+            publishLatency(builder, tookMrtFalse, "took_mrt_false");
+            builder.field("remotes_per_search_max", remotesPerSearchMax);
+            builder.field("remotes_per_search_avg", remotesPerSearchAvg);
+            builder.field("failure_reasons", failureReasons);
+            builder.field("feature_counts", featureCounts);
+            builder.field("client_counts", clientCounts);
+            builder.startObject("remote_clusters");
+            {
+                builder.field("count", byRemoteCluster.size());
+                byRemoteCluster.forEach((name, clusterData) -> {
+                    try {
+                        builder.startObject(name);
+                        clusterData.toXContent(builder, params);
+                        builder.endObject();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+            builder.endObject();
+        }
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CCSTelemetrySnapshot that = (CCSTelemetrySnapshot) o;
+        return totalCount == that.totalCount
+            && successCount == that.successCount
+            && skippedRemotes == that.skippedRemotes
+            && Objects.equals(failureReasons, that.failureReasons)
+            && Objects.equals(took, that.took)
+            && Objects.equals(tookMrtTrue, that.tookMrtTrue)
+            && Objects.equals(tookMrtFalse, that.tookMrtFalse)
+            && Objects.equals(remotesPerSearchMax, that.remotesPerSearchMax)
+            && Objects.equals(remotesPerSearchAvg, that.remotesPerSearchAvg)
+            && Objects.equals(featureCounts, that.featureCounts)
+            && Objects.equals(clientCounts, that.clientCounts)
+            && Objects.equals(byRemoteCluster, that.byRemoteCluster);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            totalCount,
+            successCount,
+            failureReasons,
+            took,
+            tookMrtTrue,
+            tookMrtFalse,
+            remotesPerSearchMax,
+            remotesPerSearchAvg,
+            skippedRemotes,
+            featureCounts,
+            clientCounts,
+            byRemoteCluster
+        );
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Holds a snapshot of the CCS telemetry statistics.
+ * Holds a snapshot of the CCS telemetry statistics from {@link CCSUsageTelemetry}.
  * Used to hold the stats for a single node that's part of a {@link ClusterStatsNodeResponse}, as well as to
  * accumulate stats for the entire cluster and return them as part of the {@link ClusterStatsResponse}.
  */
@@ -272,6 +272,8 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
             remotesPerSearchAvg = stats.remotesPerSearchAvg;
         }
         // we copy the object here since we'll be modifying it later on subsequent adds
+        // TODO: this may be sub-optimal, as we'll be copying histograms when adding first snapshot to an empty container,
+        // which we could have avoided probably.
         stats.byRemoteCluster.forEach((r, v) -> byRemoteCluster.merge(r, new PerClusterCCSTelemetry(v), PerClusterCCSTelemetry::add));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
@@ -67,7 +67,7 @@ public class CCSUsage {
             return this;
         }
 
-        public Builder skipRemote(String remote) {
+        public Builder skippedRemote(String remote) {
             this.skippedRemotes.add(remote);
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -41,8 +41,7 @@ public class CCSUsageTelemetry {
         SUCCESS("success"),
         REMOTES_UNAVAILABLE("remotes_unavailable"),
         CANCELED("canceled"),
-        // TODO: do we need this? If we subtract all known reasons, the rest is unknown.
-        // May be helpful though if there's a lot of other reasons and it may be hard to calculate the unknowns for some clients.
+        // May be helpful if there's a lot of other reasons, and it may be hard to calculate the unknowns for some clients.
         UNKNOWN("unknown");
 
         private final String name;
@@ -67,8 +66,17 @@ public class CCSUsageTelemetry {
     private final LongAdder successCount;
     private final Map<Result, LongAdder> failureReasons;
 
+    /**
+     * Latency metrics overall
+     */
     private final LongMetric took;
+    /**
+     * Latency metrics with minimize_roundtrips=true
+     */
     private final LongMetric tookMrtTrue;
+    /**
+     * Latency metrics with minimize_roundtrips=false
+     */
     private final LongMetric tookMrtFalse;
     private final LongMetric remotesPerSearch;
     private final LongAdder skippedRemotes;
@@ -143,9 +151,9 @@ public class CCSUsageTelemetry {
      */
     public static class PerClusterCCSTelemetry {
         private final String clusterAlias;
-        // TODO: are we OK to use long and not LongAdder here?
         // Right now, this is the number of successful (not skipped) requests to this cluster.
         // We need to make it clear in the docs that it does not count skipped requests.
+        // TODO: are we OK to use long and not LongAdder here?
         private long count;
         private long skippedCount;
         private final LongMetric took;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 
 import org.elasticsearch.common.util.Maps;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
@@ -198,22 +199,22 @@ public class CCSUsageTelemetry {
         Map<String, Long> reasonsMap = Maps.newMapWithExpectedSize(failureReasons.size());
         failureReasons.forEach((k, v) -> reasonsMap.put(k.getName(), v.longValue()));
 
-        // TODO: should we use immutable maps here?
-        // Since we return copies anyway it's no big deal if anybody modifies them, but it may be cleaner to return immutable.
         LongMetric.LongMetricValue remotes = remotesPerSearch.getValue();
+
+        // Maps returned here are unmodifyable, but the empty ctor produces modifyable maps
         return new CCSTelemetrySnapshot(
             totalCount.longValue(),
             successCount.longValue(),
-            reasonsMap,
+            Collections.unmodifiableMap(reasonsMap),
             took.getValue(),
             tookMrtTrue.getValue(),
             tookMrtFalse.getValue(),
             remotes.max(),
             remotes.avg(),
             skippedRemotes.longValue(),
-            Maps.transformValues(featureCounts, LongAdder::longValue),
-            Maps.transformValues(clientCounts, LongAdder::longValue),
-            Maps.transformValues(byRemoteCluster, PerClusterCCSTelemetry::getSnapshot)
+            Collections.unmodifiableMap(Maps.transformValues(featureCounts, LongAdder::longValue)),
+            Collections.unmodifiableMap(Maps.transformValues(clientCounts, LongAdder::longValue)),
+            Collections.unmodifiableMap(Maps.transformValues(byRemoteCluster, PerClusterCCSTelemetry::getSnapshot))
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -96,6 +96,10 @@ public class CCSUsageTelemetry {
     }
 
     public void updateUsage(CCSUsage ccsUsage) {
+        // Ignore empty usage objects, we only care for true cross-cluster requests
+        if (ccsUsage.getRemotesCount() == 0) {
+            return;
+        }
         // TODO: fork this to a background thread? if yes, could just pass in the SearchResponse to parse it off the response thread
         doUpdate(ccsUsage);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -41,6 +41,8 @@ public class CCSUsageTelemetry {
         SUCCESS("success"),
         REMOTES_UNAVAILABLE("remotes_unavailable"),
         CANCELED("canceled"),
+        // TODO: do we need this? If we subtract all known reasons, the rest is unknown.
+        // May be helpful though if there's a lot of other reasons and it may be hard to calculate the unknowns for some clients.
         UNKNOWN("unknown");
 
         private final String name;
@@ -58,6 +60,8 @@ public class CCSUsageTelemetry {
     public static final String MRT_FEATURE = "mrt_on";
     public static final String ASYNC_FEATURE = "async";
     public static final String WILDCARD_FEATURE = "wildcards";
+    // TODO: Do we need to count unknown clients separately?
+    // Again, total - known = unknown
     private static final String CLIENT_UNKNOWN = "unknown";
 
     // TODO: do we need LongAdder here or long is enough? Since updateUsage is synchronized, worst that can happen is

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.HdrHistogram.DoubleHistogram;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.zip.DataFormatException;
+
+/**
+ * Metric class that accepts longs and provides count, average, max and maybe percentiles.
+ * Abstracts out the details of how exactly the values are stored and calculated.
+ * {@link LongMetricValue} is a snapshot of the current state of the metric.
+ */
+public class LongMetric {
+    private final DoubleHistogram values;
+    private static final int SIGNIFICANT_DIGITS = 2;
+
+    LongMetric() {
+        values = new DoubleHistogram(SIGNIFICANT_DIGITS);
+    }
+
+    void record(long v) {
+        values.recordValue(v);
+    }
+
+    LongMetricValue getValue() {
+        return new LongMetricValue(values);
+    }
+
+    /**
+     * Snapshot of {@link LongMetric} value that provides the current state of the metric.
+     * Can be added with another {@link LongMetricValue} object.
+     */
+    public static final class LongMetricValue implements Writeable {
+        private final DoubleHistogram values;
+
+        public LongMetricValue(DoubleHistogram values) {
+            // Copy here since we don't want the snapshot value to change if somebody updates the original one
+            this.values = values.copy();
+        }
+
+        LongMetricValue() {
+            this.values = new DoubleHistogram(SIGNIFICANT_DIGITS);
+        }
+
+        public void add(LongMetricValue v) {
+            this.values.add(v.values);
+        }
+
+        public static LongMetricValue fromStream(StreamInput in) throws IOException {
+            byte[] b = in.readByteArray();
+            ByteBuffer bb = ByteBuffer.wrap(b);
+            try {
+                // TODO: not sure what is the good value for minBarForHighestToLowestValueRatio here?
+                DoubleHistogram dh = DoubleHistogram.decodeFromCompressedByteBuffer(bb, 1_000_000);
+                return new LongMetricValue(dh);
+            } catch (DataFormatException e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            ByteBuffer b = ByteBuffer.allocate(values.getNeededByteBufferCapacity());
+            values.encodeIntoCompressedByteBuffer(b);
+            int size = b.position();
+            out.writeVInt(size);
+            out.writeBytes(b.array(), 0, size);
+        }
+
+        public long count() {
+            return values.getTotalCount();
+        }
+
+        public long max() {
+            return (long) Math.ceil(values.getMaxValue());
+        }
+
+        public long avg() {
+            return (long) Math.ceil(values.getMean());
+        }
+
+        public long p90() {
+            return (long) Math.ceil(values.getValueAtPercentile(90));
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (LongMetricValue) obj;
+            return this.values.equals(that.values);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(values);
+        }
+
+        @Override
+        public String toString() {
+            return "LongMetricValue[count=" + count() + ", " + "max=" + max() + ", " + "avg=" + avg() + "]";
+        }
+
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -44,6 +44,9 @@ public class LongMetric {
      * Can be added with another {@link LongMetricValue} object.
      */
     public static final class LongMetricValue implements Writeable {
+        // We have to carry the full histogram around since we might need to calculate aggregate percentiles
+        // after collecting individual stats from the nodes, and we can't do that without having the full histogram.
+        // This costs about 2K per metric, which was deemed acceptable.
         private final DoubleHistogram values;
 
         public LongMetricValue(DoubleHistogram values) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -64,7 +64,7 @@ public class LongMetric {
             ByteBuffer bb = ByteBuffer.wrap(b);
             try {
                 // TODO: not sure what is the good value for minBarForHighestToLowestValueRatio here?
-                DoubleHistogram dh = DoubleHistogram.decodeFromCompressedByteBuffer(bb, 1_000_000);
+                DoubleHistogram dh = DoubleHistogram.decodeFromCompressedByteBuffer(bb, 1);
                 return new LongMetricValue(dh);
             } catch (DataFormatException e) {
                 throw new IOException(e);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -51,6 +51,10 @@ public class LongMetric {
             this.values = values.copy();
         }
 
+        public LongMetricValue(LongMetricValue v) {
+            this.values = v.values.copy();
+        }
+
         LongMetricValue() {
             this.values = new DoubleHistogram(SIGNIFICANT_DIGITS);
         }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1947,7 +1947,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             for (String clusterAlias : searchResponse.getClusters().getClusterAliases()) {
                 SearchResponse.Cluster cluster = searchResponse.getClusters().getCluster(clusterAlias);
                 if (cluster.getStatus() == SearchResponse.Cluster.Status.SKIPPED) {
-                    usageBuilder.skipRemote(clusterAlias);
+                    usageBuilder.skippedRemote(clusterAlias);
                 } else {
                     usageBuilder.perClusterUsage(clusterAlias, cluster.getTook());
                 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
 import org.elasticsearch.action.admin.cluster.stats.CCSUsage;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -47,6 +49,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.util.ArrayUtils;
@@ -76,6 +79,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.profile.SearchProfileShardResult;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
@@ -309,48 +313,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
     @Override
     protected void doExecute(Task task, SearchRequest searchRequest, ActionListener<SearchResponse> listener) {
-        ActionListener<SearchResponse> loggingAndMetrics = new ActionListener<>() {
-            @Override
-            public void onResponse(SearchResponse searchResponse) {
-                try {
-                    searchResponseMetrics.recordTookTime(searchResponse.getTookInMillis());
-                    SearchResponseMetrics.ResponseCountTotalStatus responseCountTotalStatus =
-                        SearchResponseMetrics.ResponseCountTotalStatus.SUCCESS;
-                    if (searchResponse.getShardFailures() != null && searchResponse.getShardFailures().length > 0) {
-                        // Deduplicate failures by exception message and index
-                        ShardOperationFailedException[] groupedFailures = ExceptionsHelper.groupBy(searchResponse.getShardFailures());
-                        for (ShardOperationFailedException f : groupedFailures) {
-                            boolean causeHas500Status = false;
-                            if (f.getCause() != null) {
-                                causeHas500Status = ExceptionsHelper.status(f.getCause()).getStatus() >= 500;
-                            }
-                            if ((f.status().getStatus() >= 500 || causeHas500Status)
-                                && ExceptionsHelper.isNodeOrShardUnavailableTypeException(f.getCause()) == false) {
-                                logger.warn("TransportSearchAction shard failure (partial results response)", f);
-                                responseCountTotalStatus = SearchResponseMetrics.ResponseCountTotalStatus.PARTIAL_FAILURE;
-                            }
-                        }
-                    }
-                    // increment after the delegated onResponse to ensure we don't
-                    // record both a success and a failure if there is an exception
-                    searchResponseMetrics.incrementResponseCount(responseCountTotalStatus);
-
-                    if (CCS_TELEMETRY_FEATURE_FLAG.isEnabled() && searchResponse.getClusters().hasRemoteClusters()) {
-                        extractCCSTelemetry(searchResponse, (SearchTask) task);
-                    }
-                    // TODO: should this be last?
-                    listener.onResponse(searchResponse);
-                } catch (Exception e) {
-                    onFailure(e);
-                }
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                searchResponseMetrics.incrementResponseCount(SearchResponseMetrics.ResponseCountTotalStatus.FAILURE);
-                listener.onFailure(e);
-            }
-        };
+        ActionListener<SearchResponse> loggingAndMetrics = new SearchResponseActionListener((SearchTask) task, listener);
         executeRequest((SearchTask) task, searchRequest, loggingAndMetrics, AsyncSearchActionProvider::new);
     }
 
@@ -405,8 +368,21 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     searchPhaseProvider.apply(delegate)
                 );
             } else {
+                if (listener instanceof TelemetryListener tl) {
+                    tl.setRemotes(resolvedIndices.getRemoteClusterIndices().size());
+                    if (isAsyncSearchTask(task)) {
+                        tl.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+                    }
+                    // TODO: is this the right way to check for wildcards?
+                    if (Arrays.stream(original.indices()).anyMatch(Regex::isSimpleMatchPattern)) {
+                        tl.setFeature(CCSUsageTelemetry.WILDCARD_FEATURE);
+                    }
+                }
                 final TaskId parentTaskId = task.taskInfo(clusterService.localNode().getId(), false).taskId();
                 if (shouldMinimizeRoundtrips(rewritten)) {
+                    if (listener instanceof TelemetryListener tl) {
+                        tl.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+                    }
                     final AggregationReduceContext.Builder aggregationReduceContextBuilder = rewritten.source() != null
                         && rewritten.source().aggregations() != null
                             ? searchService.aggReduceContextBuilder(task::isCancelled, rewritten.source().aggregations())
@@ -814,27 +790,26 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         for (Map.Entry<String, OriginalIndices> entry : remoteIndicesByCluster.entrySet()) {
             final String clusterAlias = entry.getKey();
             boolean skipUnavailable = remoteClusterService.isSkipUnavailable(clusterAlias);
-            TransportSearchAction.CCSActionListener<SearchShardsResponse, Map<String, SearchShardsResponse>> singleListener =
-                new TransportSearchAction.CCSActionListener<>(
-                    clusterAlias,
-                    skipUnavailable,
-                    responsesCountDown,
-                    exceptions,
-                    clusters,
-                    listener
-                ) {
-                    @Override
-                    void innerOnResponse(SearchShardsResponse searchShardsResponse) {
-                        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
-                        ccsClusterInfoUpdate(searchShardsResponse, clusters, clusterAlias, timeProvider);
-                        searchShardsResponses.put(clusterAlias, searchShardsResponse);
-                    }
+            CCSActionListener<SearchShardsResponse, Map<String, SearchShardsResponse>> singleListener = new CCSActionListener<>(
+                clusterAlias,
+                skipUnavailable,
+                responsesCountDown,
+                exceptions,
+                clusters,
+                listener
+            ) {
+                @Override
+                void innerOnResponse(SearchShardsResponse searchShardsResponse) {
+                    assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
+                    ccsClusterInfoUpdate(searchShardsResponse, clusters, clusterAlias, timeProvider);
+                    searchShardsResponses.put(clusterAlias, searchShardsResponse);
+                }
 
-                    @Override
-                    Map<String, SearchShardsResponse> createFinalResponse() {
-                        return searchShardsResponses;
-                    }
-                };
+                @Override
+                Map<String, SearchShardsResponse> createFinalResponse() {
+                    return searchShardsResponses;
+                }
+            };
             remoteClusterService.maybeEnsureConnectedAndGetConnection(
                 clusterAlias,
                 skipUnavailable == false,
@@ -1523,23 +1498,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         }
     }
 
-    private void extractCCSTelemetry(SearchResponse searchResponse, SearchTask searchTask) {
-        Map<String, CCSUsage.PerClusterUsage> clusterUsageMap = new HashMap<>();
-        for (String clusterAlias : searchResponse.getClusters().getClusterAliases()) {
-            SearchResponse.Cluster cluster = searchResponse.getClusters().getCluster(clusterAlias);
-            CCSUsage.PerClusterUsage clusterUsageInfo = new CCSUsage.PerClusterUsage(cluster.getTook());
-            clusterUsageMap.put(clusterAlias, clusterUsageInfo);
-        }
-
-        CCSUsage ccsUsage = new CCSUsage.Builder().took(searchResponse.getTookInMillis())
-            .async(isAsyncSearchTask(searchTask))
-            .minimizeRoundTrips(searchResponse.getClusters().isCcsMinimizeRoundtrips())
-            .numSkippedRemotes(searchResponse.getClusters().getClusterStateCount(SearchResponse.Cluster.Status.SKIPPED))
-            .perClusterUsage(clusterUsageMap)
-            .build();
-        usageService.getCcsUsageHolder().updateUsage(ccsUsage);
-    }
-
     /**
      * TransportSearchAction cannot access async-search code, so can't check whether this the Task
      * is an instance of AsyncSearchTask, so this roundabout method is used
@@ -1866,5 +1824,118 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         }
         // the returned list must support in-place sorting, so this is the most memory efficient we can do here
         return Arrays.asList(list);
+    }
+
+    private interface TelemetryListener {
+        void setRemotes(int count);
+
+        void setFeature(String feature);
+    }
+
+    private class SearchResponseActionListener implements ActionListener<SearchResponse>, TelemetryListener {
+        private final SearchTask task;
+        private final ActionListener<SearchResponse> listener;
+        private final CCSUsage.Builder usageBuilder;
+
+        SearchResponseActionListener(SearchTask task, ActionListener<SearchResponse> listener) {
+            this.task = task;
+            this.listener = listener;
+            usageBuilder = new CCSUsage.Builder();
+        }
+
+        /**
+         * Should we collect telemetry for this search?
+         */
+        private boolean collectTelemetry() {
+            return CCS_TELEMETRY_FEATURE_FLAG.isEnabled() && usageBuilder.getRemotesCount() > 0;
+        }
+
+        public void setRemotes(int count) {
+            usageBuilder.setRemotesCount(count);
+        }
+
+        @Override
+        public void setFeature(String feature) {
+            usageBuilder.setFeature(feature);
+        }
+
+        @Override
+        public void onResponse(SearchResponse searchResponse) {
+            try {
+                searchResponseMetrics.recordTookTime(searchResponse.getTookInMillis());
+                SearchResponseMetrics.ResponseCountTotalStatus responseCountTotalStatus =
+                    SearchResponseMetrics.ResponseCountTotalStatus.SUCCESS;
+                if (searchResponse.getShardFailures() != null && searchResponse.getShardFailures().length > 0) {
+                    // Deduplicate failures by exception message and index
+                    ShardOperationFailedException[] groupedFailures = ExceptionsHelper.groupBy(searchResponse.getShardFailures());
+                    for (ShardOperationFailedException f : groupedFailures) {
+                        boolean causeHas500Status = false;
+                        if (f.getCause() != null) {
+                            causeHas500Status = ExceptionsHelper.status(f.getCause()).getStatus() >= 500;
+                        }
+                        if ((f.status().getStatus() >= 500 || causeHas500Status)
+                            && ExceptionsHelper.isNodeOrShardUnavailableTypeException(f.getCause()) == false) {
+                            logger.warn("TransportSearchAction shard failure (partial results response)", f);
+                            responseCountTotalStatus = SearchResponseMetrics.ResponseCountTotalStatus.PARTIAL_FAILURE;
+                        }
+                    }
+                }
+                // increment after the delegated onResponse to ensure we don't
+                // record both a success and a failure if there is an exception
+                searchResponseMetrics.incrementResponseCount(responseCountTotalStatus);
+
+                if (collectTelemetry()) {
+                    extractCCSTelemetry(searchResponse);
+                    recordTelemetry();
+                }
+                // TODO: should this be last?
+                listener.onResponse(searchResponse);
+            } catch (Exception e) {
+                onFailure(e);
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            searchResponseMetrics.incrementResponseCount(SearchResponseMetrics.ResponseCountTotalStatus.FAILURE);
+            if (collectTelemetry()) {
+                // TODO: better failure recognition
+                Result status;
+                if (e instanceof RemoteTransportException) {
+                    status = Result.REMOTES_UNAVAILABLE;
+                } else if (task.isCancelled() || (e instanceof TaskCancelledException)) {
+                    status = Result.CANCELED;
+                } else {
+                    status = Result.UNKNOWN;
+                }
+                usageBuilder.setFailure(status);
+                // TODO: can we still get some time measurements here? Do we want to?
+                recordTelemetry();
+            }
+            listener.onFailure(e);
+        }
+
+        private void recordTelemetry() {
+            usageService.getCcsUsageHolder().updateUsage(usageBuilder.build());
+        }
+
+        /**
+         * Extract telemetry data from the search response.
+         * @param searchResponse The final response from the search.
+         */
+        private void extractCCSTelemetry(SearchResponse searchResponse) {
+            usageBuilder.took(searchResponse.getTookInMillis());
+            // TODO: what happens with the local cluster there? Are we tracking it too just like the others?
+            for (String clusterAlias : searchResponse.getClusters().getClusterAliases()) {
+                SearchResponse.Cluster cluster = searchResponse.getClusters().getCluster(clusterAlias);
+                // TODO: check if getTook is meaningful if cluster was skipped
+                usageBuilder.perClusterUsage(clusterAlias, cluster.getTook());
+                if (cluster.getStatus() == SearchResponse.Cluster.Status.SKIPPED) {
+                    usageBuilder.skipRemote(clusterAlias);
+                }
+            }
+
+        }
+
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ApproximateMatcher.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ApproximateMatcher.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matches a value that is within given range (currently 1%) of an expected value.
+ *
+ * We need this because histograms do not store exact values, but only value ranges.
+ * Since we have 2 significant digits, the value should be within 1% of the expected value.
+ */
+public class ApproximateMatcher extends TypeSafeMatcher<Long> {
+    public static double ACCURACY = 0.01;
+    private final long expectedValue;
+
+    public ApproximateMatcher(long expectedValue) {
+        this.expectedValue = expectedValue;
+    }
+
+    @Override
+    protected boolean matchesSafely(Long actualValue) {
+        double lowerBound = Math.floor(expectedValue * (1.00 - ACCURACY));
+        double upperBound = Math.ceil(expectedValue * (1.00 + ACCURACY));
+        return actualValue >= lowerBound && actualValue <= upperBound;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a long value within 1% of ").appendValue(expectedValue);
+    }
+
+    /**
+     * Matches a value that is within given range (currently 1%) of an expected value.
+     */
+    public static ApproximateMatcher closeTo(long expectedValue) {
+        return new ApproximateMatcher(expectedValue);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.action.admin.cluster.stats.LongMetric.LongMetricValue;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<CCSTelemetrySnapshot> {
+
+    private LongMetricValue randomLongMetricValue() {
+        LongMetric v = new LongMetric();
+        for (int i = 0; i < randomIntBetween(0, 10); i++) {
+            v.record(randomIntBetween(0, 1_000_000));
+        }
+        return v.getValue();
+    }
+
+    private CCSTelemetrySnapshot.PerClusterCCSTelemetry randomPerClusterCCSTelemetry() {
+        return new CCSTelemetrySnapshot.PerClusterCCSTelemetry(randomNonNegativeLong(), randomNonNegativeLong(), randomLongMetricValue());
+    }
+
+    @Override
+    protected CCSTelemetrySnapshot createTestInstance() {
+        if (randomBoolean()) {
+            return new CCSTelemetrySnapshot();
+        } else {
+            return randomCCSTelemetrySnapshot();
+        }
+    }
+
+    private CCSTelemetrySnapshot randomCCSTelemetrySnapshot() {
+        return new CCSTelemetrySnapshot(
+            randomLongBetween(0, 1_000_000_000),
+            randomLongBetween(0, 1_000_000_000),
+            Map.of(),
+            randomLongMetricValue(),
+            randomLongMetricValue(),
+            randomLongMetricValue(),
+            randomLongBetween(0, 1_000_000_000),
+            randomDoubleBetween(0.0, 100.0, false),
+            randomLongBetween(0, 1_000_000_000),
+            Map.of(),
+            Map.of(),
+            randomMap(1, 10, () -> new Tuple<>(randomAlphaOfLengthBetween(5, 10), randomPerClusterCCSTelemetry()))
+        );
+    }
+
+    @Override
+    protected Writeable.Reader<CCSTelemetrySnapshot> instanceReader() {
+        return CCSTelemetrySnapshot::new;
+    }
+
+    @Override
+    protected CCSTelemetrySnapshot mutateInstance(CCSTelemetrySnapshot instance) throws IOException {
+        // create a copy of CCSTelemetrySnapshot by extracting each field and mutating it
+        long totalCount = instance.getTotalCount();
+        long successCount = instance.getSuccessCount();
+        var failureReasons = instance.getFailureReasons();
+        LongMetricValue took = instance.getTook();
+        LongMetricValue tookMrtTrue = instance.getTookMrtTrue();
+        LongMetricValue tookMrtFalse = instance.getTookMrtFalse();
+        long skippedRemotes = instance.getSkippedRemotes();
+        long remotesPerSearchMax = instance.getRemotesPerSearchMax();
+        double remotesPerSearchAvg = instance.getRemotesPerSearchAvg();
+        var featureCounts = instance.getFeatureCounts();
+        var clientCounts = instance.getClientCounts();
+        var perClusterCCSTelemetries = instance.getByRemoteCluster();
+
+        // Mutate values
+        int i = randomInt(11);
+        switch (i) {
+            case 0:
+                totalCount += randomNonNegativeLong();
+                break;
+            case 1:
+                successCount += randomNonNegativeLong();
+                break;
+            case 2:
+                failureReasons = new HashMap<>(failureReasons);
+                if (failureReasons.isEmpty() || randomBoolean()) {
+                    failureReasons.put(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(failureReasons.keySet());
+                    failureReasons.put(key, randomNonNegativeLong());
+                }
+                break;
+            case 3:
+                took = randomLongMetricValue();
+                break;
+            case 4:
+                tookMrtTrue = randomLongMetricValue();
+                break;
+            case 5:
+                tookMrtFalse = randomLongMetricValue();
+                break;
+            case 6:
+                skippedRemotes += randomNonNegativeLong();
+                break;
+            case 7:
+                remotesPerSearchMax += randomNonNegativeLong();
+                break;
+            case 8:
+                remotesPerSearchAvg = randomDoubleBetween(0.0, 100.0, false);
+                break;
+            case 9:
+                featureCounts = new HashMap<>(featureCounts);
+                if (featureCounts.isEmpty() || randomBoolean()) {
+                    featureCounts.put(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(featureCounts.keySet());
+                    featureCounts.put(key, randomNonNegativeLong());
+                }
+                break;
+            case 10:
+                clientCounts = new HashMap<>(clientCounts);
+                if (clientCounts.isEmpty() || randomBoolean()) {
+                    clientCounts.put(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(clientCounts.keySet());
+                    clientCounts.put(key, randomNonNegativeLong());
+                }
+                break;
+            case 11:
+                perClusterCCSTelemetries = new HashMap<>(perClusterCCSTelemetries);
+                if (perClusterCCSTelemetries.isEmpty() || randomBoolean()) {
+                    perClusterCCSTelemetries.put(randomAlphaOfLengthBetween(5, 10), randomPerClusterCCSTelemetry());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(perClusterCCSTelemetries.keySet());
+                    perClusterCCSTelemetries.put(key, randomPerClusterCCSTelemetry());
+                }
+                break;
+        }
+        // Return new instance
+        return new CCSTelemetrySnapshot(
+            totalCount,
+            successCount,
+            failureReasons,
+            took,
+            tookMrtTrue,
+            tookMrtFalse,
+            remotesPerSearchMax,
+            remotesPerSearchAvg,
+            skippedRemotes,
+            featureCounts,
+            clientCounts,
+            perClusterCCSTelemetries
+        );
+    }
+
+    public void testAdd() {
+        CCSTelemetrySnapshot empty = new CCSTelemetrySnapshot();
+        CCSTelemetrySnapshot full = randomCCSTelemetrySnapshot();
+        empty.add(full);
+        assertThat(empty, equalTo(full));
+    }
+
+    private LongMetricValue manyValuesHistogram(long startingWith) {
+        LongMetric metric = new LongMetric();
+        // Produce 100 values from startingWith to 2 * startingWith with equal intervals
+        // We need to space values relative to initial value, otherwise the histogram would put them all in one bucket
+        for (long i = startingWith; i < 2 * startingWith; i += startingWith / 100) {
+            metric.record(i);
+        }
+        return metric.getValue();
+    }
+
+    public void testToXContent() throws IOException {
+        long totalCount = 10;
+        long successCount = 20;
+        // Using TreeMap's here to ensure consistent ordering in the JSON output
+        var failureReasons = new TreeMap<>(Map.of("reason1", 1L, "reason2", 2L, "unknown", 3L));
+        LongMetricValue took = manyValuesHistogram(1000);
+        LongMetricValue tookMrtTrue = manyValuesHistogram(5000);
+        LongMetricValue tookMrtFalse = manyValuesHistogram(10000);
+        long skippedRemotes = 5;
+        long remotesPerSearchMax = 6;
+        double remotesPerSearchAvg = 7.89;
+        var featureCounts = new TreeMap<>(Map.of("async", 10L, "mrt", 20L, "wildcard", 30L));
+        var clientCounts = new TreeMap<>(Map.of("kibana", 40L, "other", 500L));
+        var perClusterCCSTelemetries = new TreeMap<>(
+            Map.of(
+                "remote1",
+                new CCSTelemetrySnapshot.PerClusterCCSTelemetry(100, 22, manyValuesHistogram(2000)),
+                "remote2",
+                new CCSTelemetrySnapshot.PerClusterCCSTelemetry(300, 42, manyValuesHistogram(500000))
+            )
+        );
+
+        var snapshot = new CCSTelemetrySnapshot(
+            totalCount,
+            successCount,
+            failureReasons,
+            took,
+            tookMrtTrue,
+            tookMrtFalse,
+            remotesPerSearchMax,
+            remotesPerSearchAvg,
+            skippedRemotes,
+            featureCounts,
+            clientCounts,
+            perClusterCCSTelemetries
+        );
+        String expected = readJSONFromResource("telemetry_test.json");
+        assertEquals(expected, snapshot.toString());
+    }
+
+    private String readJSONFromResource(String fileName) throws IOException {
+        try (InputStream inputStream = getClass().getResourceAsStream("/org/elasticsearch/action/admin/cluster/stats/" + fileName)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + fileName);
+            }
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -28,7 +28,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
 
     private LongMetricValue randomLongMetricValue() {
         LongMetric v = new LongMetric();
-        for (int i = 0; i < randomIntBetween(0, 10); i++) {
+        for (int i = 0; i < randomIntBetween(1, 10); i++) {
             v.record(randomIntBetween(0, 1_000_000));
         }
         return v.getValue();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -11,8 +11,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Map;
-
+import static org.elasticsearch.action.admin.cluster.stats.ApproximateMatcher.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -33,53 +32,74 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             boolean minimizeRoundTrips = randomBoolean();
             boolean async = randomBoolean();
             took1 = randomLongBetween(5, 10000);
-            int numSkippedRemotes = randomIntBetween(0, 3);
-            expectedSearchesWithSkippedRemotes = numSkippedRemotes > 0 ? 1 : 0;
+            boolean skippedRemote = randomBoolean();
+            expectedSearchesWithSkippedRemotes = skippedRemote ? 1 : 0;
             expectedAsyncCount = async ? 1 : 0;
             expectedMinRTCount = minimizeRoundTrips ? 1 : 0;
 
             // per cluster telemetry
             long tookLocal = randomLongBetween(2, 8000);
             took1Remote1 = randomLongBetween(2, 8000);
-            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
-                "(local)",
-                new CCSUsage.PerClusterUsage(new TimeValue(tookLocal)),
-                "remote1",
-                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
-            );
 
-            CCSUsage ccsUsage = new CCSUsage.Builder().took(took1)
-                .async(async)
-                .minimizeRoundTrips(minimizeRoundTrips)
-                .numSkippedRemotes(numSkippedRemotes)
-                .perClusterUsage(perClusterUsage)
-                .build();
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(took1).setRemotesCount(1);
+            if (async) {
+                builder.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+            }
+            if (minimizeRoundTrips) {
+                builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+            }
+            if (skippedRemote) {
+                builder.skipRemote("remote1");
+            }
+            builder.perClusterUsage("(local)", new TimeValue(tookLocal));
+            builder.perClusterUsage("remote1", new TimeValue(took1Remote1));
 
+            CCSUsage ccsUsage = builder.build();
             ccsUsageHolder.updateUsage(ccsUsage);
 
-            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(1L));
-            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
-            assertThat(successfulCCSTelemetry.getCount(), equalTo(1L));
-            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
-            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
-            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1));
+            CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+
+            assertThat(snapshot.getTotalCount(), equalTo(1L));
+            assertThat(snapshot.getSuccessCount(), equalTo(1L));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
+            assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(snapshot.getTook().avg(), greaterThan(0L));
+            // Expect it to be within 1% of the actual value
+            assertThat(snapshot.getTook().avg(), closeTo(took1));
+            assertThat(snapshot.getTook().max(), lessThanOrEqualTo(took1));
+            if (minimizeRoundTrips) {
+                assertThat(snapshot.getTookMrtTrue().avg(), greaterThan(0L));
+                assertThat(snapshot.getTookMrtFalse().max(), equalTo(0L));
+            } else {
+                assertThat(snapshot.getTookMrtFalse().avg(), greaterThan(0L));
+                assertThat(snapshot.getTookMrtTrue().max(), equalTo(0L));
+            }
+            assertThat(snapshot.getClientCounts().get("unknown"), equalTo(1L));
 
             // per cluster telemetry asserts
-            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+
+            var telemetryByCluster = snapshot.getByRemoteCluster();
             assertThat(telemetryByCluster.size(), equalTo(2));
             var localClusterTelemetry = telemetryByCluster.get("(local)");
             assertNotNull(localClusterTelemetry);
             assertThat(localClusterTelemetry.getCount(), equalTo(1L));
-            assertThat(localClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(localClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) tookLocal));
+            assertThat(localClusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(localClusterTelemetry.getTook().count(), equalTo(1L));
+            assertThat(localClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(localClusterTelemetry.getTook().avg(), closeTo(tookLocal));
+            // assertThat(localClusterTelemetry.getTook().max(), greaterThanOrEqualTo(tookLocal));
 
             var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
             assertNotNull(remote1ClusterTelemetry);
             assertThat(remote1ClusterTelemetry.getCount(), equalTo(1L));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1Remote1));
+            assertThat(remote1ClusterTelemetry.getSkippedCount(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().count(), equalTo(1L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), closeTo(took1Remote1));
+            // assertThat(remote1ClusterTelemetry.getTook().max(), greaterThanOrEqualTo(took1Remote1));
         }
 
         // second search
@@ -89,45 +109,59 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             expectedAsyncCount += async ? 1 : 0;
             expectedMinRTCount += minimizeRoundTrips ? 1 : 0;
             long took2 = randomLongBetween(5, 10000);
-            int numSkippedRemotes = randomIntBetween(0, 3);
-            expectedSearchesWithSkippedRemotes += numSkippedRemotes > 0 ? 1 : 0;
-
+            boolean skippedRemote = randomBoolean();
+            expectedSearchesWithSkippedRemotes += skippedRemote ? 1 : 0;
             long took2Remote1 = randomLongBetween(2, 8000);
-            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
-                "remote1",
-                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
-            );
 
-            CCSUsage ccsUsage = new CCSUsage.Builder().took(took2)
-                .async(async)
-                .minimizeRoundTrips(minimizeRoundTrips)
-                .numSkippedRemotes(numSkippedRemotes)
-                .perClusterUsage(perClusterUsage)
-                .build();
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(took2).setRemotesCount(1).setClient("kibana");
+            if (async) {
+                builder.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+            }
+            if (minimizeRoundTrips) {
+                builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+            }
+            if (skippedRemote) {
+                builder.skipRemote("remote1");
+            }
+            builder.perClusterUsage("remote1", new TimeValue(took2Remote1));
 
+            CCSUsage ccsUsage = builder.build();
             ccsUsageHolder.updateUsage(ccsUsage);
 
-            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(2L));
-            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
-            assertThat(successfulCCSTelemetry.getCount(), equalTo(2L));
-            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
-            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
-            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1, took2)));
+            CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+
+            assertThat(snapshot.getTotalCount(), equalTo(2L));
+            assertThat(snapshot.getSuccessCount(), equalTo(2L));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
+            assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(snapshot.getTook().avg(), greaterThan(0L));
+            assertThat(snapshot.getTook().avg(), closeTo((took1 + took2) / 2));
+            // assertThat(snapshot.getTook().max(), greaterThanOrEqualTo(Math.max(took1, took2)));
+            assertThat(snapshot.getClientCounts().size(), equalTo(2));
+            assertThat(snapshot.getClientCounts().get("kibana"), equalTo(1L));
+            assertThat(snapshot.getClientCounts().get("unknown"), equalTo(1L));
 
             // per cluster telemetry asserts
-            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+
+            var telemetryByCluster = snapshot.getByRemoteCluster();
             assertThat(telemetryByCluster.size(), equalTo(2));
             var localClusterTelemetry = telemetryByCluster.get("(local)");
             assertNotNull(localClusterTelemetry);
-            assertThat(localClusterTelemetry.getCount(), equalTo(1L));  // not part of second search
+            assertThat(localClusterTelemetry.getCount(), equalTo(1L));
+            assertThat(localClusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(localClusterTelemetry.getTook().count(), equalTo(1L));
 
             var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
             assertNotNull(remote1ClusterTelemetry);
             assertThat(remote1ClusterTelemetry.getCount(), equalTo(2L));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1Remote1, took2Remote1)));
+            assertThat(remote1ClusterTelemetry.getSkippedCount(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().count(), equalTo(2L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), closeTo((took1Remote1 + took2Remote1) / 2));
+            // assertThat(remote1ClusterTelemetry.getTook().max(), greaterThanOrEqualTo(Math.max(took1Remote1, took2Remote1)));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -82,7 +82,8 @@ public class CCSUsageTelemetryTests extends ESTestCase {
                 assertThat(snapshot.getTookMrtTrue().count(), equalTo(0L));
                 assertThat(snapshot.getTookMrtTrue().max(), equalTo(0L));
             }
-            assertThat(snapshot.getClientCounts().get("unknown"), equalTo(1L));
+            // We currently don't count unknown clients
+            assertThat(snapshot.getClientCounts().size(), equalTo(0));
 
             // per cluster telemetry asserts
 
@@ -145,9 +146,10 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             assertThat(snapshot.getTook().avg(), closeTo((took1 + took2) / 2));
             // assertThat(snapshot.getTook().max(), greaterThanOrEqualTo(Math.max(took1, took2)));
-            assertThat(snapshot.getClientCounts().size(), equalTo(2));
+
+            // Counting only known clients
             assertThat(snapshot.getClientCounts().get("kibana"), equalTo(1L));
-            assertThat(snapshot.getClientCounts().get("unknown"), equalTo(1L));
+            assertThat(snapshot.getClientCounts().size(), equalTo(1));
 
             // per cluster telemetry asserts
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -50,7 +50,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
                 builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
             }
             if (skippedRemote) {
-                builder.skipRemote("remote1");
+                builder.skippedRemote("remote1");
             }
             builder.perClusterUsage("(local)", new TimeValue(tookLocal));
             builder.perClusterUsage("remote1", new TimeValue(took1Remote1));
@@ -129,7 +129,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
                 builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
             }
             if (skippedRemote) {
-                builder.skipRemote("remote1");
+                builder.skippedRemote("remote1");
             }
             builder.perClusterUsage("remote1", new TimeValue(took2Remote1));
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -70,10 +70,16 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getTook().avg(), closeTo(took1));
             assertThat(snapshot.getTook().max(), lessThanOrEqualTo(took1));
             if (minimizeRoundTrips) {
+                assertThat(snapshot.getTookMrtTrue().count(), equalTo(1L));
                 assertThat(snapshot.getTookMrtTrue().avg(), greaterThan(0L));
+                assertThat(snapshot.getTookMrtTrue().avg(), closeTo(took1));
+                assertThat(snapshot.getTookMrtFalse().count(), equalTo(0L));
                 assertThat(snapshot.getTookMrtFalse().max(), equalTo(0L));
             } else {
+                assertThat(snapshot.getTookMrtFalse().count(), equalTo(1L));
                 assertThat(snapshot.getTookMrtFalse().avg(), greaterThan(0L));
+                assertThat(snapshot.getTookMrtFalse().avg(), closeTo(took1));
+                assertThat(snapshot.getTookMrtTrue().count(), equalTo(0L));
                 assertThat(snapshot.getTookMrtTrue().max(), equalTo(0L));
             }
             assertThat(snapshot.getClientCounts().get("unknown"), equalTo(1L));

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -1,0 +1,59 @@
+{
+  "ccs_telemetry" : {
+    "total" : 10,
+    "success" : 20,
+    "skipped" : 5,
+    "took" : {
+      "max" : 1988,
+      "avg" : 1496,
+      "p90" : 1892
+    },
+    "took_mrt_true" : {
+      "max" : 9952,
+      "avg" : 7466,
+      "p90" : 9440
+    },
+    "took_mrt_false" : {
+      "max" : 19904,
+      "avg" : 14932,
+      "p90" : 18880
+    },
+    "remotes_per_search_max" : 6,
+    "remotes_per_search_avg" : 7.89,
+    "failure_reasons" : {
+      "reason1" : 1,
+      "reason2" : 2,
+      "unknown" : 3
+    },
+    "features" : {
+      "async" : 10,
+      "mrt" : 20,
+      "wildcard" : 30
+    },
+    "clients" : {
+      "kibana" : 40,
+      "other" : 500
+    },
+    "remote_clusters" : {
+      "count" : 2,
+      "remote1" : {
+        "total" : 100,
+        "skipped" : 22,
+        "took" : {
+          "max" : 3976,
+          "avg" : 2992,
+          "p90" : 3784
+        }
+      },
+      "remote2" : {
+        "total" : 300,
+        "skipped" : 42,
+        "took" : {
+          "max" : 993280,
+          "avg" : 747480,
+          "p90" : 944128
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements collecting CCS usage stats and generating stats snapshots

Features covered:
- [x] Collect per-request statistics in CCSUsage
- [x] Collect overall statistics in CCSUsageTelemetry
- [x] Produce snapshots as CCSTelemetrySnapshot
- [x] Generate XContent from the snapshot
- [x] Client recognition
- [ ] Add logic to collect and merge telemetry snapshots for stats action processing
- [ ] Add metrics to the cluster stats output
- [ ] Test that all paths through the search collect proper metrics

Also in the patch: 
- Create `LongMetric` class that encapsulates metric handling (mostly for latencies) and `LongMetricValue` as a snapshot
- Histograms will be part of the on-wire message, since they seem to require only ~2K size with 2 significant digits. 
- `SearchResponseActionListener` as a separate class which also takes care of metrics
- Metrics are built both on success and failure, though we could use some more fine grained failure recognition later
- TODO: think of how to get rid of `isAsyncSearchTask`. 