### PR TITLE
Make sure contender uses logs templates

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChallengeRestTest {
 
     public StandardVersusLogsIndexModeChallengeRestIT() {
-        super("logs-apache-baseline", "logs-apache-contender", "baseline-template", "contender-template", 99, 99);
+        super("standard-apache-baseline", "logs-apache-contender", "baseline-template", "contender-template", 101, 101);
     }
 
     @Override
@@ -52,11 +52,11 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
 
     @Override
     public void contenderMappings(XContentBuilder builder) throws IOException {
+        builder.field("subobjects", false);
         mappings(builder);
     }
 
     private static void mappings(final XContentBuilder builder) throws IOException {
-        builder.field("subobjects", false);
         if (randomBoolean()) {
             builder.startObject("properties")
 

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -47,16 +47,49 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
 
     @Override
     public void baselineMappings(XContentBuilder builder) throws IOException {
-        mappings(builder);
+        if (randomBoolean()) {
+            builder.startObject("properties")
+
+                .startObject("@timestamp")
+                .field("type", "date")
+                .endObject()
+
+                .startObject("host.name")
+                .field("type", "keyword")
+                .field("ignore_above", randomIntBetween(1000, 1200))
+                .endObject()
+
+                .startObject("message")
+                .field("type", "keyword")
+                .field("ignore_above", randomIntBetween(1000, 1200))
+                .endObject()
+
+                .startObject("method")
+                .field("type", "keyword")
+                .field("ignore_above", randomIntBetween(1000, 1200))
+                .endObject()
+
+                .startObject("memory_usage_bytes")
+                .field("type", "long")
+                .field("ignore_malformed", randomBoolean())
+                .endObject()
+
+                .endObject();
+        } else {
+            builder.startObject("properties")
+
+                .startObject("host.name")
+                .field("type", "keyword")
+                .field("ignore_above", randomIntBetween(1000, 1200))
+                .endObject()
+
+                .endObject();
+        }
     }
 
     @Override
     public void contenderMappings(XContentBuilder builder) throws IOException {
         builder.field("subobjects", false);
-        mappings(builder);
-    }
-
-    private static void mappings(final XContentBuilder builder) throws IOException {
         if (randomBoolean()) {
             builder.startObject("properties")
 


### PR DESCRIPTION
Make sure we use `logs` templates for the contender and that `host.name` is mapped
as a `keyword` when `index.mode` is `standard`. Also use `subobjects: false`
to make sure we do not run into object-related synthetic source issues.