### PR TITLE
Unmuting tests related to free_context action being processed in ESSingleNodeTestCase

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -76,9 +76,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
   method: testPopulationOfCacheWhenLoadingPrivilegesForAllApplications
   issue: https://github.com/elastic/elasticsearch/issues/110789
-- class: org.elasticsearch.xpack.security.ScrollHelperIntegTests
-  method: testFetchAllEntities
-  issue: https://github.com/elastic/elasticsearch/issues/110786
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
   method: testCacheFileCreatedAsSparseFile
   issue: https://github.com/elastic/elasticsearch/issues/110801
@@ -99,12 +96,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/110982
 - class: org.elasticsearch.multi_node.GlobalCheckpointSyncActionIT
   issue: https://github.com/elastic/elasticsearch/issues/111124
-- class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
-  method: testGetPrivilegesUsesCache
-  issue: https://github.com/elastic/elasticsearch/issues/110788
-- class: org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankTests
-  method: testRerankInferenceResultMismatch
-  issue: https://github.com/elastic/elasticsearch/issues/111133
 - class: org.elasticsearch.cluster.PrevalidateShardPathIT
   method: testCheckShards
   issue: https://github.com/elastic/elasticsearch/issues/111134

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -85,9 +85,6 @@ tests:
 - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
   method: testSystemPropertyDisabled
   issue: https://github.com/elastic/elasticsearch/issues/110949
-- class: org.elasticsearch.action.search.KnnSearchSingleNodeTests
-  method: testKnnSearchAction
-  issue: https://github.com/elastic/elasticsearch/issues/111072
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoPointIT
   method: testPushedDownQueriesSingleValue
   issue: https://github.com/elastic/elasticsearch/issues/111084


### PR DESCRIPTION
Unmuting tests now that a fix has been merged (https://github.com/elastic/elasticsearch/pull/111153) 

Related tests:
* https://github.com/elastic/elasticsearch/issues/110786
* https://github.com/elastic/elasticsearch/issues/110788
* https://github.com/elastic/elasticsearch/issues/111133
* https://github.com/elastic/elasticsearch/issues/111072