### PR TITLE
Add `andThen` override which ignores result

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -644,7 +644,7 @@ class S3BlobContainer extends AbstractBlobContainer {
 
                 // Step 4: Read the current register value.
 
-                .<OptionalBytesReference>andThen((l, ignored) -> getRegister(purpose, rawKey, l))
+                .<OptionalBytesReference>andThen(l -> getRegister(purpose, rawKey, l))
 
                 // Step 5: Perform the compare-and-swap by completing our upload iff the witnessed value matches the expected value.
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -2209,7 +2209,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
                     .anyMatch(e -> e.snapshot().getSnapshotId().getName().equals("snapshot-with-index-1") && e.state().completed())
             )
             // execute the index deletion _directly on the master_ so it happens before the snapshot finalization executes
-            .andThen((l, ignored) -> masterDeleteIndexService.deleteIndices(new DeleteIndexClusterStateUpdateRequest(l.map(r -> {
+            .andThen(l -> masterDeleteIndexService.deleteIndices(new DeleteIndexClusterStateUpdateRequest(l.map(r -> {
                 assertTrue(r.isAcknowledged());
                 return null;
             })).indices(new Index[] { internalCluster().clusterService().state().metadata().index(indexToDelete).getIndex() })

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
@@ -483,7 +483,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         SubscribableListener
 
             .<Void>newForked(l -> putShutdownMetadata(clusterService, shutdownMetadata, nodeName, l))
-            .<Void>andThen((l, ignored) -> flushMasterQueue(clusterService, l))
+            .<Void>andThen(l -> flushMasterQueue(clusterService, l))
             .addListener(listener);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -1257,7 +1257,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         )
 
                         .<Void>andThen(
-                            (l, ignored) -> clusterService.submitUnbatchedStateUpdateTask(
+                            l -> clusterService.submitUnbatchedStateUpdateTask(
                                 "unmark [" + node + "] for removal",
                                 new ClusterStateUpdateTask() {
                                     @Override

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -188,6 +188,13 @@ public interface ActionListener<Response> {
     }
 
     /**
+     * Same as {@link #delegateFailureAndWrap(CheckedBiConsumer)} except that the response is ignored and not passed to the delegate.
+     */
+    default <T> ActionListener<T> delegateFailureIgnoreResponseAndWrap(CheckedConsumer<ActionListener<Response>, ? extends Exception> c) {
+        return new ActionListenerImplementations.ResponseDroppingActionListener<>(this, c);
+    }
+
+    /**
      * Creates a listener which releases the given resource on completion (whether success or failure)
      */
     static <Response> ActionListener<Response> releasing(Releasable releasable) {

--- a/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
@@ -412,6 +412,32 @@ public class SubscribableListener<T> implements ActionListener<T> {
 
     /**
      * Creates and returns a new {@link SubscribableListener} {@code L} and subscribes {@code nextStep} to this listener such that if this
+     * listener is completed successfully then the result is discarded and {@code nextStep} is invoked with argument {@code L}. If this
+     * listener is completed with exception {@code E} then so is {@code L}.
+     * <p>
+     * This can be used to construct a sequence of async actions, each ignoring the result of the previous ones:
+     * <pre>
+     * l.andThen(l1 -> forkAction1(args1, l1)).andThen(l2 -> forkAction2(args2, l2)).addListener(finalListener);
+     * </pre>
+     * After creating this chain, completing {@code l} with a successful response will call {@code forkAction1}, which will on completion
+     * call {@code forkAction2}, which will in turn pass its response to {@code finalListener}. A failure of any step will bypass the
+     * remaining steps and ultimately fail {@code finalListener}.
+     * <p>
+     * The threading of the {@code nextStep} callback is the same as for listeners added with {@link #addListener}: if this listener is
+     * already complete then {@code nextStep} is invoked on the thread calling {@link #andThen} and in its thread context, but if this
+     * listener is incomplete then {@code nextStep} is invoked on the completing thread and in its thread context. In other words, if you
+     * want to ensure that {@code nextStep} is invoked using a particular executor, then you must do both of:
+     * <ul>
+     * <li>Ensure that this {@link SubscribableListener} is always completed using that executor, and</li>
+     * <li>Invoke {@link #andThen} using that executor.</li>
+     * </ul>
+     */
+    public <U> SubscribableListener<U> andThen(CheckedConsumer<ActionListener<U>, ? extends Exception> nextStep) {
+        return newForked(l -> addListener(l.delegateFailureIgnoreResponseAndWrap(nextStep)));
+    }
+
+    /**
+     * Creates and returns a new {@link SubscribableListener} {@code L} and subscribes {@code nextStep} to this listener such that if this
      * listener is completed successfully with result {@code R} then {@code nextStep} is invoked with arguments {@code L} and {@code R}. If
      * this listener is completed with exception {@code E} then so is {@code L}.
      * <p>

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -419,7 +419,7 @@ public final class StoreRecovery {
 
             .newForked(indexShard::preRecovery)
 
-            .<Void>andThen((l, ignored) -> {
+            .<Void>andThen(l -> {
                 final RecoveryState recoveryState = indexShard.recoveryState();
                 final boolean indexShouldExists = recoveryState.getRecoverySource().getType() != RecoverySource.Type.EMPTY_STORE;
                 indexShard.prepareForIndexRecovery();
@@ -490,7 +490,7 @@ public final class StoreRecovery {
                 indexShard.openEngineAndRecoverFromTranslog(l);
             })
 
-            .<Void>andThen((l, ignored) -> {
+            .<Void>andThen(l -> {
                 indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
                 indexShard.finalizeRecovery();
                 indexShard.postRecovery("post recovery from shard_store", l);
@@ -536,7 +536,7 @@ public final class StoreRecovery {
 
             .newForked(indexShard::preRecovery)
 
-            .<ShardAndIndexIds>andThen((shardAndIndexIdsListener, ignored) -> {
+            .<ShardAndIndexIds>andThen(shardAndIndexIdsListener -> {
                 final RecoveryState.Translog translogState = indexShard.recoveryState().getTranslog();
                 if (restoreSource == null) {
                     throw new IndexShardRestoreFailedException(shardId, "empty restore source");
@@ -585,7 +585,7 @@ public final class StoreRecovery {
                 );
             })
 
-            .<Void>andThen((l, ignored) -> {
+            .<Void>andThen(l -> {
                 indexShard.getIndexEventListener().afterFilesRestoredFromRepository(indexShard);
                 final Store store = indexShard.store();
                 bootstrap(indexShard, store);
@@ -594,7 +594,7 @@ public final class StoreRecovery {
                 indexShard.openEngineAndRecoverFromTranslog(l);
             })
 
-            .<Void>andThen((l, ignored) -> {
+            .<Void>andThen(l -> {
                 indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
                 indexShard.finalizeRecovery();
                 indexShard.postRecovery("restore done", l);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -380,7 +380,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 // run pre-recovery activities
                 .newForked(indexShard::preRecovery)
                 // recover the shard as far as possible based on data held locally
-                .<Long>andThen((l, v) -> {
+                .<Long>andThen(l -> {
                     logger.trace("{} preparing shard for peer recovery", recoveryTarget.shardId());
                     indexShard.prepareForIndexRecovery();
                     if (indexShard.indexSettings().getIndexMetadata().isSearchableSnapshot()) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -700,7 +700,7 @@ public class RecoverySourceHandler {
                 .newForked(this::sendShardRecoveryPlanFileInfo)
                 // instruct the target to recover files from snapshot, possibly updating the plan on failure
                 .<List<StoreFileMetadata>>andThen(
-                    (l, ignored) -> recoverSnapshotFiles(shardRecoveryPlan, l.delegateResponse((recoverSnapshotFilesListener, e) -> {
+                    l -> recoverSnapshotFiles(shardRecoveryPlan, l.delegateResponse((recoverSnapshotFilesListener, e) -> {
                         if (shardRecoveryPlan.canRecoverSnapshotFilesFromSourceNode() == false
                             && e instanceof CancellableThreads.ExecutionCancelledException == false) {
                             shardRecoveryPlan = shardRecoveryPlan.getFallbackPlan();
@@ -731,10 +731,7 @@ public class RecoverySourceHandler {
                 })
                 // create a retention lease
                 .<RetentionLease>andThen(
-                    (createRetentionLeaseListener, ignored) -> createRetentionLease(
-                        shardRecoveryPlan.getStartingSeqNo(),
-                        createRetentionLeaseListener
-                    )
+                    createRetentionLeaseListener -> createRetentionLease(shardRecoveryPlan.getStartingSeqNo(), createRetentionLeaseListener)
                 )
                 // run cleanFiles, renaming temp files, removing surplus ones, creating an empty translog and so on
                 .<Void>andThen((finalRecoveryPlanListener, retentionLease) -> {

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -166,7 +166,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
             // When publication has completed (and all acks received or timed out) then verify the repository.
             // (if acks timed out then acknowledgementStep completes before the master processes this cluster state, hence why we have
             // to wait for the publication to be complete too)
-            .<RegisterRepositoryTaskResult>andThen((clusterUpdateStep, ignored) -> {
+            .<RegisterRepositoryTaskResult>andThen(clusterUpdateStep -> {
                 final ListenableFuture<AcknowledgedResponse> acknowledgementStep = new ListenableFuture<>();
                 final ListenableFuture<Boolean> publicationStep = new ListenableFuture<>(); // Boolean==changed.
                 submitUnbatchedTask(
@@ -221,7 +221,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
                         })
                         // When verification has completed, get the repository data for the first time
                         .<RepositoryData>andThen(
-                            (getRepositoryDataStep, ignored) -> threadPool.generic()
+                            getRepositoryDataStep -> threadPool.generic()
                                 .execute(
                                     ActionRunnable.wrap(
                                         getRepositoryDataStep,

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1066,7 +1066,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 // First write the new shard state metadata (without the removed snapshots) and compute deletion targets
                 .newForked(this::writeUpdatedShardMetadataAndComputeDeletes)
 
-                .<RepositoryData>andThen((l, ignored) -> {
+                .<RepositoryData>andThen(l -> {
                     // Once we have put the new shard-level metadata into place, we can update the repository metadata as follows:
                     // 1. Remove the snapshots from the list of existing snapshots
                     // 2. Update the index shard generations of all updated shard folders

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1353,7 +1353,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             if (randomBoolean()) {
                 final var snapshotName = "snapshot-" + i;
                 testListener = testListener.andThen(
-                    (stepListener, v) -> scheduleNow(
+                    stepListener -> scheduleNow(
                         ActionRunnable.wrap(
                             stepListener,
                             l -> client.admin()
@@ -1367,7 +1367,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 );
             } else {
                 final var cloneName = "clone-" + i;
-                testListener = testListener.andThen((stepListener, v) -> scheduleNow(ActionRunnable.wrap(stepListener, l -> {
+                testListener = testListener.andThen(stepListener -> scheduleNow(ActionRunnable.wrap(stepListener, l -> {
                     // The clone API only responds when the clone is complete, but we only want to wait until the clone starts so we watch
                     // the cluster state instead.
                     ClusterServiceUtils.addTemporaryStateListener(
@@ -1390,7 +1390,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             }
         }
 
-        testListener = testListener.andThen((l, ignored) -> scheduleNow(() -> {
+        testListener = testListener.andThen(l -> scheduleNow(() -> {
             // Once all snapshots & clones have started, drop the data node and wait for all snapshot activity to complete
             testClusterNodes.disconnectNode(testClusterNodes.randomDataNodeSafe());
             ClusterServiceUtils.addTemporaryStateListener(masterClusterService, cs -> SnapshotsInProgress.get(cs).isEmpty()).addListener(l);
@@ -1444,7 +1444,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
             // Take the snapshot to check the reaction to having unassigned shards
             .<Void>andThen(
-                (l, ignored) -> client().admin()
+                l -> client().admin()
                     .cluster()
                     .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, randomIdentifier())
                     .setWaitForCompletion(randomBoolean())
@@ -1495,7 +1495,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         final var testListener = createRepoAndIndex(repoName, "index", between(1, 2))
             // take snapshot once
             .<CreateSnapshotResponse>andThen(
-                (l, ignored) -> client().admin()
+                l -> client().admin()
                     .cluster()
                     .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, snapshotName)
                     .setWaitForCompletion(true)
@@ -1503,7 +1503,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             )
             // take snapshot again
             .<CreateSnapshotResponse>andThen(
-                (l, ignored) -> client().admin()
+                l -> client().admin()
                     .cluster()
                     .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, snapshotName)
                     .setWaitForCompletion(randomBoolean())
@@ -1522,7 +1522,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             )
             // attempt to clone snapshot
             .<AcknowledgedResponse>andThen(
-                (l, ignored) -> client().admin()
+                l -> client().admin()
                     .cluster()
                     .prepareCloneSnapshot(TEST_REQUEST_TIMEOUT, repoName, snapshotName, snapshotName)
                     .setIndices("*")
@@ -1581,7 +1581,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             )
             // take snapshot of index that does not exist
             .<CreateSnapshotResponse>andThen(
-                (l, ignored) -> client().admin()
+                l -> client().admin()
                     .cluster()
                     .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, randomIdentifier())
                     .setIndices(indexName)
@@ -1633,7 +1633,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             )
             // attempt to take snapshot with illegal config ('none' is allowed as a feature state iff it's the only one in the list)
             .<CreateSnapshotResponse>andThen(
-                (l, ignored) -> client().admin()
+                l -> client().admin()
                     .cluster()
                     .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, repoName, randomIdentifier())
                     .setFeatureStates("none", "none")

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -159,7 +159,7 @@ public class TransportGetTrainedModelsStatsAction extends TransportAction<
             .andThenAccept(tuple -> responseBuilder.setExpandedModelIdsWithAliases(tuple.v2()).setTotalModelCount(tuple.v1()))
 
             .<NodesStatsResponse>andThen(
-                (l, ignored) -> executeAsyncWithOrigin(
+                l -> executeAsyncWithOrigin(
                     client,
                     ML_ORIGIN,
                     TransportNodesStatsAction.TYPE,


### PR DESCRIPTION
It's a reasonably common pattern for some steps in a
`SubscribableListener` chain to ignore the result of the previous step.
Today you have to include a dummy `ignored` argument to the
`BiConsumer`. This commit adds a new `andThen` override which accepts a
unary `Consumer`, avoiding the need for this unnecessary argument.