### PR TITLE
[8.15] Unmute DockerTests.test600Interrupt (#111165)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1231,7 +1231,6 @@ public class DockerTests extends PackagingTestCase {
         assertBusy(() -> assertTrue(readinessProbe(9399)));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99508")
     public void test600Interrupt() {
         waitForElasticsearch(installation, "elastic", PASSWORD);
         final Result containerLogs = getContainerLogs();


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Unmute DockerTests.test600Interrupt (#111165)