### PR TITLE
Add more logging to MetricsApmIT to identify why test fails

### DIFF
--- a/test/external-modules/apm-integration/build.gradle
+++ b/test/external-modules/apm-integration/build.gradle
@@ -22,4 +22,5 @@ tasks.named('javaRestTest').configure {
 
 dependencies {
   clusterModules project(':modules:apm')
+  implementation project(':libs:elasticsearch-logging')
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
@@ -114,10 +114,7 @@ public class MetricsApmIT extends ESRestTestCase {
         client().performRequest(new Request("GET", "/_use_apm_metrics"));
 
         var completed = finished.await(30, TimeUnit.SECONDS);
-        assertTrue(
-            "Timeout when waiting for assertions to complete. Remaining assertions to match: " + sampleAssertions,
-            completed
-        );
+        assertTrue("Timeout when waiting for assertions to complete. Remaining assertions to match: " + sampleAssertions, completed);
     }
 
     private <T> Map.Entry<String, Predicate<Map<String, Object>>> assertion(

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
@@ -89,16 +89,16 @@ public class MetricsApmIT extends ESRestTestCase {
                 var metricset = (Map<String, Object>) apmMessage.get("metricset");
                 var samples = (Map<String, Object>) metricset.get("samples");
 
-                samples.entrySet().forEach(sampleEntry -> {
-                    var assertion = sampleAssertions.get(sampleEntry.getKey());// sample name
+                samples.forEach((key, value) -> {
+                    var assertion = sampleAssertions.get(key);// sample name
                     if (assertion != null) {
-                        logger.info("Matched {}", sampleEntry.getKey());
-                        var sampleObject = (Map<String, Object>) sampleEntry.getValue();
+                        logger.info("Matched {}", key);
+                        var sampleObject = (Map<String, Object>) value;
                         if (assertion.test(sampleObject)) {// sample object
-                            logger.error("{} assertion PASSED", sampleEntry.getKey());
-                            sampleAssertions.remove(sampleEntry.getKey());
+                            logger.info("{} assertion PASSED", key);
+                            sampleAssertions.remove(key);
                         } else {
-                            logger.error("{} assertion FAILED: {}", sampleEntry.getKey(), sampleObject.get("value"));
+                            logger.error("{} assertion FAILED: {}", key, sampleObject.get("value"));
                         }
                     }
                 });

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
@@ -91,8 +91,15 @@ public class MetricsApmIT extends ESRestTestCase {
 
                 samples.entrySet().forEach(sampleEntry -> {
                     var assertion = sampleAssertions.get(sampleEntry.getKey());// sample name
-                    if (assertion != null && assertion.test((Map<String, Object>) sampleEntry.getValue())) {// sample object
-                        sampleAssertions.remove(sampleEntry.getKey());
+                    if (assertion != null) {
+                        logger.info("Matched {}", sampleEntry.getKey());
+                        var sampleObject = (Map<String, Object>) sampleEntry.getValue();
+                        if (assertion.test(sampleObject)) {// sample object
+                            logger.error("{} assertion PASSED", sampleEntry.getKey());
+                            sampleAssertions.remove(sampleEntry.getKey());
+                        } else {
+                            logger.error("{} assertion FAILED: {}", sampleEntry.getKey(), sampleObject.get("value"));
+                        }
                     }
                 });
             }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
@@ -113,9 +113,10 @@ public class MetricsApmIT extends ESRestTestCase {
 
         client().performRequest(new Request("GET", "/_use_apm_metrics"));
 
+        var completed = finished.await(30, TimeUnit.SECONDS);
         assertTrue(
             "Timeout when waiting for assertions to complete. Remaining assertions to match: " + sampleAssertions,
-            finished.await(30, TimeUnit.SECONDS)
+            completed
         );
     }
 

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestApmIntegrationRestHandler.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestApmIntegrationRestHandler.java
@@ -22,7 +22,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class TestApmIntegrationRestHandler extends BaseRestHandler {
 
-    private SetOnce<TestMeterUsages> testMeterUsages = new SetOnce<>();
+    private final SetOnce<TestMeterUsages> testMeterUsages = new SetOnce<>();
 
     TestApmIntegrationRestHandler() {}
 


### PR DESCRIPTION
Inspection of logs of failures for https://github.com/elastic/elasticsearch/issues/103286 reveal that these tests should have not failed: the APM records contain the metric we _should_ have matched, and the tests are failing for no reason. Adding more logging to see why and where matching is failing (string compare? number parsing?)