### PR TITLE
ESQL: Allow suppressed exeption in HeapAttack

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -162,7 +162,8 @@ public class HeapAttackIT extends ESRestTestCase {
             matchesMap().entry("status", 429)
                 .entry(
                     "error",
-                    matchesMap().entry("bytes_wanted", greaterThan(1000))
+                    matchesMap().extraOk()
+                        .entry("bytes_wanted", greaterThan(1000))
                         .entry("reason", matchesRegex("\\[request] Data too large, data for \\[topn] would .+"))
                         .entry("durability", "TRANSIENT")
                         .entry("type", "circuit_breaking_exception")


### PR DESCRIPTION
We're ok with suppresses exceptions in this test.

Closes #111128
