### PR TITLE
Skip writing cache if read bytes are available

### DIFF
--- a/docs/changelog/111247.yaml
+++ b/docs/changelog/111247.yaml
@@ -1,0 +1,5 @@
+pr: 111247
+summary: Skip writing cache if read bytes are available
+area: Distributed
+type: enhancement
+issues: []


### PR DESCRIPTION
Currently, when trying to read a subrange from the shared blob cache, we will also try to fill any empty gaps in the rangeToWrite range, even if the bytes to read are readily available in the cache.

With this change, we skip filling the empty gaps if the bytes to read are available. This way, we potentially save an unnecessary roundtrip to the blob store.

Closes ES-8347