### PR TITLE
Include account name in Azure settings exceptions

### DIFF
--- a/docs/changelog/111274.yaml
+++ b/docs/changelog/111274.yaml
@@ -1,0 +1,5 @@
+pr: 111274
+summary: Include account name in Azure settings exceptions
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -124,10 +124,6 @@ final class AzureStorageSettings {
     );
 
     private final String account;
-
-    @Nullable
-    private final String sasToken;
-
     private final String connectString;
     private final String endpointSuffix;
     private final TimeValue timeout;
@@ -148,7 +144,6 @@ final class AzureStorageSettings {
         String secondaryEndpoint
     ) {
         this.account = account;
-        this.sasToken = sasToken;
         this.connectString = buildConnectString(account, key, sasToken, endpointSuffix, endpoint, secondaryEndpoint);
         this.endpointSuffix = endpointSuffix;
         this.timeout = timeout;
@@ -204,10 +199,10 @@ final class AzureStorageSettings {
         final boolean hasSasToken = Strings.hasText(sasToken);
         final boolean hasKey = Strings.hasText(key);
         if (hasSasToken == false && hasKey == false) {
-            throw new SettingsException("Neither a secret key nor a shared access token was set.");
+            throw new SettingsException("Neither a secret key nor a shared access token was set for account [" + account + "]");
         }
         if (hasSasToken && hasKey) {
-            throw new SettingsException("Both a secret as well as a shared access token were set.");
+            throw new SettingsException("Both a secret as well as a shared access token were set for account [" + account + "]");
         }
         final StringBuilder connectionStringBuilder = new StringBuilder();
         connectionStringBuilder.append("DefaultEndpointsProtocol=https").append(";AccountName=").append(account);
@@ -221,15 +216,15 @@ final class AzureStorageSettings {
         final boolean hasSecondaryEndpoint = Strings.hasText(secondaryEndpoint);
 
         if (hasEndpointSuffix && hasEndpoint) {
-            throw new SettingsException("Both an endpoint suffix as well as a primary endpoint were set");
+            throw new SettingsException("Both an endpoint suffix as well as a primary endpoint were set for account [" + account + "]");
         }
 
         if (hasEndpointSuffix && hasSecondaryEndpoint) {
-            throw new SettingsException("Both an endpoint suffix as well as a secondary endpoint were set");
+            throw new SettingsException("Both an endpoint suffix as well as a secondary endpoint were set for account [" + account + "]");
         }
 
         if (hasEndpoint == false && hasSecondaryEndpoint) {
-            throw new SettingsException("A primary endpoint is required when setting a secondary endpoint");
+            throw new SettingsException("A primary endpoint is required when setting a secondary endpoint for account [" + account + "]");
         }
 
         if (hasEndpointSuffix) {

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
@@ -199,10 +199,14 @@ public class AzureStorageServiceTests extends ESTestCase {
             final AzureStorageService azureStorageService = plugin.azureStoreService.get();
             AzureBlobServiceClient client11 = azureStorageService.client("azure1", LocationMode.PRIMARY_ONLY);
             assertThat(client11.getSyncClient().getAccountUrl(), equalTo("https://myaccount1.blob.core.windows.net"));
-            final SettingsException e1 = expectThrows(SettingsException.class, () -> plugin.reload(settings2));
-            assertThat(e1.getMessage(), is("Neither a secret key nor a shared access token was set."));
-            final SettingsException e2 = expectThrows(SettingsException.class, () -> plugin.reload(settings3));
-            assertThat(e2.getMessage(), is("Both a secret as well as a shared access token were set."));
+            assertThat(
+                expectThrows(SettingsException.class, () -> plugin.reload(settings2)).getMessage(),
+                is("Neither a secret key nor a shared access token was set for account [myaccount1]")
+            );
+            assertThat(
+                expectThrows(SettingsException.class, () -> plugin.reload(settings3)).getMessage(),
+                is("Both a secret as well as a shared access token were set for account [myaccount3]")
+            );
             // existing client untouched
             assertThat(client11.getSyncClient().getAccountUrl(), equalTo("https://myaccount1.blob.core.windows.net"));
         }
@@ -499,7 +503,7 @@ public class AzureStorageServiceTests extends ESTestCase {
                         .build()
                 )
             );
-            assertEquals("A primary endpoint is required when setting a secondary endpoint", e.getMessage());
+            assertEquals("A primary endpoint is required when setting a secondary endpoint for account [myaccount1]", e.getMessage());
         }
 
         {
@@ -513,7 +517,7 @@ public class AzureStorageServiceTests extends ESTestCase {
                         .build()
                 )
             );
-            assertEquals("Both an endpoint suffix as well as a secondary endpoint were set", e.getMessage());
+            assertEquals("Both an endpoint suffix as well as a secondary endpoint were set for account [myaccount1]", e.getMessage());
         }
     }
 


### PR DESCRIPTION
If there are several Azure accounts defined, and one of them has invalid
settings, then it's hard to pinpoint the problem from the messages given
today. This commit includes the account name in the exception message to
make troubleshooting easier.