### PR TITLE
Fix IndexFoldersDeletionListenerIT#testListenersInvokedWhenIndexIsDangling

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -104,7 +104,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                     plugin.deletedIndices.contains(index)
                 );
 
-                final List<ShardId> deletedShards = plugin.deletedShards.get(index);
+                final Set<ShardId> deletedShards = plugin.deletedShards.get(index);
                 assertThat(deletedShards, notNullValue());
                 assertFalse(
                     "Listener should have been notified of deletion of one or more shards on node " + nodeName,
@@ -175,7 +175,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                         plugin.deletedIndices.contains(index)
                     );
 
-                    final List<ShardId> deletedShards = plugin.deletedShards.get(index);
+                    final Set<ShardId> deletedShards = plugin.deletedShards.get(index);
                     assertThat(deletedShards, notNullValue());
                     assertFalse(
                         "Listener should have been notified of deletion of one or more shards on node " + nodeName,
@@ -338,7 +338,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
     public static class IndexFoldersDeletionListenerPlugin extends Plugin implements IndexStorePlugin {
 
         final Set<Index> deletedIndices = ConcurrentCollections.newConcurrentSet();
-        final Map<Index, List<ShardId>> deletedShards = ConcurrentCollections.newConcurrentMap();
+        final Map<Index, Set<ShardId>> deletedShards = ConcurrentCollections.newConcurrentMap();
 
         @Override
         public List<IndexFoldersDeletionListener> getIndexFoldersDeletionListeners() {
@@ -350,7 +350,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
                 @Override
                 public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
-                    deletedShards.computeIfAbsent(shardId.getIndex(), i -> new ArrayList<>()).add(shardId);
+                    deletedShards.computeIfAbsent(shardId.getIndex(), i -> ConcurrentCollections.newConcurrentSet()).add(shardId);
                 }
             });
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -104,7 +104,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                     plugin.deletedIndices.contains(index)
                 );
 
-                final Set<ShardId> deletedShards = plugin.deletedShards.get(index);
+                final List<ShardId> deletedShards = plugin.deletedShards.get(index);
                 assertThat(deletedShards, notNullValue());
                 assertFalse(
                     "Listener should have been notified of deletion of one or more shards on node " + nodeName,
@@ -175,7 +175,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
                         plugin.deletedIndices.contains(index)
                     );
 
-                    final Set<ShardId> deletedShards = plugin.deletedShards.get(index);
+                    final List<ShardId> deletedShards = plugin.deletedShards.get(index);
                     assertThat(deletedShards, notNullValue());
                     assertFalse(
                         "Listener should have been notified of deletion of one or more shards on node " + nodeName,
@@ -338,7 +338,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
     public static class IndexFoldersDeletionListenerPlugin extends Plugin implements IndexStorePlugin {
 
         final Set<Index> deletedIndices = ConcurrentCollections.newConcurrentSet();
-        final Map<Index, Set<ShardId>> deletedShards = ConcurrentCollections.newConcurrentMap();
+        final Map<Index, List<ShardId>> deletedShards = ConcurrentCollections.newConcurrentMap();
 
         @Override
         public List<IndexFoldersDeletionListener> getIndexFoldersDeletionListeners() {
@@ -350,7 +350,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
                 @Override
                 public void beforeShardFoldersDeleted(ShardId shardId, IndexSettings indexSettings, Path[] shardPaths) {
-                    deletedShards.computeIfAbsent(shardId.getIndex(), i -> ConcurrentCollections.newConcurrentSet()).add(shardId);
+                    deletedShards.computeIfAbsent(shardId.getIndex(), i -> Collections.synchronizedList(new ArrayList<>())).add(shardId);
                 }
             });
         }


### PR DESCRIPTION
I was unable to reproduce this locally, but it smells very strongly of concurrent access to the `ArrayList`.

```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0 
   at java.base/java.util.ArrayList.add(ArrayList.java:485) 
   at java.base/java.util.ArrayList.add(ArrayList.java:497)  
   at org.elasticsearch.plugins.IndexFoldersDeletionListenerIT$IndexFoldersDeletionListenerPlugin$1.beforeShardFoldersDeleted(IndexFoldersDeletionListenerIT.java:353)
```


We require the the `List` structure, because we have assertions that count distinct notifications for the same shard, so I just wrapped it in a `synchronizedList`. I don't _think_ this fundamentally changes the nature of the test, as we're already interacting with a `ConcurrentHashMap` here.

It may be that this concurrency is unexpected and indicates a more significant issue, but from reading the code it looked like we only ensure mutual exclusion at the shard level, and not the index level.

See
https://github.com/elastic/elasticsearch/blob/e9888de64dfa67a65844a15ffaa2cde059410d9d/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java#L107-L115

If the concurrency does indicate a problem we should probably beef up the test to log a more descriptive error when it occurs.

Closes #111192