### PR TITLE
ES|QL: sort execution clusters on local nodes

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
@@ -278,6 +278,9 @@ public class TopNOperator implements Operator, Accountable {
 
     private Iterator<Page> output;
 
+    // profiling
+    private long rowsProcessed = 0;
+
     public TopNOperator(
         BlockFactory blockFactory,
         CircuitBreaker breaker,
@@ -366,6 +369,7 @@ public class TopNOperator implements Operator, Accountable {
                 spareValuesPreAllocSize = Math.max(spare.values.length(), spareValuesPreAllocSize / 2);
 
                 spare = inputQueue.insertWithOverflow(spare);
+                rowsProcessed++;
             }
         } finally {
             Releasables.close(() -> page.releaseBlocks());
@@ -531,7 +535,7 @@ public class TopNOperator implements Operator, Accountable {
 
     @Override
     public Status status() {
-        return new TopNOperatorStatus(inputQueue.size(), ramBytesUsed());
+        return new TopNOperatorStatus(inputQueue.size(), ramBytesUsed(), rowsProcessed);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperatorStatus.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperatorStatus.java
@@ -27,21 +27,25 @@ public class TopNOperatorStatus implements Operator.Status {
     );
     private final int occupiedRows;
     private final long ramBytesUsed;
+    private final long processedRows;
 
-    public TopNOperatorStatus(int occupiedRows, long ramBytesUsed) {
+    public TopNOperatorStatus(int occupiedRows, long ramBytesUsed, long processedRows) {
         this.occupiedRows = occupiedRows;
         this.ramBytesUsed = ramBytesUsed;
+        this.processedRows = processedRows;
     }
 
     TopNOperatorStatus(StreamInput in) throws IOException {
         this.occupiedRows = in.readVInt();
         this.ramBytesUsed = in.readVLong();
+        this.processedRows = in.readVLong();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(occupiedRows);
         out.writeVLong(ramBytesUsed);
+        out.writeVLong(processedRows);
     }
 
     @Override
@@ -53,6 +57,10 @@ public class TopNOperatorStatus implements Operator.Status {
         return occupiedRows;
     }
 
+    public long processedRows() {
+        return processedRows;
+    }
+
     public long ramBytesUsed() {
         return ramBytesUsed;
     }
@@ -61,6 +69,7 @@ public class TopNOperatorStatus implements Operator.Status {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("occupied_rows", occupiedRows);
+        builder.field("processed_rows", processedRows);
         builder.field("ram_bytes_used", ramBytesUsed);
         builder.field("ram_used", ByteSizeValue.ofBytes(ramBytesUsed));
         return builder.endObject();
@@ -72,12 +81,12 @@ public class TopNOperatorStatus implements Operator.Status {
             return false;
         }
         TopNOperatorStatus that = (TopNOperatorStatus) o;
-        return occupiedRows == that.occupiedRows && ramBytesUsed == that.ramBytesUsed;
+        return occupiedRows == that.occupiedRows && ramBytesUsed == that.ramBytesUsed && processedRows == that.processedRows;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(occupiedRows, ramBytesUsed);
+        return Objects.hash(occupiedRows, ramBytesUsed, processedRows);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorStatusTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorStatusTests.java
@@ -15,8 +15,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class TopNOperatorStatusTests extends AbstractWireSerializingTestCase<TopNOperatorStatus> {
     public void testToXContent() {
-        assertThat(Strings.toString(new TopNOperatorStatus(10, 2000)), equalTo("""
-            {"occupied_rows":10,"ram_bytes_used":2000,"ram_used":"1.9kb"}"""));
+        assertThat(Strings.toString(new TopNOperatorStatus(10, 2000, 20)), equalTo("""
+            {"occupied_rows":10,"processed_rows":20,"ram_bytes_used":2000,"ram_used":"1.9kb"}"""));
     }
 
     @Override
@@ -26,23 +26,27 @@ public class TopNOperatorStatusTests extends AbstractWireSerializingTestCase<Top
 
     @Override
     protected TopNOperatorStatus createTestInstance() {
-        return new TopNOperatorStatus(randomNonNegativeInt(), randomNonNegativeLong());
+        return new TopNOperatorStatus(randomNonNegativeInt(), randomNonNegativeLong(), randomNonNegativeLong());
     }
 
     @Override
     protected TopNOperatorStatus mutateInstance(TopNOperatorStatus instance) {
         int occupiedRows = instance.occupiedRows();
         long ramBytesUsed = instance.ramBytesUsed();
-        switch (between(0, 1)) {
+        long processedRows = instance.processedRows();
+        switch (between(0, 2)) {
             case 0:
                 occupiedRows = randomValueOtherThan(occupiedRows, () -> randomNonNegativeInt());
                 break;
             case 1:
                 ramBytesUsed = randomValueOtherThan(ramBytesUsed, () -> randomNonNegativeLong());
                 break;
+            case 2:
+                processedRows = randomValueOtherThan(ramBytesUsed, () -> randomNonNegativeLong());
+                break;
             default:
                 throw new IllegalArgumentException();
         }
-        return new TopNOperatorStatus(occupiedRows, ramBytesUsed);
+        return new TopNOperatorStatus(occupiedRows, ramBytesUsed, processedRows);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/NamedWriteablesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/NamedWriteablesTests.java
@@ -20,7 +20,7 @@ public class NamedWriteablesTests extends ESTestCase {
     public void testTopNStatus() throws Exception {
         try (EsqlPlugin plugin = new EsqlPlugin()) {
             NamedWriteableRegistry registry = new NamedWriteableRegistry(plugin.getNamedWriteables());
-            TopNOperatorStatus origin = new TopNOperatorStatus(randomNonNegativeInt(), randomNonNegativeLong());
+            TopNOperatorStatus origin = new TopNOperatorStatus(randomNonNegativeInt(), randomNonNegativeLong(), randomNonNegativeLong());
             TopNOperatorStatus copy = (TopNOperatorStatus) copyNamedWriteable(origin, registry, Operator.Status.class);
             assertThat(copy.occupiedRows(), equalTo(origin.occupiedRows()));
             assertThat(copy.ramBytesUsed(), equalTo(origin.ramBytesUsed()));


### PR DESCRIPTION
On local node, sorting clusters by creation date.

If there is no `SORT` command in the local plan, then clusters are sorted by creation date DESC, ie. newer first (and clusterId ASC as a tiebreaker).
If there is a SORT by `@timestamp` in the local plan, then the sorting of the clusters is performed accordingly, ie. newer first if `SORT @timestamp DESC`, older first if `SORT @timestamp ASC`