### PR TITLE
Use READONCE for reading the segment file and computing checksums

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -273,7 +273,7 @@ public class StoreTests extends ESTestCase {
         metadata = store.getMetadata(randomBoolean() ? indexCommit : null);
         assertThat(metadata.fileMetadataMap().isEmpty(), is(false));
         for (StoreFileMetadata meta : metadata) {
-            try (IndexInput input = store.directory().openInput(meta.name(), IOContext.DEFAULT)) {
+            try (IndexInput input = store.directory().openInput(meta.name(), IOContext.READONCE)) {
                 String checksum = Store.digestToString(CodecUtil.retrieveChecksum(input));
                 assertThat("File: " + meta.name() + " has a different checksum", meta.checksum(), equalTo(checksum));
                 assertThat(meta.writtenBy(), equalTo(Version.LATEST.toString()));

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr.repository;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
@@ -244,9 +245,10 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
 
         private long readFileBytes(String fileName, ByteArray reference) throws IOException {
             try (Releasable ignored = keyedLock.acquire(fileName)) {
+                var context = fileName.startsWith(IndexFileNames.SEGMENTS) ? IOContext.READONCE : IOContext.READ;
                 final IndexInput indexInput = cachedInputs.computeIfAbsent(fileName, f -> {
                     try {
-                        return commitRef.getIndexCommit().getDirectory().openInput(fileName, IOContext.READ);
+                        return commitRef.getIndexCommit().getDirectory().openInput(fileName, context);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -256,7 +258,7 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
 
                 long offsetAfterRead = indexInput.getFilePointer();
 
-                if (offsetAfterRead == indexInput.length()) {
+                if (offsetAfterRead == indexInput.length() || context == IOContext.READONCE) {
                     cachedInputs.remove(fileName);
                     IOUtils.close(indexInput);
                 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRestoreSourceService.java
@@ -246,7 +246,7 @@ public class CcrRestoreSourceService extends AbstractLifecycleComponent implemen
             try (Releasable ignored = keyedLock.acquire(fileName)) {
                 final IndexInput indexInput = cachedInputs.computeIfAbsent(fileName, f -> {
                     try {
-                        return commitRef.getIndexCommit().getDirectory().openInput(fileName, IOContext.READONCE);
+                        return commitRef.getIndexCommit().getDirectory().openInput(fileName, IOContext.READ);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/OldSegmentInfos.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/OldSegmentInfos.java
@@ -196,7 +196,7 @@ public class OldSegmentInfos implements Cloneable, Iterable<SegmentCommitInfo> {
 
         long generation = generationFromSegmentsFileName(segmentFileName);
         // System.out.println(Thread.currentThread() + ": SegmentInfos.readCommit " + segmentFileName);
-        try (ChecksumIndexInput input = directory.openChecksumInput(segmentFileName, IOContext.READ)) {
+        try (ChecksumIndexInput input = directory.openChecksumInput(segmentFileName, IOContext.READONCE)) {
             try {
                 return readCommit(directory, input, generation, minSupportedMajorVersion);
             } catch (EOFException | NoSuchFileException | FileNotFoundException e) {


### PR DESCRIPTION
This commit uses READONCE for reading the segment file and computing checksums