### PR TITLE
Use bundled jdk as default runtime jdk instead of build jvm

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
@@ -15,17 +15,23 @@ abstract class AbstractGradleInternalPluginFuncTest extends AbstractJavaGradleFu
     abstract <T extends Plugin> Class<T> getPluginClassUnderTest();
 
     def setup() {
+        settingsFile.text = """
+        plugins {
+            id 'elasticsearch.java-toolchain'
+        }
+        """ + settingsFile.text
+
         buildFile << """
         import ${getPluginClassUnderTest().getName()}
-        
+
         plugins {
           // bring in build-tools-internal onto the classpath
           id 'elasticsearch.global-build-info'
         }
         // internally used plugins do not have a plugin id as they are
-        // not intended to be used directly from build scripts 
+        // not intended to be used directly from build scripts
         plugins.apply(${getPluginClassUnderTest().getSimpleName()})
-        
+
         """
     }
 }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
@@ -19,22 +19,22 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
         given:
         someLibProject()
         subProject("some-depending-lib") {
-            buildFile << """               
+            buildFile << """
                 plugins {
                     id 'elasticsearch.java-doc'
                     id 'java'
                 }
                 group = 'org.acme.depending'
-                
+
                 dependencies {
                     implementation project(':some-lib')
                 }
             """
             classFile('org.acme.depending.SomeDepending') << """
                 package org.acme.depending;
-                
+
                 import org.acme.Something;
-                
+
                 public class SomeDepending {
                     public Something createSomething() {
                         return new Something();
@@ -66,16 +66,17 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
 
     def "sources of shadowed dependencies are added to projects javadoc"() {
         given:
+        settingsFile.text = ""
         someLibProject() << """version = 1.0"""
         subProject("some-depending-lib") {
-            buildFile << """               
+            buildFile << """
                 plugins {
                     id 'elasticsearch.java-doc'
                     id 'com.github.johnrengelman.shadow' version '7.1.2'
                     id 'java'
                 }
                 group = 'org.acme.depending'
-                
+
                 dependencies {
                     implementation project(':some-lib')
                     shadow project(':some-shadowed-lib')
@@ -83,9 +84,9 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
             """
             classFile('org.acme.depending.SomeDepending') << """
                 package org.acme.depending;
-                
+
                 import org.acme.Something;
-                
+
                 public class SomeDepending {
                     public Something createSomething() {
                         return new Something();
@@ -94,9 +95,9 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
             """
             classFile('org.acme.depending.SomeShadowedDepending') << """
                 package org.acme.depending;
-                
+
                 import org.acme.shadowed.Shadowed;
-                
+
                 public class SomeShadowedDepending {
                     public Shadowed createShadowed() {
                         return new Shadowed();
@@ -114,7 +115,7 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
             """
             classFile('org.acme.shadowed.Shadowed') << """
                 package org.acme.shadowed;
-                
+
                 public class Shadowed {
                 }
             """
@@ -145,22 +146,22 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
             tasks.named("javadoc").configure { enabled = false }
         """
         subProject("some-depending-lib") {
-            buildFile << """               
+            buildFile << """
                 plugins {
                     id 'elasticsearch.java-doc'
                     id 'java'
                 }
                 group = 'org.acme.depending'
-                
+
                 dependencies {
                     implementation project(':some-lib')
                 }
             """
             classFile('org.acme.depending.SomeDepending') << """
                 package org.acme.depending;
-                
+
                 import org.acme.Something;
-                
+
                 public class SomeDepending {
                     public Something createSomething() {
                         return new Something();
@@ -264,7 +265,7 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
 
             classFile('org.acme.Something') << """
                 package org.acme;
-                
+
                 public class Something {
                 }
             """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTaskFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTaskFuncTest.groovy
@@ -18,6 +18,7 @@ import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
 import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersPrecommitPlugin
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
+import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 
 
@@ -209,6 +210,10 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleInternalPluginFuncTest {
                 .intercept(FixedValue.nullValue())
                 .make()
         loggingDynamicType.toJar(targetFile(dir("${baseGroupFolderPath}/broken-log4j/0.0.1/"), "broken-log4j-0.0.1.jar"))
+    }
+
+    GradleRunner gradleRunner(Object... arguments) {
+        return super.gradleRunner(arguments).withEnvironment([RUNTIME_JAVA_HOME: System.getProperty("java.home")])
     }
 
     static File targetFile(File dir, String fileName) {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
@@ -12,6 +12,7 @@ import spock.lang.IgnoreIf
 
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.fixtures.AbstractRestResourcesFuncTest
+import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 
 @IgnoreIf({ os.isWindows() })
@@ -204,5 +205,9 @@ echo "Running elasticsearch \$0"
                 it.add("extracted", buildExpanded)
             }
         """
+    }
+
+    GradleRunner gradleRunner(Object... arguments) {
+        return super.gradleRunner(arguments).withEnvironment([RUNTIME_JAVA_HOME: System.getProperty("java.home")])
     }
 }

--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -46,12 +46,4 @@ configure(allprojects) {
             }
         }
     }
-    project.plugins.withType(ThirdPartyAuditPrecommitPlugin) {
-      project.getTasks().withType(ThirdPartyAuditTask.class).configureEach {
-        if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
-          javaHome.set(launcher.map { it.metadata.installationPath.asFile.path })
-          targetCompatibility.set(providers.provider(() -> JavaVersion.toVersion(launcher.map { it.metadata.javaRuntimeVersion }.get())))
-        }
-      }
-    }
 }

--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -25,7 +25,6 @@ configure(allprojects) {
         JvmVendorSpec.ORACLE :
         JvmVendorSpec.matching(VersionProperties.bundledJdkVendor)
     }
-
   project.tasks.withType(Test).configureEach { Test test ->
         if (BuildParams.getIsRuntimeJavaHomeSet()) {
             test.executable = "${BuildParams.runtimeJavaHome}/bin/java" +

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
@@ -26,15 +26,15 @@ import java.util.function.Consumer;
 import static java.util.Objects.requireNonNull;
 
 public class BuildParams {
-    private static File runtimeJavaHome;
+    private static Provider<File> runtimeJavaHome;
     private static Boolean isRuntimeJavaHomeSet;
     private static List<JavaHome> javaVersions;
     private static JavaVersion minimumCompilerVersion;
     private static JavaVersion minimumRuntimeVersion;
     private static JavaVersion gradleJavaVersion;
-    private static JavaVersion runtimeJavaVersion;
+    private static Provider<JavaVersion> runtimeJavaVersion;
     private static Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec;
-    private static String runtimeJavaDetails;
+    private static Provider<String> runtimeJavaDetails;
     private static Boolean inFipsJvm;
     private static String gitRevision;
     private static String gitOrigin;
@@ -58,7 +58,7 @@ public class BuildParams {
     }
 
     public static File getRuntimeJavaHome() {
-        return value(runtimeJavaHome);
+        return value(runtimeJavaHome).get();
     }
 
     public static Boolean getIsRuntimeJavaHomeSet() {
@@ -82,11 +82,11 @@ public class BuildParams {
     }
 
     public static JavaVersion getRuntimeJavaVersion() {
-        return value(runtimeJavaVersion);
+        return value(runtimeJavaVersion.get());
     }
 
     public static String getRuntimeJavaDetails() {
-        return value(runtimeJavaDetails);
+        return value(runtimeJavaDetails.get());
     }
 
     public static Boolean isInFipsJvm() {
@@ -126,7 +126,7 @@ public class BuildParams {
     }
 
     public static Boolean isGraalVmRuntime() {
-        return value(runtimeJavaDetails.toLowerCase().contains("graalvm"));
+        return value(runtimeJavaDetails.get().toLowerCase().contains("graalvm"));
     }
 
     public static Integer getDefaultParallel() {
@@ -182,16 +182,18 @@ public class BuildParams {
             });
         }
 
-        public void setRuntimeJavaHome(File runtimeJavaHome) {
-            try {
-                BuildParams.runtimeJavaHome = requireNonNull(runtimeJavaHome).getCanonicalFile();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+        public void setRuntimeJavaHome(Provider<File> runtimeJavaHome) {
+            BuildParams.runtimeJavaHome = runtimeJavaHome.map(javaHome -> {
+                try {
+                    return javaHome.getCanonicalFile();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
         }
 
-        public void setIsRuntimeJavaHomeSet(boolean isRutimeJavaHomeSet) {
-            BuildParams.isRuntimeJavaHomeSet = isRutimeJavaHomeSet;
+        public void setIsRuntimeJavaHomeSet(boolean isRuntimeJavaHomeSet) {
+            BuildParams.isRuntimeJavaHomeSet = isRuntimeJavaHomeSet;
         }
 
         public void setJavaVersions(List<JavaHome> javaVersions) {
@@ -210,11 +212,11 @@ public class BuildParams {
             BuildParams.gradleJavaVersion = requireNonNull(gradleJavaVersion);
         }
 
-        public void setRuntimeJavaVersion(JavaVersion runtimeJavaVersion) {
+        public void setRuntimeJavaVersion(Provider<JavaVersion> runtimeJavaVersion) {
             BuildParams.runtimeJavaVersion = requireNonNull(runtimeJavaVersion);
         }
 
-        public void setRuntimeJavaDetails(String runtimeJavaDetails) {
+        public void setRuntimeJavaDetails(Provider<String> runtimeJavaDetails) {
             BuildParams.runtimeJavaDetails = runtimeJavaDetails;
         }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.gradle.internal.info;
 
 import org.apache.commons.io.IOUtils;
+import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.BwcVersions;
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
 import org.elasticsearch.gradle.internal.conventions.info.ParallelDetector;
@@ -98,7 +99,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(getResourceContents("/minimumRuntimeVersion"));
 
         Optional<File> selectedRuntimeJavaHome = findRuntimeJavaHome();
-        File actualRuntimeJavaHome = selectedRuntimeJavaHome.orElse(Jvm.current().getJavaHome());
+        File actualRuntimeJavaHome = selectedRuntimeJavaHome.orElse(
+            resolveJavaHomeFromToolChainService(VersionProperties.getBundledJdkMajorVersion())
+        );
         boolean isRuntimeJavaHomeSet = selectedRuntimeJavaHome.isPresent();
 
         GitInfo gitInfo = GitInfo.gitInfo(project.getRootDir());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -32,7 +32,6 @@ import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
 import org.gradle.internal.jvm.inspection.JvmVendor;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
-import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
@@ -51,7 +50,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -98,11 +96,11 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         JavaVersion minimumCompilerVersion = JavaVersion.toVersion(getResourceContents("/minimumCompilerVersion"));
         JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(getResourceContents("/minimumRuntimeVersion"));
 
-        Optional<File> selectedRuntimeJavaHome = findRuntimeJavaHome();
-        File actualRuntimeJavaHome = selectedRuntimeJavaHome.orElse(
-            resolveJavaHomeFromToolChainService(VersionProperties.getBundledJdkMajorVersion())
-        );
-        boolean isRuntimeJavaHomeSet = selectedRuntimeJavaHome.isPresent();
+        Provider<File> explicitRuntimeJavaHome = findRuntimeJavaHome();
+        boolean isExplicitRuntimeJavaHomeSet = explicitRuntimeJavaHome.isPresent();
+        Provider<File> actualRuntimeJavaHome = isExplicitRuntimeJavaHomeSet
+            ? explicitRuntimeJavaHome
+            : resolveJavaHomeFromToolChainService(VersionProperties.getBundledJdkMajorVersion());
 
         GitInfo gitInfo = GitInfo.gitInfo(project.getRootDir());
 
@@ -110,16 +108,22 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.reset();
             params.setRuntimeJavaHome(actualRuntimeJavaHome);
             params.setJavaToolChainSpec(resolveToolchainSpecFromEnv());
+            Provider<JvmInstallationMetadata> runtimeJdkMetaData = actualRuntimeJavaHome.map(
+                runtimeJavaHome -> metadataDetector.getMetadata(getJavaInstallation(runtimeJavaHome))
+            );
             params.setRuntimeJavaVersion(
-                determineJavaVersion(
-                    "runtime java.home",
-                    actualRuntimeJavaHome,
-                    isRuntimeJavaHomeSet ? minimumRuntimeVersion : Jvm.current().getJavaVersion()
+                actualRuntimeJavaHome.map(
+                    javaHome -> determineJavaVersion(
+                        "runtime java.home",
+                        javaHome,
+                        isExplicitRuntimeJavaHomeSet
+                            ? minimumRuntimeVersion
+                            : JavaVersion.toVersion(VersionProperties.getBundledJdkMajorVersion())
+                    )
                 )
             );
-            params.setIsRuntimeJavaHomeSet(isRuntimeJavaHomeSet);
-            JvmInstallationMetadata runtimeJdkMetaData = metadataDetector.getMetadata(getJavaInstallation(actualRuntimeJavaHome));
-            params.setRuntimeJavaDetails(formatJavaVendorDetails(runtimeJdkMetaData));
+            params.setIsRuntimeJavaHomeSet(isExplicitRuntimeJavaHomeSet);
+            params.setRuntimeJavaDetails(runtimeJdkMetaData.map(m -> formatJavaVendorDetails(m)));
             params.setJavaVersions(getAvailableJavaVersions());
             params.setMinimumCompilerVersion(minimumCompilerVersion);
             params.setMinimumRuntimeVersion(minimumRuntimeVersion);
@@ -302,28 +306,30 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         }
     }
 
-    private Optional<File> findRuntimeJavaHome() {
+    private Provider<File> findRuntimeJavaHome() {
         String runtimeJavaProperty = System.getProperty("runtime.java");
 
         if (runtimeJavaProperty != null) {
-            return Optional.of(resolveJavaHomeFromToolChainService(runtimeJavaProperty));
+            return resolveJavaHomeFromToolChainService(runtimeJavaProperty);
         }
-        String env = System.getenv("RUNTIME_JAVA_HOME");
-        if (env != null) {
-            return Optional.of(new File(env));
+        if (System.getenv("RUNTIME_JAVA_HOME") != null) {
+            return providers.provider(() -> new File(System.getenv("RUNTIME_JAVA_HOME")));
         }
         // fall back to tool chain if set.
-        env = System.getenv("JAVA_TOOLCHAIN_HOME");
-        return env == null ? Optional.empty() : Optional.of(new File(env));
+        String env = System.getenv("JAVA_TOOLCHAIN_HOME");
+        return providers.provider(() -> {
+            if (env == null) {
+                return null;
+            }
+            return new File(env);
+        });
     }
 
     @NotNull
-    private File resolveJavaHomeFromToolChainService(String version) {
+    private Provider<File> resolveJavaHomeFromToolChainService(String version) {
         Property<JavaLanguageVersion> value = objectFactory.property(JavaLanguageVersion.class).value(JavaLanguageVersion.of(version));
-        Provider<JavaLauncher> javaLauncherProvider = toolChainService.launcherFor(javaToolchainSpec -> {
-            javaToolchainSpec.getLanguageVersion().value(value);
-        });
-        return javaLauncherProvider.get().getMetadata().getInstallationPath().getAsFile();
+        return toolChainService.launcherFor(javaToolchainSpec -> javaToolchainSpec.getLanguageVersion().value(value))
+            .map(launcher -> launcher.getMetadata().getInstallationPath().getAsFile());
     }
 
     public static String getResourceContents(String resourcePath) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -66,10 +66,8 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
                     )
                 );
             t.dependsOn(resourcesTask);
-            if (BuildParams.getIsRuntimeJavaHomeSet()) {
-                t.getJavaHome().set(project.provider(BuildParams::getRuntimeJavaHome).map(File::getPath));
-            }
             t.getTargetCompatibility().set(project.provider(BuildParams::getRuntimeJavaVersion));
+            t.getJavaHome().set(project.provider(BuildParams::getRuntimeJavaHome).map(File::getPath));
             t.setSignatureFile(resourcesDir.resolve("forbidden/third-party-audit.txt").toFile());
             t.getJdkJarHellClasspath().from(jdkJarHellConfig);
             t.getForbiddenAPIsClasspath().from(project.getConfigurations().getByName("forbiddenApisCliJar").plus(compileOnly));

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -101,7 +101,6 @@ abstract class AbstractGradleFuncTest extends Specification {
                                 .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
                                         .toString().indexOf("-agentlib:jdwp") > 0
                                 )
-                                .withEnvironment([RUNTIME_JAVA_HOME: System.getProperty("java.home")])
                                 .withProjectDir(projectDir)
                                 .withPluginClasspath()
                                 .forwardOutput()

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -13,6 +13,7 @@ import org.elasticsearch.gradle.internal.test.BuildConfigurationAwareGradleRunne
 import org.elasticsearch.gradle.internal.test.InternalAwareGradleRunner
 import org.elasticsearch.gradle.internal.test.NormalizeOutputGradleRunner
 import org.elasticsearch.gradle.internal.test.TestResultExtension
+import org.gradle.internal.component.external.model.ComponentVariant
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -22,6 +23,7 @@ import spock.lang.TempDir
 
 import java.lang.management.ManagementFactory
 import java.nio.file.Files
+import java.io.File
 import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
@@ -99,6 +101,7 @@ abstract class AbstractGradleFuncTest extends Specification {
                                 .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
                                         .toString().indexOf("-agentlib:jdwp") > 0
                                 )
+                                .withEnvironment([RUNTIME_JAVA_HOME: System.getProperty("java.home")])
                                 .withProjectDir(projectDir)
                                 .withPluginClasspath()
                                 .forwardOutput()


### PR DESCRIPTION
If no runtime java version is declared we want to use the bundled jdk. That reflects reality better and makes developer builds more stable / reproducible.