### PR TITLE
[Bugfix] Add accessDeclaredMembers permission for ObjectMapper to work.

### DIFF
--- a/docs/changelog/111285.yaml
+++ b/docs/changelog/111285.yaml
@@ -1,5 +1,5 @@
 pr: 111285
-summary: "[Bugfix] Add `accessDeclaredMembers` permission for `ObjectMapper` to work"
+summary: "[Bugfix] Add `accessDeclaredMembers` permission to fix bug in rendered search application templates"
 area: Relevance
 type: bug
 issues: []

--- a/docs/changelog/111285.yaml
+++ b/docs/changelog/111285.yaml
@@ -1,0 +1,5 @@
+pr: 111285
+summary: "[Bugfix] Add `accessDeclaredMembers` permission for `ObjectMapper` to work"
+area: Relevance
+type: bug
+issues: []

--- a/docs/changelog/111285.yaml
+++ b/docs/changelog/111285.yaml
@@ -1,5 +1,5 @@
 pr: 111285
-summary: "[Bugfix] Add `accessDeclaredMembers` permission to fix bug in rendered search application templates"
+summary: "[Bugfix] Add `accessDeclaredMembers` permission to allow search application templates to parse floats"
 area: Relevance
 type: bug
 issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/52_search_application_render_query.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/52_search_application_render_query.yml
@@ -221,6 +221,36 @@ teardown:
   }
 
 ---
+"Render query for search application with floats":
+
+  - do:
+      search_application.render_query:
+        name: test-search-application-with-list
+        body:
+          params:
+            query_string: value3
+            text_fields:
+              - name: field1
+                boost: 1.2
+              - name: field2
+                boost: 2.3
+              - name: field3
+                boost: 3
+
+  - match: {
+    query: {
+      multi_match: {
+        query: "value3",
+        fields: [
+          "field1^1.2",
+          "field2^2.3",
+          "field3^3.0"
+        ]
+      }
+    }
+  }
+
+---
 "Render query for search application - not found":
 
   - do:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
@@ -15,13 +15,14 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
-import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -92,7 +93,11 @@ public class TemplateParamValidator implements ToXContentObject, Writeable {
                 return OBJECT_MAPPER.valueToTree(templateParams);
             });
         } catch (PrivilegedActionException e) {
-            throw new ElasticsearchException("failed to convert parameters while validating", e);
+            throw new ElasticsearchStatusException(
+                "failed to convert parameters while validating",
+                RestStatus.INTERNAL_SERVER_ERROR,
+                e.getCause()
+            );
         }
         validateWithSchema(this.jsonSchema, secondParam);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.Objects;
@@ -90,7 +91,7 @@ public class TemplateParamValidator implements ToXContentObject, Writeable {
             secondParam = AccessController.doPrivileged((PrivilegedExceptionAction<JsonNode>) () -> {
                 return OBJECT_MAPPER.valueToTree(templateParams);
             });
-        } catch (Exception e) {
+        } catch (PrivilegedActionException e) {
             throw new ElasticsearchException("failed to convert parameters while validating", e);
         }
         validateWithSchema(this.jsonSchema, secondParam);

--- a/x-pack/plugin/ent-search/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/ent-search/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,4 @@
+grant {
+  // needed for Jackson ObjectMapper
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+};

--- a/x-pack/plugin/ent-search/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/ent-search/src/main/plugin-metadata/plugin-security.policy
@@ -1,4 +1,4 @@
 grant {
-  // needed for Jackson ObjectMapper
+  // needed for Jackson ObjectMapper to parse floats
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/TemplateParamValidatorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/TemplateParamValidatorTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.search;
+
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TemplateParamValidatorTests extends ESTestCase {
+
+    public void testValidateThrowsWhenSchemaDontMatch() {
+        Map<String, Object> failingParams = new HashMap<>();
+        failingParams.put("fail", null);
+        TemplateParamValidator validator = new TemplateParamValidator(
+            "{\"properties\":{\"title_boost\":{\"type\":\"number\"},\"additionalProperties\":false},\"required\":[\"query_string\"]}"
+        );
+
+        assertThrows(ValidationException.class, () -> validator.validate(failingParams));
+
+    }
+
+    public void testValidateWithFloats() {
+        Map<String, Object> passingParams = new HashMap<>();
+        passingParams.put("title_boost", 1.0f);
+        passingParams.put("query_string", "query_string");
+        TemplateParamValidator validator = new TemplateParamValidator(
+            "{\"properties\":{\"title_boost\":{\"type\":\"number\"},\"additionalProperties\":false},\"required\":[\"query_string\"]}"
+        );
+        try {
+            validator.validate(passingParams);
+        } catch (Exception e) {
+            // We don't have nice assertions for this in JUnit 4
+            fail("Should not throw an exception");
+        }
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/TemplateParamValidatorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/TemplateParamValidatorTests.java
@@ -33,12 +33,9 @@ public class TemplateParamValidatorTests extends ESTestCase {
         TemplateParamValidator validator = new TemplateParamValidator(
             "{\"properties\":{\"title_boost\":{\"type\":\"number\"},\"additionalProperties\":false},\"required\":[\"query_string\"]}"
         );
-        try {
-            validator.validate(passingParams);
-        } catch (Exception e) {
-            // We don't have nice assertions for this in JUnit 4
-            fail("Should not throw an exception");
-        }
+        // This shouldn't throw
+        // We don't have nice assertions for this in JUnit 4
+        validator.validate(passingParams);
     }
 
 }


### PR DESCRIPTION
This fixes a bug where passing floating point values to search application template throwing `accessDeclaredMembers` runtime permission error from Jackson ObjectMapper.

This PR grants `accessDeclaredMembers` permission and wraps `ObjectWrapepr.valueToTree` with privileged context.

#### To reproduce: 

```
PUT _application/search_application/my-app
{
  "indices": ["index1"],
  "updated_at_millis": 1682105622204,
  "template": {
    "script": {
      "lang": "mustache",
      "source": """
      {
        "query": {
          "multi_match": {
            "query": "{{query_string}}",
            "fields": ["title^{{title_boost}}", "description"]
          }
        },
        "from": "{{from}}",
        "size": "{{size}}"
      }
      """,
      "params": {
        "query_string": "*",
        "title_boost": 10,
        "from": 0,
        "size": 10
      }
    },
    "dictionary": {
      "properties": {
        "query_string": {
          "type": "string"
        },
        "title_boost": {
          "type": "number"
        },
        "additionalProperties": false
      },
      "required": [
        "query_string"
      ]
    }
  }
}

POST _application/search_application/my-app/_render_query
{
  "params": {
    "query_string": "my first query",
    "title_boost": 1.5
  }
}
```

This ends up with following error
```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": """access denied ("java.lang.RuntimePermission" "accessDeclaredMembers") (through reference chain: java.util.HashMap["title_boost"])"""
      }
    ],
    "type": "illegal_argument_exception",
    "reason": """access denied ("java.lang.RuntimePermission" "accessDeclaredMembers") (through reference chain: java.util.HashMap["title_boost"])""",
    "caused_by": {
      "type": "json_mapping_exception",
      "reason": """access denied ("java.lang.RuntimePermission" "accessDeclaredMembers") (through reference chain: java.util.HashMap["title_boost"])""",
      "caused_by": {
        "type": "access_control_exception",
        "reason": """access denied ("java.lang.RuntimePermission" "accessDeclaredMembers")"""
      }
    }
  },
  "status": 400
}
```
