### PR TITLE
[DOCS] Expands top_n parameter description in the PUT inference API docs

### DIFF
--- a/docs/reference/inference/service-cohere.asciidoc
+++ b/docs/reference/inference/service-cohere.asciidoc
@@ -131,7 +131,7 @@ Specify whether to return doc text within the results.
 `top_n`::
 (Optional, integer)
 The number of most relevant documents to return, defaults to the number of the documents.
-If this inference endpoint is used in a `text_similarity_reranker` retriever query and `top_n` is set, it must be greater than or equal to `rank_window_size` in the query.
+If this {infer} endpoint is used in a `text_similarity_reranker` retriever query and `top_n` is set, it must be greater than or equal to `rank_window_size` in the query.
 =====
 +
 .`task_settings` for the `text_embedding` task type

--- a/docs/reference/inference/service-cohere.asciidoc
+++ b/docs/reference/inference/service-cohere.asciidoc
@@ -131,7 +131,7 @@ Specify whether to return doc text within the results.
 `top_n`::
 (Optional, integer)
 The number of most relevant documents to return, defaults to the number of the documents.
-If `top_n` set to a greater number than the number of document to rerank, the request will fail.
+If this inference endpoint is used in a `text_similarity_reranker` retriever query and `top_n` is set, it must be greater than or equal to `rank_window_size` in the query.
 =====
 +
 .`task_settings` for the `text_embedding` task type

--- a/docs/reference/inference/service-cohere.asciidoc
+++ b/docs/reference/inference/service-cohere.asciidoc
@@ -131,6 +131,7 @@ Specify whether to return doc text within the results.
 `top_n`::
 (Optional, integer)
 The number of most relevant documents to return, defaults to the number of the documents.
+If `top_n` set to a greater number than the number of document to rerank, the request will fail.
 =====
 +
 .`task_settings` for the `text_embedding` task type


### PR DESCRIPTION
## Overview

This PR expands the `top_n` parameter description with the behavior if the parameter is set to a greater number than the number of documents to rerank.