### PR TITLE
Support booleans in routing path

### DIFF
--- a/docs/changelog/111445.yaml
+++ b/docs/changelog/111445.yaml
@@ -1,0 +1,5 @@
+pr: 111445
+summary: Support booleans in routing path
+area: TSDB
+type: enhancement
+issues: []

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -1052,3 +1052,87 @@ dimensions with ignore_malformed and ignore_above:
   - length: { aggregations.keyword_dims.buckets: 1 }
   - match: { aggregations.keyword_dims.buckets.0.key: "foo" }
   - match: { aggregations.keyword_dims.buckets.0.doc_count: 2 }
+
+---
+non string dimension fields:
+  - requires:
+      cluster_features: ["mapper.pass_through_priority"]
+      reason: support for priority in passthrough objects
+  - do:
+      allowed_warnings:
+        - "index template [my-dynamic-template] has index patterns [k9s*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-dynamic-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-dynamic-template
+        body:
+          index_patterns: [k9s*]
+          data_stream: {}
+          template:
+            settings:
+              index:
+                number_of_shards: 1
+                mode: time_series
+                time_series:
+                  start_time: 2023-08-31T13:03:08.138Z
+
+            mappings:
+              properties:
+                attributes:
+                  type: passthrough
+                  dynamic: true
+                  time_series_dimension: true
+                  priority: 0
+                metrics:
+                  type: passthrough
+                  priority: 1
+              dynamic_templates:
+                - counter_metric:
+                    mapping:
+                      type: integer
+                      time_series_metric: counter
+                - ip_attributes:
+                    path_match: "*.ip"
+                    match_mapping_type: string
+                    mapping:
+                      type: ip
+                - strings_as_keywords:
+                    match_mapping_type: string
+                    mapping:
+                      type: keyword
+                # ES doesn't support boolean fields as dimensions, yet
+                # however, support has been added to have boolean fields in the routing path
+                # as long as these boolean fields are converted to a field type that supports dimensions
+                - booleans_as_keywords:
+                    match_mapping_type: boolean
+                    mapping:
+                      type: keyword
+
+  - do:
+      bulk:
+        index: k9s
+        refresh: true
+        body:
+          - '{ "create": { "dynamic_templates": { "metrics.data": "counter_metric" } } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "metrics.data": "10", "attributes.string": "foo", "attributes.boolean": true, "attributes.integer": 1, "attributes.float": 1.1, "attributes.host.ip": "127.0.0.1" }'
+  - is_false: errors
+
+  - do:
+      search:
+        index: k9s
+        body:
+          size: 1
+  - match: { hits.total.value: 1 }
+
+  - do:
+      indices.get_data_stream:
+        name: k9s
+  - set: { data_streams.0.indices.0.index_name: idx0name }
+
+  - do:
+      indices.get_mapping:
+        index: $idx0name
+        expand_wildcards: hidden
+  - match: { .$idx0name.mappings.properties.attributes.properties.string.type: 'keyword' }
+  - match: { .$idx0name.mappings.properties.attributes.properties.boolean.type: 'keyword' }
+  - match: { .$idx0name.mappings.properties.attributes.properties.integer.type: 'long' }
+  - match: { .$idx0name.mappings.properties.attributes.properties.float.type: 'float' }
+  - match: { .$idx0name.mappings.properties.attributes.properties.host\.ip.type: 'ip' }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -1105,6 +1105,10 @@ non string dimension fields:
                     match_mapping_type: boolean
                     mapping:
                       type: keyword
+                - double_as_double:
+                    match_mapping_type: double
+                    mapping:
+                      type: double
 
   - do:
       bulk:
@@ -1112,7 +1116,7 @@ non string dimension fields:
         refresh: true
         body:
           - '{ "create": { "dynamic_templates": { "metrics.data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "metrics.data": "10", "attributes.string": "foo", "attributes.boolean": true, "attributes.integer": 1, "attributes.float": 1.1, "attributes.host.ip": "127.0.0.1" }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "metrics.data": "10", "attributes.string": "foo", "attributes.boolean": true, "attributes.integer": 1, "attributes.double": 1.1, "attributes.host.ip": "127.0.0.1" }'
   - is_false: errors
 
   - do:
@@ -1132,7 +1136,7 @@ non string dimension fields:
                     attributes.integer:
                       value: 1
                 - term:
-                    attributes.float:
+                    attributes.double:
                       value: 1.1
                 - term:
                     attributes.host.ip:
@@ -1143,7 +1147,7 @@ non string dimension fields:
   - match: { hits.hits.0.fields.attributes\.string: [ "foo" ] }
   - match: { hits.hits.0.fields.attributes\.boolean: [ "true" ] }
   - match: { hits.hits.0.fields.attributes\.integer: [ 1 ] }
-  - match: { hits.hits.0.fields.attributes\.float: [ 1.1 ] }
+  - match: { hits.hits.0.fields.attributes\.double: [ 1.1 ] }
   - match: { hits.hits.0.fields.attributes\.host\.ip: [ "127.0.0.1" ] }
 
   - do:
@@ -1158,5 +1162,5 @@ non string dimension fields:
   - match: { .$idx0name.mappings.properties.attributes.properties.string.type: 'keyword' }
   - match: { .$idx0name.mappings.properties.attributes.properties.boolean.type: 'keyword' }
   - match: { .$idx0name.mappings.properties.attributes.properties.integer.type: 'long' }
-  - match: { .$idx0name.mappings.properties.attributes.properties.float.type: 'float' }
+  - match: { .$idx0name.mappings.properties.attributes.properties.double.type: 'double' }
   - match: { .$idx0name.mappings.properties.attributes.properties.host\.ip.type: 'ip' }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -1119,8 +1119,32 @@ non string dimension fields:
       search:
         index: k9s
         body:
+          query:
+            bool:
+              must:
+                - term:
+                    attributes.string:
+                      value: foo
+                - term:
+                    attributes.boolean:
+                      value: true
+                - term:
+                    attributes.integer:
+                      value: 1
+                - term:
+                    attributes.float:
+                      value: 1.1
+                - term:
+                    attributes.host.ip:
+                      value: 127.0.0.1
           size: 1
+          fields: [ "*" ]
   - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.attributes\.string: [ "foo" ] }
+  - match: { hits.hits.0.fields.attributes\.boolean: [ "true" ] }
+  - match: { hits.hits.0.fields.attributes\.integer: [ 1 ] }
+  - match: { hits.hits.0.fields.attributes\.float: [ 1.1 ] }
+  - match: { hits.hits.0.fields.attributes\.host\.ip: [ "127.0.0.1" ] }
 
   - do:
       indices.get_data_stream:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -1056,7 +1056,7 @@ dimensions with ignore_malformed and ignore_above:
 ---
 non string dimension fields:
   - requires:
-      cluster_features: ["mapper.pass_through_priority"]
+      cluster_features: ["mapper.pass_through_priority", "routing.boolean_routing_path"]
       reason: support for priority in passthrough objects
   - do:
       allowed_warnings:

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
 import org.elasticsearch.transport.Transports;
@@ -48,6 +49,9 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
  * Generates the shard id for {@code (id, routing)} pairs.
  */
 public abstract class IndexRouting {
+
+    static final NodeFeature BOOLEAN_ROUTING_PATH = new NodeFeature("routing.boolean_routing_path");
+
     /**
      * Build the routing from {@link IndexMetadata}.
      */

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -361,6 +361,7 @@ public abstract class IndexRouting {
                         break;
                     case VALUE_STRING:
                     case VALUE_NUMBER:
+                    case VALUE_BOOLEAN:
                         hashes.add(new NameAndHash(new BytesRef(path), hash(new BytesRef(source.text()))));
                         source.nextToken();
                         break;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingFeatures.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingFeatures.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class RoutingFeatures implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(IndexRouting.BOOLEAN_ROUTING_PATH);
+    }
+}

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -20,3 +20,4 @@ org.elasticsearch.search.SearchFeatures
 org.elasticsearch.search.retriever.RetrieversFeatures
 org.elasticsearch.script.ScriptFeatures
 org.elasticsearch.reservedstate.service.FileSettingsFeatures
+org.elasticsearch.cluster.routing.RoutingFeatures

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTests.java
@@ -589,6 +589,14 @@ public class IndexRoutingTests extends ESTestCase {
         assertIndexShard(routing, Map.of("foo", 123), Math.floorMod(hash(List.of("foo", "123")), shards));
     }
 
+    public void testRoutingPathBooleansInSource() throws IOException {
+        int shards = between(2, 1000);
+        IndexRouting routing = indexRoutingForPath(shards, "foo");
+        assertIndexShard(routing, Map.of("foo", true), Math.floorMod(hash(List.of("foo", "true")), shards));
+        assertIndexShard(routing, Map.of("foo", false), Math.floorMod(hash(List.of("foo", "false")), shards));
+
+    }
+
     public void testRoutingPathBwc() throws IOException {
         IndexVersion version = IndexVersionUtils.randomCompatibleVersion(random());
         IndexRouting routing = indexRoutingForPath(version, 8, "dim.*,other.*,top");


### PR DESCRIPTION
This doesn't add full support for booleans as dimensions (#111338). But it does make it possible to send boolean values that are within the routing_path. These booleans need to be converted to a keyword field in the mappings.