### PR TITLE
[Transform] Always pick the user maxPageSize value

### DIFF
--- a/docs/changelog/109876.yaml
+++ b/docs/changelog/109876.yaml
@@ -1,6 +1,0 @@
-pr: 109876
-summary: Always pick the user `maxPageSize` value
-area: Transform
-type: bug
-issues:
- - 109844

--- a/docs/changelog/109876.yaml
+++ b/docs/changelog/109876.yaml
@@ -1,0 +1,6 @@
+pr: 109876
+summary: Always pick the user `maxPageSize` value
+area: Transform
+type: bug
+issues:
+ - 109844

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -63,6 +63,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
@@ -287,7 +288,8 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         ActionListener<Void> finalListener = listener.delegateFailureAndWrap((l, r) -> {
             // if we haven't set the page size yet, if it is set we might have reduced it after running into an out of memory
             if (context.getPageSize() == 0) {
-                configurePageSize(getConfig().getSettings().getMaxPageSearchSize());
+                // check the pageSize again in case another thread has updated it
+                configurePageSize(() -> context.getPageSize() == 0, getConfig().getSettings().getMaxPageSearchSize());
             }
 
             runState = determineRunStateAtStart();
@@ -544,7 +546,11 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     private void finalizeCheckpoint(ActionListener<Void> listener) {
         try {
             // reset the page size, so we do not memorize a low page size forever
-            resetPageSize();
+            var pageSize = initialConfiguredPageSize;
+            // only update if the initialConfiguredPageSize hadn't been changed by the user between the last line and the next line
+            // if the user also called configurePageSize, keep their new value rather than resetting it to their previous value
+            configurePageSize(() -> Objects.equals(pageSize, initialConfiguredPageSize), pageSize);
+
             // reset the changed bucket to free memory
             if (changeCollector != null) {
                 changeCollector.clear();
@@ -659,9 +665,10 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         logger.info("[{}] transform settings have been updated.", transformConfig.getId());
 
         docsPerSecond = newSettings.getDocsPerSecond() != null ? newSettings.getDocsPerSecond() : -1;
-        if (Objects.equals(newSettings.getMaxPageSearchSize(), initialConfiguredPageSize) == false) {
-            configurePageSize(newSettings.getMaxPageSearchSize());
-        }
+        configurePageSize(
+            () -> Objects.equals(newSettings.getMaxPageSearchSize(), initialConfiguredPageSize) == false,
+            newSettings.getMaxPageSearchSize()
+        );
         rethrottle();
     }
 
@@ -1220,19 +1227,19 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         return RunState.IDENTIFY_CHANGES;
     }
 
-    private void configurePageSize(Integer newPageSize) {
-        initialConfiguredPageSize = newPageSize;
-        resetPageSize();
-    }
-
-    private void resetPageSize() {
-        if (initialConfiguredPageSize != null && initialConfiguredPageSize > 0) {
-            context.setPageSize(initialConfiguredPageSize);
-        } else if (function != null) {
-            context.setPageSize(function.getInitialPageSize());
-        } else {
-            // we should never be in a state where both initialConfiguredPageSize and function are null, but just in case...
-            context.setPageSize(Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE);
+    private void configurePageSize(Supplier<Boolean> shouldUpdate, Integer newPageSize) {
+        synchronized (context) {
+            if (shouldUpdate.get()) {
+                initialConfiguredPageSize = newPageSize;
+                if (newPageSize != null && newPageSize > 0) {
+                    context.setPageSize(initialConfiguredPageSize);
+                } else if (function != null) {
+                    context.setPageSize(function.getInitialPageSize());
+                } else {
+                    // we should never be in a state where both initialConfiguredPageSize and function are null, but just in case...
+                    context.setPageSize(Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Backporting commit to 8.14.

maxPageSize's update functionality has been reprioritized.  If a user calls the update API to change the max page size, that update will lock out other threads from changing the max page size.  Once the lock is released, the other threads will check again if they can reset the max page size and otherwise keep the value that the user just updated with.

Relate #109844
Fix #111386
