### PR TITLE
[Inference API] Replace model_id with inference_id in inference API except when stored

### DIFF
--- a/docs/changelog/111366.yaml
+++ b/docs/changelog/111366.yaml
@@ -1,0 +1,6 @@
+pr: 111366
+summary: "[Inference API] Replace `model_id` with `inference_id` in inference API\
+  \ except when stored"
+area: Machine Learning
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
@@ -20,7 +20,11 @@ import java.util.Objects;
 
 public class ModelConfigurations implements ToFilteredXContentObject, VersionedNamedWriteable {
 
-    public static final String MODEL_ID = "model_id";
+    // Due to refactoring, we now have different field names for the inference ID when it is serialized and stored to an index vs when it
+    // is returned as part of a GetInferenceModelAction
+    public static final String INDEX_ONLY_ID_FIELD_NAME = "model_id";
+    public static final String INFERENCE_ID_FIELD_NAME = "inference_id";
+    public static final String USE_ID_FOR_INDEX = "for_index";
     public static final String SERVICE = "service";
     public static final String SERVICE_SETTINGS = "service_settings";
     public static final String TASK_SETTINGS = "task_settings";
@@ -119,7 +123,11 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(MODEL_ID, inferenceEntityId);
+        if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+        } else {
+            builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
+        }
         builder.field(TaskType.NAME, taskType.toString());
         builder.field(SERVICE, service);
         builder.field(SERVICE_SETTINGS, serviceSettings);
@@ -131,7 +139,11 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
     @Override
     public XContentBuilder toFilteredXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(MODEL_ID, inferenceEntityId);
+        if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+        } else {
+            builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
+        }
         builder.field(TaskType.NAME, taskType.toString());
         builder.field(SERVICE, service);
         builder.field(SERVICE_SETTINGS, serviceSettings.getFilteredXContentObject());

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -49,7 +49,7 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
 
         var singleModel = getModels("se_model_1", TaskType.SPARSE_EMBEDDING);
         assertThat(singleModel, hasSize(1));
-        assertEquals("se_model_1", singleModel.get(0).get("model_id"));
+        assertEquals("se_model_1", singleModel.get(0).get("inference_id"));
 
         for (int i = 0; i < 5; i++) {
             deleteModel("se_model_" + i, TaskType.SPARSE_EMBEDDING);
@@ -82,7 +82,7 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         String inferenceEntityId = "sparse_embedding_model";
         putModel(inferenceEntityId, mockSparseServiceModelConfig(), TaskType.SPARSE_EMBEDDING);
         var singleModel = getModels(inferenceEntityId, TaskType.ANY);
-        assertEquals(inferenceEntityId, singleModel.get(0).get("model_id"));
+        assertEquals(inferenceEntityId, singleModel.get(0).get("inference_id"));
         assertEquals(TaskType.SPARSE_EMBEDDING.toString(), singleModel.get(0).get("task_type"));
     }
 
@@ -91,7 +91,7 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         String modelId = "no_task_type_in_url";
         putModel(modelId, mockSparseServiceModelConfig(TaskType.SPARSE_EMBEDDING));
         var singleModel = getModel(modelId);
-        assertEquals(modelId, singleModel.get("model_id"));
+        assertEquals(modelId, singleModel.get("inference_id"));
         assertEquals(TaskType.SPARSE_EMBEDDING.toString(), singleModel.get("task_type"));
 
         var inference = inferOnMockService(modelId, List.of(randomAlphaOfLength(10)));

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockDenseInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockDenseInferenceServiceIT.java
@@ -22,7 +22,7 @@ public class MockDenseInferenceServiceIT extends InferenceBaseRestTest {
         var model = getModels(inferenceEntityId, TaskType.TEXT_EMBEDDING).get(0);
 
         for (var modelMap : List.of(putModel, model)) {
-            assertEquals(inferenceEntityId, modelMap.get("model_id"));
+            assertEquals(inferenceEntityId, modelMap.get("inference_id"));
             assertEquals(TaskType.TEXT_EMBEDDING, TaskType.fromString((String) modelMap.get("task_type")));
             assertEquals("text_embedding_test_service", modelMap.get("service"));
         }

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockSparseInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockSparseInferenceServiceIT.java
@@ -24,7 +24,7 @@ public class MockSparseInferenceServiceIT extends InferenceBaseRestTest {
         var model = getModels(inferenceEntityId, TaskType.SPARSE_EMBEDDING).get(0);
 
         for (var modelMap : List.of(putModel, model)) {
-            assertEquals(inferenceEntityId, modelMap.get("model_id"));
+            assertEquals(inferenceEntityId, modelMap.get("inference_id"));
             assertEquals(TaskType.SPARSE_EMBEDDING, TaskType.fromString((String) modelMap.get("task_type")));
             assertEquals("test_service", modelMap.get("service"));
         }
@@ -77,7 +77,7 @@ public class MockSparseInferenceServiceIT extends InferenceBaseRestTest {
         var model = getModels(inferenceEntityId, TaskType.SPARSE_EMBEDDING).get(0);
 
         for (var modelMap : List.of(putModel, model)) {
-            assertEquals(inferenceEntityId, modelMap.get("model_id"));
+            assertEquals(inferenceEntityId, modelMap.get("inference_id"));
             assertThat(modelMap.get("service_settings"), is(Map.of("model", "my_model")));
             assertEquals(TaskType.SPARSE_EMBEDDING, TaskType.fromString((String) modelMap.get("task_type")));
             assertEquals("test_service", modelMap.get("service"));
@@ -95,7 +95,7 @@ public class MockSparseInferenceServiceIT extends InferenceBaseRestTest {
         var model = getModels(inferenceEntityId, TaskType.SPARSE_EMBEDDING).get(0);
 
         for (var modelMap : List.of(putModel, model)) {
-            assertEquals(inferenceEntityId, modelMap.get("model_id"));
+            assertEquals(inferenceEntityId, modelMap.get("inference_id"));
             assertThat(modelMap.get("service_settings"), is(Map.of("model", "my_model", "hidden_field", "my_hidden_value")));
             assertEquals(TaskType.SPARSE_EMBEDDING, TaskType.fromString((String) modelMap.get("task_type")));
             assertEquals("test_service", modelMap.get("service"));

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
@@ -410,7 +410,7 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field("unknown_field", "foo");
-            builder.field(MODEL_ID, getInferenceEntityId());
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, getInferenceEntityId());
             builder.field(TaskType.NAME, getTaskType().toString());
             builder.field(SERVICE, getService());
             builder.field(SERVICE_SETTINGS, getServiceSettings());
@@ -436,7 +436,7 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field("unknown_field", "foo");
-            builder.field(MODEL_ID, getInferenceEntityId());
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, getInferenceEntityId());
             builder.field(TaskType.NAME, getTaskType().toString());
             builder.field(SERVICE, getService());
             builder.field(SERVICE_SETTINGS, getServiceSettings());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
@@ -74,7 +74,10 @@ public class ModelRegistry {
             if (modelConfigMap.config() == null) {
                 throw new ElasticsearchStatusException("Missing config map", RestStatus.BAD_REQUEST);
             }
-            String inferenceEntityId = ServiceUtils.removeStringOrThrowIfNull(modelConfigMap.config(), ModelConfigurations.MODEL_ID);
+            String inferenceEntityId = ServiceUtils.removeStringOrThrowIfNull(
+                modelConfigMap.config(),
+                ModelConfigurations.INDEX_ONLY_ID_FIELD_NAME
+            );
             String service = ServiceUtils.removeStringOrThrowIfNull(modelConfigMap.config(), ModelConfigurations.SERVICE);
             String taskTypeStr = ServiceUtils.removeStringOrThrowIfNull(modelConfigMap.config(), TaskType.NAME);
             TaskType taskType = TaskType.fromString(taskTypeStr);
@@ -375,7 +378,10 @@ public class ModelRegistry {
     private static IndexRequest createIndexRequest(String docId, String indexName, ToXContentObject body, boolean allowOverwriting) {
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             var request = new IndexRequest(indexName);
-            XContentBuilder source = body.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            XContentBuilder source = body.toXContent(
+                builder,
+                new ToXContent.MapParams(Map.of(ModelConfigurations.USE_ID_FOR_INDEX, Boolean.TRUE.toString()))
+            );
             var operation = allowOverwriting ? DocWriteRequest.OpType.INDEX : DocWriteRequest.OpType.CREATE;
 
             return request.opType(operation).id(docId).source(source);


### PR DESCRIPTION
Previously we had updated the clients and documentation to specify that GetInference would return an "inference_id" field instead of a "model_id" field, but we missed updating the code to actually do that. This PR finishes this up. This PR will need to be backported to 8.15 to allow the language clients to work. 

cc @szabosteve for docs 