### PR TITLE
Fix SnapshotLifecycleStatsTests.testEqualsAndHashcode

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -120,9 +120,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvTests
   method: test {inlinestats.ShadowingSelf}
   issue: https://github.com/elastic/elasticsearch/issues/111261
-- class: org.elasticsearch.xpack.core.slm.SnapshotLifecycleStatsTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/111300
 
 # Examples:
 #

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStatsTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class SnapshotLifecycleStatsTests extends AbstractXContentSerializingTestCase<SnapshotLifecycleStats> {
 
@@ -120,7 +121,7 @@ public class SnapshotLifecycleStatsTests extends AbstractXContentSerializingTest
             case 0 -> instance.withRetentionRunIncremented();
             case 1 -> instance.withRetentionFailedIncremented();
             case 2 -> instance.withRetentionTimedOutIncremented();
-            case 3 -> instance.withDeletionTimeUpdated(randomTimeValue());
+            case 3 -> instance.withDeletionTimeUpdated(randomTimeValue(1, 1_000_000, TimeUnit.MILLISECONDS));
             case 4 -> instance.withTakenIncremented(policy);
             case 5 -> instance.withFailedIncremented(policy);
             case 6 -> instance.withDeletedIncremented(policy);


### PR DESCRIPTION
mutateInstance returned unchanged object because randomTimeValue could return 0 or a value smaller than 1 millisecond. This was truncated to 0ms causing the call to SnapshotLifecycleStatsTests.withDeletionTimeUpdated to leave the object unchanged.

Closes #111300