### PR TITLE
ESQL: Remove some unused test infrastructure

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
@@ -46,7 +46,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
-import static org.elasticsearch.xpack.esql.core.type.DataType.isSpatial;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -701,17 +700,5 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     protected static Stream<DataType> representable() {
         return DataType.types().stream().filter(DataType::isRepresentable);
-    }
-
-    protected static DataType[] representableTypes() {
-        return representable().toArray(DataType[]::new);
-    }
-
-    protected static Stream<DataType> representableNonSpatial() {
-        return representable().filter(t -> isSpatial(t) == false);
-    }
-
-    protected static DataType[] representableNonSpatialTypes() {
-        return representableNonSpatial().toArray(DataType[]::new);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
@@ -615,13 +615,6 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
 
     protected abstract Expression build(Source source, Expression field);
 
-    protected abstract DataType[] supportedTypes();
-
-    protected final DataType[] representableNumerics() {
-        // TODO numeric should only include representable numbers but that is a change for a followup
-        return DataType.types().stream().filter(DataType::isNumeric).filter(DataType::isRepresentable).toArray(DataType[]::new);
-    }
-
     protected DataType expectedType(List<DataType> argTypes) {
         return argTypes.get(0);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvAvgTests.java
@@ -64,11 +64,6 @@ public class MvAvgTests extends AbstractMultivalueFunctionTestCase {
     }
 
     @Override
-    protected DataType[] supportedTypes() {
-        return representableNumerics();
-    }
-
-    @Override
     protected DataType expectedType(List<DataType> argTypes) {
         return DataType.DOUBLE;  // Averages are always a double
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvCountTests.java
@@ -49,11 +49,6 @@ public class MvCountTests extends AbstractMultivalueFunctionTestCase {
     }
 
     @Override
-    protected DataType[] supportedTypes() {
-        return representableTypes();
-    }
-
-    @Override
     protected DataType expectedType(List<DataType> argTypes) {
         return DataType.INTEGER;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvDedupeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvDedupeTests.java
@@ -57,11 +57,6 @@ public class MvDedupeTests extends AbstractMultivalueFunctionTestCase {
         return new MvDedupe(source, field);
     }
 
-    @Override
-    protected DataType[] supportedTypes() {
-        return representableTypes();
-    }
-
     @SuppressWarnings("unchecked")
     private static Matcher<Object> getMatcher(Stream<?> v) {
         Set<Object> values = v.collect(Collectors.toSet());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvFirstTests.java
@@ -50,11 +50,6 @@ public class MvFirstTests extends AbstractMultivalueFunctionTestCase {
     }
 
     @Override
-    protected DataType[] supportedTypes() {
-        return representableTypes();
-    }
-
-    @Override
     protected DataType expectedType(List<DataType> argTypes) {
         return argTypes.get(0);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvLastTests.java
@@ -50,11 +50,6 @@ public class MvLastTests extends AbstractMultivalueFunctionTestCase {
     }
 
     @Override
-    protected DataType[] supportedTypes() {
-        return representableTypes();
-    }
-
-    @Override
     protected DataType expectedType(List<DataType> argTypes) {
         return argTypes.get(0);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMaxTests.java
@@ -12,7 +12,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
 import java.math.BigInteger;
@@ -44,10 +43,5 @@ public class MvMaxTests extends AbstractMultivalueFunctionTestCase {
     @Override
     protected Expression build(Source source, Expression field) {
         return new MvMax(source, field);
-    }
-
-    @Override
-    protected DataType[] supportedTypes() {
-        return representableNonSpatialTypes();
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMedianTests.java
@@ -99,9 +99,4 @@ public class MvMedianTests extends AbstractMultivalueFunctionTestCase {
     protected Expression build(Source source, Expression field) {
         return new MvMedian(source, field);
     }
-
-    @Override
-    protected DataType[] supportedTypes() {
-        return representableNumerics();
-    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvMinTests.java
@@ -12,7 +12,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
 import java.math.BigInteger;
@@ -44,10 +43,5 @@ public class MvMinTests extends AbstractMultivalueFunctionTestCase {
     @Override
     protected Expression build(Source source, Expression field) {
         return new MvMin(source, field);
-    }
-
-    @Override
-    protected DataType[] supportedTypes() {
-        return representableNonSpatialTypes();
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSumTests.java
@@ -87,9 +87,4 @@ public class MvSumTests extends AbstractMultivalueFunctionTestCase {
     protected Expression build(Source source, Expression field) {
         return new MvSum(source, field);
     }
-
-    @Override
-    protected DataType[] supportedTypes() {
-        return representableNumerics();
-    }
 }


### PR DESCRIPTION
Now that we've fully migrated to parameterized tests for functions we no longer need `AbstractMultivalueFunctionTestCase#supportedTypes`. It isn't called. This removes it, all implementations of it, and all methods that existed solely to power it.
