### PR TITLE
Fix geoip processor isp_organization_name property and docs

### DIFF
--- a/docs/changelog/111372.yaml
+++ b/docs/changelog/111372.yaml
@@ -1,5 +1,0 @@
-pr: 111372
-summary: Fix geoip processor `isp_organization_name` property and docs
-area: Ingest Node
-type: bug
-issues: []

--- a/docs/changelog/111372.yaml
+++ b/docs/changelog/111372.yaml
@@ -1,0 +1,5 @@
+pr: 111372
+summary: Fix geoip processor `isp_organization_name` property and docs
+area: Ingest Node
+type: bug
+issues: []

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -64,12 +64,12 @@ depend on what has been found and which properties were configured in `propertie
 * If the GeoIP2 Domain database is used, then the following fields may be added under the `target_field`: `ip`, and `domain`.
 The fields actually added depend on what has been found and which properties were configured in `properties`.
 * If the GeoIP2 ISP database is used, then the following fields may be added under the `target_field`: `ip`, `asn`,
-`organization_name`, `network`, `isp`, `isp_organization`, `mobile_country_code`, and `mobile_network_code`. The fields actually added
+`organization_name`, `network`, `isp`, `isp_organization_name`, `mobile_country_code`, and `mobile_network_code`. The fields actually added
 depend on what has been found and which properties were configured in `properties`.
 * If the GeoIP2 Enterprise database is used, then the following fields may be added under the `target_field`: `ip`,
 `country_iso_code`, `country_name`, `continent_code`, `continent_name`, `region_iso_code`, `region_name`, `city_name`, `timezone`,
 `location`, `asn`, `organization_name`, `network`, `hosting_provider`, `tor_exit_node`, `anonymous_vpn`, `anonymous`, `public_proxy`,
-`residential_proxy`, `domain`, `isp`, `isp_organization`, `mobile_country_code`, `mobile_network_code`, `user_type`, and
+`residential_proxy`, `domain`, `isp`, `isp_organization_name`, `mobile_country_code`, `mobile_network_code`, `user_type`, and
 `connection_type`. The fields actually added  depend on what has been found and which properties were configured in `properties`.
 
 preview::["Do not use the GeoIP2 Anonymous IP, GeoIP2 Connection Type, GeoIP2 Domain, GeoIP2 ISP, and GeoIP2 Enterprise databases in production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -592,7 +592,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 }
                 case ISP_ORGANIZATION_NAME -> {
                     if (ispOrganization != null) {
-                        geoData.put("isp_organization", ispOrganization);
+                        geoData.put("isp_organization_name", ispOrganization);
                     }
                 }
                 case MOBILE_COUNTRY_CODE -> {
@@ -660,7 +660,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 }
                 case ISP_ORGANIZATION_NAME -> {
                     if (ispOrganization != null) {
-                        geoData.put("isp_organization", ispOrganization);
+                        geoData.put("isp_organization_name", ispOrganization);
                     }
                 }
                 case MOBILE_COUNTRY_CODE -> {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -463,7 +463,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("residential_proxy"), equalTo(false));
         assertThat(geoData.get("domain"), equalTo("frpt.net"));
         assertThat(geoData.get("isp"), equalTo("Fairpoint Communications"));
-        assertThat(geoData.get("isp_organization"), equalTo("Fairpoint Communications"));
+        assertThat(geoData.get("isp_organization_name"), equalTo("Fairpoint Communications"));
         assertThat(geoData.get("user_type"), equalTo("residential"));
         assertThat(geoData.get("connection_type"), equalTo("Cable/DSL"));
     }
@@ -497,7 +497,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("organization_name"), equalTo("CELLCO-PART"));
         assertThat(geoData.get("network"), equalTo("149.101.100.0/28"));
         assertThat(geoData.get("isp"), equalTo("Verizon Wireless"));
-        assertThat(geoData.get("isp_organization"), equalTo("Verizon Wireless"));
+        assertThat(geoData.get("isp_organization_name"), equalTo("Verizon Wireless"));
         assertThat(geoData.get("mobile_network_code"), equalTo("004"));
         assertThat(geoData.get("mobile_country_code"), equalTo("310"));
     }


### PR DESCRIPTION
The property that you put into the `geoip` processor `properties` list is `isp_organization_name` (no change), but the docs accidentally said that it's `isp_organization`, so this PR fixes that. Additionally the field that was written into the output object was also `isp_organization`, and this PR fixes that as well.

While a bit verbose, it's all intended to mirror the `organization_name` for the ASN database, so there's a reason for it to be what it is.