### PR TITLE
Adding support for data streams with a match-all template

### DIFF
--- a/docs/changelog/111311.yaml
+++ b/docs/changelog/111311.yaml
@@ -1,0 +1,6 @@
+pr: 111311
+summary: Adding support for data streams with a match-all template
+area: Data streams
+type: bug
+issues:
+ - 111204

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -1150,3 +1150,48 @@ setup:
         name: simple-data-stream2
   - is_true: acknowledged
 
+---
+"Create data stream with match all template":
+  - requires:
+      cluster_features: ["gte_v7.9.0"]
+      reason: "data streams only supported in 7.9+"
+
+  - do:
+      allowed_warnings:
+        - "index template [match-all-template] has index patterns [*] matching patterns from existing older templates [.monitoring-logstash,.monitoring-es,.monitoring-beats,.monitoring-alerts-7,.monitoring-kibana] with patterns (.monitoring-logstash => [.monitoring-logstash-7-*],.monitoring-es => [.monitoring-es-7-*],.monitoring-beats => [.monitoring-beats-7-*],.monitoring-alerts-7 => [.monitoring-alerts-7],.monitoring-kibana => [.monitoring-kibana-7-*]); this template [match-all-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: match-all-template
+        body:
+          index_patterns: [ "*" ]
+          priority: 1
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: match-all-data-stream
+  - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - match: { data_streams.0.name: match-all-data-stream }
+  - match: { data_streams.0.generation: 1 }
+  - length: { data_streams.0.indices: 1 }
+  - match: { data_streams.0.indices.0.index_name: '/\.ds-match-all-data-stream-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { data_streams.0.status: 'GREEN' }
+  - match: { data_streams.0.template: 'match-all-template' }
+  - match: { data_streams.0.hidden: false }
+
+  - do:
+      indices.delete_data_stream:
+        name: match-all-data-stream
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_index_template:
+        name: match-all-template
+  - is_true: acknowledged

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -1153,8 +1153,8 @@ setup:
 ---
 "Create data stream with match all template":
   - requires:
-      cluster_features: ["gte_v7.9.0"]
-      reason: "data streams only supported in 7.9+"
+      cluster_features: ["gte_v8.16.0"]
+      reason: "data streams supoprt for match all templates only supported in 8.16"
 
   - do:
       allowed_warnings:
@@ -1195,3 +1195,49 @@ setup:
       indices.delete_index_template:
         name: match-all-template
   - is_true: acknowledged
+
+---
+"Create hidden data stream with match all template":
+  - requires:
+      cluster_features: [ "gte_v8.16.0" ]
+      reason: "data streams supoprt for match all templates only supported in 8.16"
+  - do:
+      allowed_warnings:
+        - "index template [match-all-hidden-template] has index patterns [*] matching patterns from existing older templates [.monitoring-logstash,.monitoring-es,.monitoring-beats,.monitoring-alerts-7,.monitoring-kibana] with patterns (.monitoring-logstash => [.monitoring-logstash-7-*],.monitoring-es => [.monitoring-es-7-*],.monitoring-beats => [.monitoring-beats-7-*],.monitoring-alerts-7 => [.monitoring-alerts-7],.monitoring-kibana => [.monitoring-kibana-7-*]); this template [match-all-hidden-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: match-all-hidden-template
+        body:
+          index_patterns: [ "*" ]
+          priority: 1
+          data_stream:
+            hidden: true
+  - do:
+      indices.create_data_stream:
+        name: match-all-hidden-data-stream
+  - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - length: { data_streams: 0 }
+
+  - do:
+      indices.get_data_stream:
+        name: ['*']
+        expand_wildcards: hidden
+  - length: { data_streams: 1 }
+  - match: { data_streams.0.name: match-all-hidden-data-stream }
+  - match: { data_streams.0.hidden: true }
+
+  - do:
+      indices.delete_data_stream:
+        name: match-all-hidden-data-stream
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_index_template:
+        name: match-all-hidden-template

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1309,7 +1309,7 @@ public class MetadataIndexTemplateService {
         for (Map.Entry<String, ComposableIndexTemplate> entry : metadata.templatesV2().entrySet()) {
             final String name = entry.getKey();
             final ComposableIndexTemplate template = entry.getValue();
-            if (isHidden == false || (template.getDataStreamTemplate() != null && template.getDataStreamTemplate().isHidden() == false)) {
+            if (isHidden == false || template.getDataStreamTemplate() != null) {
                 final boolean matched = template.indexPatterns().stream().anyMatch(patternMatchPredicate);
                 if (matched) {
                     candidates.add(Tuple.tuple(name, template));

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1309,7 +1309,7 @@ public class MetadataIndexTemplateService {
         for (Map.Entry<String, ComposableIndexTemplate> entry : metadata.templatesV2().entrySet()) {
             final String name = entry.getKey();
             final ComposableIndexTemplate template = entry.getValue();
-            if (isHidden == false) {
+            if (isHidden == false || (template.getDataStreamTemplate() != null && template.getDataStreamTemplate().isHidden() == false)) {
                 final boolean matched = template.indexPatterns().stream().anyMatch(patternMatchPredicate);
                 if (matched) {
                     candidates.add(Tuple.tuple(name, template));

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1309,6 +1309,11 @@ public class MetadataIndexTemplateService {
         for (Map.Entry<String, ComposableIndexTemplate> entry : metadata.templatesV2().entrySet()) {
             final String name = entry.getKey();
             final ComposableIndexTemplate template = entry.getValue();
+            /*
+             * We do not ordinarily return match-all templates for hidden indices. But all backing indices for data streams are hidden,
+             * and we do want to return even match-all templates for those. Not doing so can result in a situation where a data stream is
+             * built with a template that none of its indices match.
+             */
             if (isHidden == false || template.getDataStreamTemplate() != null) {
                 final boolean matched = template.indexPatterns().stream().anyMatch(patternMatchPredicate);
                 if (matched) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -2158,6 +2158,23 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         MetadataIndexTemplateService.innerRemoveIndexTemplateV2(stateWithTwoTemplates, "logs");
     }
 
+    public void testDataStreamsUsingMatchAllTemplate() throws Exception {
+        ClusterState state = ClusterState.EMPTY_STATE;
+        final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
+
+        ComposableIndexTemplate template = ComposableIndexTemplate.builder()
+            .indexPatterns(Collections.singletonList("*"))
+            .priority(100L)
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate())
+            .build();
+        final String templateName = "all-data-streams-template";
+        state = service.addIndexTemplateV2(state, false, templateName, template);
+        // When creating a data stream, we'll look for templates. The data stream is not hidden
+        assertThat(MetadataIndexTemplateService.findV2Template(state.metadata(), "some-data-stream", false), equalTo(templateName));
+        // The write index for a data stream will be a hidden index. We need to make sure it matches the same template:
+        assertThat(MetadataIndexTemplateService.findV2Template(state.metadata(), "some-data-stream", true), equalTo(templateName));
+    }
+
     public void testRemovingHigherOrderTemplateOfDataStreamWithMultipleTemplates() throws Exception {
         ClusterState state = ClusterState.EMPTY_STATE;
         final MetadataIndexTemplateService service = getMetadataIndexTemplateService();


### PR DESCRIPTION
Right now you cna create a match-all data stream template. But when you actually create a data stream that matches the template, it fails an assertion, crashing the node if assertions are enabled If assertions are not enabled, the request to create the data stream causes an IllegalStateException.
The problem is that we do not return matching templates for hidden indices. We find a template for the data stream. But then when creating the index we do not find a matching template since the backing indices for data streams are hidden. So the backing index does not have any mappings, which is what triggers the assertion failure.
Closes #111204