### PR TITLE
Ignore more warnings in upgrade test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -133,17 +133,11 @@ tests:
   method: testGroupingAggregate {TestCase=<long unicode KEYWORDs>}
   issue: https://github.com/elastic/elasticsearch/issues/111428
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testSingleDoc {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/111430
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testSingleDoc {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111434
 - class: org.elasticsearch.xpack.snapshotbasedrecoveries.recovery.AzureSnapshotBasedRecoveryIT
   method: testRecoveryUsingSnapshots
   issue: https://github.com/elastic/elasticsearch/issues/111377
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testDataStreams {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/111389
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testDataStreams {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111448

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -99,6 +99,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             Request createDoc = new Request("PUT", docLocation);
             createDoc.addParameter("refresh", "true");
             createDoc.setJsonEntity(doc);
+            createDoc.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(fieldNamesFieldOk()));
             client().performRequest(createDoc);
         }
 
@@ -974,6 +975,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
                 .field("@timestamp", System.currentTimeMillis())
                 .endObject();
             indexRequest.setJsonEntity(Strings.toString(builder));
+            indexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(fieldNamesFieldOk()));
             assertOK(client().performRequest(indexRequest));
         }
 


### PR DESCRIPTION
These warnings come spuriously from 7.x about the field names field. We're not going to fix the mistaken warnings, but we can ignore them in these tests.

Closes #111430
Closes #111389
