### PR TITLE
Fix score count validation in reranker response

### DIFF
--- a/docs/changelog/111212.yaml
+++ b/docs/changelog/111212.yaml
@@ -1,0 +1,6 @@
+pr: 111212
+summary: Fix score count validation in reranker response
+area: Ranking
+type: bug
+issues:
+ - 111202

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -152,8 +152,8 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContext extends RankFe
         } else if (modelConfigurations.getService().equals(GoogleVertexAiService.NAME)
             && modelConfigurations.getTaskType().equals(TaskType.RERANK)
             && modelConfigurations.getTaskSettings() instanceof GoogleVertexAiRerankTaskSettings) {
-            return ((GoogleVertexAiRerankTaskSettings) modelConfigurations.getTaskSettings()).topN();
-        }
+                return ((GoogleVertexAiRerankTaskSettings) modelConfigurations.getTaskSettings()).topN();
+            }
 
         return null;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -22,8 +22,8 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVe
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A {@code RankFeaturePhaseRankCoordinatorContext} that performs a rerank inference call to determine relevance scores for documents within

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -22,8 +22,8 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVe
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A {@code RankFeaturePhaseRankCoordinatorContext} that performs a rerank inference call to determine relevance scores for documents within
@@ -83,12 +83,14 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContext extends RankFe
             // The rerank inference endpoint may have an override to return top N documents only, in that case let's fail fast to avoid
             // assigning scores to the wrong input
             Integer configuredTopN = null;
-            if (r.getEndpoints().get(0).getTaskSettings() instanceof CohereRerankTaskSettings cohereTaskSettings) {
+            if (r.getEndpoints().isEmpty() == false
+                && r.getEndpoints().get(0).getTaskSettings() instanceof CohereRerankTaskSettings cohereTaskSettings) {
                 configuredTopN = cohereTaskSettings.getTopNDocumentsOnly();
-            } else if (r.getEndpoints().get(0).getTaskSettings() instanceof GoogleVertexAiRerankTaskSettings googleVertexAiTaskSettings) {
-                configuredTopN = googleVertexAiTaskSettings.topN();
-            }
-            if (configuredTopN != null && configuredTopN < featureDocs.length) {
+            } else if (r.getEndpoints().isEmpty() == false
+                && r.getEndpoints().get(0).getTaskSettings() instanceof GoogleVertexAiRerankTaskSettings googleVertexAiTaskSettings) {
+                    configuredTopN = googleVertexAiTaskSettings.topN();
+                }
+            if (configuredTopN != null && configuredTopN < rankWindowSize) {
                 l.onFailure(
                     new IllegalArgumentException(
                         "Inference endpoint ["

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -85,11 +85,9 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContext extends RankFe
             Integer configuredTopN = null;
             if (r.getEndpoints().get(0).getTaskSettings() instanceof CohereRerankTaskSettings cohereTaskSettings) {
                 configuredTopN = cohereTaskSettings.getTopNDocumentsOnly();
-            } else if (r.getEndpoints()
-                .get(0)
-                .getTaskSettings() instanceof GoogleVertexAiRerankTaskSettings googleVertexAiTaskSettings) {
-                    configuredTopN = googleVertexAiTaskSettings.topN();
-                }
+            } else if (r.getEndpoints().get(0).getTaskSettings() instanceof GoogleVertexAiRerankTaskSettings googleVertexAiTaskSettings) {
+                configuredTopN = googleVertexAiTaskSettings.topN();
+            }
             if (configuredTopN != null && configuredTopN < featureDocs.length) {
                 l.onFailure(
                     new IllegalArgumentException(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContextTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContextTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.search.rank.feature.RankFeatureDoc;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -54,10 +54,9 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContextTests extends E
                 fail();
             }
         });
-
         verify(mockClient).execute(
-            eq(InferenceAction.INSTANCE),
-            argThat(actionRequest -> ((InferenceAction.Request) actionRequest).getTaskType().equals(TaskType.RERANK)),
+            eq(GetInferenceModelAction.INSTANCE),
+            argThat(actionRequest -> ((GetInferenceModelAction.Request) actionRequest).getTaskType().equals(TaskType.RERANK)),
             any()
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
@@ -168,7 +168,10 @@ public class TextSimilarityRankTests extends ESSingleNodeTestCase {
                 )
                 .setQuery(QueryBuilders.matchAllQuery())
         );
-        assertThat(ex.getDetailedMessage(), containsString("Reduce rank_window_size to be less than or equal to this value"));
+        assertThat(
+            ex.getDetailedMessage(),
+            containsString("Reduce rank_window_size to be less than or equal to the configured top N value.")
+        );
     }
 
     public void testRerankInputSizeAndInferenceResultsMismatch() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
@@ -21,7 +21,9 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.inference.EmptyTaskSettings;
 import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -39,8 +41,12 @@ import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
+import org.elasticsearch.xpack.inference.services.cohere.CohereService;
+import org.elasticsearch.xpack.inference.services.cohere.rerank.CohereRerankServiceSettings;
+import org.elasticsearch.xpack.inference.services.cohere.rerank.CohereRerankTaskSettings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +54,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -108,35 +116,49 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
             ActionListener<Response> listener,
             ActionFilterChain<Request, Response> chain
         ) {
-            // For any other action than inference, execute normally
-            if (action.equals(InferenceAction.INSTANCE.name()) == false) {
-                chain.proceed(task, action, request, listener);
-                return;
-            }
-
-            assert request instanceof InferenceAction.Request;
-            Map<String, Object> taskSettings = ((InferenceAction.Request) request).getTaskSettings();
-            boolean shouldThrow = (boolean) taskSettings.getOrDefault("throwing", false);
-            boolean hasInvalidInferenceResultCount = (boolean) taskSettings.getOrDefault("invalidInferenceResultCount", false);
-            boolean hasInvalidDocumentIndices = (boolean) taskSettings.getOrDefault("invalidDocumentIndices", false);
-
-            if (shouldThrow) {
-                listener.onFailure(new UnsupportedOperationException("simulated failure"));
-            } else {
-                List<RankedDocsResults.RankedDoc> rankedDocsResults = new ArrayList<>();
-                List<String> inputs = ((InferenceAction.Request) request).getInput();
-                int resultCount = hasInvalidInferenceResultCount ? inputs.size() - 1 : inputs.size();
-                for (int i = 0; i < resultCount; i++) {
-                    rankedDocsResults.add(
-                        new RankedDocsResults.RankedDoc(
-                            hasInvalidDocumentIndices ? i * 2 : i,
-                            Float.parseFloat(inputs.get(i)),
-                            inputs.get(i)
-                        )
-                    );
+            if (action.equals(GetInferenceModelAction.INSTANCE.name())) {
+                assert request instanceof GetInferenceModelAction.Request;
+                GetInferenceModelAction.Request getInferenceModelRequest = (GetInferenceModelAction.Request) request;
+                String inferenceEntityId = getInferenceModelRequest.getInferenceEntityId();
+                Integer topN = null;
+                Matcher extractTopN = Pattern.compile(".*(task-settings-top-\\d+).*").matcher(inferenceEntityId);
+                if (extractTopN.find()) {
+                    topN = Integer.parseInt(extractTopN.group(1).replaceAll("\\D", ""));
                 }
-                ActionResponse response = new InferenceAction.Response(new RankedDocsResults(rankedDocsResults));
+
+                ActionResponse response = new GetInferenceModelAction.Response(
+                    List.of(
+                        new ModelConfigurations(
+                            getInferenceModelRequest.getInferenceEntityId(),
+                            getInferenceModelRequest.getTaskType(),
+                            CohereService.NAME,
+                            new CohereRerankServiceSettings("uri", "model", null),
+                            topN == null ? new EmptyTaskSettings() : new CohereRerankTaskSettings(topN, null, null)
+                        )
+                    )
+                );
                 listener.onResponse((Response) response);
+            } else if (action.equals(InferenceAction.INSTANCE.name())) {
+                assert request instanceof InferenceAction.Request;
+                Map<String, Object> taskSettings = ((InferenceAction.Request) request).getTaskSettings();
+                boolean shouldThrow = (boolean) taskSettings.getOrDefault("throwing", false);
+                Integer inferenceResultCount = (Integer) taskSettings.get("inferenceResultCount");
+
+                if (shouldThrow) {
+                    listener.onFailure(new UnsupportedOperationException("simulated failure"));
+                } else {
+                    List<RankedDocsResults.RankedDoc> rankedDocsResults = new ArrayList<>();
+                    List<String> inputs = ((InferenceAction.Request) request).getInput();
+                    int resultCount = inferenceResultCount == null ? inputs.size() : inferenceResultCount;
+                    for (int i = 0; i < resultCount; i++) {
+                        rankedDocsResults.add(new RankedDocsResults.RankedDoc(i, Float.parseFloat(inputs.get(i)), inputs.get(i)));
+                    }
+                    ActionResponse response = new InferenceAction.Response(new RankedDocsResults(rankedDocsResults));
+                    listener.onResponse((Response) response);
+                }
+            } else {
+                // For any other action than get model and inference, execute normally
+                chain.proceed(task, action, request, listener);
             }
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
@@ -115,9 +115,10 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
             }
 
             assert request instanceof InferenceAction.Request;
-            boolean shouldThrow = (boolean) ((InferenceAction.Request) request).getTaskSettings().getOrDefault("throwing", false);
-            boolean hasInvalidInferenceResultCount = (boolean) ((InferenceAction.Request) request).getTaskSettings()
-                .getOrDefault("invalidInferenceResultCount", false);
+            Map<String, Object> taskSettings = ((InferenceAction.Request) request).getTaskSettings();
+            boolean shouldThrow = (boolean) taskSettings.getOrDefault("throwing", false);
+            boolean hasInvalidInferenceResultCount = (boolean) taskSettings.getOrDefault("invalidInferenceResultCount", false);
+            boolean hasInvalidDocumentIndices = (boolean) taskSettings.getOrDefault("invalidDocumentIndices", false);
 
             if (shouldThrow) {
                 listener.onFailure(new UnsupportedOperationException("simulated failure"));
@@ -126,7 +127,13 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
                 List<String> inputs = ((InferenceAction.Request) request).getInput();
                 int resultCount = hasInvalidInferenceResultCount ? inputs.size() - 1 : inputs.size();
                 for (int i = 0; i < resultCount; i++) {
-                    rankedDocsResults.add(new RankedDocsResults.RankedDoc(i, Float.parseFloat(inputs.get(i)), inputs.get(i)));
+                    rankedDocsResults.add(
+                        new RankedDocsResults.RankedDoc(
+                            hasInvalidDocumentIndices ? i * 2 : i,
+                            Float.parseFloat(inputs.get(i)),
+                            inputs.get(i)
+                        )
+                    );
                 }
                 ActionResponse response = new InferenceAction.Response(new RankedDocsResults(rankedDocsResults));
                 listener.onResponse((Response) response);


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/111202.

The text_similarity_reranker retriever query fails if `rank_window_size` is greater than `top_n` in the rerank inference endpoint's task settings. More details and steps to reproduce in the above mentioned issue.

The cause is [this line](https://github.com/elastic/elasticsearch/blob/61cb0a2b6be3ca2611c7a2d99a3243631684e211/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java#L95). The `rerank` inference response contains document indices in reference to the `rank_window_size` inputs. However if `task_settings.top_n` is specified in the inference endpoint, it only returns the top N of those. For example with `rank_window_size==20` and `top_n==10` this is a valid response:

```
[RankedDoc{index='1', relevanceScore='0.9961155', text='null', hashcode=-1335808012},
RankedDoc{index='15', relevanceScore='0.9865199', text='null', hashcode=-1340785186},
RankedDoc{index='3', relevanceScore='0.049773447', text='null', hashcode=1815090117}, 
... (7 more RankedDoc-s)]
```

The problematic line creates a `scores` array with a length of 10, but processing the 2nd item (`index='15'`) triggers the out-of-bounds exception.

The validation of rereanker input == score output is already in place (and covered by the `TextSimilarityRankTests#testRerankInferenceFailure` test), however due to the above bug the process never reaches that state, it fails with an index out of bounds exception. The solution is to move the validation logic before the scores are extracted.