### PR TITLE
[8.15] Make docker packaging test more resilient (#111205)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -44,15 +44,9 @@ tests:
 - class: "org.elasticsearch.xpack.test.rest.XPackRestIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109687"
   method: "test {p0=sql/translate/Translate SQL}"
-- class: "org.elasticsearch.xpack.esql.action.AsyncEsqlQueryActionIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109944"
-  method: "testBasicAsyncExecution"
 - class: "org.elasticsearch.action.admin.indices.rollover.RolloverIT"
   issue: "https://github.com/elastic/elasticsearch/issues/110034"
   method: "testRolloverWithClosedWriteIndex"
-- class: org.elasticsearch.xpack.transform.transforms.TransformIndexerTests
-  method: testMaxPageSearchSizeIsResetToConfiguredValue
-  issue: https://github.com/elastic/elasticsearch/issues/109844
 - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
   method: testStoreDirectory
   issue: https://github.com/elastic/elasticsearch/issues/110210
@@ -64,9 +58,6 @@ tests:
 - class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
   method: testMetadataMigratedAfterUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/110232
-- class: org.elasticsearch.compute.lucene.ValueSourceReaderTypeConversionTests
-  method: testLoadAll
-  issue: https://github.com/elastic/elasticsearch/issues/110244
 - class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
   method: testMinVersionAsNewVersion
   issue: https://github.com/elastic/elasticsearch/issues/95384
@@ -79,16 +70,50 @@ tests:
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110591"
-- class: org.elasticsearch.preallocate.PreallocateTests
+- class: org.elasticsearch.xpack.security.LicenseDLSFLSRoleIT
+  method: testQueryDLSFLSRolesShowAsDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/110729
+- class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
+  method: testPopulationOfCacheWhenLoadingPrivilegesForAllApplications
+  issue: https://github.com/elastic/elasticsearch/issues/110789
+- class: org.elasticsearch.xpack.security.ScrollHelperIntegTests
+  method: testFetchAllEntities
+  issue: https://github.com/elastic/elasticsearch/issues/110786
+- class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
+  method: testCacheFileCreatedAsSparseFile
+  issue: https://github.com/elastic/elasticsearch/issues/110801
+- class: org.elasticsearch.nativeaccess.PreallocateTests
   method: testPreallocate
   issue: https://github.com/elastic/elasticsearch/issues/110948
+- class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
+  method: testSystemPropertyDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/110949
+- class: org.elasticsearch.action.search.KnnSearchSingleNodeTests
+  method: testKnnSearchAction
+  issue: https://github.com/elastic/elasticsearch/issues/111072
+- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoPointIT
+  method: testPushedDownQueriesSingleValue
+  issue: https://github.com/elastic/elasticsearch/issues/111084
+- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownCartesianPointIT
+  method: testPushedDownQueriesSingleValue
+  issue: https://github.com/elastic/elasticsearch/issues/110982
+- class: org.elasticsearch.multi_node.GlobalCheckpointSyncActionIT
+  issue: https://github.com/elastic/elasticsearch/issues/111124
+- class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
+  method: testGetPrivilegesUsesCache
+  issue: https://github.com/elastic/elasticsearch/issues/110788
+- class: org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankTests
+  method: testRerankInferenceResultMismatch
+  issue: https://github.com/elastic/elasticsearch/issues/111133
+- class: org.elasticsearch.cluster.PrevalidateShardPathIT
+  method: testCheckShards
+  issue: https://github.com/elastic/elasticsearch/issues/111134
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test021InstallPlugin
   issue: https://github.com/elastic/elasticsearch/issues/110343
-- class: org.elasticsearch.multi_node.GlobalCheckpointSyncActionIT
-  issue: https://github.com/elastic/elasticsearch/issues/111124
+- class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
+  method: testAuthenticateWithImplicitFlow
+  issue: https://github.com/elastic/elasticsearch/issues/111191
 
 # Examples:
 #
@@ -119,4 +144,12 @@ tests:
 #    method: "test {union_types.MultiIndexIpStringStatsInline}"
 #    issue: "https://github.com/elastic/elasticsearch/..."
 #  Note that this mutes for the unit-test-like CsvTests only.
-#  Muting for the integration tests needs to be done for each IT class individually.
+#  Muting all the integration tests can be done using the class "org.elasticsearch.xpack.esql.**".
+#  Consider however, that some tests are named as "test {file.test SYNC}" and "ASYNC" in the integration tests.
+#  To mute all 3 tests safely everywhere use:
+#  - class: "org.elasticsearch.xpack.esql.**"
+#    method: "test {union_types.MultiIndexIpStringStatsInline}"
+#    issue: "https://github.com/elastic/elasticsearch/..."
+#  - class: "org.elasticsearch.xpack.esql.**"
+#    method: "test {union_types.MultiIndexIpStringStatsInline *}"
+#    issue: "https://github.com/elastic/elasticsearch/..."

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1231,7 +1231,7 @@ public class DockerTests extends PackagingTestCase {
         assertBusy(() -> assertTrue(readinessProbe(9399)));
     }
 
-    public void test600Interrupt() {
+    public void test600Interrupt() throws Exception {
         waitForElasticsearch(installation, "elastic", PASSWORD);
         final Result containerLogs = getContainerLogs();
 
@@ -1241,10 +1241,12 @@ public class DockerTests extends PackagingTestCase {
         final int maxPid = infos.stream().map(i -> i.pid()).max(Integer::compareTo).get();
 
         sh.run("bash -c 'kill -int " + maxPid + "'"); // send ctrl+c to all java processes
-        final Result containerLogsAfter = getContainerLogs();
 
-        assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));
-        assertThat("No errors stdout", containerLogsAfter.stdout(), not(containsString("java.security.AccessControlException:")));
-        assertThat("No errors stderr", containerLogsAfter.stderr(), not(containsString("java.security.AccessControlException:")));
+        assertBusy(() -> {
+            final Result containerLogsAfter = getContainerLogs();
+            assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));
+            assertThat("No errors stdout", containerLogsAfter.stdout(), not(containsString("java.security.AccessControlException:")));
+            assertThat("No errors stderr", containerLogsAfter.stderr(), not(containsString("java.security.AccessControlException:")));
+        });
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Make docker packaging test more resilient (#111205)