### PR TITLE
Replace search_shards with search API in tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -556,10 +556,13 @@
               url:
                 type: keyword
   - do:
-      search_shards:
+      search:
         index:  index1
+        body:
+          profile: true
+
   - set:
-      shards.0.0.node: node_id
+      profile.shards.0.node_id: node_id
 
   - do:
       nodes.stats: { metric: _all, level: "indices", human: true }


### PR DESCRIPTION
The `search_shards` API is not available in serverless. This PR replaces its usage in the newly added test with the `search` API with profiling.

Relates #111123