### PR TITLE
Use routing_table for allocated node in tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -556,13 +556,10 @@
               url:
                 type: keyword
   - do:
-      search:
-        index:  index1
-        body:
-          profile: true
+      cluster.state: {}
 
   - set:
-      profile.shards.0.node_id: node_id
+      routing_table.indices.index1.shards.0.0.node: node_id
 
   - do:
       nodes.stats: { metric: _all, level: "indices", human: true }


### PR DESCRIPTION
The previous fix, which uses the search API, doesn't work with the indexing tier only. This change uses the routing table from the cluster state instead. I have tested this change in a serverless environment.


Relates #111211