### PR TITLE
Add release version to setCompatibleVersions task

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
@@ -52,7 +52,7 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
 
         project.getTasks().register("extractCurrentVersions", ExtractCurrentVersionsTask.class);
         project.getTasks().register("tagVersions", TagVersionsTask.class);
-        project.getTasks().register("setCompatibleVersions", SetCompatibleVersionsTask.class);
+        project.getTasks().register("setCompatibleVersions", SetCompatibleVersionsTask.class, t -> t.setThisVersion(version));
 
         final FileTree yamlFiles = projectDirectory.dir("docs/changelog")
             .getAsFileTree()


### PR DESCRIPTION
Add a `release` option to specify the version being released, so it can not update CCS version if it's for a different major