### PR TITLE
Fix enrich policy runner exception handling on empty segments response

### DIFF
--- a/docs/changelog/111290.yaml
+++ b/docs/changelog/111290.yaml
@@ -1,0 +1,5 @@
+pr: 111290
+summary: Fix enrich policy runner exception handling on empty segments response
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -36,7 +36,7 @@ public class IndicesSegmentResponse extends ChunkedBroadcastResponse {
 
     private volatile Map<String, IndexSegments> indicesSegments;
 
-    IndicesSegmentResponse(
+    public IndicesSegmentResponse(
         ShardSegments[] shards,
         int totalShards,
         int successfulShards,


### PR DESCRIPTION
In the event that an empty index segment response is returned to the enrich policy runner, an exception is thrown. The action listener that throws this exception is not wrapped and so the exception boils up the chain and the original listener is never resolved. The executing enrich policy subsequently becomes stuck waiting for the execution to complete and thus permanently locks the policy for execution until the master node is restarted.

This PR correctly wraps the action listener to pass the thrown exception on to the onFailure method. Additionally, the PR adds supplemental logging to capture the reason for the empty segments response for further debugging.