### PR TITLE
[DOCS] Fixed text_similarity_reranker retriever example

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -256,13 +256,13 @@ GET /index/_search
         "text_similarity_reranker": {
             "retriever": {
                 "standard": { ... }
-            }
-        },
-        "field": "text",
-        "inference_id": "my-cohere-rerank-model",
-        "inference_text": "Most famous landmark in Paris",
-        "rank_window_size": 100,
-        "min_score": 0.5
+            },
+            "field": "text",
+            "inference_id": "my-cohere-rerank-model",
+            "inference_text": "Most famous landmark in Paris",
+            "rank_window_size": 100,
+            "min_score": 0.5
+        }
     }
 }
 ----


### PR DESCRIPTION
The text_similarity_reranker parameters are placed in the wrong place. Just put them in the right place.