### PR TITLE
Update setCompatibleVersions task to just exit if there's no transport versions

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/SetCompatibleVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/SetCompatibleVersionsTask.java
@@ -45,11 +45,12 @@ public class SetCompatibleVersionsTask extends AbstractVersionsTask {
         if (versionIds.isEmpty()) {
             throw new IllegalArgumentException("No version ids specified");
         }
+
         Integer transportVersion = versionIds.get(TRANSPORT_VERSION_TYPE);
         if (transportVersion == null) {
-            throw new IllegalArgumentException("TransportVersion id not specified");
+            // the release being done does not have transport versions - don't need to update CCS version
+            return;
         }
-
         Path versionJava = rootDir.resolve(TRANSPORT_VERSIONS_FILE_PATH);
         CompilationUnit file = LexicalPreservingPrinter.setup(StaticJavaParser.parse(versionJava));
 


### PR DESCRIPTION
When doing a release that doesn't have a transport version, this is valid (v7 release), so just exit, don't throw an error