### PR TITLE
ESQL: Fix inlinestats beforeKeep test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -108,18 +108,6 @@ tests:
 - class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
   method: testReadNonexistentBlobThrowsNoSuchFileException
   issue: https://github.com/elastic/elasticsearch/issues/111233
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {inlinestats.BeforeKeep ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/111257
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {inlinestats.BeforeKeep ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/111259
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {inlinestats.BeforeKeep SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/111260
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {inlinestats.BeforeKeep SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/111262
 - class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
   method: testInlineStatsProfile {SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/111263

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -336,18 +336,16 @@ emp_no:integer | languages:integer | max_salary:integer
          10003 |                 4 | 74572
 ;
 
-beforeKeep
+beforeKeepWhere
 required_capability: inlinestats
 
 FROM employees
 | INLINESTATS max_salary = MAX(salary) by languages
 | KEEP emp_no, languages, max_salary
-| LIMIT 3;
+| WHERE emp_no == 10003;
 
 ignoreOrder:true
 emp_no:integer | languages:integer | max_salary:integer
-         10001 |                 2 | 73578
-         10002 |                 5 | 66817
          10003 |                 4 | 74572
 ;
 


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/111257
Fix https://github.com/elastic/elasticsearch/issues/111259
Fix https://github.com/elastic/elasticsearch/issues/111260
Fix https://github.com/elastic/elasticsearch/issues/111262

Make the test deterministic.