### PR TITLE
Update get snapshot status API doc

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get snapshot status</titleabbrev>
 ++++
 
-Retrieves a detailed description of the current state for each shard participating in the snapshot.
+Retrieves a detailed description of the current state for each shard participating in the snapshot. Note that this API should only be used to obtain detailed shard-level information for ongoing snapshots. If this detail is not needed, or you want to obtain information about one or more existing snapshots, use the <<get-snapshot-api,get snapshot API>>.
 
 ////
 [source,console]
@@ -172,13 +172,8 @@ Indicates the current snapshot state.
 `STARTED`::
   The snapshot is currently running.
 
-`PARTIAL`::
-  The global cluster state was stored, but data of at least one shard was not stored successfully.
-  The <<get-snapshot-api-response-failures,`failures`>> section of the response contains more detailed information about shards
-  that were not processed correctly.
-
 `SUCCESS`::
-  The snapshot finished and all shards were stored successfully.
+  The snapshot completed.
 ====
 --
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -332,8 +332,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                     final SnapshotsInProgress.State state = switch (snapshotInfo.state()) {
                         case FAILED -> SnapshotsInProgress.State.FAILED;
                         case SUCCESS, PARTIAL ->
-                            // Translating both PARTIAL and SUCCESS to SUCCESS for now
-                            // TODO: add the differentiation on the metadata level in the next major release
+                            // Both of these means the snapshot has completed.
                             SnapshotsInProgress.State.SUCCESS;
                         default -> throw new IllegalArgumentException("Unexpected snapshot state " + snapshotInfo.state());
                     };


### PR DESCRIPTION
Make it clear that this API should be used only if the detailed shard info is needed and only on ongoing snapshots. Remove incorrectly mentioned `STATE` value. 