### PR TITLE
Add `availableCodecs` to the `CodecProvider` interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/CodecProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecProvider.java
@@ -13,7 +13,11 @@ import org.apache.lucene.codecs.Codec;
 /**
  * Abstracts codec lookup by name, to make CodecService extensible.
  */
-@FunctionalInterface
 public interface CodecProvider {
     Codec codec(String name);
+
+    /**
+     * Returns all registered available codec names.
+     */
+    String[] availableCodecs();
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -87,8 +87,8 @@ public class CodecService implements CodecProvider {
 
     /**
      * Returns all registered available codec names.
-     * Public visibility for tests.
      */
+    @Override
     public String[] availableCodecs() {
         return codecs.keySet().toArray(new String[0]);
     }


### PR DESCRIPTION
Extract the `availableCodecs` method in `CodecService` to the `CodecProvider` interface, so inheritors/filters can use it to know which codecs are available.
