### PR TITLE
ESQL: Speed up test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -123,9 +123,6 @@ tests:
 - class: org.elasticsearch.xpack.core.ml.job.config.DetectionRuleTests
   method: testEqualsAndHashcode
   issue: https://github.com/elastic/elasticsearch/issues/111308
-- class: org.elasticsearch.compute.lucene.LuceneQueryExpressionEvaluatorTests
-  method: testTermsQueryShuffled
-  issue: https://github.com/elastic/elasticsearch/issues/111318
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsRestIT
   issue: https://github.com/elastic/elasticsearch/issues/111319
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneQueryExpressionEvaluatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneQueryExpressionEvaluatorTests.java
@@ -231,7 +231,7 @@ public class LuceneQueryExpressionEvaluatorTests extends ComputeTestCase {
     }
 
     private Set<String> values() {
-        int maxNumDocs = between(10, 10_000);
+        int maxNumDocs = between(10, 1_000);
         int keyLength = randomIntBetween(1, 10);
         Set<String> values = new HashSet<>();
         for (int i = 0; i < maxNumDocs; i++) {


### PR DESCRIPTION
This speeds up a test that was timing out in CI by sending it less data. Bigger data is fun but smaller data still proves things here.

Closes #111318
