### PR TITLE
Spike chainguard for ES docker image base

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
@@ -25,7 +25,10 @@ public enum DockerBase {
 
     // Based on CLOUD above, with more extras. We don't set a base image because
     // we programmatically extend from the Cloud image.
-    CLOUD_ESS(null, "-cloud-ess");
+    CLOUD_ESS(null, "-cloud-ess"),
+
+    // Chainguard based wolfi image with latest jdk
+    WOLFI("docker.elastic.co/wolfi/chainguard-base:latest", "wolfi");
 
     private final String image;
     private final String suffix;

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -182,11 +182,19 @@ ext.dockerBuildContext = { Architecture architecture, DockerBase base ->
         from projectDir.resolve("src/docker/config")
       }
     }
-
-    from(projectDir.resolve("src/docker/Dockerfile")) {
-      expand(varExpansions)
-      filter SquashNewlinesFilter
+    if(base == DockerBase.WOLFI) {
+      from(projectDir.resolve("src/docker/Dockerfile.wolfi")) {
+        rename ~/Dockerfile\.wolfi$/, 'Dockerfile'
+        //expand(varExpansions)
+        filter SquashNewlinesFilter
+      }
+    } else {
+      from(projectDir.resolve("src/docker/Dockerfile")) {
+        expand(varExpansions)
+        filter SquashNewlinesFilter
+      }
     }
+
   }
 }
 //

--- a/distribution/docker/src/docker/Dockerfile.wolfi
+++ b/distribution/docker/src/docker/Dockerfile.wolfi
@@ -92,6 +92,7 @@ RUN for iter in 1 2 3 4 5 6 7 8 9 10; do \
               curl \
               netcat-openbsd \
               p11-kit \
+              p11-kit-trust \
               shadow \
               zstd \
               unzip \
@@ -139,7 +140,7 @@ RUN chmod g=u /etc/passwd && \
 # Update "cacerts" bundle to use Ubuntu's CA certificates (and make sure it
 # stays up-to-date with changes to Ubuntu's store)
 COPY bin/docker-openjdk /etc/ca-certificates/update.d/docker-openjdk
-#RUN /etc/ca-certificates/update.d/docker-openjdk
+RUN /etc/ca-certificates/update.d/docker-openjdk
 
 EXPOSE 9200 9300
 

--- a/distribution/docker/src/docker/Dockerfile.wolfi
+++ b/distribution/docker/src/docker/Dockerfile.wolfi
@@ -1,0 +1,175 @@
+################################################################################
+# This Dockerfile was generated from the template at distribution/src/docker/Dockerfile
+#
+# Beginning of multi stage Dockerfile
+################################################################################
+
+################################################################################
+# Build stage 1 `builder`:
+# Extract Elasticsearch artifact
+################################################################################
+
+FROM docker.elastic.co/wolfi/chainguard-base:latest AS builder
+
+# Install required packages to extract the Elasticsearch distribution
+
+RUN for iter in 1 2 3 4 5 6 7 8 9 10; do \
+      apk update && DEBIAN_FRONTEND=noninteractive apk add curl  && \
+      exit_code=0 && break || \
+        exit_code=\$? && echo "apk error: retry $iter in 10s" && sleep 10; \
+    done; \
+    exit $exit_code
+
+# `tini` is a tiny but valid init for containers. This is used to cleanly
+# control how ES and any child processes are shut down.
+#
+# The tini GitHub page gives instructions for verifying the binary using
+# gpg, but the keyservers are slow to return the key and this can fail the
+# build. Instead, we check the binary against the published checksum.
+RUN set -eux ; \
+    tini_bin="" ; \
+    case "$(arch)" in \
+        aarch64) tini_bin='tini-arm64' ;; \
+        x86_64)  tini_bin='tini-amd64' ;; \
+        *) echo >&2 ; echo >&2 "Unsupported architecture $(arch)" ; echo >&2 ; exit 1 ;; \
+    esac ; \
+    curl --retry 10 -S -L -O https://github.com/krallin/tini/releases/download/v0.19.0/${tini_bin} ; \
+    curl --retry 10 -S -L -O https://github.com/krallin/tini/releases/download/v0.19.0/${tini_bin}.sha256sum ; \
+    sha256sum -c ${tini_bin}.sha256sum ; \
+    rm ${tini_bin}.sha256sum ; \
+    mv ${tini_bin} /bin/tini ; \
+    chmod 0555 /bin/tini
+
+RUN mkdir /usr/share/elasticsearch
+WORKDIR /usr/share/elasticsearch
+
+RUN curl --retry 10 -S -L --output /tmp/elasticsearch.tar.gz https://artifacts-no-kpi.elastic.co/downloads/elasticsearch/elasticsearch-8.16.0-SNAPSHOT-linux-$(arch).tar.gz
+
+RUN tar -zxf /tmp/elasticsearch.tar.gz --strip-components=1
+
+# The distribution includes a `config` directory, no need to create it
+COPY config/elasticsearch.yml config/
+COPY config/log4j2.properties config/log4j2.docker.properties
+
+#  1. Configure the distribution for Docker
+#  2. Create required directory
+#  3. Move the distribution's default logging config aside
+#  4. Move the generated docker logging config so that it is the default
+#  5. Reset permissions on all directories
+#  6. Reset permissions on all files
+#  7. Make CLI tools executable
+#  8. Make some directories writable. `bin` must be writable because
+#     plugins can install their own CLI utilities.
+#  9. Make some files writable
+RUN sed -i -e 's/ES_DISTRIBUTION_TYPE=tar/ES_DISTRIBUTION_TYPE=docker/' bin/elasticsearch-env && \
+    mkdir data && \
+    mv config/log4j2.properties config/log4j2.file.properties && \
+    mv config/log4j2.docker.properties config/log4j2.properties && \
+    find . -type d -exec chmod 0555 {} + && \
+    find . -type f -exec chmod 0444 {} + && \
+    chmod 0555 bin/* jdk/bin/* jdk/lib/jspawnhelper modules/x-pack-ml/platform/linux-*/bin/* && \
+    chmod 0775 bin config config/jvm.options.d data logs plugins && \
+    find config -type f -exec chmod 0664 {} +
+
+################################################################################
+# Build stage 2 (the actual Elasticsearch image):
+#
+# Copy elasticsearch from stage 1
+# Add entrypoint
+################################################################################
+
+FROM docker.elastic.co/wolfi/chainguard-base:latest
+
+# Change default shell to bash, then install required packages with retries.
+RUN for iter in 1 2 3 4 5 6 7 8 9 10; do \
+      export DEBIAN_FRONTEND=noninteractive && \
+      apk update && \
+      apk upgrade && \
+      apk update && \
+      apk add --no-cache \
+              bash \
+              ca-certificates \
+              curl \
+              netcat-openbsd \
+              p11-kit \
+              shadow \
+              zstd \
+              unzip \
+              zip && \
+      rm -rf /var/cache/apk/* && \
+      exit_code=0 && break || \
+        exit_code=\$? && echo "apk error: retry $iter in 10s" && sleep 10; \
+    done; \
+    exit $exit_code
+
+RUN groupadd -g 1000 elasticsearch && \
+    adduser -G elasticsearch -u 1000 elasticsearch -D --home /usr/share/elasticsearch elasticsearch && \
+    adduser elasticsearch root && \
+    chown -R 0:0 /usr/share/elasticsearch
+
+ENV ELASTIC_CONTAINER=true
+
+WORKDIR /usr/share/elasticsearch
+
+COPY --from=0 --chown=0:0 /usr/share/elasticsearch /usr/share/elasticsearch
+COPY --from=0 --chown=0:0 /bin/tini /bin/tini
+
+ENV PATH=/usr/share/elasticsearch/bin:$PATH
+
+COPY bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# 1. Sync the user and group permissions of /etc/passwd
+# 2. Set correct permissions of the entrypoint
+# 3. Ensure that there are no files with setuid or setgid, in order to mitigate "stackclash" attacks.
+#    We've already run this in previous layers so it ought to be a no-op.
+# 4. Replace OpenJDK's built-in CA certificate keystore with the one from the OS
+#    vendor. The latter is superior in several ways.
+#    REF: https://github.com/elastic/elasticsearch-docker/issues/171
+# 5. Tighten up permissions on the ES home dir (the permissions of the contents are handled earlier)
+# 6. You can't install plugins that include configuration when running as `elasticsearch` and the `config`
+#    dir is owned by `root`, because the installed tries to manipulate the permissions on the plugin's
+#    config directory.
+RUN chmod g=u /etc/passwd && \
+    chmod 0555 /usr/local/bin/docker-entrypoint.sh && \
+    find / -xdev -perm -4000 -exec chmod ug-s {} + && \
+    chmod 0775 /usr/share/elasticsearch && \
+    chown elasticsearch bin config config/jvm.options.d data logs plugins
+
+# Update "cacerts" bundle to use Ubuntu's CA certificates (and make sure it
+# stays up-to-date with changes to Ubuntu's store)
+COPY bin/docker-openjdk /etc/ca-certificates/update.d/docker-openjdk
+#RUN /etc/ca-certificates/update.d/docker-openjdk
+
+EXPOSE 9200 9300
+
+LABEL org.label-schema.build-date="2024-07-25T00:00Z" \
+  org.label-schema.license="Elastic-License-2.0" \
+  org.label-schema.name="Elasticsearch" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.url="https://www.elastic.co/products/elasticsearch" \
+  org.label-schema.usage="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" \
+  org.label-schema.vcs-ref="f755e809e7b48546debdf3889583319ed4f2f87e" \
+  org.label-schema.vcs-url="https://github.com/elastic/elasticsearch" \
+  org.label-schema.vendor="Elastic" \
+  org.label-schema.version="8.16.0-SNAPSHOT" \
+  org.opencontainers.image.created="2024-07-25T00:00Z" \
+  org.opencontainers.image.documentation="https://www.elastic.co/guide/en/elasticsearch/reference/index.html" \
+  org.opencontainers.image.licenses="Elastic-License-2.0" \
+  org.opencontainers.image.revision="f755e809e7b48546debdf3889583319ed4f2f87e" \
+  org.opencontainers.image.source="https://github.com/elastic/elasticsearch" \
+  org.opencontainers.image.title="Elasticsearch" \
+  org.opencontainers.image.url="https://www.elastic.co/products/elasticsearch" \
+  org.opencontainers.image.vendor="Elastic" \
+  org.opencontainers.image.version="8.16.0-SNAPSHOT"
+
+# Our actual entrypoint is `tini`, a minimal but functional init program. It
+# calls the entrypoint we provide, while correctly forwarding signals.
+ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
+# Dummy overridable parameter parsed by entrypoint
+CMD ["eswrapper"]
+
+USER 1000:0
+
+################################################################################
+# End of multi-stage Dockerfile
+################################################################################

--- a/distribution/docker/src/docker/Dockerfile.wolfi
+++ b/distribution/docker/src/docker/Dockerfile.wolfi
@@ -95,6 +95,7 @@ RUN for iter in 1 2 3 4 5 6 7 8 9 10; do \
               shadow \
               zstd \
               unzip \
+              libsystemd \
               zip && \
       rm -rf /var/cache/apk/* && \
       exit_code=0 && break || \

--- a/distribution/docker/src/docker/bin/docker-entrypoint-wolfi.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint-wolfi.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+set -e
+
+# Files created by Elasticsearch should always be group writable too
+umask 0002
+
+# Allow user specify custom CMD, maybe bin/elasticsearch itself
+# for example to directly specify `-E` style parameters for elasticsearch on k8s
+# or simply to run /bin/bash to check the image
+if [ "$1" = "eswrapper" ] || [ "$(basename "$1")" = "elasticsearch" ]; then
+  # Rewrite CMD args to remove the explicit command,
+  # so that we are backwards compatible with the docs
+  # from the previous Elasticsearch versions < 6
+  # and configuration option:
+  # https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docker.html#_d_override_the_image_8217_s_default_ulink_url_https_docs_docker_com_engine_reference_run_cmd_default_command_or_options_cmd_ulink
+  # Without this, user could specify `elasticsearch -E x.y=z` but
+  # `bin/elasticsearch -E x.y=z` would not work. In any case,
+  # we want to continue through this script, and not exec early.
+  set -- "${@:2}"
+else
+  # Run whatever command the user wanted
+  exec "$@"
+fi
+
+# Allow environment variables to be set by creating a file with the
+# contents, and setting an environment variable with the suffix _FILE to
+# point to it. This can be used to provide secrets to a container, without
+# the values being specified explicitly when running the container.
+#
+# This is also sourced in elasticsearch-env, and is only needed here
+# as well because we use ELASTIC_PASSWORD below. Sourcing this script
+# is idempotent.
+. /usr/share/elasticsearch/bin/elasticsearch-env-from-file
+
+if [ -f bin/elasticsearch-users ]; then
+  # Check for the ELASTIC_PASSWORD environment variable to set the
+  # bootstrap password for Security.
+  #
+  # This is only required for the first node in a cluster with Security
+  # enabled, but we have no way of knowing which node we are yet. We'll just
+  # honor the variable if it's present.
+  if [ -n "$ELASTIC_PASSWORD" ]; then
+    [ -f /usr/share/elasticsearch/config/elasticsearch.keystore ] || (elasticsearch-keystore create)
+    if ! (elasticsearch-keystore has-passwd --silent); then
+      # keystore is unencrypted
+      if ! (elasticsearch-keystore list | grep -q '^bootstrap.password$'); then
+        (echo "$ELASTIC_PASSWORD" | elasticsearch-keystore add -x 'bootstrap.password')
+      fi
+    else
+      # keystore requires password
+      if ! (echo "$KEYSTORE_PASSWORD" | elasticsearch-keystore list | grep -q '^bootstrap.password$'); then
+        COMMANDS="$(printf "%s\n%s" "$KEYSTORE_PASSWORD" "$ELASTIC_PASSWORD")"
+        (echo "$COMMANDS" | elasticsearch-keystore add -x 'bootstrap.password')
+      fi
+    fi
+  fi
+fi
+
+if [ -n "$ES_LOG_STYLE" ]; then
+  case "$ES_LOG_STYLE" in
+    console)
+      # This is the default. Nothing to do.
+      ;;
+    file)
+      # Overwrite the default config with the stack config. Do this as a
+      # copy, not a move, in case the container is restarted.
+      cp -f /usr/share/elasticsearch/config/log4j2.file.properties /usr/share/elasticsearch/config/log4j2.properties
+      ;;
+    *)
+      echo "ERROR: ES_LOG_STYLE set to [$ES_LOG_STYLE]. Expected [console] or [file]" >&2
+      exit 1 ;;
+  esac
+fi
+
+if [ -n "$ENROLLMENT_TOKEN" ]; then
+  POSITIONAL_PARAMETERS="--enrollment-token $ENROLLMENT_TOKEN"
+else
+  POSITIONAL_PARAMETERS=""
+fi
+
+# Signal forwarding and child reaping is handled by `tini`, which is the
+# actual entrypoint of the container
+exec /usr/share/elasticsearch/bin/elasticsearch "$@" $POSITIONAL_PARAMETERS <<EOF
+$KEYSTORE_PASSWORD
+EOF

--- a/distribution/docker/wolfi-docker-export/build.gradle
+++ b/distribution/docker/wolfi-docker-export/build.gradle
@@ -1,0 +1,2 @@
+// This file is intentionally blank. All configuration of the
+// export is done in the parent project.

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -195,18 +195,18 @@ final class BootstrapChecks {
         if (Constants.LINUX) {
             checks.add(new MaxNumberOfThreadsCheck());
         }
-        if (Constants.LINUX || Constants.MAC_OS_X) {
-            checks.add(new MaxSizeVirtualMemoryCheck());
-        }
-        if (Constants.LINUX || Constants.MAC_OS_X) {
-            checks.add(new MaxFileSizeCheck());
-        }
+//        if (Constants.LINUX || Constants.MAC_OS_X) {
+//            checks.add(new MaxSizeVirtualMemoryCheck());
+//        }
+//        if (Constants.LINUX || Constants.MAC_OS_X) {
+//            checks.add(new MaxFileSizeCheck());
+//        }
         if (Constants.LINUX) {
             checks.add(new MaxMapCountCheck());
         }
         checks.add(new ClientJvmCheck());
         checks.add(new UseSerialGCCheck());
-        checks.add(new SystemCallFilterCheck());
+//        checks.add(new SystemCallFilterCheck());
         checks.add(new OnErrorCheck());
         checks.add(new OnOutOfMemoryErrorCheck());
         checks.add(new EarlyAccessCheck());

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -195,18 +195,18 @@ final class BootstrapChecks {
         if (Constants.LINUX) {
             checks.add(new MaxNumberOfThreadsCheck());
         }
-//        if (Constants.LINUX || Constants.MAC_OS_X) {
-//            checks.add(new MaxSizeVirtualMemoryCheck());
-//        }
-//        if (Constants.LINUX || Constants.MAC_OS_X) {
-//            checks.add(new MaxFileSizeCheck());
-//        }
+        if (Constants.LINUX || Constants.MAC_OS_X) {
+            checks.add(new MaxSizeVirtualMemoryCheck());
+        }
+        if (Constants.LINUX || Constants.MAC_OS_X) {
+            checks.add(new MaxFileSizeCheck());
+        }
         if (Constants.LINUX) {
             checks.add(new MaxMapCountCheck());
         }
         checks.add(new ClientJvmCheck());
         checks.add(new UseSerialGCCheck());
-//        checks.add(new SystemCallFilterCheck());
+        checks.add(new SystemCallFilterCheck());
         checks.add(new OnErrorCheck());
         checks.add(new OnOutOfMemoryErrorCheck());
         checks.add(new EarlyAccessCheck());

--- a/settings.gradle
+++ b/settings.gradle
@@ -73,6 +73,7 @@ List projects = [
   'distribution:docker:ironbank-docker-export',
   'distribution:docker:ubi-docker-aarch64-export',
   'distribution:docker:ubi-docker-export',
+  'distribution:docker:wolfi-docker-export',
   'distribution:packages:aarch64-deb',
   'distribution:packages:deb',
   'distribution:packages:aarch64-rpm',


### PR DESCRIPTION
This is spiking Wolfi/Chainguard Image usage.

We use a two stage docker build and base our image on `docker.elastic.co/wolfi/chainguard-base:latest` and install in addition these packages via `apk`:

- bash
- ca-certificates
- curl
- netcat-openbsd
- p11-kit
- p11-kit-trust
- shadow (used for e.g. groupadd / adduser ) can probably be removed in the final image
- zstd
- unzip
- libsystemd
- zip

Reproduce current state of this experiment:

```
./gradlew :distribution:docker:buildArch64WolfiDockerImage
docker run -it --rm elasticsearchwolfi:aarch64
```