### PR TITLE
Unmute HistogramPercentileAggregationTests.testBoxplotHistogram

### DIFF
--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistogramPercentileAggregationTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistogramPercentileAggregationTests.java
@@ -241,7 +241,6 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/110406")
     public void testBoxplotHistogram() throws Exception {
         int compression = TestUtil.nextInt(random(), 200, 300);
         setupTDigestHistogram(compression);


### PR DESCRIPTION
Test was fixed in https://github.com/elastic/elasticsearch/pull/111153

fixes https://github.com/elastic/elasticsearch/issues/110406