### PR TITLE
[DOCS] Documents automatic text chunking behavior for semantic text

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -65,6 +65,9 @@ To allow for large amounts of text to be used in semantic search, `semantic_text
 Each chunk will include the text subpassage and the corresponding embedding generated from it.
 When querying, the individual passages will be automatically searched for each document, and the most relevant passage will be used to compute a score.
 
+Documents are split into 250-word sections with a 100-word overlap so that each section shares 100 words with the previous section.
+This overlap ensures continuity and prevents vital contextual information in the input text from being lost by a hard break.
+
 
 [discrete]
 [[semantic-text-structure]]


### PR DESCRIPTION
## Overview

This PR adds details about automatic text chunking behavior to the `semantic_text` field type documentation


### Preview

[`semantic_text`](https://elasticsearch_bk_111331.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-text.html#auto-text-chunking)