### PR TITLE
ESQL: Move numeric widening

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypeConverter.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypeConverter.java
@@ -23,16 +23,13 @@ import java.util.function.DoubleFunction;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
-import static org.elasticsearch.xpack.esql.core.type.DataType.BYTE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
-import static org.elasticsearch.xpack.esql.core.type.DataType.FLOAT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
-import static org.elasticsearch.xpack.esql.core.type.DataType.SHORT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.VERSION;
@@ -152,15 +149,6 @@ public final class DataTypeConverter {
         }
         if (to == INTEGER) {
             return conversionToInt(from);
-        }
-        if (to == SHORT) {
-            return conversionToShort(from);
-        }
-        if (to == BYTE) {
-            return conversionToByte(from);
-        }
-        if (to == FLOAT) {
-            return conversionToFloat(from);
         }
         if (to == DOUBLE) {
             return conversionToDouble(from);
@@ -446,12 +434,6 @@ public final class DataTypeConverter {
     public static Number toInteger(double x, DataType dataType) {
         long l = safeDoubleToLong(x);
 
-        if (dataType == BYTE) {
-            return safeToByte(l);
-        }
-        if (dataType == SHORT) {
-            return safeToShort(l);
-        }
         if (dataType == INTEGER) {
             return safeToInt(l);
         }

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/LiteralTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/LiteralTests.java
@@ -22,13 +22,10 @@ import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
-import static org.elasticsearch.xpack.esql.core.type.DataType.BYTE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
-import static org.elasticsearch.xpack.esql.core.type.DataType.FLOAT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
-import static org.elasticsearch.xpack.esql.core.type.DataType.SHORT;
 
 public class LiteralTests extends AbstractNodeTestCase<Literal, Expression> {
     static class ValueAndCompatibleTypes {
@@ -49,12 +46,12 @@ public class LiteralTests extends AbstractNodeTestCase<Literal, Expression> {
      */
     private static final List<ValueAndCompatibleTypes> GENERATORS = Arrays.asList(
         new ValueAndCompatibleTypes(() -> randomBoolean() ? randomBoolean() : randomFrom("true", "false"), BOOLEAN),
-        new ValueAndCompatibleTypes(ESTestCase::randomByte, BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BOOLEAN),
-        new ValueAndCompatibleTypes(ESTestCase::randomShort, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BOOLEAN),
-        new ValueAndCompatibleTypes(ESTestCase::randomInt, INTEGER, LONG, FLOAT, DOUBLE, BOOLEAN),
-        new ValueAndCompatibleTypes(ESTestCase::randomLong, LONG, FLOAT, DOUBLE, BOOLEAN),
-        new ValueAndCompatibleTypes(ESTestCase::randomFloat, FLOAT, LONG, DOUBLE, BOOLEAN),
-        new ValueAndCompatibleTypes(ESTestCase::randomDouble, DOUBLE, LONG, FLOAT, BOOLEAN),
+        new ValueAndCompatibleTypes(ESTestCase::randomByte, INTEGER, LONG, DOUBLE, BOOLEAN),
+        new ValueAndCompatibleTypes(ESTestCase::randomShort, INTEGER, LONG, DOUBLE, BOOLEAN),
+        new ValueAndCompatibleTypes(ESTestCase::randomInt, INTEGER, LONG, DOUBLE, BOOLEAN),
+        new ValueAndCompatibleTypes(ESTestCase::randomLong, LONG, DOUBLE, BOOLEAN),
+        new ValueAndCompatibleTypes(ESTestCase::randomFloat, LONG, DOUBLE, BOOLEAN),
+        new ValueAndCompatibleTypes(ESTestCase::randomDouble, DOUBLE, LONG, BOOLEAN),
         new ValueAndCompatibleTypes(() -> randomAlphaOfLength(5), KEYWORD)
     );
 
@@ -131,7 +128,7 @@ public class LiteralTests extends AbstractNodeTestCase<Literal, Expression> {
 
     private static List<DataType> validReplacementDataTypes(Object value, DataType type) {
         List<DataType> validDataTypes = new ArrayList<>();
-        List<DataType> options = Arrays.asList(BYTE, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BOOLEAN);
+        List<DataType> options = Arrays.asList(INTEGER, LONG, DOUBLE, BOOLEAN);
         for (DataType candidate : options) {
             try {
                 Converter c = DataTypeConverter.converterFor(type, candidate);

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/RangeTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/predicate/RangeTests.java
@@ -19,11 +19,9 @@ import java.util.Arrays;
 import static org.elasticsearch.xpack.esql.core.expression.function.scalar.FunctionTestUtils.l;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
-import static org.elasticsearch.xpack.esql.core.type.DataType.FLOAT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
-import static org.elasticsearch.xpack.esql.core.type.DataType.SHORT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
 
@@ -220,7 +218,7 @@ public class RangeTests extends ESTestCase {
     }
 
     private static DataType randomNumericType() {
-        return randomFrom(INTEGER, SHORT, LONG, UNSIGNED_LONG, FLOAT, DOUBLE);
+        return randomFrom(INTEGER, LONG, UNSIGNED_LONG, DOUBLE);
     }
 
     private static DataType randomTextType() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/ArrayStateTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/ArrayStateTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockTestUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,29 +28,29 @@ public class ArrayStateTests extends ESTestCase {
         List<Object[]> params = new ArrayList<>();
 
         for (boolean inOrder : new boolean[] { true, false }) {
-            params.add(new Object[] { DataType.INTEGER, 1000, inOrder });
-            params.add(new Object[] { DataType.LONG, 1000, inOrder });
-            params.add(new Object[] { DataType.FLOAT, 1000, inOrder });
-            params.add(new Object[] { DataType.DOUBLE, 1000, inOrder });
-            params.add(new Object[] { DataType.IP, 1000, inOrder });
+            params.add(new Object[] { "integer", 1000, inOrder });
+            params.add(new Object[] { "long", 1000, inOrder });
+            params.add(new Object[] { "float", 1000, inOrder });
+            params.add(new Object[] { "double", 1000, inOrder });
+            params.add(new Object[] { "ip", 1000, inOrder });
         }
         return params;
     }
 
-    private final DataType type;
+    private final String type;
     private final ElementType elementType;
     private final int valueCount;
     private final boolean inOrder;
 
-    public ArrayStateTests(DataType type, int valueCount, boolean inOrder) {
+    public ArrayStateTests(String type, int valueCount, boolean inOrder) {
         this.type = type;
         this.elementType = switch (type) {
-            case INTEGER -> ElementType.INT;
-            case LONG -> ElementType.LONG;
-            case FLOAT -> ElementType.FLOAT;
-            case DOUBLE -> ElementType.DOUBLE;
-            case BOOLEAN -> ElementType.BOOLEAN;
-            case IP -> ElementType.BYTES_REF;
+            case "integer" -> ElementType.INT;
+            case "long" -> ElementType.LONG;
+            case "float" -> ElementType.FLOAT;
+            case "double" -> ElementType.DOUBLE;
+            case "boolean" -> ElementType.BOOLEAN;
+            case "ip" -> ElementType.BYTES_REF;
             default -> throw new IllegalArgumentException();
         };
         this.valueCount = valueCount;
@@ -171,44 +170,44 @@ public class ArrayStateTests extends ESTestCase {
 
     private AbstractArrayState newState() {
         return switch (type) {
-            case INTEGER -> new IntArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
-            case LONG -> new LongArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
-            case FLOAT -> new FloatArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
-            case DOUBLE -> new DoubleArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
-            case BOOLEAN -> new BooleanArrayState(BigArrays.NON_RECYCLING_INSTANCE, false);
-            case IP -> new IpArrayState(BigArrays.NON_RECYCLING_INSTANCE, new BytesRef(new byte[16]));
+            case "integer" -> new IntArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
+            case "long" -> new LongArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
+            case "float" -> new FloatArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
+            case "double" -> new DoubleArrayState(BigArrays.NON_RECYCLING_INSTANCE, 1);
+            case "boolean" -> new BooleanArrayState(BigArrays.NON_RECYCLING_INSTANCE, false);
+            case "ip" -> new IpArrayState(BigArrays.NON_RECYCLING_INSTANCE, new BytesRef(new byte[16]));
             default -> throw new IllegalArgumentException();
         };
     }
 
     private void set(AbstractArrayState state, int groupId, Object value) {
         switch (type) {
-            case INTEGER -> ((IntArrayState) state).set(groupId, (Integer) value);
-            case LONG -> ((LongArrayState) state).set(groupId, (Long) value);
-            case FLOAT -> ((FloatArrayState) state).set(groupId, (Float) value);
-            case DOUBLE -> ((DoubleArrayState) state).set(groupId, (Double) value);
-            case BOOLEAN -> ((BooleanArrayState) state).set(groupId, (Boolean) value);
-            case IP -> ((IpArrayState) state).set(groupId, (BytesRef) value);
+            case "integer" -> ((IntArrayState) state).set(groupId, (Integer) value);
+            case "long" -> ((LongArrayState) state).set(groupId, (Long) value);
+            case "float" -> ((FloatArrayState) state).set(groupId, (Float) value);
+            case "double" -> ((DoubleArrayState) state).set(groupId, (Double) value);
+            case "boolean" -> ((BooleanArrayState) state).set(groupId, (Boolean) value);
+            case "ip" -> ((IpArrayState) state).set(groupId, (BytesRef) value);
             default -> throw new IllegalArgumentException();
         }
     }
 
     private Object get(AbstractArrayState state, int index) {
         return switch (type) {
-            case INTEGER -> ((IntArrayState) state).get(index);
-            case LONG -> ((LongArrayState) state).get(index);
-            case FLOAT -> ((FloatArrayState) state).get(index);
-            case DOUBLE -> ((DoubleArrayState) state).get(index);
-            case BOOLEAN -> ((BooleanArrayState) state).get(index);
-            case IP -> ((IpArrayState) state).get(index, new BytesRef());
+            case "integer" -> ((IntArrayState) state).get(index);
+            case "long" -> ((LongArrayState) state).get(index);
+            case "float" -> ((FloatArrayState) state).get(index);
+            case "double" -> ((DoubleArrayState) state).get(index);
+            case "boolean" -> ((BooleanArrayState) state).get(index);
+            case "ip" -> ((IpArrayState) state).get(index, new BytesRef());
             default -> throw new IllegalArgumentException();
         };
     }
 
     private Object randomValue() {
         return switch (type) {
-            case INTEGER, LONG, FLOAT, DOUBLE, BOOLEAN -> BlockTestUtils.randomValue(elementType);
-            case IP -> new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean())));
+            case "integer", "long", "float", "double", "boolean" -> BlockTestUtils.randomValue(elementType);
+            case "ip" -> new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean())));
             default -> throw new IllegalArgumentException();
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -165,8 +165,8 @@ abstract class PositionToXContent {
                     }
                 }
             };
-            case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, SHORT, BYTE, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT,
-                PARTIAL_AGG -> throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
+            case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, OBJECT, NESTED, PARTIAL_AGG ->
+                throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
@@ -140,8 +140,8 @@ public final class ResponseValueUtils {
                     throw new UncheckedIOException(e);
                 }
             }
-            case SHORT, BYTE, FLOAT, HALF_FLOAT, SCALED_FLOAT, OBJECT, NESTED, DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE,
-                NULL, PARTIAL_AGG -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
+            case OBJECT, NESTED, DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, NULL, PARTIAL_AGG ->
+                throw EsqlIllegalArgumentException.illegalDataType(dataType);
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -105,7 +105,6 @@ import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.GEO_MATCH_TYPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
-import static org.elasticsearch.xpack.esql.core.type.DataType.FLOAT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
@@ -230,7 +229,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             if (t != null) {
                 name = parent == null ? name : parent.fieldName() + "." + name;
                 var fieldProperties = t.getProperties();
-                var type = t.getDataType().widenSmallNumeric();
+                var type = t.getDataType();
                 // due to a bug also copy the field since the Attribute hierarchy extracts the data type
                 // directly even if the data type is passed explicitly
                 if (type != t.getDataType()) {
@@ -832,7 +831,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
         }
 
         private static final DataType[] GEO_TYPES = new DataType[] { GEO_POINT, GEO_SHAPE };
-        private static final DataType[] NON_GEO_TYPES = new DataType[] { KEYWORD, TEXT, IP, LONG, INTEGER, FLOAT, DOUBLE, DATETIME };
+        private static final DataType[] NON_GEO_TYPES = new DataType[] { KEYWORD, TEXT, IP, LONG, INTEGER, DOUBLE, DATETIME };
 
         private DataType[] allowedEnrichTypes(String matchType) {
             return matchType.equals(GEO_MATCH_TYPE) ? GEO_TYPES : NON_GEO_TYPES;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Grok.java
@@ -35,7 +35,7 @@ public class Grok extends RegexExtract {
                 .stream()
                 .sorted(Comparator.comparing(GrokCaptureConfig::name))
                 // promote small numeric types, since Grok can produce float values
-                .map(x -> new ReferenceAttribute(Source.EMPTY, x.name(), toDataType(x.type()).widenSmallNumeric()))
+                .map(x -> new ReferenceAttribute(Source.EMPTY, x.name(), toDataType(x.type())))
                 .collect(Collectors.toList());
         }
 
@@ -44,8 +44,7 @@ public class Grok extends RegexExtract {
                 case STRING -> DataType.KEYWORD;
                 case INTEGER -> DataType.INTEGER;
                 case LONG -> DataType.LONG;
-                case FLOAT -> DataType.FLOAT;
-                case DOUBLE -> DataType.DOUBLE;
+                case FLOAT, DOUBLE -> DataType.DOUBLE;
                 case BOOLEAN -> DataType.BOOLEAN;
             };
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlExpressionTranslators.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlExpressionTranslators.java
@@ -306,13 +306,7 @@ public final class EsqlExpressionTranslators {
             // Determine min/max for dataType. Use BigDecimals as doubles will have rounding errors for long/ulong.
             BigDecimal minValue;
             BigDecimal maxValue;
-            if (numericFieldDataType == DataType.BYTE) {
-                minValue = BigDecimal.valueOf(Byte.MIN_VALUE);
-                maxValue = BigDecimal.valueOf(Byte.MAX_VALUE);
-            } else if (numericFieldDataType == DataType.SHORT) {
-                minValue = BigDecimal.valueOf(Short.MIN_VALUE);
-                maxValue = BigDecimal.valueOf(Short.MAX_VALUE);
-            } else if (numericFieldDataType == DataType.INTEGER) {
+            if (numericFieldDataType == DataType.INTEGER) {
                 minValue = BigDecimal.valueOf(Integer.MIN_VALUE);
                 maxValue = BigDecimal.valueOf(Integer.MAX_VALUE);
             } else if (numericFieldDataType == DataType.LONG) {
@@ -321,14 +315,7 @@ public final class EsqlExpressionTranslators {
             } else if (numericFieldDataType == DataType.UNSIGNED_LONG) {
                 minValue = BigDecimal.ZERO;
                 maxValue = UNSIGNED_LONG_MAX;
-            } else if (numericFieldDataType == DataType.HALF_FLOAT) {
-                minValue = HALF_FLOAT_MAX.negate();
-                maxValue = HALF_FLOAT_MAX;
-            } else if (numericFieldDataType == DataType.FLOAT) {
-                minValue = BigDecimal.valueOf(-Float.MAX_VALUE);
-                maxValue = BigDecimal.valueOf(Float.MAX_VALUE);
-            } else if (numericFieldDataType == DataType.DOUBLE || numericFieldDataType == DataType.SCALED_FLOAT) {
-                // Scaled floats are represented as doubles in ESQL.
+            } else if (numericFieldDataType == DataType.DOUBLE) {
                 minValue = BigDecimal.valueOf(-Double.MAX_VALUE);
                 maxValue = BigDecimal.valueOf(Double.MAX_VALUE);
             } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -350,8 +350,8 @@ public class LocalExecutionPlanner {
                 case IP -> TopNEncoder.IP;
                 case TEXT, KEYWORD -> TopNEncoder.UTF8;
                 case VERSION -> TopNEncoder.VERSION;
-                case BOOLEAN, NULL, BYTE, SHORT, INTEGER, LONG, DOUBLE, FLOAT, HALF_FLOAT, DATETIME, DATE_PERIOD, TIME_DURATION, OBJECT,
-                    NESTED, SCALED_FLOAT, UNSIGNED_LONG, DOC_DATA_TYPE, TSID_DATA_TYPE -> TopNEncoder.DEFAULT_SORTABLE;
+                case BOOLEAN, NULL, INTEGER, LONG, DOUBLE, DATETIME, DATE_PERIOD, TIME_DURATION, OBJECT, NESTED, UNSIGNED_LONG,
+                    DOC_DATA_TYPE, TSID_DATA_TYPE -> TopNEncoder.DEFAULT_SORTABLE;
                 case GEO_POINT, CARTESIAN_POINT, GEO_SHAPE, CARTESIAN_SHAPE, COUNTER_LONG, COUNTER_INTEGER, COUNTER_DOUBLE ->
                     TopNEncoder.DEFAULT_UNSORTABLE;
                 // unsupported fields are encoded as BytesRef, we'll use the same encoder; all values should be null at this point

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -253,8 +253,7 @@ public class PlannerUtils {
             case GEO_POINT, CARTESIAN_POINT -> fieldExtractPreference == DOC_VALUES ? ElementType.LONG : ElementType.BYTES_REF;
             case GEO_SHAPE, CARTESIAN_SHAPE -> ElementType.BYTES_REF;
             case PARTIAL_AGG -> ElementType.COMPOSITE;
-            case SHORT, BYTE, DATE_PERIOD, TIME_DURATION, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT ->
-                throw EsqlIllegalArgumentException.illegalDataType(dataType);
+            case DATE_PERIOD, TIME_DURATION, OBJECT, NESTED -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
@@ -38,11 +38,9 @@ public class EsqlDataTypeRegistry implements DataTypeRegistry {
         DataType type = DataType.fromEs(typeName);
         /*
          * If we're handling a time series COUNTER type field then convert it
-         * into it's counter. But *first* we have to widen it because we only
-         * have time series counters for `double`, `long` and `int`, not `float`
-         * and `half_float`, etc.
+         * into it's counter.
          */
-        return metricType == TimeSeriesParams.MetricType.COUNTER ? type.widenSmallNumeric().counter() : type;
+        return metricType == TimeSeriesParams.MetricType.COUNTER ? type.counter() : type;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -132,7 +132,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 || t == DataType.TIME_DURATION
                 || t == DataType.PARTIAL_AGG,
             () -> randomFrom(DataType.types())
-        ).widenSmallNumeric();
+        );
         return new ColumnInfoImpl(randomAlphaOfLength(10), type.esType());
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -11,7 +11,6 @@ import com.carrotsearch.randomizedtesting.ClassModel;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.document.InetAddressPoint;
-import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -139,15 +138,11 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     public static Literal randomLiteral(DataType type) {
         return new Literal(Source.EMPTY, switch (type) {
             case BOOLEAN -> randomBoolean();
-            case BYTE -> randomByte();
-            case SHORT -> randomShort();
             case INTEGER, COUNTER_INTEGER -> randomInt();
             case UNSIGNED_LONG, LONG, COUNTER_LONG -> randomLong();
             case DATE_PERIOD -> Period.of(randomIntBetween(-1000, 1000), randomIntBetween(-13, 13), randomIntBetween(-32, 32));
             case DATETIME -> randomMillisUpToYear9999();
-            case DOUBLE, SCALED_FLOAT, COUNTER_DOUBLE -> randomDouble();
-            case FLOAT -> randomFloat();
-            case HALF_FLOAT -> HalfFloatPoint.sortableShortToHalfFloat(HalfFloatPoint.halfFloatToSortableShort(randomFloat()));
+            case DOUBLE, COUNTER_DOUBLE -> randomDouble();
             case KEYWORD -> new BytesRef(randomAlphaOfLength(5));
             case IP -> new BytesRef(InetAddressPoint.encode(randomIp(randomBoolean())));
             case TIME_DURATION -> Duration.ofMillis(randomLongBetween(-604800000L, 604800000L)); // plus/minus 7 days

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgTests.java
@@ -65,7 +65,7 @@ public class AvgTests extends AbstractAggregationTestCase {
         return new TestCaseSupplier(List.of(fieldSupplier.type()), () -> {
             var fieldTypedData = fieldSupplier.get();
 
-            Object expected = switch (fieldTypedData.type().widenSmallNumeric()) {
+            Object expected = switch (fieldTypedData.type()) {
                 case INTEGER -> fieldTypedData.multiRowData()
                     .stream()
                     .map(v -> (Integer) v)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
@@ -92,7 +92,7 @@ public class SumTests extends AbstractAggregationTestCase {
             Object expected;
 
             try {
-                expected = switch (fieldTypedData.type().widenSmallNumeric()) {
+                expected = switch (fieldTypedData.type()) {
                     case INTEGER -> fieldTypedData.multiRowData()
                         .stream()
                         .map(v -> (Integer) v)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -213,11 +213,11 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         allFieldRowSize = testData.mapping.values()
             .stream()
             .mapToInt(
-                f -> (EstimatesRowSize.estimateSize(f.getDataType().widenSmallNumeric()) + f.getProperties()
+                f -> (EstimatesRowSize.estimateSize(f.getDataType()) + f.getProperties()
                     .values()
                     .stream()
                     // check one more level since the mapping contains TEXT fields with KEYWORD multi-fields
-                    .mapToInt(x -> EstimatesRowSize.estimateSize(x.getDataType().widenSmallNumeric()))
+                    .mapToInt(x -> EstimatesRowSize.estimateSize(x.getDataType()))
                     .sum())
             )
             .sum();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1388,8 +1388,8 @@ public class StatementParserTests extends AbstractStatementParserTests {
         assertThat(matchField.name(), equalTo("j"));
     }
 
-    public void testInlineConvertUnsupportedType() {
-        expectError("ROW 3::BYTE", "line 1:6: Unsupported conversion to type [BYTE]");
+    public void testInlineConvertUnknownType() {
+        expectError("ROW 3::BYTE", "line 1:9: Unknown data type named [BYTE]");
     }
 
     public void testMetricsWithoutStats() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
@@ -147,7 +147,6 @@ public class MultiTypeEsFieldTests extends AbstractNamedWriteableTestCase<MultiT
             DataType.BOOLEAN,
             DataType.DATETIME,
             DataType.DOUBLE,
-            DataType.FLOAT,
             DataType.INTEGER,
             DataType.IP,
             DataType.KEYWORD,
@@ -168,7 +167,7 @@ public class MultiTypeEsFieldTests extends AbstractNamedWriteableTestCase<MultiT
             return switch (toType) {
                 case BOOLEAN -> new ToBoolean(Source.EMPTY, fromField);
                 case DATETIME -> new ToDatetime(Source.EMPTY, fromField);
-                case DOUBLE, FLOAT -> new ToDouble(Source.EMPTY, fromField);
+                case DOUBLE -> new ToDouble(Source.EMPTY, fromField);
                 case INTEGER -> new ToInteger(Source.EMPTY, fromField);
                 case LONG -> new ToLong(Source.EMPTY, fromField);
                 case IP -> new ToIP(Source.EMPTY, fromField);


### PR DESCRIPTION
Previously we parsed Elasticsearch field types to `DataType`s and then widened those. But that meant we had to have a ton of barely used `DataType`s. They are really not valid in ESQL - just as a temporary destination on the way *into* ESQL.

This drops those mostly invalid types and moves the widening into the data type parsing code. This should make it easier to contribute to ESQL because fewer of the `DataType` members are "special".
