### PR TITLE
EQL: fix validation of TEXT fields with case insensitive comparison

### DIFF
--- a/docs/changelog/111238.yaml
+++ b/docs/changelog/111238.yaml
@@ -1,0 +1,6 @@
+pr: 111238
+summary: Fix validation of TEXT fields with case insensitive comparison
+area: EQL
+type: bug
+issues:
+ - 111235

--- a/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/60_no_exact.yml
+++ b/x-pack/plugin/eql/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/eql/60_no_exact.yml
@@ -1,0 +1,37 @@
+---
+setup:
+  - do:
+      indices.create:
+          index:  eql_test
+          body:
+            mappings:
+              properties:
+                some_text:
+                  type: text
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: eql_test
+              _id:    "1"
+          - event:
+              - category: process
+            "@timestamp": 2020-02-03T12:34:56Z
+            user: SYSTEM
+            id: 123
+            valid: false
+            some_text: foo
+
+
+---
+
+"Case insensitive match on text field":
+  - do:
+      catch: "bad_request"
+      eql.search:
+        index: eql_test
+        body:
+          query: 'process where some_text: "foo"'
+  - match: { error.root_cause.0.type: "verification_exception" }
+  - match: { error.root_cause.0.reason: "Found 1 problem\nline 1:15: [:] cannot operate on first argument field of data type [text]: No keyword/multi-field defined exact matches for [some_text]; define one or use MATCH/QUERY instead" }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/predicate/operator/comparison/InsensitiveBinaryComparison.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/predicate/operator/comparison/InsensitiveBinaryComparison.java
@@ -55,11 +55,7 @@ public abstract class InsensitiveBinaryComparison extends BinaryOperator<Object,
         }
         resolution = TypeResolutions.isExact(e, op, paramOrdinal);
         if (resolution.unresolved()) {
-            String message = LoggerMessageFormat.format(
-                null,
-                "{}",
-                resolution.message()
-            );
+            String message = LoggerMessageFormat.format(null, "{}", resolution.message());
             resolution = new TypeResolution(message);
         }
         return resolution;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/predicate/operator/comparison/InsensitiveBinaryComparison.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/predicate/operator/comparison/InsensitiveBinaryComparison.java
@@ -51,6 +51,15 @@ public abstract class InsensitiveBinaryComparison extends BinaryOperator<Object,
                 resolution.message(),
                 regularOperatorSymbol()
             );
+            return new TypeResolution(message);
+        }
+        resolution = TypeResolutions.isExact(e, op, paramOrdinal);
+        if (resolution.unresolved()) {
+            String message = LoggerMessageFormat.format(
+                null,
+                "{}",
+                resolution.message()
+            );
             resolution = new TypeResolution(message);
         }
         return resolution;


### PR DESCRIPTION
Enhancing validation of case insensitive comparisons, so that in case of non-exact fields we return a meaningful validation exception (ie. an error 400)

Fixes https://github.com/elastic/elasticsearch/issues/111235