### PR TITLE
[ML] Return both modelId and inferenceId

### DIFF
--- a/docs/changelog/111490.yaml
+++ b/docs/changelog/111490.yaml
@@ -1,5 +1,5 @@
 pr: 111490
-summary: Return both `modelId` and `inferenceId`
+summary: Temporarily return both `modelId` and `inferenceId` for GET /_inference until we migrate clients to only `inferenceId`
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/111490.yaml
+++ b/docs/changelog/111490.yaml
@@ -1,0 +1,5 @@
+pr: 111490
+summary: Return both `modelId` and `inferenceId`
+area: Machine Learning
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
@@ -123,8 +123,12 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
-        builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
+        if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+        } else {
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+            builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
+        }
         builder.field(TaskType.NAME, taskType.toString());
         builder.field(SERVICE, service);
         builder.field(SERVICE_SETTINGS, serviceSettings);
@@ -136,8 +140,12 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
     @Override
     public XContentBuilder toFilteredXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
-        builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
+        if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+        } else {
+            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+            builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
+        }
         builder.field(TaskType.NAME, taskType.toString());
         builder.field(SERVICE, service);
         builder.field(SERVICE_SETTINGS, serviceSettings.getFilteredXContentObject());

--- a/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
@@ -123,11 +123,8 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
-            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
-        } else {
-            builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
-        }
+        builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+        builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
         builder.field(TaskType.NAME, taskType.toString());
         builder.field(SERVICE, service);
         builder.field(SERVICE_SETTINGS, serviceSettings);
@@ -139,11 +136,8 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
     @Override
     public XContentBuilder toFilteredXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
-            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
-        } else {
-            builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
-        }
+        builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
+        builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
         builder.field(TaskType.NAME, taskType.toString());
         builder.field(SERVICE, service);
         builder.field(SERVICE_SETTINGS, serviceSettings.getFilteredXContentObject());


### PR DESCRIPTION
Until all clients migrate to inferenceId, return both.