### PR TITLE
Skip on any instance of node or version features being present

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsCommonYamlTestSuiteIT.java
@@ -310,8 +310,11 @@ public class CcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
                 getClusterStateFeatures(adminSearchClient),
                 semanticNodeVersions
             );
-            final TestFeatureService combinedTestFeatureService = featureId -> testFeatureService.clusterHasFeature(featureId)
-                && searchTestFeatureService.clusterHasFeature(featureId);
+            final TestFeatureService combinedTestFeatureService = (featureId, any) -> {
+                boolean adminFeature = testFeatureService.clusterHasFeature(featureId, any);
+                boolean searchFeature = searchTestFeatureService.clusterHasFeature(featureId, any);
+                return any ? adminFeature || searchFeature : adminFeature && searchFeature;
+            };
             final Set<String> combinedOsSet = Stream.concat(osSet.stream(), Stream.of(searchOs)).collect(Collectors.toSet());
             final Set<String> combinedNodeVersions = Stream.concat(nodesVersions.stream(), searchNodeVersions.stream())
                 .collect(Collectors.toSet());

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -294,8 +294,11 @@ public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
                 getClusterStateFeatures(adminSearchClient),
                 semanticNodeVersions
             );
-            final TestFeatureService combinedTestFeatureService = featureId -> testFeatureService.clusterHasFeature(featureId)
-                && searchTestFeatureService.clusterHasFeature(featureId);
+            final TestFeatureService combinedTestFeatureService = (featureId, any) -> {
+                boolean adminFeature = testFeatureService.clusterHasFeature(featureId, any);
+                boolean searchFeature = searchTestFeatureService.clusterHasFeature(featureId, any);
+                return any ? adminFeature || searchFeature : adminFeature && searchFeature;
+            };
 
             final Set<String> combinedOsSet = Stream.concat(osSet.stream(), Stream.of(searchOs)).collect(Collectors.toSet());
             final Set<String> combinedNodeVersions = Stream.concat(nodesVersions.stream(), searchNodeVersions.stream())

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -44,7 +44,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.WarningsHandler;
-import org.elasticsearch.cluster.ClusterFeatures;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -307,11 +306,11 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected static boolean clusterHasFeature(String featureId) {
-        return testFeatureService.clusterHasFeature(featureId);
+        return testFeatureService.clusterHasFeature(featureId, false);
     }
 
     protected static boolean clusterHasFeature(NodeFeature feature) {
-        return testFeatureService.clusterHasFeature(feature.id());
+        return testFeatureService.clusterHasFeature(feature.id(), false);
     }
 
     protected static boolean testFeatureServiceInitialized() {
@@ -418,11 +417,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                 RestTestLegacyFeatures.class.getCanonicalName()
             );
         }
-        return new ESRestTestFeatureService(
-            additionalTestOnlyHistoricalFeatures(),
-            semanticNodeVersions,
-            ClusterFeatures.calculateAllNodeFeatures(clusterStateFeatures.values())
-        );
+        return new ESRestTestFeatureService(additionalTestOnlyHistoricalFeatures(), semanticNodeVersions, clusterStateFeatures.values());
     }
 
     protected static boolean has(ProductFeature feature) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,11 +49,15 @@ class ESRestTestFeatureService implements TestFeatureService {
      */
     private static final Pattern VERSION_FEATURE_PATTERN = Pattern.compile("gte_v(\\d+\\.\\d+\\.\\d+)");
 
-    private final Set<String> allSupportedFeatures;
     private final Set<String> knownHistoricalFeatureNames;
-    private final Version version;
+    private final Collection<Version> nodeVersions;
+    private final Collection<Set<String>> nodeFeatures;
 
-    ESRestTestFeatureService(List<FeatureSpecification> featureSpecs, Collection<Version> nodeVersions, Set<String> clusterStateFeatures) {
+    ESRestTestFeatureService(
+        List<FeatureSpecification> featureSpecs,
+        Collection<Version> nodeVersions,
+        Collection<Set<String>> nodeFeatures
+    ) {
         List<FeatureSpecification> specs = new ArrayList<>(featureSpecs);
         specs.add(new RestTestLegacyFeatures());
         if (MetadataHolder.HISTORICAL_FEATURES != null) {
@@ -65,17 +70,24 @@ class ESRestTestFeatureService implements TestFeatureService {
                 featureData.getNodeFeatures().keySet()
             );
         this.knownHistoricalFeatureNames = featureData.getHistoricalFeatures().lastEntry().getValue();
-        this.version = nodeVersions.stream().min(Comparator.naturalOrder()).orElse(Version.CURRENT);
-        this.allSupportedFeatures = Sets.union(clusterStateFeatures, featureData.getHistoricalFeatures().floorEntry(version).getValue());
+        this.nodeVersions = nodeVersions;
+        // add historical features to the set of node features
+        Version minVersion = nodeVersions.stream().min(Comparator.naturalOrder()).orElse(Version.CURRENT);
+        Set<String> allHistoricalFeatures = featureData.getHistoricalFeatures().floorEntry(minVersion).getValue();
+        this.nodeFeatures = nodeFeatures.stream().map(fs -> Sets.union(fs, allHistoricalFeatures)).toList();
     }
 
     public static boolean hasFeatureMetadata() {
         return MetadataHolder.HISTORICAL_FEATURES != null;
     }
 
+    private static <T> boolean checkCollection(Collection<T> coll, Predicate<T> pred, boolean any) {
+        return any ? coll.stream().anyMatch(pred) : coll.stream().allMatch(pred);
+    }
+
     @Override
-    public boolean clusterHasFeature(String featureId) {
-        if (allSupportedFeatures.contains(featureId)) {
+    public boolean clusterHasFeature(String featureId, boolean any) {
+        if (checkCollection(nodeFeatures, s -> s.contains(featureId), any)) {
             return true;
         }
         if (MetadataHolder.FEATURE_NAMES.contains(featureId) || knownHistoricalFeatureNames.contains(featureId)) {
@@ -86,7 +98,7 @@ class ESRestTestFeatureService implements TestFeatureService {
         Matcher matcher = VERSION_FEATURE_PATTERN.matcher(featureId);
         if (matcher.matches()) {
             Version extractedVersion = Version.fromString(matcher.group(1));
-            return version.onOrAfter(extractedVersion);
+            return checkCollection(nodeVersions, v -> v.onOrAfter(extractedVersion), any);
         }
 
         if (hasFeatureMetadata()) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -82,7 +82,7 @@ class ESRestTestFeatureService implements TestFeatureService {
     }
 
     private static <T> boolean checkCollection(Collection<T> coll, Predicate<T> pred, boolean any) {
-        return any ? coll.stream().anyMatch(pred) : coll.stream().allMatch(pred);
+        return any ? coll.stream().anyMatch(pred) : coll.isEmpty() == false && coll.stream().allMatch(pred);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -9,7 +9,20 @@
 package org.elasticsearch.test.rest;
 
 public interface TestFeatureService {
-    TestFeatureService ALL_FEATURES = feature -> true;
+    TestFeatureService ALL_FEATURES = (feature, any) -> true;
 
-    boolean clusterHasFeature(String featureId);
+    /**
+     * Returns {@code true} if all nodes in the cluster have feature {@code featureId}
+     */
+    default boolean clusterHasFeature(String featureId) {
+        return clusterHasFeature(featureId, false);
+    }
+
+    /**
+     * @param featureId The feature to check
+     * @param any
+     *         {@code true} if it should check if any node has the feature,
+     *         {@code false} if it should check if all nodes have the feature
+     */
+    boolean clusterHasFeature(String featureId, boolean any);
 }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -276,8 +276,8 @@ public class ClientYamlTestExecutionContext {
         return clientYamlTestCandidate;
     }
 
-    public boolean clusterHasFeature(String featureId) {
-        return testFeatureService.clusterHasFeature(featureId);
+    public boolean clusterHasFeature(String featureId, boolean any) {
+        return testFeatureService.clusterHasFeature(featureId, any);
     }
 
     public Optional<Boolean> clusterHasCapabilities(String method, String path, String parametersString, String capabilitiesString) {

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -374,9 +374,10 @@ public class DoSection implements ExecutableSection {
             // This is really difficult to express just with features, so I will break it down into 2 parts: version check for v7,
             // and feature check for v8. This way the version check can be removed once we move to v9
             @UpdateForV9
-            var fixedInV7 = executionContext.clusterHasFeature("gte_v7.17.2") && executionContext.clusterHasFeature("gte_v8.0.0") == false;
+            var fixedInV7 = executionContext.clusterHasFeature("gte_v7.17.2", false)
+                && executionContext.clusterHasFeature("gte_v8.0.0", false) == false;
             var fixedProductionHeader = fixedInV7
-                || executionContext.clusterHasFeature(RestTestLegacyFeatures.REST_ELASTIC_PRODUCT_HEADER_PRESENT.id());
+                || executionContext.clusterHasFeature(RestTestLegacyFeatures.REST_ELASTIC_PRODUCT_HEADER_PRESENT.id(), false);
             if (fixedProductionHeader) {
                 checkElasticProductHeader(response.getHeaders("X-elastic-product"));
             }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Prerequisites.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Prerequisites.java
@@ -41,16 +41,16 @@ public class Prerequisites {
     }
 
     static Predicate<ClientYamlTestExecutionContext> requireClusterFeatures(Set<String> clusterFeatures) {
-        return context -> clusterFeatures.stream().allMatch(context::clusterHasFeature);
+        return context -> clusterFeatures.stream().allMatch(f -> context.clusterHasFeature(f, false));
     }
 
     static Predicate<ClientYamlTestExecutionContext> skipOnClusterFeatures(Set<String> clusterFeatures) {
-        return context -> clusterFeatures.stream().anyMatch(context::clusterHasFeature);
+        return context -> clusterFeatures.stream().anyMatch(f -> context.clusterHasFeature(f, true));
     }
 
     static Predicate<ClientYamlTestExecutionContext> skipOnKnownIssue(List<KnownIssue> knownIssues) {
         return context -> knownIssues.stream()
-            .anyMatch(i -> context.clusterHasFeature(i.clusterFeature()) && context.clusterHasFeature(i.fixedBy()) == false);
+            .anyMatch(i -> context.clusterHasFeature(i.clusterFeature(), true) && context.clusterHasFeature(i.fixedBy(), false) == false);
     }
 
     static CapabilitiesPredicate requireCapabilities(List<CapabilitiesCheck> checks) {

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSectionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSectionTests.java
@@ -457,8 +457,8 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         );
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
-        when(mockContext.clusterHasFeature("required-feature-1")).thenReturn(true);
-        when(mockContext.clusterHasFeature("required-feature-2")).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-1", false)).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-2", false)).thenReturn(true);
 
         assertFalse(section.skipCriteriaMet(mockContext));
         assertTrue(section.requiresCriteriaMet(mockContext));
@@ -474,8 +474,8 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         );
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
-        when(mockContext.clusterHasFeature("required-feature-1")).thenReturn(true);
-        when(mockContext.clusterHasFeature("required-feature-2")).thenReturn(false);
+        when(mockContext.clusterHasFeature("required-feature-1", false)).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-2", false)).thenReturn(false);
 
         assertFalse(section.skipCriteriaMet(mockContext));
         assertFalse(section.requiresCriteriaMet(mockContext));
@@ -491,7 +491,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         );
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
-        when(mockContext.clusterHasFeature("undesired-feature-1")).thenReturn(true);
+        when(mockContext.clusterHasFeature("undesired-feature-1", true)).thenReturn(true);
 
         assertTrue(section.skipCriteriaMet(mockContext));
     }
@@ -521,9 +521,9 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         assertFalse(section.hasCapabilitiesCheck());
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
-        when(mockContext.clusterHasFeature("required-feature-1")).thenReturn(true);
-        when(mockContext.clusterHasFeature("required-feature-2")).thenReturn(true);
-        when(mockContext.clusterHasFeature("undesired-feature-1")).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-1", false)).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-2", false)).thenReturn(true);
+        when(mockContext.clusterHasFeature("undesired-feature-1", true)).thenReturn(true);
 
         assertTrue(section.skipCriteriaMet(mockContext));
         assertTrue(section.requiresCriteriaMet(mockContext));
@@ -540,8 +540,8 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         assertFalse(section.hasCapabilitiesCheck());
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
-        when(mockContext.clusterHasFeature("required-feature-1")).thenReturn(true);
-        when(mockContext.clusterHasFeature("required-feature-2")).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-1", false)).thenReturn(true);
+        when(mockContext.clusterHasFeature("required-feature-2", false)).thenReturn(true);
 
         assertFalse(section.skipCriteriaMet(mockContext));
         assertTrue(section.requiresCriteriaMet(mockContext));
@@ -560,16 +560,16 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         var mockContext = mock(ClientYamlTestExecutionContext.class);
         assertFalse(section.skipCriteriaMet(mockContext));
 
-        when(mockContext.clusterHasFeature("bug1")).thenReturn(true);
+        when(mockContext.clusterHasFeature("bug1", true)).thenReturn(true);
         assertTrue(section.skipCriteriaMet(mockContext));
 
-        when(mockContext.clusterHasFeature("fix1")).thenReturn(true);
+        when(mockContext.clusterHasFeature("fix1", false)).thenReturn(true);
         assertFalse(section.skipCriteriaMet(mockContext));
 
-        when(mockContext.clusterHasFeature("bug2")).thenReturn(true);
+        when(mockContext.clusterHasFeature("bug2", true)).thenReturn(true);
         assertTrue(section.skipCriteriaMet(mockContext));
 
-        when(mockContext.clusterHasFeature("fix2")).thenReturn(true);
+        when(mockContext.clusterHasFeature("fix2", false)).thenReturn(true);
         assertFalse(section.skipCriteriaMet(mockContext));
     }
 


### PR DESCRIPTION
If any node has a specific feature or version feature specified in a skip YAML test, then skip that test, instead of only skipping if all nodes have that feature