### PR TITLE
[DOCS] Clarify copy_to behavior with strict dynamic mappings

### DIFF
--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -68,12 +68,55 @@ Some important points:
 `field_1` to `field_2` and `copy_to` on `field_2` to `field_3` expecting 
 indexing into `field_1` will eventuate in `field_3`, instead use copy_to 
 directly to multiple fields from the originating field.
+
+NOTE: `copy_to` is _not_ supported for field types where values take the form of objects, e.g. `date_range`
+
+==== Dynamic mapping
+
+Here are some important points to consider when using `copy_to` with dynamic mappings:
+
 * If the target field does not exist in the index mappings, the usual
 <<dynamic-mapping,dynamic mapping>> behavior applies. By default, with
 <<dynamic,`dynamic`>> set to `true`, a non-existent target field will be
-dynamically added to the index mappings. If `dynamic` is set to `false`, the
+dynamically added to the index mappings.
+* If `dynamic` is set to `false`, the
 target field will not be added to the index mappings, and the value will not be
-copied. If `dynamic` is set to `strict`, copying to a non-existent field will
+copied.
+* If `dynamic` is set to `strict`, copying to a non-existent field will
 result in an error.
++
+** `copy_to` fields must specify the full path if the target field is _nested_.
+Omitting the full path will lead to a `strict_dynamic_mapping_exception`.
+Use `"copy_to": ["parent_field.child_field"]` to correctly target a nested field.
++
+For example:
++
+[source,console]
+--------------------------------------------------
+PUT /test_index
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "description": {
+        "properties": {
+          "notes": {
+            "type": "text",
+            "copy_to": [ "description.notes_raw"], <1>
+            "analyzer": "standard",
+            "search_analyzer": "standard"
+          },
+          "notes_raw": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
 
-NOTE: `copy_to` is _not_ supported for field types where values take the form of objects, e.g. `date_range`
+<1> The `notes` field is copied to the `notes_raw` field. Targeting only `notes_raw`, instead of `description.notes_raw`, without specifying the fully qualified path,
+would lead to a `strict_dynamic_mapping_exception`. 
+
+

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -118,7 +118,5 @@ PUT /test_index
 }
 --------------------------------------------------
 
-<1> The `notes` field is copied to the `notes_raw` field. Targeting only `notes_raw`, instead of `description.notes_raw`, without specifying the fully qualified path,
-would lead to a `strict_dynamic_mapping_exception`. 
-
-
+<1> The `notes` field is copied to the `notes_raw` field. Targeting `notes_raw` alone, instead of `description.notes_raw`
+would lead to a `strict_dynamic_mapping_exception`.

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -69,7 +69,7 @@ The following configuration will not copy data from `field_1` to `field_3`:
 +
 [source,console]
 ----
-PUT /bad_example_index
+PUT bad_example_index
 {
   "mappings": {
     "properties": {
@@ -92,7 +92,7 @@ Instead, copy to multiple fields from the source field:
 +
 [source,console]
 ----
-PUT /good_example_index
+PUT good_example_index
 {
   "mappings": {
     "properties": {

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -118,5 +118,5 @@ PUT /test_index
 }
 --------------------------------------------------
 
-<1> The `notes` field is copied to the `notes_raw` field. Targeting `notes_raw` alone, instead of `description.notes_raw`
+<1> The `notes` field is copied to the `notes_raw` field. Targeting `notes_raw` alone instead of `description.notes_raw`
 would lead to a `strict_dynamic_mapping_exception`.

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -120,3 +120,6 @@ PUT /test_index
 
 <1> The `notes` field is copied to the `notes_raw` field. Targeting `notes_raw` alone instead of `description.notes_raw`
 would lead to a `strict_dynamic_mapping_exception`.
++
+In this example, `notes_raw` is not defined at the root of the mapping, but under the `description` field.
+Without the fully qualified path, {es} would interpret the `copy_to` target as a root-level field, not as a nested field under `description`. 

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -80,6 +80,7 @@ The following configuration will not copy data from `field_1` to `field_3`:
   }
 }
 ----
+// TEST[skip:]
 Instead, copy to multiple fields from the source field:
 +
 [source,console]
@@ -91,6 +92,7 @@ Instead, copy to multiple fields from the source field:
   }
 }
 ----
+// TEST[skip:]
 
 NOTE: `copy_to` is not supported for field types where values take the form of objects, e.g. `date_range`.
 

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -71,6 +71,8 @@ directly to multiple fields from the originating field.
 
 NOTE: `copy_to` is _not_ supported for field types where values take the form of objects, e.g. `date_range`
 
+[float]
+[[copy-to-dynamic-mapping]]
 ==== Dynamic mapping
 
 Here are some important points to consider when using `copy_to` with dynamic mappings:

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -69,30 +69,47 @@ The following configuration will not copy data from `field_1` to `field_3`:
 +
 [source,console]
 ----
+PUT /bad_example_index
 {
-  "field_1": {
-    "type": "text",
-    "copy_to": "field_2"
-  },
-  "field_2": {
-    "type": "text",
-    "copy_to": "field_3"
+  "mappings": {
+    "properties": {
+      "field_1": {
+        "type": "text",
+        "copy_to": "field_2"
+      },
+      "field_2": {
+        "type": "text",
+        "copy_to": "field_3"
+      },
+      "field_3": {
+        "type": "text"
+      }
+    }
   }
 }
 ----
-// TEST[skip:]
 Instead, copy to multiple fields from the source field:
 +
 [source,console]
 ----
+PUT /good_example_index
 {
-  "field_1": {
-    "type": "text",
-    "copy_to": [ "field_2", "field_3" ]
+  "mappings": {
+    "properties": {
+      "field_1": {
+        "type": "text",
+        "copy_to": ["field_2", "field_3"]
+      },
+      "field_2": {
+        "type": "text"
+      },
+      "field_3": {
+        "type": "text"
+      }
+    }
   }
 }
 ----
-// TEST[skip:]
 
 NOTE: `copy_to` is not supported for field types where values take the form of objects, e.g. `date_range`.
 

--- a/docs/reference/mapping/params/copy-to.asciidoc
+++ b/docs/reference/mapping/params/copy-to.asciidoc
@@ -64,18 +64,41 @@ Some important points:
 * It is the field _value_ which is copied, not the terms (which result from the analysis process).
 * The original <<mapping-source-field,`_source`>> field will not be modified to show the copied values.
 * The same value can be copied to multiple fields, with `"copy_to": [ "field_1", "field_2" ]`
-* You cannot copy recursively via intermediary fields such as a `copy_to` on 
-`field_1` to `field_2` and `copy_to` on `field_2` to `field_3` expecting 
-indexing into `field_1` will eventuate in `field_3`, instead use copy_to 
-directly to multiple fields from the originating field.
+* You cannot copy recursively using intermediary fields.
+The following configuration will not copy data from `field_1` to `field_3`:
++
+[source,console]
+----
+{
+  "field_1": {
+    "type": "text",
+    "copy_to": "field_2"
+  },
+  "field_2": {
+    "type": "text",
+    "copy_to": "field_3"
+  }
+}
+----
+Instead, copy to multiple fields from the source field:
++
+[source,console]
+----
+{
+  "field_1": {
+    "type": "text",
+    "copy_to": [ "field_2", "field_3" ]
+  }
+}
+----
 
-NOTE: `copy_to` is _not_ supported for field types where values take the form of objects, e.g. `date_range`
+NOTE: `copy_to` is not supported for field types where values take the form of objects, e.g. `date_range`.
 
 [float]
 [[copy-to-dynamic-mapping]]
 ==== Dynamic mapping
 
-Here are some important points to consider when using `copy_to` with dynamic mappings:
+Consider the following points when using `copy_to` with dynamic mappings:
 
 * If the target field does not exist in the index mappings, the usual
 <<dynamic-mapping,dynamic mapping>> behavior applies. By default, with
@@ -87,7 +110,7 @@ copied.
 * If `dynamic` is set to `strict`, copying to a non-existent field will
 result in an error.
 +
-** `copy_to` fields must specify the full path if the target field is _nested_.
+** If the target field is nested, then `copy_to` fields must specify the full path to the nested field.
 Omitting the full path will lead to a `strict_dynamic_mapping_exception`.
 Use `"copy_to": ["parent_field.child_field"]` to correctly target a nested field.
 +


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/97817

- Group dynamic mapping behavior into its own section
- Mention how `strict` requires fully qualified paths when working with nested fields


### [URL preview](https://elasticsearch_bk_111408.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/copy-to.html)