### PR TITLE
[8.15] [DOCS] Clarifies semantic query behavior on sparse and dense vector fields (#111339)

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -121,7 +121,12 @@ In case you want to customize data indexing, use the
 <<sparse-vector,`sparse_vector`>> or <<dense-vector,`dense_vector`>> field
 types and create an ingest pipeline with an
 <<inference-processor, {infer} processor>> to generate the embeddings.
-<<semantic-search-inference,This tutorial>> walks you through the process.
+<<semantic-search-inference,This tutorial>> walks you through the process. In
+these cases - when you use `sparse_vector` or `dense_vector` field types instead
+of the `semantic_text` field type to customize indexing - using the 
+<<query-dsl-semantic-query,`semantic_query`>> is not supported for querying the 
+field data.
+
 
 [discrete]
 [[update-script]]

--- a/docs/reference/query-dsl/semantic-query.asciidoc
+++ b/docs/reference/query-dsl/semantic-query.asciidoc
@@ -128,6 +128,10 @@ If you want to fine-tune a search on a `semantic_text` field, you need to know t
 You can find the task type using the <<get-inference-api>>, and check the `task_type` associated with the {infer} service.
 Depending on the `task_type`, use either the <<query-dsl-sparse-vector-query,`sparse_vector`>> or the <<query-dsl-knn-query,`knn`>> query for greater flexibility and customization.
 
+NOTE: While it is possible to use the `sparse_vector` query or the `knn` query
+on a `semantic_text` field, it is not supported to use the `semantic_query` on a
+`sparse_vector` or `dense_vector` field type.
+
 
 [discrete]
 [[search-sparse-inference]]


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [DOCS] Clarifies semantic query behavior on sparse and dense vector fields (#111339)