### PR TITLE
Remove 4096 bool query max limit from docs

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -30,7 +30,7 @@ If you don't need to support a query syntax, consider using the
 syntax, use the <<query-dsl-simple-query-string-query,`simple_query_string`>>
 query, which is less strict.
 ====
- 
+
 
 [[query-string-query-ex-request]]
 ==== Example request
@@ -83,7 +83,7 @@ could be expensive.
 
 There is a limit on the number of fields times terms that can be queried at once.
 It is defined by the `indices.query.bool.max_clause_count`
-<<search-settings,search setting>>, which defaults to 4096.
+<<search-settings,search setting>>.
 ====
 --
 

--- a/docs/reference/query-dsl/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-multi-term-query.asciidoc
@@ -39,7 +39,8 @@ GET /_search
 --------------------------------------------------
 
 WARNING: `span_multi` queries will hit too many clauses failure if the number of terms that match the query exceeds the
-boolean query limit (defaults to 4096).To avoid an unbounded expansion you can set the <<query-dsl-multi-term-rewrite,
+`indices.query.bool.max_clause_count` <<search-settings,search setting>>.
+To avoid an unbounded expansion you can set the <<query-dsl-multi-term-rewrite,
 rewrite method>> of the multi term query to `top_terms_*` rewrite. Or, if you use `span_multi` on `prefix` query only,
 you can activate the <<index-prefixes,`index_prefixes`>> field option of the `text` field instead. This will
 rewrite any prefix query on the field to a single term query that matches the indexed prefix.


### PR DESCRIPTION
indices.query.bool.max_clause_count is set automatically and does not default to 4096 as before. This remove mentions of `4096` default max from query documentations.

Relates to PR #91811