### PR TITLE
Add nodeId option to _capabilities, to get the capabilities of specific nodes in the cluster

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/nodescapabilities/SimpleNodesCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/nodescapabilities/SimpleNodesCapabilitiesIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.cluster.node.capabilities.NodesCapabilitie
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.hasSize;
@@ -51,5 +52,23 @@ public class SimpleNodesCapabilitiesIT extends ESIntegTestCase {
             .actionGet();
         assertThat(response.getNodes(), hasSize(2));
         assertThat(response.isSupported(), isPresentWith(false));*/
+    }
+
+    public void testSpecificNodesCapabilities() {
+        List<String> nodes = internalCluster().startNodes(3);
+
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("3").get();
+        logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
+
+        NodesCapabilitiesResponse response = clusterAdmin().nodesCapabilities(
+            new NodesCapabilitiesRequest(nodes.get(0)).path("_capabilities")
+        ).actionGet();
+        assertThat(response.getNodes(), hasSize(1));
+        assertThat(response.isSupported(), isPresentWith(true));
+
+        response = clusterAdmin().nodesCapabilities(new NodesCapabilitiesRequest(nodes.get(1), nodes.get(2)).path("_capabilities"))
+            .actionGet();
+        assertThat(response.getNodes(), hasSize(2));
+        assertThat(response.isSupported(), isPresentWith(true));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/NodesCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/NodesCapabilitiesRequest.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.admin.cluster.node.capabilities;
 
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest;
 
@@ -23,9 +22,8 @@ public class NodesCapabilitiesRequest extends BaseNodesRequest<NodesCapabilities
     private Set<String> capabilities = Set.of();
     private RestApiVersion restApiVersion = RestApiVersion.current();
 
-    public NodesCapabilitiesRequest() {
-        // always send to all nodes
-        super(Strings.EMPTY_ARRAY);
+    public NodesCapabilitiesRequest(String... nodeIds) {
+        super(nodeIds);
     }
 
     public NodesCapabilitiesRequest path(String path) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesCapabilitiesAction.java
@@ -33,7 +33,7 @@ public class RestNodesCapabilitiesAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(RestRequest.Method.GET, "/_capabilities"));
+        return List.of(new Route(RestRequest.Method.GET, "/_capabilities"), new Route(RestRequest.Method.GET, "/_capabilities/{nodeId}"));
     }
 
     @Override
@@ -48,7 +48,9 @@ public class RestNodesCapabilitiesAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        NodesCapabilitiesRequest r = new NodesCapabilitiesRequest().timeout(getTimeout(request))
+
+        String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
+        NodesCapabilitiesRequest r = new NodesCapabilitiesRequest(nodesIds).timeout(getTimeout(request))
             .method(RestRequest.Method.valueOf(request.param("method", "GET")))
             .path(URLDecoder.decode(request.param("path"), StandardCharsets.UTF_8))
             .parameters(request.paramAsStringArray("parameters", Strings.EMPTY_ARRAY))


### PR DESCRIPTION
Following on from other patterns of rest handlers, add `nodeId` comma-separated list to specify the nodes you want to check the capabilities of. This is largely for tests, so they can get the caps of specific nodes to check them individually.