### PR TITLE
Search coordinator rewrites to MatchNone on searchable snapshots when @timestamp data on shards is empty

### DIFF
--- a/docs/changelog/111419.yaml
+++ b/docs/changelog/111419.yaml
@@ -1,0 +1,6 @@
+pr: 111419
+summary: Search coordinator rewrites to `MatchNone` on searchable snapshots when @timestamp
+  data on shards is empty
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -57,16 +57,8 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
         this.timestampFieldType = timestampFieldType;
     }
 
-    long getMinTimestamp() {
-        return indexLongFieldRange.getMin();
-    }
-
     long getMaxTimestamp() {
         return indexLongFieldRange.getMax();
-    }
-
-    boolean hasTimestampData() {
-        return indexLongFieldRange.isComplete() && indexLongFieldRange != IndexLongFieldRange.EMPTY;
     }
 
     @Nullable
@@ -76,6 +68,15 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
         }
 
         return timestampFieldType;
+    }
+
+    @Nullable
+    public IndexLongFieldRange getFieldRange(String fieldName) {
+        if (fieldName.equals(timestampFieldType.name()) == false) {
+            return null;
+        }
+
+        return indexLongFieldRange;
     }
 
     @Override


### PR DESCRIPTION
RangeQueryBuilder, on search coordinator rewrites against @timestamp,
returns DISJOINT when the range is EMPTY on the shards.

This results in a MatchNone query rewrite for that case, which we were not doing before.
