### PR TITLE
Add support for partial http requests handling with pipelining

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4RequestContentPublisherIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4RequestContentPublisherIT.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ESNetty4IntegTestCase;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.http.HttpContent;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public class Netty4RequestContentPublisherIT extends ESNetty4IntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.concatLists(List.of(RequestContentStreamPlugin.class), super.nodePlugins());
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false; // enable http
+    }
+
+    public void testBasicStream() throws IOException {
+        var totalBytes = 1024 * 1024;
+        var request = new Request("POST", RequestContentStreamPlugin.ROUTE);
+        request.setEntity(new ByteArrayEntity(randomByteArrayOfLength(totalBytes), ContentType.APPLICATION_JSON));
+
+        var respose = getRestClient().performRequest(request);
+        assertEquals(200, respose.getStatusLine().getStatusCode());
+        var gotTotalBytes = new BytesArray(respose.getEntity().getContent().readAllBytes()).utf8ToString();
+        assertEquals("" + totalBytes, gotTotalBytes);
+    }
+
+    public static class RequestContentStreamPlugin extends Plugin implements ActionPlugin {
+
+        static final String ROUTE = "/_test/request-stream/basic";
+        private static final Logger LOGGER = LogManager.getLogger("StreamRestHandler");
+
+        @Override
+        public Collection<RestHandler> getRestHandlers(
+            Settings settings,
+            NamedWriteableRegistry namedWriteableRegistry,
+            RestController restController,
+            ClusterSettings clusterSettings,
+            IndexScopedSettings indexScopedSettings,
+            SettingsFilter settingsFilter,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<DiscoveryNodes> nodesInCluster,
+            Predicate<NodeFeature> clusterSupportsFeature
+        ) {
+            return List.of(new BaseRestHandler() {
+                @Override
+                public String getName() {
+                    return ROUTE;
+                }
+
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(RestRequest.Method.POST, ROUTE));
+                }
+
+                @Override
+                protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+                    return new RestChannelConsumer() {
+                        @Override
+                        public void accept(RestChannel channel) {
+
+                            // netty channel will hold all chunks until we subscribe
+                            request.contentPublisher().subscribe(new Flow.Subscriber<>() {
+                                Flow.Subscription subscription;
+                                int totalReceivedBytes;
+
+                                @Override
+                                public void onSubscribe(Flow.Subscription subscription) {
+                                    this.subscription = subscription;
+                                    // after subscription, we can request N next messages, for example 5 chunks
+                                    subscription.request(5);
+                                }
+
+                                @Override
+                                public void onNext(HttpContent item) {
+                                    // chunk handler
+                                    var contentSize = item.content().length();
+                                    LOGGER.info("got next item of a size {}", contentSize);
+                                    totalReceivedBytes += contentSize;
+                                    item.release();
+                                    // we need explicitly ask for next N chunks
+                                    subscription.request(1);
+                                }
+
+                                @Override
+                                public void onError(Throwable throwable) {
+                                    // not implemented yet
+                                    assert false : throwable.getMessage();
+                                }
+
+                                @Override
+                                public void onComplete() {
+                                    // completion event after LastHttpContent
+                                    LOGGER.info("complete");
+                                    channel.sendResponse(new RestResponse(RestStatus.OK, Integer.toString(totalReceivedBytes)));
+                                }
+                            });
+
+                        }
+                    };
+                }
+            });
+        }
+    }
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4ContentDecompressor.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4ContentDecompressor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import java.util.List;
+
+/**
+ * A wrapper around {@link HttpContentDecompressor} that consumes and produces {@link PipelinedHttpRequest} and
+ * {@link PipelinedHttpContent}.
+ */
+public class Netty4ContentDecompressor extends HttpContentDecompressor {
+
+    @Override
+    public boolean acceptInboundMessage(Object msg) throws Exception {
+        return msg instanceof PipelinedHttpObject;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
+        super.decode(ctx, msg, out);
+        final var sequence = ((PipelinedHttpObject) msg).sequence();
+        out.replaceAll(obj -> {
+            if (obj instanceof PipelinedHttpObject) {
+                return obj;
+            } else if (obj instanceof FullHttpRequest request) {
+                return new PipelinedFullHttpRequest(request, sequence);
+            } else if (obj instanceof HttpRequest request) {
+                return new PipelinedHttpRequest(request, sequence);
+            } else if (obj instanceof LastHttpContent lastContent) {
+                return new PipelinedLastHttpContent(lastContent, sequence);
+            } else if (obj instanceof HttpContent content) {
+                return new PipelinedHttpContent(content, sequence);
+            } else {
+                throw new IllegalArgumentException();
+            }
+        });
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -22,13 +22,13 @@ import java.util.function.Predicate;
  */
 public class Netty4HttpAggregator extends HttpObjectAggregator {
 
-    private static final Predicate<PipelinedHttpRequest> ALWAYS_AGGREGATE = (req) -> true;
+    private static final Predicate<PipelinedHttpRequest> IGNORE_TEST = (req) -> req.uri().startsWith("/_test/request-stream") == false;
 
     private final Predicate<PipelinedHttpRequest> decider;
     private boolean shouldAggregate;
 
     public Netty4HttpAggregator(int maxContentLength) {
-        this(maxContentLength, ALWAYS_AGGREGATE);
+        this(maxContentLength, IGNORE_TEST);
     }
 
     public Netty4HttpAggregator(int maxContentLength, Predicate<PipelinedHttpRequest> decider) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A wrapper around {@link HttpObjectAggregator}, provides optional aggregation for {@link PipelinedHttpObject}'s.
+ * A {@code decider} predicate selects HTTP requests that will be aggregated into {@link PipelinedFullHttpRequest}.
+ */
+public class Netty4HttpAggregator extends HttpObjectAggregator {
+
+    private static final Predicate<PipelinedHttpRequest> ALWAYS_AGGREGATE = (req) -> true;
+
+    private final Predicate<PipelinedHttpRequest> decider;
+    private boolean shouldAggregate;
+
+    public Netty4HttpAggregator(int maxContentLength) {
+        this(maxContentLength, ALWAYS_AGGREGATE);
+    }
+
+    public Netty4HttpAggregator(int maxContentLength, Predicate<PipelinedHttpRequest> decider) {
+        super(maxContentLength);
+        this.decider = decider;
+    }
+
+    @Override
+    public boolean acceptInboundMessage(Object msg) {
+        if (msg instanceof PipelinedHttpRequest request) {
+            shouldAggregate = decider.test(request);
+            return shouldAggregate;
+        } else if (msg instanceof PipelinedHttpContent || msg instanceof PipelinedLastHttpContent) {
+            return shouldAggregate;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
+        super.decode(ctx, msg, out);
+        out.replaceAll(o -> new PipelinedFullHttpRequest((FullHttpRequest) o, ((PipelinedHttpObject) msg).sequence()));
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpContent.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpContent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.http.HttpContent;
+import org.elasticsearch.transport.netty4.Netty4Utils;
+
+public class Netty4HttpContent implements HttpContent {
+
+    private final io.netty.handler.codec.http.HttpContent nettyContent;
+    private final BytesReference ref;
+
+    Netty4HttpContent(io.netty.handler.codec.http.HttpContent httpContent) {
+        nettyContent = httpContent;
+        ref = Netty4Utils.toBytesReference(httpContent.content());
+    }
+
+    @Override
+    public BytesReference content() {
+        return ref;
+    }
+
+    @Override
+    public void release() {
+        nettyContent.release();
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -21,7 +21,6 @@ import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpContentCompressor;
-import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
@@ -363,11 +362,12 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                         )
                     );
             }
+            ch.pipeline().addLast("inbound_pipelining", new Netty4InboundHttpPipeliningHandler());
             // combines the HTTP message pieces into a single full HTTP request (with headers and body)
-            final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.maxContentLength());
+            final HttpObjectAggregator aggregator = new Netty4HttpAggregator(handlingSettings.maxContentLength());
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             ch.pipeline()
-                .addLast("decoder_compress", new HttpContentDecompressor()) // this handles request body decompression
+                .addLast("decoder_compress", new Netty4ContentDecompressor()) // this handles request body decompression
                 .addLast("encoder", new HttpResponseEncoder() {
                     @Override
                     protected boolean isContentAlwaysEmpty(HttpResponse msg) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4InboundHttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4InboundHttpPipeliningHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.LastHttpContent;
+
+/**
+ * Inbound HTTP pipelining handler that marks all incoming HTTP messages with a sequence number.
+ */
+public class Netty4InboundHttpPipeliningHandler extends ChannelInboundHandlerAdapter {
+
+    private int sequence = -1;
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        assert msg instanceof HttpRequest || msg instanceof HttpContent;
+        if (msg instanceof FullHttpRequest request) {
+            sequence++;
+            ctx.fireChannelRead(new PipelinedFullHttpRequest(request, sequence));
+        } else if (msg instanceof LastHttpContent content) {
+            ctx.fireChannelRead(new PipelinedLastHttpContent(content, sequence));
+        } else if (msg instanceof HttpContent content) {
+            ctx.fireChannelRead(new PipelinedHttpContent(content, sequence));
+        } else {
+            var request = (HttpRequest) msg;
+            sequence++;
+            ctx.fireChannelRead(new PipelinedHttpRequest(request, sequence));
+        }
+    }
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4RequestContentPublisher.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4RequestContentPublisher.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import org.elasticsearch.http.HttpContent;
+
+import java.util.concurrent.Flow;
+
+public class Netty4RequestContentPublisher implements Flow.Publisher<HttpContent> {
+
+    private final Channel channel;
+    private long requested = 0;
+    private Flow.Subscriber<? super HttpContent> subscriber;
+
+    public Netty4RequestContentPublisher(Channel channel) {
+        this.channel = channel;
+        channel.config().setAutoRead(false);
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super HttpContent> subscriber) {
+        this.subscriber = subscriber;
+        subscriber.onSubscribe(new Flow.Subscription() {
+            @Override
+            public void request(long n) {
+                requested += n;
+                if (requested > 0) {
+                    channel.read();
+                }
+            }
+
+            @Override
+            public void cancel() {}
+        });
+    }
+
+    public void sendChunk(io.netty.handler.codec.http.HttpContent chunk) {
+        assert subscriber != null;
+        if (chunk != LastHttpContent.EMPTY_LAST_CONTENT) {
+            var content = new Netty4HttpContent(chunk);
+            subscriber.onNext(content);
+            requested -= 1;
+            if (requested > 0) channel.read();
+        }
+        if (chunk instanceof LastHttpContent) {
+            subscriber.onComplete();
+            channel.config().setAutoRead(true);
+        }
+    }
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedFullHttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedFullHttpRequest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+/**
+ * A {@link FullHttpRequest} with pipeline sequence number
+ */
+public record PipelinedFullHttpRequest(FullHttpRequest request, int sequence) implements PipelinedHttpObject, FullHttpRequest {
+
+    public PipelinedFullHttpRequest withRequest(FullHttpRequest request) {
+        return new PipelinedFullHttpRequest(request, sequence);
+    }
+
+    @Override
+    public ByteBuf content() {
+        return request.content();
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return request.headers();
+    }
+
+    @Override
+    public FullHttpRequest copy() {
+        return withRequest(request.copy());
+    }
+
+    @Override
+    public FullHttpRequest duplicate() {
+        return withRequest(request.duplicate());
+    }
+
+    @Override
+    public FullHttpRequest retainedDuplicate() {
+        return withRequest(request.retainedDuplicate());
+    }
+
+    @Override
+    public FullHttpRequest replace(ByteBuf content) {
+        return withRequest(request.replace(content));
+    }
+
+    @Override
+    public FullHttpRequest retain(int increment) {
+        request.retain();
+        return this;
+    }
+
+    @Override
+    public int refCnt() {
+        return request.refCnt();
+    }
+
+    @Override
+    public FullHttpRequest retain() {
+        request.retain();
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch() {
+        request.touch();
+        return this;
+    }
+
+    @Override
+    public FullHttpRequest touch(Object hint) {
+        request.touch(hint);
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return request.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return request.release(decrement);
+    }
+
+    @Override
+    public HttpVersion getProtocolVersion() {
+        return request.protocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return request.protocolVersion();
+    }
+
+    @Override
+    public FullHttpRequest setProtocolVersion(HttpVersion version) {
+        request.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return request.headers();
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return request.method();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return request.method();
+    }
+
+    @Override
+    public FullHttpRequest setMethod(HttpMethod method) {
+        request.setMethod(method);
+        return this;
+    }
+
+    @Override
+    public String getUri() {
+        return request.uri();
+    }
+
+    @Override
+    public String uri() {
+        return request.uri();
+    }
+
+    @Override
+    public FullHttpRequest setUri(String uri) {
+        request.setUri(uri);
+        return this;
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return request.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        request.setDecoderResult(result);
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return request.decoderResult();
+    }
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpContent.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpContent.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+
+/**
+ * A {@link HttpContent} with pipeline sequence number
+ */
+public record PipelinedHttpContent(HttpContent httpContent, int sequence)
+    implements
+        PipelinedHttpObject,
+        HttpContent,
+        PipelinedHttpRequestPart {
+
+    public PipelinedHttpContent(ByteBuf buf, int sequence) {
+        this(new DefaultHttpContent(buf), sequence);
+    }
+
+    public PipelinedHttpContent withContent(HttpContent httpContent) {
+        return new PipelinedHttpContent(httpContent, sequence);
+    }
+
+    @Override
+    public ByteBuf content() {
+        return httpContent.content();
+    }
+
+    @Override
+    public HttpContent copy() {
+        return withContent(httpContent.copy());
+    }
+
+    @Override
+    public HttpContent duplicate() {
+        return withContent(httpContent.duplicate());
+    }
+
+    @Override
+    public HttpContent retainedDuplicate() {
+        return withContent(httpContent.retainedDuplicate());
+    }
+
+    @Override
+    public HttpContent replace(ByteBuf content) {
+        return withContent(httpContent.replace(content));
+    }
+
+    @Override
+    public int refCnt() {
+        return httpContent.refCnt();
+    }
+
+    @Override
+    public HttpContent retain() {
+        httpContent.retain();
+        return this;
+    }
+
+    @Override
+    public HttpContent retain(int increment) {
+        httpContent.retain(increment);
+        return this;
+    }
+
+    @Override
+    public HttpContent touch() {
+        httpContent.touch();
+        return this;
+    }
+
+    @Override
+    public HttpContent touch(Object hint) {
+        httpContent.touch(hint);
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return httpContent.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return httpContent.release(decrement);
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return httpContent.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        httpContent.setDecoderResult(result);
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return httpContent.decoderResult();
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpContent.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpContent.java
@@ -16,11 +16,7 @@ import io.netty.handler.codec.http.HttpContent;
 /**
  * A {@link HttpContent} with pipeline sequence number
  */
-public record PipelinedHttpContent(HttpContent httpContent, int sequence)
-    implements
-        PipelinedHttpObject,
-        HttpContent,
-        PipelinedHttpRequestPart {
+public record PipelinedHttpContent(HttpContent httpContent, int sequence) implements PipelinedHttpObject, HttpContent {
 
     public PipelinedHttpContent(ByteBuf buf, int sequence) {
         this(new DefaultHttpContent(buf), sequence);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpObject.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpObject.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+public sealed interface PipelinedHttpObject permits PipelinedFullHttpRequest, PipelinedHttpContent, PipelinedHttpRequest,
+    PipelinedHttpRequestPart, PipelinedLastHttpContent {
+
+    /**
+     * HTTP request sequence number, indicates order of arrival within same channel (connection).
+     * All parts of a single HTTP request - {@link PipelinedHttpRequest} and {@link PipelinedHttpContent} - has same sequence number.
+     */
+    int sequence();
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpObject.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpObject.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.http.netty4;
 
 public sealed interface PipelinedHttpObject permits PipelinedFullHttpRequest, PipelinedHttpContent, PipelinedHttpRequest,
-    PipelinedHttpRequestPart, PipelinedLastHttpContent {
+    PipelinedLastHttpContent {
 
     /**
      * HTTP request sequence number, indicates order of arrival within same channel (connection).

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpRequest.java
@@ -18,11 +18,7 @@ import io.netty.handler.codec.http.HttpVersion;
 /**
  * A {@link HttpRequest} with pipeline sequence number.
  */
-public record PipelinedHttpRequest(HttpRequest request, int sequence)
-    implements
-        PipelinedHttpObject,
-        PipelinedHttpRequestPart,
-        HttpRequest {
+public record PipelinedHttpRequest(HttpRequest request, int sequence) implements PipelinedHttpObject, HttpRequest {
 
     public PipelinedHttpRequest(HttpMethod method, String uri, int sequence) {
         this(new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, uri), sequence);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpRequest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+
+/**
+ * A {@link HttpRequest} with pipeline sequence number.
+ */
+public record PipelinedHttpRequest(HttpRequest request, int sequence)
+    implements
+        PipelinedHttpObject,
+        PipelinedHttpRequestPart,
+        HttpRequest {
+
+    public PipelinedHttpRequest(HttpMethod method, String uri, int sequence) {
+        this(new DefaultHttpRequest(HttpVersion.HTTP_1_1, method, uri), sequence);
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return method();
+    }
+
+    @Override
+    public HttpMethod method() {
+        return request.method();
+    }
+
+    @Override
+    public HttpRequest setMethod(HttpMethod method) {
+        request.setMethod(method);
+        return this;
+    }
+
+    @Override
+    public String getUri() {
+        return uri();
+    }
+
+    @Override
+    public String uri() {
+        return request.uri();
+    }
+
+    @Override
+    public HttpRequest setUri(String uri) {
+        request.setUri(uri);
+        return this;
+    }
+
+    @Override
+    public HttpVersion getProtocolVersion() {
+        return protocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return request.protocolVersion();
+    }
+
+    @Override
+    public HttpRequest setProtocolVersion(HttpVersion version) {
+        request.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return request.headers();
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        request.setDecoderResult(result);
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return request.decoderResult();
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpRequestPart.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedHttpRequestPart.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+/**
+ * A part of HTTP request that has HTTP pipelining sequence number
+ */
+public sealed interface PipelinedHttpRequestPart extends PipelinedHttpObject permits PipelinedHttpRequest, PipelinedHttpContent,
+    PipelinedLastHttpContent {
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedLastHttpContent.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedLastHttpContent.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.LastHttpContent;
+
+/**
+ * A {@link LastHttpContent} with pipeline sequence number
+ */
+public record PipelinedLastHttpContent(LastHttpContent httpContent, int sequence)
+    implements
+        PipelinedHttpObject,
+        LastHttpContent,
+        PipelinedHttpRequestPart {
+
+    public PipelinedLastHttpContent(ByteBuf buf, int sequence) {
+        this(new DefaultLastHttpContent(buf), sequence);
+    }
+
+    public PipelinedLastHttpContent withContent(LastHttpContent httpContent) {
+        return new PipelinedLastHttpContent(httpContent, sequence);
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return httpContent.trailingHeaders();
+    }
+
+    @Override
+    public ByteBuf content() {
+        return httpContent.content();
+    }
+
+    @Override
+    public LastHttpContent copy() {
+        return withContent(httpContent.copy());
+    }
+
+    @Override
+    public LastHttpContent duplicate() {
+        return withContent(httpContent.duplicate());
+    }
+
+    @Override
+    public LastHttpContent retainedDuplicate() {
+        return withContent(httpContent.retainedDuplicate());
+    }
+
+    @Override
+    public LastHttpContent replace(ByteBuf content) {
+        return withContent(httpContent.replace(content));
+    }
+
+    @Override
+    public LastHttpContent retain(int increment) {
+        httpContent.retain(increment);
+        return this;
+    }
+
+    @Override
+    public int refCnt() {
+        return httpContent.refCnt();
+    }
+
+    @Override
+    public LastHttpContent retain() {
+        httpContent.retain();
+        return this;
+    }
+
+    @Override
+    public LastHttpContent touch() {
+        httpContent.touch();
+        return this;
+    }
+
+    @Override
+    public LastHttpContent touch(Object hint) {
+        httpContent.touch(hint);
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return httpContent.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return httpContent.release(decrement);
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return httpContent.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        httpContent.setDecoderResult(result);
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return httpContent.decoderResult();
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedLastHttpContent.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/PipelinedLastHttpContent.java
@@ -17,11 +17,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 /**
  * A {@link LastHttpContent} with pipeline sequence number
  */
-public record PipelinedLastHttpContent(LastHttpContent httpContent, int sequence)
-    implements
-        PipelinedHttpObject,
-        LastHttpContent,
-        PipelinedHttpRequestPart {
+public record PipelinedLastHttpContent(LastHttpContent httpContent, int sequence) implements PipelinedHttpObject, LastHttpContent {
 
     public PipelinedLastHttpContent(ByteBuf buf, int sequence) {
         this(new DefaultLastHttpContent(buf), sequence);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4ContentDecompressorTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4ContentDecompressorTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
+import static org.hamcrest.Matchers.sameInstance;
+
+public class Netty4ContentDecompressorTests extends ESTestCase {
+
+    public void testDecompressRequest() throws IOException {
+        var chan = new EmbeddedChannel(new Netty4ContentDecompressor(), new HttpObjectAggregator(1024 * 1024));
+
+        for (int i = 0; i < randomIntBetween(1, 10); i++) {
+            var data = randomByteArrayOfLength(512 * 1024);
+            var zipped = Unpooled.buffer(data.length); // zipped version would about same size
+            try (var zos = new GZIPOutputStream(new ByteBufOutputStream(zipped))) {
+                zos.write(data);
+                zos.flush();
+            }
+
+            var sendReq = new PipelinedHttpRequest(HttpMethod.POST, "/uri", 0);
+            sendReq.headers().add(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.GZIP);
+            chan.writeInbound(sendReq);
+            chan.writeInbound(new PipelinedLastHttpContent(zipped, 0));
+
+            var msg = chan.readInbound();
+            assertNotNull(msg);
+            var recvReq = (FullHttpRequest) msg;
+            assertTrue(ByteBufUtil.equals(Unpooled.wrappedBuffer(data), recvReq.content()));
+            recvReq.release();
+        }
+    }
+
+    public void testSkipDecompression() {
+        var chan = new EmbeddedChannel(new Netty4ContentDecompressor());
+
+        for (int i = 0; i < randomIntBetween(1, 10); i++) {
+            var data = randomByteArrayOfLength(512 * 1024);
+            var req = new PipelinedHttpRequest(HttpMethod.POST, "/uri", 0);
+            var content = new PipelinedLastHttpContent(Unpooled.wrappedBuffer(data), 0);
+            chan.writeInbound(req);
+            chan.writeInbound(content);
+            assertThat(chan.readInbound(), sameInstance(req));
+            assertThat(chan.readInbound(), sameInstance(content));
+        }
+    }
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpAggregatorTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpAggregatorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+import static org.hamcrest.Matchers.sameInstance;
+
+public class Netty4HttpAggregatorTests extends ESTestCase {
+
+    public void testAggregateParts() {
+        var chan = new EmbeddedChannel(new Netty4HttpAggregator(1024 * 1024));
+        var reqNum = randomIntBetween(1, 100);
+        var wantData = new ArrayList<ByteBuf>();
+
+        for (var sequence = 0; sequence < reqNum; sequence++) {
+            chan.writeInbound(new PipelinedHttpRequest(HttpMethod.GET, "/uri", sequence));
+            var data = Unpooled.buffer(128);
+            for (var part = 0; part < randomInt(10); part++) {
+                var chunk = randomByteArrayOfLength(128);
+                data.writeBytes(chunk);
+                chan.writeInbound(new PipelinedHttpContent(Unpooled.wrappedBuffer(chunk), sequence));
+            }
+            if (randomBoolean()) {
+                chan.writeInbound(new PipelinedLastHttpContent(LastHttpContent.EMPTY_LAST_CONTENT, sequence));
+            } else {
+                var last = randomByteArrayOfLength(128);
+                data.writeBytes(last);
+                chan.writeInbound(new PipelinedLastHttpContent(Unpooled.wrappedBuffer(last), sequence));
+            }
+            wantData.add(data);
+        }
+
+        assertEquals("should aggregate all requests", reqNum, chan.inboundMessages().size());
+        for (int sequence = 0; sequence < reqNum; sequence++) {
+            var fullReq = (PipelinedFullHttpRequest) chan.inboundMessages().poll();
+            assertEquals("sequence must match", fullReq.sequence(), sequence);
+            assertTrue("content must match", ByteBufUtil.equals(wantData.get(sequence), fullReq.content()));
+        }
+    }
+
+    public void testSkipAggregationByPredicate() {
+        Predicate<PipelinedHttpRequest> skipBulkApi = (req) -> req.uri().equals("_bulk") == false;
+        var chan = new EmbeddedChannel(new Netty4HttpAggregator(1024, skipBulkApi));
+
+        var req = new PipelinedHttpRequest(HttpMethod.POST, "_bulk", 0);
+        var content = new PipelinedLastHttpContent(LastHttpContent.EMPTY_LAST_CONTENT, 0);
+        chan.writeInbound(req, content);
+
+        assertThat(chan.readInbound(), sameInstance(req));
+        assertThat(chan.readInbound(), sameInstance(content));
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/http/HttpContent.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpContent.java
@@ -6,12 +6,14 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.http.netty4;
+package org.elasticsearch.http;
 
-/**
- * A part of HTTP request that has HTTP pipelining sequence number
- */
-public sealed interface PipelinedHttpRequestPart extends PipelinedHttpObject permits PipelinedHttpRequest, PipelinedHttpContent,
-    PipelinedLastHttpContent {
+import org.elasticsearch.common.bytes.BytesReference;
+
+public interface HttpContent {
+
+    BytesReference content();
+
+    void release();
 
 }

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestStatus;
 
 import java.util.List;
+import java.util.concurrent.Flow;
 
 /**
  * A basic http request abstraction. Http modules needs to implement this interface to integrate with the
@@ -28,6 +29,10 @@ public interface HttpRequest extends HttpPreRequest {
     }
 
     BytesReference content();
+
+    default Flow.Publisher<HttpContent> contentPublisher() {
+        throw new IllegalArgumentException();
+    }
 
     List<String> strictCookies();
 

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -109,7 +109,7 @@ public abstract class BaseRestHandler implements RestHandler {
                 throw new IllegalArgumentException(unrecognized(request, unconsumedParams, candidateParams, "parameter"));
             }
 
-            if (request.hasContent() && request.isContentConsumed() == false) {
+            if (request.hasContent() && request.isContentConsumed() == false && request.contentPublisher() == null) {
                 throw new IllegalArgumentException(
                     "request [" + request.method() + " " + request.path() + "] does not support having a body"
                 );

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.http.HttpChannel;
+import org.elasticsearch.http.HttpContent;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.telemetry.tracing.Traceable;
 import org.elasticsearch.xcontent.ParsedMediaType;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
@@ -288,6 +290,10 @@ public class RestRequest implements ToXContent.Params, Traceable {
     public BytesReference content() {
         this.contentConsumed = true;
         return httpRequest.content();
+    }
+
+    public Flow.Publisher<HttpContent> contentPublisher() {
+        return httpRequest.contentPublisher();
     }
 
     /**


### PR DESCRIPTION
UPDATE: 
Created a leaner and cleaner version here https://github.com/elastic/elasticsearch/pull/111438. 
Most of changes here are irrelevant in new PR.


-----

This PR adds support to `Netty4HttpPipeliningHandler` to handle parts of HTTP request. Right now we always aggregate HTTP request content before passing to `RestController`. With this change `Netty4HttpPipeliningHandler` can receive `FullHttpRequests` and `HttpRequests`/`HttpContents` with correct sequence number.

To make it possible I made several changes in Netty channel pipeline.
1. Add HTTP pipeline sequence to parts of HTTP request. Before `Netty4HttpPipeliningHandler` would keep track of all incoming `FullHttpRequests` and increase sequence number. With this change addition of sequence number happens sooner, after `HttpRequestDecoder`, but before decompression and aggregation. It happens in `Netty4InboundHttpPipeliningHandler`.

2. Propagation of sequence number through `HttpObjectAggregator` and `HttpContentDecompressor`. Since netty does not know about our pipelining implementation, I have to wrap both classes that can consume and produce a "pipelined" versions of `HttpObjects`. Besides wrapper handler classes I introduced strong-typed versions of `HttpRequest, HttpContent, LastHttpContent, FullHttpRequest` with pipeline sequence number, for example 
`public record PipelinedHttpContent(HttpContent httpContent, int sequence)`
3. Make HTTP aggregation optional. In this PR we still do full aggregation to all requests. But I added a predicate that can control which requests can skip aggregation, and unit tests.

After change pipeline looks like this:
```
| from                        | to                                 | note                       |
|-----------------------------+------------------------------------+----------------------------|
| HttpRequestDecoder          | HttpRequestDecoder                 |                            |
| Netty4HttpHeaderValidator   | Netty4HttpHeaderValidator          |                            |
|                             | Netty4InboundHttpPipeliningHandler | emits PipelinedHttpObjects |
| HttpContentDecompressor     | Netty4ContentDecompressor          | wrapped decompressor       |
| HttpObjectAggregator        | Netty4HttpAggregator               | optional aggregation       |
| Netty4HttpPipeliningHandler | Netty4HttpPipeliningHandler        |                            |
```

Most interesting changes in `Netty4ContentDecompressor, Netty4HttpAggregator, Netty4InboundHttpPipeliningHandler , Netty4HttpPipeliningHandler` and related unit tests at the end. The rest is boilerplate.

**Update**:
Added example of RestHandler with chunked content. I use [reactive streams model](https://www.reactive-streams.org/). Rather than exposing `BytesReference` as content, I use `Flow.Publisher<HttpContent>`. The RestHandler will subscribe to publisher and consume parts at it's own rate - by [`Subscription.request(long n)`](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/concurrent/Flow.Subscription.html#request(long)). The publisher will read from netty channel on demand and invoke `onNext(HttpContent)` when number of requested parts is greater than 0.

Content publisher - `Netty4RequestContentPublisher`
Rest handler example - `Netty4RequestContentPublisherIT`

I omitted error handling and edge cases for brevity. There many things to consider with publisher state machine: for example avoid multiple subscriptions, handling terminal states, handling errors, handling subscriber cancellation. I did some drafts, and I can say it's pretty easy to add them.
