### PR TITLE
ESQL: Fix some test randomization

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -138,9 +138,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPSeriesWeightedSumTests
   method: testFold {TestCase=<double>, <double>}
   issue: https://github.com/elastic/elasticsearch/issues/111479
-- class: org.elasticsearch.xpack.esql.plan.logical.local.LocalRelationSerialiationTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/111480
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AbstractLogicalPlanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AbstractLogicalPlanSerializationTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
 import org.elasticsearch.xpack.esql.plan.AbstractNodeSerializationTests;
-import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelationSerialiationTests;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelationSerializationTests;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ public abstract class AbstractLogicalPlanSerializationTests<T extends LogicalPla
             return LookupSerializationTests.randomLookup(depth + 1);
         }
         // TODO more random options
-        return LocalRelationSerialiationTests.randomLocalRelation();
+        return LocalRelationSerializationTests.randomLocalRelation();
     }
 
     public static List<Attribute> randomFieldAttributes(int min, int max, boolean onlyRepresentable) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/LookupSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/LookupSerializationTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
-import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelationSerialiationTests;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelationSerializationTests;
 
 import java.io.IOException;
 import java.util.List;
@@ -23,7 +23,7 @@ public class LookupSerializationTests extends AbstractLogicalPlanSerializationTe
         LogicalPlan child = randomChild(depth);
         Expression tableName = AbstractExpressionSerializationTests.randomChild();
         List<Attribute> matchFields = randomFieldAttributes(1, 10, false);
-        LocalRelation localRelation = randomBoolean() ? null : LocalRelationSerialiationTests.randomLocalRelation();
+        LocalRelation localRelation = randomBoolean() ? null : LocalRelationSerializationTests.randomLocalRelation();
         return new Lookup(source, child, tableName, matchFields, localRelation);
     }
 
@@ -45,7 +45,7 @@ public class LookupSerializationTests extends AbstractLogicalPlanSerializationTe
             case 2 -> matchFields = randomValueOtherThan(matchFields, () -> randomFieldAttributes(1, 10, false));
             case 3 -> localRelation = randomValueOtherThan(
                 localRelation,
-                () -> randomBoolean() ? null : LocalRelationSerialiationTests.randomLocalRelation()
+                () -> randomBoolean() ? null : LocalRelationSerializationTests.randomLocalRelation()
             );
         }
         return new Lookup(source, child, tableName, matchFields, localRelation);


### PR DESCRIPTION
Fix a test that would sometimes get stuck in an infinite loop because it couldn't randomize some data. In some cases the configuration would lock it to never making changes. In that case, we have to randomize in a different way.

Closes #111480
