### PR TITLE
Use HTTP for Azure fixture in FIPS tests

### DIFF
--- a/modules/repository-azure/src/yamlRestTest/java/org/elasticsearch/repositories/azure/RepositoryAzureClientYamlTestSuiteIT.java
+++ b/modules/repository-azure/src/yamlRestTest/java/org/elasticsearch/repositories/azure/RepositoryAzureClientYamlTestSuiteIT.java
@@ -14,6 +14,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestTrustStore;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
@@ -30,7 +31,9 @@ public class RepositoryAzureClientYamlTestSuiteIT extends ESClientYamlSuiteTestC
     private static final String AZURE_TEST_SASTOKEN = System.getProperty("test.azure.sas_token");
 
     private static AzureHttpFixture fixture = new AzureHttpFixture(
-        USE_FIXTURE ? AzureHttpFixture.Protocol.HTTPS : AzureHttpFixture.Protocol.NONE,
+        USE_FIXTURE
+            ? ESTestCase.inFipsJvm() ? AzureHttpFixture.Protocol.HTTP : AzureHttpFixture.Protocol.HTTPS
+            : AzureHttpFixture.Protocol.NONE,
         AZURE_TEST_ACCOUNT,
         AZURE_TEST_CONTAINER,
         AzureHttpFixture.sharedKeyForAccountPredicate(AZURE_TEST_ACCOUNT)
@@ -59,7 +62,11 @@ public class RepositoryAzureClientYamlTestSuiteIT extends ESClientYamlSuiteTestC
             s -> USE_FIXTURE
         )
         .setting("thread_pool.repository_azure.max", () -> String.valueOf(randomIntBetween(1, 10)), s -> USE_FIXTURE)
-        .systemProperty("javax.net.ssl.trustStore", () -> trustStore.getTrustStorePath().toString(), s -> USE_FIXTURE)
+        .systemProperty(
+            "javax.net.ssl.trustStore",
+            () -> trustStore.getTrustStorePath().toString(),
+            s -> USE_FIXTURE && ESTestCase.inFipsJvm() == false
+        )
         .build();
 
     @ClassRule(order = 1)

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -113,18 +113,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/111308
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsRestIT
   issue: https://github.com/elastic/elasticsearch/issues/111319
-- class: org.elasticsearch.xpack.searchablesnapshots.AzureSearchableSnapshotsIT
-  issue: https://github.com/elastic/elasticsearch/issues/111279
-- class: org.elasticsearch.repositories.azure.RepositoryAzureClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/111345
-- class: org.elasticsearch.xpack.repositories.metering.azure.AzureRepositoriesMeteringIT
-  issue: https://github.com/elastic/elasticsearch/issues/111307
-- class: org.elasticsearch.xpack.snapshotbasedrecoveries.recovery.AzureSnapshotBasedRecoveryIT
-  method: testRecoveryUsingSnapshots
-  issue: https://github.com/elastic/elasticsearch/issues/111377
-- class: org.elasticsearch.repositories.blobstore.testkit.AzureSnapshotRepoTestKitIT
-  method: testRepositoryAnalysis
-  issue: https://github.com/elastic/elasticsearch/issues/111280
 - class: org.elasticsearch.xpack.esql.analysis.VerifierTests
   method: testMatchFilter
   issue: https://github.com/elastic/elasticsearch/issues/111380

--- a/test/framework/src/main/java/org/elasticsearch/test/TestTrustStore.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestTrustStore.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.apache.lucene.tests.util.LuceneTestCase.createTempDir;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestTrustStore extends ExternalResource {
@@ -35,6 +36,7 @@ public class TestTrustStore extends ExternalResource {
     private Path trustStorePath;
 
     public Path getTrustStorePath() {
+        assertFalse("Tests in FIPS mode cannot supply a custom trust store", ESTestCase.inFipsJvm());
         return Objects.requireNonNullElseGet(trustStorePath, () -> ESTestCase.fail(null, "trust store not created"));
     }
 

--- a/x-pack/plugin/repositories-metering-api/qa/azure/src/javaRestTest/java/org/elasticsearch/xpack/repositories/metering/azure/AzureRepositoriesMeteringIT.java
+++ b/x-pack/plugin/repositories-metering-api/qa/azure/src/javaRestTest/java/org/elasticsearch/xpack/repositories/metering/azure/AzureRepositoriesMeteringIT.java
@@ -10,6 +10,7 @@ import fixture.azure.AzureHttpFixture;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestTrustStore;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.repositories.metering.AbstractRepositoriesMeteringAPIRestTestCase;
@@ -28,7 +29,9 @@ public class AzureRepositoriesMeteringIT extends AbstractRepositoriesMeteringAPI
     private static final String AZURE_TEST_SASTOKEN = System.getProperty("test.azure.sas_token");
 
     private static AzureHttpFixture fixture = new AzureHttpFixture(
-        USE_FIXTURE ? AzureHttpFixture.Protocol.HTTPS : AzureHttpFixture.Protocol.NONE,
+        USE_FIXTURE
+            ? ESTestCase.inFipsJvm() ? AzureHttpFixture.Protocol.HTTP : AzureHttpFixture.Protocol.HTTPS
+            : AzureHttpFixture.Protocol.NONE,
         AZURE_TEST_ACCOUNT,
         AZURE_TEST_CONTAINER,
         AzureHttpFixture.sharedKeyForAccountPredicate(AZURE_TEST_ACCOUNT)
@@ -57,7 +60,11 @@ public class AzureRepositoriesMeteringIT extends AbstractRepositoriesMeteringAPI
             () -> "ignored;DefaultEndpointsProtocol=https;BlobEndpoint=" + fixture.getAddress(),
             s -> USE_FIXTURE
         )
-        .systemProperty("javax.net.ssl.trustStore", () -> trustStore.getTrustStorePath().toString(), s -> USE_FIXTURE)
+        .systemProperty(
+            "javax.net.ssl.trustStore",
+            () -> trustStore.getTrustStorePath().toString(),
+            s -> USE_FIXTURE && ESTestCase.inFipsJvm() == false
+        )
         .build();
 
     @ClassRule(order = 1)

--- a/x-pack/plugin/searchable-snapshots/qa/azure/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
@@ -11,6 +11,7 @@ import fixture.azure.AzureHttpFixture;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestTrustStore;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -29,7 +30,9 @@ public class AzureSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestT
     private static final String AZURE_TEST_SASTOKEN = System.getProperty("test.azure.sas_token");
 
     private static AzureHttpFixture fixture = new AzureHttpFixture(
-        USE_FIXTURE ? AzureHttpFixture.Protocol.HTTPS : AzureHttpFixture.Protocol.NONE,
+        USE_FIXTURE
+            ? ESTestCase.inFipsJvm() ? AzureHttpFixture.Protocol.HTTP : AzureHttpFixture.Protocol.HTTPS
+            : AzureHttpFixture.Protocol.NONE,
         AZURE_TEST_ACCOUNT,
         AZURE_TEST_CONTAINER,
         AzureHttpFixture.sharedKeyForAccountPredicate(AZURE_TEST_ACCOUNT)

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
@@ -10,6 +10,7 @@ import fixture.azure.AzureHttpFixture;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestTrustStore;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.junit.ClassRule;
@@ -27,7 +28,9 @@ public class AzureSnapshotRepoTestKitIT extends AbstractSnapshotRepoTestKitRestT
     private static final String AZURE_TEST_SASTOKEN = System.getProperty("test.azure.sas_token");
 
     private static AzureHttpFixture fixture = new AzureHttpFixture(
-        USE_FIXTURE ? AzureHttpFixture.Protocol.HTTPS : AzureHttpFixture.Protocol.NONE,
+        USE_FIXTURE
+            ? ESTestCase.inFipsJvm() ? AzureHttpFixture.Protocol.HTTP : AzureHttpFixture.Protocol.HTTPS
+            : AzureHttpFixture.Protocol.NONE,
         AZURE_TEST_ACCOUNT,
         AZURE_TEST_CONTAINER,
         AzureHttpFixture.sharedKeyForAccountPredicate(AZURE_TEST_ACCOUNT)
@@ -62,7 +65,11 @@ public class AzureSnapshotRepoTestKitIT extends AbstractSnapshotRepoTestKitRestT
                 c.systemProperty("test.repository_test_kit.skip_cas", "true");
             }
         })
-        .systemProperty("javax.net.ssl.trustStore", () -> trustStore.getTrustStorePath().toString(), s -> USE_FIXTURE)
+        .systemProperty(
+            "javax.net.ssl.trustStore",
+            () -> trustStore.getTrustStorePath().toString(),
+            s -> USE_FIXTURE && ESTestCase.inFipsJvm() == false
+        )
         .build();
 
     @ClassRule(order = 1)


### PR DESCRIPTION
We cannot (easily) override the JVM trust store in FIPS tests. This
commit falls back to using HTTP in these cases.

Closes #111279
Closes #111345
Closes #111307
Closes #111377
Closes #111280