### PR TITLE
Use the right stopTrace() call at the end of search query phase.

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -692,7 +692,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 }
                 afterQueryTime = executor.success();
             } finally {
-                tracer.stopTrace(task);
+                tracer.stopTrace();
             }
             if (request.numberOfShards() == 1 && (request.source() == null || request.source().rankBuilder() == null)) {
                 // we already have query results, but we can run fetch at the same time


### PR DESCRIPTION
This seems asymmetrical as currently implemented. The startTrace call at the start of the phase uses the no-context version of the tracer. However, the stop-trace was passing the task-aware version. We should instead be passing the no-context version, and then letting task completion call Tracer#stopTrace(task) afterwards.
