### PR TITLE
PoC: 2-phase rollover represent  pending rollovers with a set

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -181,6 +181,7 @@ public class TransportVersions {
     public static final TransportVersion SEGMENT_LEVEL_FIELDS_STATS = def(8_711_00_0);
     public static final TransportVersion ML_ADD_DETECTION_RULE_PARAMS = def(8_712_00_0);
     public static final TransportVersion FIX_VECTOR_SIMILARITY_INNER_HITS = def(8_713_00_0);
+    public static final TransportVersion TWO_PHASE_ROLLOVER = def(8_714_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -144,8 +144,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             indexMode,
             lifecycle,
             failureStoreEnabled,
-            new DataStreamIndices(BACKING_INDEX_PREFIX, List.copyOf(indices), rolloverOnWrite, autoShardingEvent),
-            new DataStreamIndices(FAILURE_STORE_PREFIX, List.copyOf(failureIndices), false, null)
+            new DataStreamIndices(BACKING_INDEX_PREFIX, List.copyOf(indices), rolloverOnWrite, autoShardingEvent, Set.of()),
+            new DataStreamIndices(FAILURE_STORE_PREFIX, List.copyOf(failureIndices), false, null, Set.of())
         );
     }
 
@@ -212,6 +212,11 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             failureIndicesBuilder.setRolloverOnWrite(in.readBoolean())
                 .setAutoShardingEvent(in.readOptionalWriteable(DataStreamAutoShardingEvent::new));
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.TWO_PHASE_ROLLOVER)) {
+            backingIndicesBuilder.setPendingIndices(in.readCollectionAsImmutableSet(Index::new));
+            failureIndicesBuilder.setPendingIndices(in.readCollectionAsImmutableSet(Index::new));
+        }
+
         return new DataStream(
             name,
             generation,
@@ -246,7 +251,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
 
     @Override
     public List<Index> getIndices() {
-        return backingIndices.indices;
+        return backingIndices.getSearchableIndices();
     }
 
     public long getGeneration() {
@@ -1055,6 +1060,10 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             out.writeBoolean(failureIndices.rolloverOnWrite);
             out.writeOptionalWriteable(failureIndices.autoShardingEvent);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.TWO_PHASE_ROLLOVER)) {
+            out.writeCollection(backingIndices.pendingIndices);
+            out.writeCollection(failureIndices.pendingIndices);
+        }
     }
 
     public static final ParseField NAME_FIELD = new ParseField("name");
@@ -1068,26 +1077,29 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     public static final ParseField ALLOW_CUSTOM_ROUTING = new ParseField("allow_custom_routing");
     public static final ParseField INDEX_MODE = new ParseField("index_mode");
     public static final ParseField LIFECYCLE = new ParseField("lifecycle");
+    public static final ParseField PENDING_INDICES_FIELD = new ParseField("pending_indices");
     public static final ParseField FAILURE_STORE_FIELD = new ParseField("failure_store");
     public static final ParseField FAILURE_INDICES_FIELD = new ParseField("failure_indices");
     public static final ParseField ROLLOVER_ON_WRITE_FIELD = new ParseField("rollover_on_write");
     public static final ParseField AUTO_SHARDING_FIELD = new ParseField("auto_sharding");
     public static final ParseField FAILURE_ROLLOVER_ON_WRITE_FIELD = new ParseField("failure_rollover_on_write");
     public static final ParseField FAILURE_AUTO_SHARDING_FIELD = new ParseField("failure_auto_sharding");
+    public static final ParseField FAILURE_PENDING_INDICES_FIELD = new ParseField("failure_pending_indices");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStream, Void> PARSER = new ConstructingObjectParser<>("data_stream", args -> {
         // Fields behind a feature flag need to be parsed last otherwise the parser will fail when the feature flag is disabled.
         // Until the feature flag is removed we keep them separately to be mindful of this.
-        boolean failureStoreEnabled = DataStream.isFailureStoreFeatureFlagEnabled() && args[12] != null && (boolean) args[12];
+        boolean failureStoreEnabled = DataStream.isFailureStoreFeatureFlagEnabled() && args[13] != null && (boolean) args[13];
         DataStreamIndices failureIndices = DataStream.isFailureStoreFeatureFlagEnabled()
             ? new DataStreamIndices(
                 FAILURE_STORE_PREFIX,
-                args[13] != null ? (List<Index>) args[13] : List.of(),
-                args[14] != null && (boolean) args[14],
-                (DataStreamAutoShardingEvent) args[15]
+                args[14] != null ? (List<Index>) args[14] : List.of(),
+                args[15] != null && (boolean) args[15],
+                (DataStreamAutoShardingEvent) args[16],
+                args[17] != null ? (Set<Index>) args[17] : Set.of()
             )
-            : new DataStreamIndices(FAILURE_STORE_PREFIX, List.of(), false, null);
+            : new DataStreamIndices(FAILURE_STORE_PREFIX, List.of(), false, null, Set.of());
         return new DataStream(
             (String) args[0],
             (Long) args[2],
@@ -1104,7 +1116,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
                 BACKING_INDEX_PREFIX,
                 (List<Index>) args[1],
                 args[10] != null && (boolean) args[10],
-                (DataStreamAutoShardingEvent) args[11]
+                (DataStreamAutoShardingEvent) args[11],
+                args[12] != null ? (Set<Index>) args[12] : Set.of()
             ),
             failureIndices
         );
@@ -1135,6 +1148,11 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             (p, c) -> DataStreamAutoShardingEvent.fromXContent(p),
             AUTO_SHARDING_FIELD
         );
+        PARSER.declareObjectArray(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> Index.fromXContent(p),
+            PENDING_INDICES_FIELD
+        );
         // The fields behind the feature flag should always be last.
         if (DataStream.isFailureStoreFeatureFlagEnabled()) {
             PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), FAILURE_STORE_FIELD);
@@ -1148,6 +1166,11 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
                 ConstructingObjectParser.optionalConstructorArg(),
                 (p, c) -> DataStreamAutoShardingEvent.fromXContent(p),
                 FAILURE_AUTO_SHARDING_FIELD
+            );
+            PARSER.declareObjectArray(
+                ConstructingObjectParser.optionalConstructorArg(),
+                (p, c) -> Index.fromXContent(p),
+                FAILURE_PENDING_INDICES_FIELD
             );
         }
     }
@@ -1177,6 +1200,9 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             .field(NAME_FIELD.getPreferredName(), TIMESTAMP_FIELD_NAME)
             .endObject();
         builder.xContentList(INDICES_FIELD.getPreferredName(), backingIndices.indices);
+        if (backingIndices.pendingIndices.isEmpty() == false) {
+            builder.xContentList(PENDING_INDICES_FIELD.getPreferredName(), backingIndices.pendingIndices);
+        }
         builder.field(GENERATION_FIELD.getPreferredName(), generation);
         if (metadata != null) {
             builder.field(METADATA_FIELD.getPreferredName(), metadata);
@@ -1189,6 +1215,9 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             builder.field(FAILURE_STORE_FIELD.getPreferredName(), failureStoreEnabled);
             if (failureIndices.indices.isEmpty() == false) {
                 builder.xContentList(FAILURE_INDICES_FIELD.getPreferredName(), failureIndices.indices);
+            }
+            if (failureIndices.pendingIndices.isEmpty() == false) {
+                builder.xContentList(FAILURE_PENDING_INDICES_FIELD.getPreferredName(), failureIndices.pendingIndices);
             }
             builder.field(FAILURE_ROLLOVER_ON_WRITE_FIELD.getPreferredName(), failureIndices.rolloverOnWrite);
             if (failureIndices.autoShardingEvent != null) {
@@ -1406,12 +1435,14 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         @Nullable
         private final DataStreamAutoShardingEvent autoShardingEvent;
         private Set<String> lookup;
+        private final Set<Index> pendingIndices;
 
         protected DataStreamIndices(
             String namePrefix,
             List<Index> indices,
             boolean rolloverOnWrite,
-            DataStreamAutoShardingEvent autoShardingEvent
+            DataStreamAutoShardingEvent autoShardingEvent,
+            Set<Index> pendingIndices
         ) {
             this.namePrefix = namePrefix;
             // The list of indices is expected to be an immutable list. We don't create an immutable copy here, as it might have
@@ -1419,6 +1450,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             this.indices = indices;
             this.rolloverOnWrite = rolloverOnWrite;
             this.autoShardingEvent = autoShardingEvent;
+            this.pendingIndices = pendingIndices;
 
             assert getLookup().size() == indices.size() : "found duplicate index entries in " + indices;
         }
@@ -1431,6 +1463,14 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         }
 
         public Index getWriteIndex() {
+            if (pendingIndices.isEmpty() == false) {
+                for (int i = indices.size() - 1; i >= 0; i--) {
+                    Index candidate = indices.get(i);
+                    if (pendingIndices.contains(candidate) == false) {
+                        return candidate;
+                    }
+                }
+            }
             return indices.get(indices.size() - 1);
         }
 
@@ -1458,12 +1498,20 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             return indices;
         }
 
+        public List<Index> getSearchableIndices() {
+            return indices.stream().filter(index -> pendingIndices.contains(index) == false).toList();
+        }
+
         public boolean isRolloverOnWrite() {
             return rolloverOnWrite;
         }
 
         public DataStreamAutoShardingEvent getAutoShardingEvent() {
             return autoShardingEvent;
+        }
+
+        public Set<Index> getPendingIndices() {
+            return pendingIndices;
         }
 
         @Override
@@ -1474,12 +1522,13 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             return rolloverOnWrite == that.rolloverOnWrite
                 && Objects.equals(namePrefix, that.namePrefix)
                 && Objects.equals(indices, that.indices)
-                && Objects.equals(autoShardingEvent, that.autoShardingEvent);
+                && Objects.equals(autoShardingEvent, that.autoShardingEvent)
+                && Objects.equals(pendingIndices, that.pendingIndices);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(namePrefix, indices, rolloverOnWrite, autoShardingEvent);
+            return Objects.hash(namePrefix, indices, rolloverOnWrite, autoShardingEvent, pendingIndices);
         }
 
         public static class Builder {
@@ -1488,6 +1537,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             private boolean rolloverOnWrite = false;
             @Nullable
             private DataStreamAutoShardingEvent autoShardingEvent = null;
+            private Set<Index> pendingIndices = Set.of();
 
             private Builder(String namePrefix, List<Index> indices) {
                 this.namePrefix = namePrefix;
@@ -1499,6 +1549,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
                 this.indices = dataStreamIndices.indices;
                 this.rolloverOnWrite = dataStreamIndices.rolloverOnWrite;
                 this.autoShardingEvent = dataStreamIndices.autoShardingEvent;
+                this.pendingIndices = dataStreamIndices.pendingIndices;
             }
 
             /**
@@ -1506,6 +1557,14 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
              */
             public Builder setIndices(List<Index> indices) {
                 this.indices = List.copyOf(indices);
+                return this;
+            }
+
+            /**
+             * Set the list of pending indices. We always create an immutable copy as that's what the constructor expects.
+             */
+            public Builder setPendingIndices(Set<Index> pendingIndices) {
+                this.pendingIndices = Set.copyOf(pendingIndices);
                 return this;
             }
 
@@ -1520,7 +1579,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             }
 
             public DataStreamIndices build() {
-                return new DataStreamIndices(namePrefix, indices, rolloverOnWrite, autoShardingEvent);
+                return new DataStreamIndices(namePrefix, indices, rolloverOnWrite, autoShardingEvent, pendingIndices);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -347,10 +348,16 @@ public class MetadataCreateDataStreamService {
             indexMode,
             lifecycle == null && isDslOnlyMode ? DataStreamLifecycle.DEFAULT : lifecycle,
             template.getDataStreamTemplate().hasFailureStore(),
-            new DataStream.DataStreamIndices(DataStream.BACKING_INDEX_PREFIX, dsBackingIndices, false, null),
+            new DataStream.DataStreamIndices(DataStream.BACKING_INDEX_PREFIX, dsBackingIndices, false, null, Set.of()),
             // If the failure store shouldn't be initialized on data stream creation, we're marking it for "lazy rollover", which will
             // initialize the failure store on first write.
-            new DataStream.DataStreamIndices(DataStream.FAILURE_STORE_PREFIX, failureIndices, initializeFailureStore == false, null)
+            new DataStream.DataStreamIndices(
+                DataStream.FAILURE_STORE_PREFIX,
+                failureIndices,
+                initializeFailureStore == false,
+                null,
+                Set.of()
+            )
         );
         Metadata.Builder builder = Metadata.builder(currentState.metadata()).put(newDataStream);
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -99,7 +99,9 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         var autoShardingEvent = instance.getAutoShardingEvent();
         var failureRolloverOnWrite = instance.getFailureIndices().isRolloverOnWrite();
         var failureAutoShardingEvent = instance.getBackingIndices().getAutoShardingEvent();
-        switch (between(0, 14)) {
+        var backingPendingIndices = instance.getBackingIndices().getPendingIndices();
+        var failurePendingIndices = instance.getFailureIndices().getPendingIndices();
+        switch (between(0, 16)) {
             case 0 -> name = randomAlphaOfLength(10);
             case 1 -> indices = randomNonEmptyIndexInstances();
             case 2 -> generation = instance.getGeneration() + randomIntBetween(1, 10);
@@ -170,6 +172,18 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
                         randomMillisUpToYear9999()
                     );
             }
+            case 15 -> {
+                backingPendingIndices = randomValueOtherThan(
+                    backingPendingIndices,
+                    () -> new HashSet<>(randomSubsetOf(instance.getIndices()))
+                );
+            }
+            case 16 -> {
+                failurePendingIndices = randomValueOtherThan(
+                    failurePendingIndices,
+                    () -> new HashSet<>(randomSubsetOf(instance.getIndices()))
+                );
+            }
         }
 
         return new DataStream(
@@ -184,12 +198,19 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             indexMode,
             lifecycle,
             failureStore,
-            new DataStream.DataStreamIndices(DataStream.BACKING_INDEX_PREFIX, indices, rolloverOnWrite, autoShardingEvent),
+            new DataStream.DataStreamIndices(
+                DataStream.BACKING_INDEX_PREFIX,
+                indices,
+                rolloverOnWrite,
+                autoShardingEvent,
+                backingPendingIndices
+            ),
             new DataStream.DataStreamIndices(
                 DataStream.BACKING_INDEX_PREFIX,
                 failureIndices,
                 failureRolloverOnWrite,
-                failureAutoShardingEvent
+                failureAutoShardingEvent,
+                failurePendingIndices
             )
         );
     }


### PR DESCRIPTION
Alternative of https://github.com/elastic/elasticsearch/pull/111458. Here we keep the list of backing indices as is but we "mark" the pending ones in a set.