### PR TITLE
Revert "Mute org.elasticsearch.xpack.esql.CsvTests test {inlinestats.…

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -126,9 +126,6 @@ tests:
 - class: org.elasticsearch.xpack.core.ml.job.config.DetectionRuleTests
   method: testEqualsAndHashcode
   issue: https://github.com/elastic/elasticsearch/issues/111308
-- class: org.elasticsearch.xpack.esql.CsvTests
-  method: test {inlinestats.ShadowingMulti}
-  issue: https://github.com/elastic/elasticsearch/issues/111309
 
 # Examples:
 #


### PR DESCRIPTION
…ShadowingMulti} #111309"

This reverts commit a6eec4b62f9dca1f428b9f2609fe6d9834f10f64 becaus I believe the problem is fixed by #111302.

Closes #111309
