### PR TITLE
Simplify Azure test setup

### DIFF
--- a/modules/repository-azure/build.gradle
+++ b/modules/repository-azure/build.gradle
@@ -304,9 +304,6 @@ tasks.named("yamlRestTest") {
 tasks.register("managedIdentityYamlRestTest", RestIntegTestTask) {
   testClassesDirs = sourceSets.yamlRestTest.output.classesDirs
   classpath = sourceSets.yamlRestTest.runtimeClasspath
-}
-
-tasks.named("managedIdentityYamlRestTest") {
   systemProperty 'test.azure.fixture', Boolean.toString(useFixture)
   systemProperty 'test.azure.account', azureAccount
   systemProperty 'test.azure.container', azureContainer

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/azure/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/azure/build.gradle
@@ -50,9 +50,6 @@ tasks.register("azureThirdPartyTest") {
 tasks.register("managedIdentityJavaRestTest", RestIntegTestTask) {
   testClassesDirs = sourceSets.javaRestTest.output.classesDirs
   classpath = sourceSets.javaRestTest.runtimeClasspath
-}
-
-tasks.named("managedIdentityJavaRestTest") {
   systemProperty 'test.azure.fixture', Boolean.toString(useFixture)
   systemProperty 'test.azure.account', azureAccount
   systemProperty 'test.azure.container', azureContainer


### PR DESCRIPTION
No need to separate registration from configuration of these test tasks.

Relates #111344