### PR TITLE
Fix floating-point comparison in testRandomSamplerConsistentSeed method

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -93,6 +93,7 @@ public class RandomSamplerIT extends ESIntegTestCase {
         double[] sampleMonotonicValue = new double[1];
         double[] sampleNumericValue = new double[1];
         long[] sampledDocCount = new long[1];
+        double tolerance = 1e-14;
         // initialize the values
         assertResponse(
             prepareSearch("idx").setPreference("shard:0")
@@ -123,9 +124,12 @@ public class RandomSamplerIT extends ESIntegTestCase {
                     ),
                 response -> {
                     InternalRandomSampler sampler = response.getAggregations().get("sampler");
-                    assertThat(((Avg) sampler.getAggregations().get("mean_monotonic")).getValue(), equalTo(sampleMonotonicValue[0]));
-                    assertThat(((Avg) sampler.getAggregations().get("mean_numeric")).getValue(), equalTo(sampleNumericValue[0]));
-                    assertThat(sampler.getDocCount(), equalTo(sampledDocCount[0]));
+                    double monotonicValue = ((Avg) sampler.getAggregations().get("mean_monotonic")).getValue();
+                    double numericValue = ((Avg) sampler.getAggregations().get("mean_numeric")).getValue();
+                    long docCount = sampler.getDocCount();
+                    assertThat(Math.abs(monotonicValue - sampleMonotonicValue[0]) < tolerance, equalTo(true));
+                    assertThat(Math.abs(numericValue - sampleNumericValue[0]) < tolerance, equalTo(true));
+                    assertThat(docCount, equalTo(sampledDocCount[0]));
                 }
             );
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -25,7 +25,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 
 @ESIntegTestCase.SuiteScopeTestCase
@@ -127,9 +126,9 @@ public class RandomSamplerIT extends ESIntegTestCase {
                     double monotonicValue = ((Avg) sampler.getAggregations().get("mean_monotonic")).getValue();
                     double numericValue = ((Avg) sampler.getAggregations().get("mean_numeric")).getValue();
                     long docCount = sampler.getDocCount();
-                    assertThat(Math.abs(monotonicValue - sampleMonotonicValue[0]) < tolerance, equalTo(true));
-                    assertThat(Math.abs(numericValue - sampleNumericValue[0]) < tolerance, equalTo(true));
-                    assertThat(docCount, equalTo(sampledDocCount[0]));
+                    assertEquals(monotonicValue, sampleMonotonicValue[0], tolerance);
+                    assertEquals(numericValue, sampleNumericValue[0], tolerance);
+                    assertEquals(docCount, sampledDocCount[0]);
                 }
             );
         }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
# Fix floating-point comparison in test Random Samples Consistent Seed method
## Description:
This pull request addresses an issue with floating-point precision in the testRandomSamplerConsistentSeed method. Previously, the test was comparing floating-point numbers for exact equality, which led to test failures due to minor precision errors.
## Changes:
Updated the testRandomSamplerConsistentSeed method to use a tolerance-based comparison for floating-point values.
Replaced exact equality checks with comparisons that account for minor discrepancies using a defined tolerance level (1e-14).
## Related Issues:
Closes #108841
## Checklist:

- [x]  Signed the Contributor License Agreement (CLA)
- [x]  Followed the contributor guidelines
- [x]  Built and tested your changes locally using gradle check
- [x]  Your pull request is against the main branch
- [x]  Verified that your submission targets an OS and architecture we support