### PR TITLE
[8.15] [DOCS] Amends PUT inference API docs with model download info (#111278)

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -6,10 +6,17 @@ experimental[]
 
 Creates an {infer} endpoint to perform an {infer} task.
 
-IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
-{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Mistral, Azure OpenAI, Google AI Studio, Google Vertex AI or Hugging Face.
-For built-in models and models uploaded through Eland, the {infer} APIs offer an alternative way to use and manage trained models.
-However, if you do not plan to use the {infer} APIs to use these models or if you want to use non-NLP models, use the <<ml-df-trained-models-apis>>.
+[IMPORTANT]
+====
+* The {infer} APIs enable you to use certain services, such as built-in
+{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Mistral,
+Azure OpenAI, Google AI Studio, Google Vertex AI or Hugging Face.
+* For built-in models and models uploaded through Eland, the {infer} APIs offer an
+alternative way to use and manage trained models. However, if you do not plan to
+use the {infer} APIs to use these models or if you want to use non-NLP models,
+use the <<ml-df-trained-models-apis>>.
+====
+
 
 [discrete]
 [[put-inference-api-request]]
@@ -43,3 +50,6 @@ The following services are available through the {infer} API, click the links to
 * <<infer-service-hugging-face,Hugging Face>>
 * <<infer-service-mistral,Mistral>>
 * <<infer-service-openai,OpenAI>>
+
+The {es} and ELSER services run on a {ml} node in your {es} cluster. The rest of
+the services connect to external providers.

--- a/docs/reference/inference/service-elasticsearch.asciidoc
+++ b/docs/reference/inference/service-elasticsearch.asciidoc
@@ -1,7 +1,12 @@
 [[infer-service-elasticsearch]]
 === Elasticsearch {infer} service
 
-Creates an {infer} endpoint to perform an {infer} task with the `elasticsearch` service.
+Creates an {infer} endpoint to perform an {infer} task with the `elasticsearch`
+service.
+
+NOTE: If you use the E5 model through the `elasticsearch` service, the API
+request will automatically download and deploy the model if it isn't downloaded
+yet.
 
 
 [discrete]
@@ -80,6 +85,9 @@ Returns the document instead of only the index. Defaults to `true`.
 
 The following example shows how to create an {infer} endpoint called
 `my-e5-model` to perform a `text_embedding` task type.
+
+The API request below will automatically download the E5 model if it isn't
+already downloaded and then deploy the model.
 
 [source,console]
 ------------------------------------------------------------

--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -3,6 +3,9 @@
 
 Creates an {infer} endpoint to perform an {infer} task with the `elser` service.
 
+NOTE: The API request will automatically download and deploy the ELSER model if
+it isn't already downloaded.
+
 
 [discrete]
 [[infer-service-elser-api-request]]
@@ -62,6 +65,9 @@ Must be a power of 2. Max allowed value is 32.
 The following example shows how to create an {infer} endpoint called
 `my-elser-model` to perform a `sparse_embedding` task type.
 Refer to the {ml-docs}/ml-nlp-elser.html[ELSER model documentation] for more info.
+
+The request below will automatically download the ELSER model if it isn't
+already downloaded and then deploy the model.
 
 [source,console]
 ------------------------------------------------------------


### PR DESCRIPTION
## Overview

This PR backports the changes of the following commits to the 8.15 branch:
https://github.com/elastic/elasticsearch/pull/111278