### PR TITLE
ESQL: Wait for memory to clear in CSV tests 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -117,9 +117,6 @@ tests:
 - class: org.elasticsearch.action.admin.indices.create.SplitIndexIT
   method: testSplitIndexPrimaryTerm
   issue: https://github.com/elastic/elasticsearch/issues/111282
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {inlinestats.ShadowingSelf}
-  issue: https://github.com/elastic/elasticsearch/issues/111261
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -286,7 +286,8 @@ public class CsvTests extends ESTestCase {
             assertWarnings(actualResults.responseHeaders().getOrDefault("Warning", List.of()));
         } finally {
             Releasables.close(() -> Iterators.map(actualResults.pages().iterator(), p -> p::releaseBlocks));
-            assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
+            // Give the breaker service some time to clear in case we got results before the rest of the driver had cleaned up
+            assertBusy(() -> assertThat(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L)));
         }
     }
 


### PR DESCRIPTION
The CSV tests have been running ESQL async for a little while now to
line up better with production and reuse a bunch of code but they'll
sometimes fail with a breaker-not-cleared failure. I haven't been able
to track down the cause after playing with it most of the day so I'm
going to take a bit of a stab in the dark and blame it on the
async-ness. After all, we're proceeding as soon as the results are
ready, not as soon as the driver has fully shutdown. This may be the
cause. Or not. We'll see if we get this again tomorrow.....

closes https://github.com/elastic/elasticsearch/issues/111261