### PR TITLE
Add IT tests for CCS Usage telemetry

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -363,6 +363,9 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         String remoteIndex = (String) testClusterInfo.get("remote.index");
 
         SearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex);
+        // This works only with minimize_roundtrips enabled, since otherwise timed out shards will be counted as
+        // partial failure, and we disable partial results..
+        searchRequest.setCcsMinimizeRoundtrips(true);
 
         TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
         // query builder that will sleep for the specified amount of time in the query phase

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.WILDCARD_FEATURE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -133,6 +134,8 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         } else {
             assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(null));
         }
+        assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(null));
+
         var perCluster = telemetry.getByRemoteCluster();
         assertThat(perCluster.size(), equalTo(3));
         for (String clusterAlias : remoteClusterAlias()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.ccs;
+
+import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.usage.UsageService;
+import org.junit.Assert;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.WILDCARD_FEATURE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
+    private static final String REMOTE1 = "cluster-a";
+    private static final String REMOTE2 = "cluster-b";
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    @Override
+    protected Collection<String> remoteClusterAlias() {
+        return List.of(REMOTE1, REMOTE2);
+    }
+
+    @Override
+    protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
+        return Map.of(REMOTE1, true, REMOTE2, true);
+    }
+
+    private SearchRequest makeSearchRequest(String... indices) {
+        SearchRequest searchRequest = new SearchRequest(indices);
+        searchRequest.allowPartialSearchResults(false);
+        searchRequest.setBatchedReduceSize(randomIntBetween(3, 20));
+        searchRequest.setCcsMinimizeRoundtrips(randomBoolean());
+        if (randomBoolean()) {
+            searchRequest.setPreFilterShardSize(1);
+        }
+        searchRequest.source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).size(10));
+        return searchRequest;
+    }
+
+    /**
+     * Search on all remotes
+     */
+    public void testAllRemotesSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        boolean minimizeRoundtrips = searchRequest.isCcsMinimizeRoundtrips();
+
+        String randomClient = randomAlphaOfLength(10);
+        // We want to send search to a specific node (we don't care which one) so that we could
+        // collect the CCS telemetry from it later
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        // We don't care here too much about the response, we just want to trigger the telemetry collection.
+        // So we check it's not null and leave the rest to other tests.
+        assertResponse(
+            cluster(LOCAL_CLUSTER).client(nodeName)
+                .filterWithHeader(Map.of(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, randomClient))
+                .search(searchRequest),
+            Assert::assertNotNull
+        );
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(minimizeRoundtrips ? 1L : 0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 1L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getClientCounts().size(), equalTo(1));
+        assertThat(telemetry.getClientCounts().get(randomClient), equalTo(1L));
+        if (minimizeRoundtrips) {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(1L));
+        } else {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(null));
+        }
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String clusterAlias : remoteClusterAlias()) {
+            var clusterTelemetry = perCluster.get(clusterAlias);
+            assertThat(clusterTelemetry.getCount(), equalTo(1L));
+            assertThat(clusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(clusterTelemetry.getTook().count(), equalTo(1L));
+        }
+
+        // another search
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(2L));
+        assertThat(telemetry.getSuccessCount(), equalTo(2L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(2L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(minimizeRoundtrips ? 2L : 0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 2L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getClientCounts().size(), equalTo(1));
+        perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String clusterAlias : remoteClusterAlias()) {
+            var clusterTelemetry = perCluster.get(clusterAlias);
+            assertThat(clusterTelemetry.getCount(), equalTo(2L));
+            assertThat(clusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(clusterTelemetry.getTook().count(), equalTo(2L));
+        }
+    }
+
+    /**
+     * Search on a specific remote
+     */
+    public void testOneRemoteSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        // Make request to cluster a
+        SearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex);
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(2));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2), equalTo(null));
+
+        // Make request to cluster b
+        searchRequest = makeSearchRequest(localIndex, REMOTE2 + ":" + remoteIndex);
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(2L));
+        assertThat(telemetry.getSuccessCount(), equalTo(2L));
+        perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getTook().count(), equalTo(1L));
+    }
+
+    /**
+     * Local search should not produce any telemetry at all
+     */
+    public void testLocalSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex);
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(0L));
+    }
+
+    /**
+     * Count wildcard searches. Only wildcards in index names (not in cluster names) are counted.
+     */
+    public void testWildcardSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(null));
+
+        searchRequest = makeSearchRequest("*", REMOTE1 + ":" + remoteIndex);
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(2L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(1L));
+
+        searchRequest = makeSearchRequest(localIndex, REMOTE2 + ":*");
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(3L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(2L));
+
+        searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(4L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(2L));
+    }
+
+    // TODO: implement the following tests:
+    // - failed search
+    // - search with one remote skipped
+    // - search with a remote failing
+    // - async search
+    // - various search failure reasons
+
+    private CCSTelemetrySnapshot getTelemetrySnapshot(String nodeName) {
+        var usage = cluster(LOCAL_CLUSTER).getInstance(UsageService.class, nodeName);
+        return usage.getCcsUsageHolder().getCCSTelemetrySnapshot();
+    }
+
+    private Map<String, Object> setupClusters() {
+        String localIndex = "demo";
+        int numShardsLocal = randomIntBetween(2, 10);
+        Settings localSettings = indexSettings(numShardsLocal, randomIntBetween(0, 1)).build();
+        assertAcked(
+            client(LOCAL_CLUSTER).admin()
+                .indices()
+                .prepareCreate(localIndex)
+                .setSettings(localSettings)
+                .setMapping("@timestamp", "type=date", "f", "type=text")
+        );
+        indexDocs(client(LOCAL_CLUSTER), localIndex);
+
+        String remoteIndex = "prod";
+        int numShardsRemote = randomIntBetween(2, 10);
+        for (String clusterAlias : remoteClusterAlias()) {
+            final InternalTestCluster remoteCluster = cluster(clusterAlias);
+            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+            assertAcked(
+                client(clusterAlias).admin()
+                    .indices()
+                    .prepareCreate(remoteIndex)
+                    .setSettings(indexSettings(numShardsRemote, randomIntBetween(0, 1)))
+                    .setMapping("@timestamp", "type=date", "f", "type=text")
+            );
+            assertFalse(
+                client(clusterAlias).admin()
+                    .cluster()
+                    .prepareHealth(remoteIndex)
+                    .setWaitForYellowStatus()
+                    .setTimeout(TimeValue.timeValueSeconds(10))
+                    .get()
+                    .isTimedOut()
+            );
+            indexDocs(client(clusterAlias), remoteIndex);
+        }
+
+        Map<String, Object> clusterInfo = new HashMap<>();
+        clusterInfo.put("local.num_shards", numShardsLocal);
+        clusterInfo.put("local.index", localIndex);
+        clusterInfo.put("remote.num_shards", numShardsRemote);
+        clusterInfo.put("remote.index", remoteIndex);
+        clusterInfo.put("remote.skip_unavailable", true);
+        return clusterInfo;
+    }
+
+    private int indexDocs(Client client, String index) {
+        int numDocs = between(5, 20);
+        for (int i = 0; i < numDocs; i++) {
+            client.prepareIndex(index).setSource("f", "v", "@timestamp", randomNonNegativeLong()).get();
+        }
+        client.admin().indices().prepareRefresh(index).get();
+        return numDocs;
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -158,6 +158,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
         assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
         assertThat(telemetry.getClientCounts().size(), equalTo(1));
+        assertThat(telemetry.getClientCounts().get("kibana"), equalTo(1L));
         perCluster = telemetry.getByRemoteCluster();
         assertThat(perCluster.size(), equalTo(3));
         for (String clusterAlias : remoteClusterAlias()) {
@@ -186,6 +187,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
         assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
         assertThat(perCluster.get(REMOTE2), equalTo(null));
+        assertThat(telemetry.getClientCounts().size(), equalTo(0));
 
         // Make request to cluster b
         searchRequest = makeSearchRequest(localIndex, REMOTE2 + ":" + remoteIndex);
@@ -227,6 +229,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         assertThat(telemetry.getFailureReasons().size(), equalTo(0));
         assertThat(telemetry.getTook().count(), equalTo(1L));
         assertThat(perCluster.size(), equalTo(2));
+        assertThat(telemetry.getClientCounts().size(), equalTo(0));
         assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
         assertThat(perCluster.get(REMOTE1).getSkippedCount(), equalTo(0L));
         assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -413,7 +413,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         // partial failure, and we disable partial results..
         searchRequest.setCcsMinimizeRoundtrips(true);
 
-        TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
+        TimeValue searchTimeout = new TimeValue(200, TimeUnit.MILLISECONDS);
         // query builder that will sleep for the specified amount of time in the query phase
         SlowRunningQueryBuilder slowRunningQueryBuilder = new SlowRunningQueryBuilder(searchTimeout.millis() * 5, remoteIndex);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(slowRunningQueryBuilder).timeout(searchTimeout);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -171,7 +171,7 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
         return remotesPerSearchAvg;
     }
 
-    public long getSkippedRemotes() {
+    public long getSearchCountWithSkippedRemotes() {
         return skippedRemotes;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -78,7 +78,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         LongMetricValue took = instance.getTook();
         LongMetricValue tookMrtTrue = instance.getTookMrtTrue();
         LongMetricValue tookMrtFalse = instance.getTookMrtFalse();
-        long skippedRemotes = instance.getSkippedRemotes();
+        long skippedRemotes = instance.getSearchCountWithSkippedRemotes();
         long remotesPerSearchMax = instance.getRemotesPerSearchMax();
         double remotesPerSearchAvg = instance.getRemotesPerSearchAvg();
         var featureCounts = instance.getFeatureCounts();
@@ -184,7 +184,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         assertThat(empty.getTook().count(), equalTo(full.getTook().count() * 2));
         assertThat(empty.getTookMrtTrue().count(), equalTo(full.getTookMrtTrue().count() * 2));
         assertThat(empty.getTookMrtFalse().count(), equalTo(full.getTookMrtFalse().count() * 2));
-        assertThat(empty.getSkippedRemotes(), equalTo(full.getSkippedRemotes() * 2));
+        assertThat(empty.getSearchCountWithSkippedRemotes(), equalTo(full.getSearchCountWithSkippedRemotes() * 2));
         assertThat(empty.getRemotesPerSearchMax(), equalTo(full.getRemotesPerSearchMax()));
         assertThat(empty.getRemotesPerSearchAvg(), closeTo(full.getRemotesPerSearchAvg(), 0.01));
         empty.getFeatureCounts().forEach((k, v) -> assertThat(v, equalTo(full.getFeatureCounts().get(k) * 2)));
@@ -215,7 +215,10 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         assertThat(empty.getTook().count(), equalTo(full.getTook().count() + full2.getTook().count()));
         assertThat(empty.getTookMrtTrue().count(), equalTo(full.getTookMrtTrue().count() + full2.getTookMrtTrue().count()));
         assertThat(empty.getTookMrtFalse().count(), equalTo(full.getTookMrtFalse().count() + full2.getTookMrtFalse().count()));
-        assertThat(empty.getSkippedRemotes(), equalTo(full.getSkippedRemotes() + full2.getSkippedRemotes()));
+        assertThat(
+            empty.getSearchCountWithSkippedRemotes(),
+            equalTo(full.getSearchCountWithSkippedRemotes() + full2.getSearchCountWithSkippedRemotes())
+        );
         assertThat(empty.getRemotesPerSearchMax(), equalTo(Math.max(full.getRemotesPerSearchMax(), full2.getRemotesPerSearchMax())));
         double expectedAvg = (full.getRemotesPerSearchAvg() * full.getTotalCount() + full2.getRemotesPerSearchAvg() * full2.getTotalCount())
             / empty.getTotalCount();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -13,6 +13,9 @@ import org.elasticsearch.test.ESTestCase;
 
 import static org.elasticsearch.action.admin.cluster.stats.ApproximateMatcher.closeTo;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.KNOWN_CLIENTS;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result.CANCELED;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -45,10 +48,10 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             CCSUsage.Builder builder = new CCSUsage.Builder();
             builder.took(took1).setRemotesCount(1);
             if (async) {
-                builder.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+                builder.setFeature(ASYNC_FEATURE);
             }
             if (minimizeRoundTrips) {
-                builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+                builder.setFeature(MRT_FEATURE);
             }
             if (skippedRemote) {
                 builder.skippedRemote("remote1");
@@ -63,8 +66,8 @@ public class CCSUsageTelemetryTests extends ESTestCase {
 
             assertThat(snapshot.getTotalCount(), equalTo(1L));
             assertThat(snapshot.getSuccessCount(), equalTo(1L));
-            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
-            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
             assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             // Expect it to be within 1% of the actual value
@@ -124,10 +127,10 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             CCSUsage.Builder builder = new CCSUsage.Builder();
             builder.took(took2).setRemotesCount(1).setClient("kibana");
             if (async) {
-                builder.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+                builder.setFeature(ASYNC_FEATURE);
             }
             if (minimizeRoundTrips) {
-                builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+                builder.setFeature(MRT_FEATURE);
             }
             if (skippedRemote) {
                 builder.skippedRemote("remote1");
@@ -141,8 +144,8 @@ public class CCSUsageTelemetryTests extends ESTestCase {
 
             assertThat(snapshot.getTotalCount(), equalTo(2L));
             assertThat(snapshot.getSuccessCount(), equalTo(2L));
-            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
-            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
             assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             assertThat(snapshot.getTook().avg(), closeTo((took1 + took2) / 2));
@@ -173,8 +176,6 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             // assertThat(remote1ClusterTelemetry.getTook().max(), greaterThanOrEqualTo(Math.max(took1Remote1, took2Remote1)));
         }
     }
-
-    // TODO: add tests for failure scenarios
 
     public void testClientsLimit() {
         CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
@@ -208,5 +209,69 @@ public class CCSUsageTelemetryTests extends ESTestCase {
         ccsUsageHolder.updateUsage(ccsUsage);
         counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
         assertThat(counts.get(randomClient), equalTo(null));
+    }
+
+    public void testFailures() {
+        CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
+
+        // first search
+        {
+            boolean skippedRemote = randomBoolean();
+            boolean minimizeRoundTrips = randomBoolean();
+            boolean async = randomBoolean();
+
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.setRemotesCount(1).took(10L);
+            if (skippedRemote) {
+                builder.skippedRemote("remote1");
+            }
+            builder.perClusterUsage("(local)", new TimeValue(1));
+            builder.perClusterUsage("remote1", new TimeValue(2));
+            builder.setFailure(CANCELED);
+            if (async) {
+                builder.setFeature(ASYNC_FEATURE);
+            }
+            if (minimizeRoundTrips) {
+                builder.setFeature(MRT_FEATURE);
+            }
+
+            CCSUsage ccsUsage = builder.build();
+            ccsUsageHolder.updateUsage(ccsUsage);
+
+            CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+
+            assertThat(snapshot.getTotalCount(), equalTo(1L));
+            assertThat(snapshot.getSuccessCount(), equalTo(0L));
+            assertThat(snapshot.getSkippedRemotes(), equalTo(skippedRemote ? 1L : 0L));
+            assertThat(snapshot.getTook().count(), equalTo(0L));
+            assertThat(snapshot.getFailureReasons().size(), equalTo(1));
+            assertThat(snapshot.getFailureReasons().get(CANCELED.getName()), equalTo(1L));
+            // still counting features on failure
+            assertThat(snapshot.getFeatureCounts().getOrDefault(ASYNC_FEATURE, 0L), equalTo(async ? 1L : 0L));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(MRT_FEATURE, 0L), equalTo(minimizeRoundTrips ? 1L : 0L));
+        }
+
+        // second search
+        {
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            boolean skippedRemote = randomBoolean();
+            builder.setRemotesCount(1).took(10L).setClient("kibana");
+            if (skippedRemote) {
+                builder.skippedRemote("remote1");
+            }
+            builder.setFailure(CANCELED);
+            CCSUsage ccsUsage = builder.build();
+
+            ccsUsageHolder.updateUsage(ccsUsage);
+
+            CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+
+            assertThat(snapshot.getTotalCount(), equalTo(2L));
+            assertThat(snapshot.getSuccessCount(), equalTo(0L));
+            assertThat(snapshot.getTook().count(), equalTo(0L));
+            assertThat(snapshot.getFailureReasons().size(), equalTo(1));
+            assertThat(snapshot.getFailureReasons().get(CANCELED.getName()), equalTo(2L));
+            assertThat(snapshot.getClientCounts().get("kibana"), equalTo(1L));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -68,7 +68,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getSuccessCount(), equalTo(1L));
             assertThat(snapshot.getFeatureCounts().getOrDefault(ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
             assertThat(snapshot.getFeatureCounts().getOrDefault(MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
-            assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(snapshot.getSearchCountWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             // Expect it to be within 1% of the actual value
             assertThat(snapshot.getTook().avg(), closeTo(took1));
@@ -146,7 +146,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getSuccessCount(), equalTo(2L));
             assertThat(snapshot.getFeatureCounts().getOrDefault(ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
             assertThat(snapshot.getFeatureCounts().getOrDefault(MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
-            assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(snapshot.getSearchCountWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             assertThat(snapshot.getTook().avg(), closeTo((took1 + took2) / 2));
             // assertThat(snapshot.getTook().max(), greaterThanOrEqualTo(Math.max(took1, took2)));
@@ -242,7 +242,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
 
             assertThat(snapshot.getTotalCount(), equalTo(1L));
             assertThat(snapshot.getSuccessCount(), equalTo(0L));
-            assertThat(snapshot.getSkippedRemotes(), equalTo(skippedRemote ? 1L : 0L));
+            assertThat(snapshot.getSearchCountWithSkippedRemotes(), equalTo(skippedRemote ? 1L : 0L));
             assertThat(snapshot.getTook().count(), equalTo(0L));
             assertThat(snapshot.getFailureReasons().size(), equalTo(1));
             assertThat(snapshot.getFailureReasons().get(CANCELED.getName()), equalTo(1L));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -12,8 +12,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.elasticsearch.action.admin.cluster.stats.ApproximateMatcher.closeTo;
-import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.KNOWN_CLIENTS;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.KNOWN_CLIENTS;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result.CANCELED;
 import static org.hamcrest.Matchers.equalTo;

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryAsyncSearchIT.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
+public class CCSUsageTelemetryAsyncSearchIT extends AbstractMultiClustersTestCase {
     private static final String REMOTE1 = "cluster-a";
     private static final String REMOTE2 = "cluster-b";
 
@@ -181,7 +181,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         String remoteIndex = (String) testClusterInfo.get("remote.index");
 
         SubmitAsyncSearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
-        boolean minimizeRoundtrips = searchRequest.isCcsMinimizeRoundtrips();
+        boolean minimizeRoundtrips = TransportSearchAction.shouldMinimizeRoundtrips(searchRequest.getSearchRequest());
         CrossClusterAsyncSearchIT.SearchListenerPlugin.negate();
 
         CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(searchRequest);
@@ -194,7 +194,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 1L));
         assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
         assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
-        assertThat(telemetry.getSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
         assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(1L));
         if (minimizeRoundtrips) {
             assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(1L));

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryIT.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot;
+import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
+import org.elasticsearch.xpack.async.AsyncResultsIndexPlugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result.CANCELED;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
+    private static final String REMOTE1 = "cluster-a";
+    private static final String REMOTE2 = "cluster-b";
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    @Override
+    protected Collection<String> remoteClusterAlias() {
+        return List.of(REMOTE1, REMOTE2);
+    }
+
+    @Override
+    protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
+        return Map.of(REMOTE1, true, REMOTE2, true);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        List<Class<? extends Plugin>> plugs = Arrays.asList(
+            CrossClusterAsyncSearchIT.SearchListenerPlugin.class,
+            AsyncSearch.class,
+            AsyncResultsIndexPlugin.class,
+            LocalStateCompositeXPackPlugin.class,
+            CrossClusterAsyncSearchIT.TestQueryBuilderPlugin.class
+        );
+        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+    }
+
+    @Before
+    public void resetSearchListenerPlugin() {
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.reset();
+    }
+
+    private SubmitAsyncSearchRequest makeSearchRequest(String... indices) {
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.blockQueryPhase();
+
+        SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(indices);
+        request.setCcsMinimizeRoundtrips(randomBoolean());
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1));
+        request.setKeepOnCompletion(true);
+        request.getSearchRequest().allowPartialSearchResults(false);
+        request.getSearchRequest().source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).size(10));
+        if (randomBoolean()) {
+            request.setBatchedReduceSize(randomIntBetween(2, 256));
+        }
+
+        return request;
+    }
+
+    /**
+    * Run async search request and get telemetry from it
+    */
+    private CCSTelemetrySnapshot getTelemetryFromSearch(SubmitAsyncSearchRequest searchRequest) throws Exception {
+        // We want to send search to a specific node (we don't care which one) so that we could
+        // collect the CCS telemetry from it later
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        final AsyncSearchResponse response = cluster(LOCAL_CLUSTER).client(nodeName)
+            .execute(SubmitAsyncSearchAction.INSTANCE, searchRequest)
+            .get();
+        // We don't care here too much about the response, we just want to trigger the telemetry collection.
+        // So we check it's not null and leave the rest to other tests.
+        final String responseId;
+        try {
+            assertNotNull(response.getSearchResponse());
+            responseId = response.getId();
+        } finally {
+            response.decRef();
+        }
+        waitForSearchTasksToFinish();
+        final AsyncSearchResponse finishedResponse = cluster(LOCAL_CLUSTER).client(nodeName)
+            .execute(GetAsyncSearchAction.INSTANCE, new GetAsyncResultRequest(responseId))
+            .get();
+        try {
+            assertNotNull(finishedResponse.getSearchResponse());
+        } finally {
+            finishedResponse.decRef();
+        }
+        return getTelemetrySnapshot(nodeName);
+
+    }
+
+    private void waitForSearchTasksToFinish() throws Exception {
+        assertBusy(() -> {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(TransportSearchAction.TYPE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(0));
+
+            for (String clusterAlias : remoteClusterAlias()) {
+                ListTasksResponse remoteTasksResponse = client(clusterAlias).admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .setActions(TransportSearchAction.TYPE.name())
+                    .get();
+                List<TaskInfo> remoteTasks = remoteTasksResponse.getTasks();
+                assertThat(remoteTasks.size(), equalTo(0));
+            }
+        });
+
+        assertBusy(() -> {
+            for (String clusterAlias : remoteClusterAlias()) {
+                final Iterable<TransportService> transportServices = cluster(clusterAlias).getInstances(TransportService.class);
+                for (TransportService transportService : transportServices) {
+                    assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
+                }
+            }
+        });
+    }
+
+    /**
+     * Create search request for indices and get telemetry from it
+     */
+    private CCSTelemetrySnapshot getTelemetryFromSearch(String... indices) throws Exception {
+        return getTelemetryFromSearch(makeSearchRequest(indices));
+    }
+
+    /**
+     * Async search on all remotes
+     */
+    public void testAllRemotesSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SubmitAsyncSearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        boolean minimizeRoundtrips = searchRequest.isCcsMinimizeRoundtrips();
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.negate();
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(searchRequest);
+
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(minimizeRoundtrips ? 1L : 0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 1L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(1L));
+        if (minimizeRoundtrips) {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(1L));
+        } else {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(null));
+        }
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String clusterAlias : remoteClusterAlias()) {
+            var clusterTelemetry = perCluster.get(clusterAlias);
+            assertThat(clusterTelemetry.getCount(), equalTo(1L));
+            assertThat(clusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(clusterTelemetry.getTook().count(), equalTo(1L));
+        }
+    }
+
+    /**
+     * Search that is cancelled
+     */
+    public void testCancelledSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SubmitAsyncSearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex);
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.blockQueryPhase();
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        final AsyncSearchResponse response = cluster(LOCAL_CLUSTER).client(nodeName)
+            .execute(SubmitAsyncSearchAction.INSTANCE, searchRequest)
+            .get();
+        try {
+            assertNotNull(response.getSearchResponse());
+        } finally {
+            response.decRef();
+            assertTrue(response.isRunning());
+        }
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.waitSearchStarted();
+
+        ActionFuture<ListTasksResponse> cancelFuture;
+        try {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(TransportSearchAction.TYPE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(1));
+            final TaskInfo rootTask = tasks.get(0);
+
+            AtomicReference<List<TaskInfo>> remoteClusterSearchTasks = new AtomicReference<>();
+            assertBusy(() -> {
+                List<TaskInfo> remoteSearchTasks = client(REMOTE1).admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .get()
+                    .getTasks()
+                    .stream()
+                    .filter(t -> t.action().contains(TransportSearchAction.TYPE.name()))
+                    .collect(Collectors.toList());
+                assertThat(remoteSearchTasks.size(), greaterThan(0));
+                remoteClusterSearchTasks.set(remoteSearchTasks);
+            });
+
+            for (TaskInfo taskInfo : remoteClusterSearchTasks.get()) {
+                assertFalse("taskInfo on remote cluster should not be cancelled yet: " + taskInfo, taskInfo.cancelled());
+            }
+
+            final CancelTasksRequest cancelRequest = new CancelTasksRequest().setTargetTaskId(rootTask.taskId());
+            cancelRequest.setWaitForCompletion(randomBoolean());
+            cancelFuture = client().admin().cluster().cancelTasks(cancelRequest);
+            assertBusy(() -> {
+                final Iterable<TransportService> transportServices = cluster(REMOTE1).getInstances(TransportService.class);
+                for (TransportService transportService : transportServices) {
+                    Collection<CancellableTask> cancellableTasks = transportService.getTaskManager().getCancellableTasks().values();
+                    for (CancellableTask cancellableTask : cancellableTasks) {
+                        if (cancellableTask.getAction().contains(TransportSearchAction.TYPE.name())) {
+                            assertTrue(cancellableTask.getDescription(), cancellableTask.isCancelled());
+                        }
+                    }
+                }
+            });
+
+            List<TaskInfo> remoteSearchTasksAfterCancellation = client(REMOTE1).admin()
+                .cluster()
+                .prepareListTasks()
+                .get()
+                .getTasks()
+                .stream()
+                .filter(t -> t.action().contains(TransportSearchAction.TYPE.name()))
+                .toList();
+            for (TaskInfo taskInfo : remoteSearchTasksAfterCancellation) {
+                assertTrue(taskInfo.description(), taskInfo.cancelled());
+            }
+        } finally {
+            CrossClusterAsyncSearchIT.SearchListenerPlugin.allowQueryPhase();
+        }
+
+        assertBusy(() -> assertTrue(cancelFuture.isDone()));
+        waitForSearchTasksToFinish();
+
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(0L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(1));
+        assertThat(telemetry.getFailureReasons().get(CANCELED.getName()), equalTo(1L));
+        assertThat(telemetry.getTook().count(), equalTo(0L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(1.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(1L));
+        // Still counts as async search
+        assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(1L));
+    }
+
+    private CCSTelemetrySnapshot getTelemetrySnapshot(String nodeName) {
+        var usage = cluster(LOCAL_CLUSTER).getInstance(UsageService.class, nodeName);
+        return usage.getCcsUsageHolder().getCCSTelemetrySnapshot();
+    }
+
+    private Map<String, Object> setupClusters() {
+        String localIndex = "demo";
+        int numShardsLocal = randomIntBetween(2, 10);
+        Settings localSettings = indexSettings(numShardsLocal, randomIntBetween(0, 1)).build();
+        assertAcked(
+            client(LOCAL_CLUSTER).admin()
+                .indices()
+                .prepareCreate(localIndex)
+                .setSettings(localSettings)
+                .setMapping("@timestamp", "type=date", "f", "type=text")
+        );
+        indexDocs(client(LOCAL_CLUSTER), localIndex);
+
+        String remoteIndex = "prod";
+        int numShardsRemote = randomIntBetween(2, 10);
+        for (String clusterAlias : remoteClusterAlias()) {
+            final InternalTestCluster remoteCluster = cluster(clusterAlias);
+            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+            assertAcked(
+                client(clusterAlias).admin()
+                    .indices()
+                    .prepareCreate(remoteIndex)
+                    .setSettings(indexSettings(numShardsRemote, randomIntBetween(0, 1)))
+                    .setMapping("@timestamp", "type=date", "f", "type=text")
+            );
+            assertFalse(
+                client(clusterAlias).admin()
+                    .cluster()
+                    .prepareHealth(remoteIndex)
+                    .setWaitForYellowStatus()
+                    .setTimeout(TimeValue.timeValueSeconds(10))
+                    .get()
+                    .isTimedOut()
+            );
+            indexDocs(client(clusterAlias), remoteIndex);
+        }
+
+        Map<String, Object> clusterInfo = new HashMap<>();
+        clusterInfo.put("local.num_shards", numShardsLocal);
+        clusterInfo.put("local.index", localIndex);
+        clusterInfo.put("remote.num_shards", numShardsRemote);
+        clusterInfo.put("remote.index", remoteIndex);
+        clusterInfo.put("remote.skip_unavailable", true);
+        return clusterInfo;
+    }
+
+    private int indexDocs(Client client, String index) {
+        int numDocs = between(5, 20);
+        for (int i = 0; i < numDocs; i++) {
+            client.prepareIndex(index).setSource("f", "v", "@timestamp", randomNonNegativeLong()).get();
+        }
+        client.admin().indices().prepareRefresh(index).get();
+        return numDocs;
+    }
+}


### PR DESCRIPTION
IT tests for CCS usage telemetry, for sync & async search.

Also adds failure unit tests. 

Not all types of search failures are covered, this is the next step together with better failure indentification. 