### PR TITLE
Updating error message for missing shards in open_point_in_time  action

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhase.java
@@ -15,7 +15,6 @@ import org.elasticsearch.transport.Transport;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -43,7 +42,7 @@ abstract class SearchPhase implements CheckedRunnable<IOException> {
         }
     }
 
-    protected String missingShardsErrorMessage(StringBuilder missingShards){
+    protected String missingShardsErrorMessage(StringBuilder missingShards) {
         return "Search rejected due to missing shards ["
             + missingShards
             + "]. Consider using `allow_partial_search_results` setting to bypass this error.";

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhase.java
@@ -42,7 +42,7 @@ abstract class SearchPhase implements CheckedRunnable<IOException> {
         }
     }
 
-    static void doCheckNoMissingShards(String phaseName, SearchRequest request, GroupShardsIterator<SearchShardIterator> shardsIts) {
+    protected void doCheckNoMissingShards(String phaseName, SearchRequest request, GroupShardsIterator<SearchShardIterator> shardsIts) {
         assert request.allowPartialSearchResults() != null : "SearchRequest missing setting for allowPartialSearchResults";
         if (request.allowPartialSearchResults() == false) {
             final StringBuilder missingShards = new StringBuilder();

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -215,7 +215,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             ) {
                 @Override
                 protected String missingShardsErrorMessage(StringBuilder missingShards) {
-                    return "Cannot execute [open_point_in_time] action due to missing shards [" + missingShards + "].";
+                    return "Search rejected due to missing shards. [open_point_in_time] action requires all shards to be available.";
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -214,27 +214,8 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                 clusters
             ) {
                 @Override
-                protected void doCheckNoMissingShards(
-                    String phaseName,
-                    SearchRequest request,
-                    GroupShardsIterator<SearchShardIterator> shardsIts
-                ) {
-                    final StringBuilder missingShards = new StringBuilder();
-                    // Fail-fast verification of all shards being available
-                    for (int index = 0; index < shardsIts.size(); index++) {
-                        final SearchShardIterator shardRoutings = shardsIts.get(index);
-                        if (shardRoutings.size() == 0) {
-                            if (missingShards.isEmpty() == false) {
-                                missingShards.append(", ");
-                            }
-                            missingShards.append(shardRoutings.shardId());
-                        }
-                    }
-                    if (missingShards.isEmpty() == false) {
-                        // Status red - shard is missing all copies and would produce partial results for an index search
-                        final String msg = "Cannot execute [open_point_in_time] action due to missing shards [" + missingShards + "].";
-                        throw new SearchPhaseExecutionException(phaseName, msg, null, ShardSearchFailure.EMPTY_ARRAY);
-                    }
+                protected String missingShardsErrorMessage(StringBuilder missingShards) {
+                    return "Cannot execute [open_point_in_time] action due to missing shards [" + missingShards + "].";
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -215,7 +215,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             ) {
                 @Override
                 protected String missingShardsErrorMessage(StringBuilder missingShards) {
-                    return "Search rejected due to missing shards. [open_point_in_time] action requires all shards to be available.";
+                    return "[open_point_in_time] action requires all shards to be available. Missing shards: " + missingShards;
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -232,9 +232,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                     }
                     if (missingShards.isEmpty() == false) {
                         // Status red - shard is missing all copies and would produce partial results for an index search
-                        final String msg = "Search rejected - cannot execute [open_point_in_time_action] due to missing shards ["
-                            + missingShards
-                            + "].";
+                        final String msg = "Cannot execute [open_point_in_time] action due to missing shards [" + missingShards + "].";
                         throw new SearchPhaseExecutionException(phaseName, msg, null, ShardSearchFailure.EMPTY_ARRAY);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -215,7 +215,7 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             ) {
                 @Override
                 protected String missingShardsErrorMessage(StringBuilder missingShards) {
-                    return "[open_point_in_time] action requires all shards to be available. Missing shards: " + missingShards;
+                    return "[open_point_in_time] action requires all shards to be available. Missing shards: [" + missingShards + "]";
                 }
 
                 @Override

--- a/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
@@ -76,7 +76,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
     public void testPartialResponseHandling() throws SQLException {
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(exception.getMessage(), containsString("Search rejected due to missing shards"));
+            assertThat(exception.getMessage(), containsString("[open_point_in_time] action requires all shards to be available"));
         }
     }
 }

--- a/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
@@ -76,7 +76,10 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
     public void testPartialResponseHandling() throws SQLException {
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(exception.getMessage(), containsString("Search rejected due to missing shards"));
+            assertThat(
+                exception.getMessage(),
+                containsString("Search rejected - cannot execute [open_point_in_time_action] due to missing shards")
+            );
         }
     }
 }

--- a/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
@@ -76,7 +76,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
     public void testPartialResponseHandling() throws SQLException {
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(exception.getMessage(), containsString("Cannot execute [open_point_in_time] action due to missing shards"));
+            assertThat(exception.getMessage(), containsString("Search rejected due to missing shards"));
         }
     }
 }

--- a/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/jdbc/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/jdbc/single_node/JdbcShardFailureIT.java
@@ -76,10 +76,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
     public void testPartialResponseHandling() throws SQLException {
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(
-                exception.getMessage(),
-                containsString("Search rejected - cannot execute [open_point_in_time_action] due to missing shards")
-            );
+            assertThat(exception.getMessage(), containsString("Cannot execute [open_point_in_time] action due to missing shards"));
         }
     }
 }

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
@@ -89,7 +89,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
         createTestIndex();
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(exception.getMessage(), containsString("Search rejected due to missing shards"));
+            assertThat(exception.getMessage(), containsString("[open_point_in_time] action requires all shards to be available"));
         }
     }
 

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
@@ -89,7 +89,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
         createTestIndex();
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(exception.getMessage(), containsString("Cannot execute [open_point_in_time] action due to missing shards"));
+            assertThat(exception.getMessage(), containsString("Search rejected due to missing shards"));
         }
     }
 

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
@@ -89,7 +89,10 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
         createTestIndex();
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(exception.getMessage(), containsString("Search rejected due to missing shards"));
+            assertThat(
+                exception.getMessage(),
+                containsString("Search rejected - cannot execute [open_point_in_time_action] due to missing shards")
+            );
         }
     }
 

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
@@ -89,10 +89,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
         createTestIndex();
         try (Connection c = esJdbc(); Statement s = c.createStatement()) {
             SQLException exception = expectThrows(SQLException.class, () -> s.executeQuery("SELECT * FROM test ORDER BY test_field ASC"));
-            assertThat(
-                exception.getMessage(),
-                containsString("Search rejected - cannot execute [open_point_in_time_action] due to missing shards")
-            );
+            assertThat(exception.getMessage(), containsString("Cannot execute [open_point_in_time] action due to missing shards"));
         }
     }
 


### PR DESCRIPTION
In this PR we update the exception message for the `open_point_in_time` action to avoid suggesting the use of `allow_partial_search_results` as it is not currently supported, and explicitly set to false for PIT.  

Relates to https://github.com/elastic/elasticsearch/issues/103165 and [this PR comment](https://github.com/elastic/elasticsearch/pull/110482#pullrequestreview-2183811451). 


