### PR TITLE
Add last refresh times and unwritten changes state to RefreshStats

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -498,6 +498,17 @@ A value of `-1` indicates that this is not available.
 `listeners`::
 (integer) Number of refresh listeners.
 
+`last_refresh_timestamp`::
+(integer) Time of the last internal refresh.
+Recorded in milliseconds since the {wikipedia}/Unix_time[Unix Epoch].
+
+`last_external_refresh_timestamp`::
+(integer) Time of the last external refresh.
+Recorded in milliseconds since the {wikipedia}/Unix_time[Unix Epoch].
+
+`has_unwritten_changes`::
+(Boolean) Whether there are changes that require a refresh to be written to disk.
+
 =======
 
 `flush`::

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -217,6 +217,7 @@ public class TransportVersions {
     public static final TransportVersion ENRICH_CACHE_STATS_SIZE_ADDED = def(8_707_00_0);
     public static final TransportVersion ENTERPRISE_GEOIP_DOWNLOADER = def(8_708_00_0);
     public static final TransportVersion NODES_STATS_ENUM_SET = def(8_709_00_0);
+    public static final TransportVersion LAST_REFRESH_TIME_STATS = def(8_710_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1199,6 +1199,10 @@ public abstract class Engine implements Closeable {
     public abstract List<Segment> segments(boolean includeVectorFormatsInfo);
 
     public boolean refreshNeeded() {
+        return refreshNeeded("refresh_needed");
+    }
+
+    public boolean refreshNeeded(String source) {
         if (store.tryIncRef()) {
             /*
               we need to inc the store here since we acquire a searcher and that might keep a file open on the
@@ -1206,7 +1210,7 @@ public abstract class Engine implements Closeable {
               the store is closed so we need to make sure we increment it here
              */
             try {
-                try (Searcher searcher = acquireSearcher("refresh_needed", SearcherScope.EXTERNAL)) {
+                try (Searcher searcher = acquireSearcher(source, SearcherScope.EXTERNAL)) {
                     return searcher.getDirectoryReader().isCurrent() == false;
                 }
             } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -511,8 +511,10 @@ public class InternalEngine extends Engine {
         if (scope == SearcherScope.EXTERNAL) {
             switch (source) {
                 // we can access segment_stats while a shard is still in the recovering state.
+                // we may also access refresh state before the searcher is warmed up.
                 case "segments":
                 case "segments_stats":
+                case "refresh_needed_stats":
                     break;
                 default:
                     assert externalReaderManager.isWarmedUp : "searcher was not warmed up yet for source[" + source + "]";

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -628,7 +628,7 @@ public class NodeStatsTests extends ESTestCase {
         mergeStats.add(++iota, ++iota, ++iota, ++iota, ++iota, ++iota, ++iota, ++iota, ++iota, 1.0 * ++iota);
 
         indicesCommonStats.getMerge().add(mergeStats);
-        indicesCommonStats.getRefresh().add(new RefreshStats(++iota, ++iota, ++iota, ++iota, ++iota));
+        indicesCommonStats.getRefresh().add(new RefreshStats(++iota, ++iota, ++iota, ++iota, ++iota, ++iota, ++iota, false));
         indicesCommonStats.getFlush().add(new FlushStats(++iota, ++iota, ++iota, ++iota));
         indicesCommonStats.getWarmer().add(new WarmerStats(++iota, ++iota, ++iota));
         indicesCommonStats.getCompletion().add(new CompletionStats(++iota, null));

--- a/server/src/test/java/org/elasticsearch/index/refresh/RefreshStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/refresh/RefreshStatsTests.java
@@ -22,7 +22,10 @@ public class RefreshStatsTests extends ESTestCase {
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
-            between(0, Integer.MAX_VALUE)
+            between(0, Integer.MAX_VALUE),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomBoolean()
         );
         BytesStreamOutput out = new BytesStreamOutput();
         stats.writeTo(out);
@@ -34,5 +37,8 @@ public class RefreshStatsTests extends ESTestCase {
         assertEquals(stats.getListeners(), read.getListeners());
         assertEquals(stats.getTotalTimeInMillis(), read.getTotalTimeInMillis());
         assertEquals(stats.getExternalTotalTimeInMillis(), read.getExternalTotalTimeInMillis());
+        assertEquals(stats.getLastRefreshTime(), read.getLastRefreshTime());
+        assertEquals(stats.getLastExternalRefreshTime(), read.getLastExternalRefreshTime());
+        assertEquals(stats.getHasUnwrittenChanges(), read.getHasUnwrittenChanges());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -101,7 +102,8 @@ public class RefreshListenersTests extends ESTestCase {
             () -> engine.refresh("too-many-listeners"),
             logger,
             threadPool.getThreadContext(),
-            new MeanMetric()
+            new MeanMetric(),
+            new AtomicLong()
         );
 
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
@@ -387,7 +387,7 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
         commonStats.getQueryCache().add(new QueryCacheStats(++iota, ++iota, ++iota, ++iota, no));
         commonStats.getRequestCache().add(new RequestCacheStats(++iota, ++iota, ++iota, ++iota));
         commonStats.getStore().add(new StoreStats(++iota, no, no));
-        commonStats.getRefresh().add(new RefreshStats(no, ++iota, no, ++iota, (int) no));
+        commonStats.getRefresh().add(new RefreshStats(no, ++iota, no, ++iota, (int) no, no, no, false));
 
         final IndexingStats.Stats indexingStats = new IndexingStats.Stats(++iota, ++iota, no, no, no, no, no, no, false, ++iota, no, no);
         commonStats.getIndexing().add(new IndexingStats(indexingStats));


### PR DESCRIPTION
Adds several fields to RefreshStats, including the last external and
internal refresh times, and a flag indicating if the shard has unwritten
changes.

Fixes #110852