### PR TITLE
Limit number of unknown clients accepted by CCS telemetry

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -77,11 +77,6 @@ public class CCSUsageTelemetry {
         "connectors-cli"
     );
 
-    /**
-     * Maximum number of clients to keep in the telemetry. The clients from KNOWN_CLIENTS are always kept.
-     */
-    public static final int MAX_CLIENTS = 20;
-
     // TODO: do we need LongAdder here or long is enough? Since updateUsage is synchronized, worst that can happen is
     // we may miss a count on read.
     private final LongAdder totalCount;
@@ -152,11 +147,9 @@ public class CCSUsageTelemetry {
         }
         ccsUsage.getFeatures().forEach(f -> featureCounts.computeIfAbsent(f, k -> new LongAdder()).increment());
         String client = ccsUsage.getClient();
-        if (client != null) {
-            // We only keep limited number of unknown clients to prevent memory exhaustion
-            if (KNOWN_CLIENTS.contains(client) || clientCounts.containsKey(client) || clientCounts.size() < MAX_CLIENTS) {
-                clientCounts.computeIfAbsent(ccsUsage.getClient(), k -> new LongAdder()).increment();
-            } // else we ignore the client
+        if (client != null && KNOWN_CLIENTS.contains(client)) {
+            // We count only known clients for now
+            clientCounts.computeIfAbsent(ccsUsage.getClient(), k -> new LongAdder()).increment();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import static org.elasticsearch.action.admin.cluster.stats.ApproximateMatcher.closeTo;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.KNOWN_CLIENTS;
-import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MAX_CLIENTS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -178,16 +177,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
     // TODO: add tests for failure scenarios
 
     public void testClientsLimit() {
-        // Accept only MAX_CLIENTS clients
         CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
-        int howMany = randomIntBetween(MAX_CLIENTS, MAX_CLIENTS * 2);
-        for (int i = 0; i < howMany; i++) {
-            CCSUsage.Builder builder = new CCSUsage.Builder();
-            builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient("client" + i);
-            CCSUsage ccsUsage = builder.build();
-            ccsUsageHolder.updateUsage(ccsUsage);
-        }
-        assertThat(ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts().size(), equalTo(MAX_CLIENTS));
         // Add known clients
         for (String knownClient : KNOWN_CLIENTS) {
             CCSUsage.Builder builder = new CCSUsage.Builder();
@@ -198,17 +188,6 @@ public class CCSUsageTelemetryTests extends ESTestCase {
         var counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
         for (String knownClient : KNOWN_CLIENTS) {
             assertThat(counts.get(knownClient), equalTo(1L));
-        }
-        // Check that existing clients are counted
-        for (int i = 0; i < MAX_CLIENTS; i++) {
-            CCSUsage.Builder builder = new CCSUsage.Builder();
-            builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient("client" + i);
-            CCSUsage ccsUsage = builder.build();
-            ccsUsageHolder.updateUsage(ccsUsage);
-        }
-        counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
-        for (int i = 0; i < MAX_CLIENTS; i++) {
-            assertThat(counts.get("client" + i), equalTo(2L));
         }
         // Check that knowns are counted
         for (String knownClient : KNOWN_CLIENTS) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -12,6 +12,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.elasticsearch.action.admin.cluster.stats.ApproximateMatcher.closeTo;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.KNOWN_CLIENTS;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MAX_CLIENTS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -171,5 +173,61 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(remote1ClusterTelemetry.getTook().avg(), closeTo((took1Remote1 + took2Remote1) / 2));
             // assertThat(remote1ClusterTelemetry.getTook().max(), greaterThanOrEqualTo(Math.max(took1Remote1, took2Remote1)));
         }
+    }
+
+    // TODO: add tests for failure scenarios
+
+    public void testClientsLimit() {
+        // Accept only MAX_CLIENTS clients
+        CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
+        int howMany = randomIntBetween(MAX_CLIENTS, MAX_CLIENTS * 2);
+        for (int i = 0; i < howMany; i++) {
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient("client" + i);
+            CCSUsage ccsUsage = builder.build();
+            ccsUsageHolder.updateUsage(ccsUsage);
+        }
+        assertThat(ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts().size(), equalTo(MAX_CLIENTS));
+        // Add known clients
+        for (String knownClient : KNOWN_CLIENTS) {
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient(knownClient);
+            CCSUsage ccsUsage = builder.build();
+            ccsUsageHolder.updateUsage(ccsUsage);
+        }
+        var counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
+        for (String knownClient : KNOWN_CLIENTS) {
+            assertThat(counts.get(knownClient), equalTo(1L));
+        }
+        // Check that existing clients are counted
+        for (int i = 0; i < MAX_CLIENTS; i++) {
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient("client" + i);
+            CCSUsage ccsUsage = builder.build();
+            ccsUsageHolder.updateUsage(ccsUsage);
+        }
+        counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
+        for (int i = 0; i < MAX_CLIENTS; i++) {
+            assertThat(counts.get("client" + i), equalTo(2L));
+        }
+        // Check that knowns are counted
+        for (String knownClient : KNOWN_CLIENTS) {
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient(knownClient);
+            CCSUsage ccsUsage = builder.build();
+            ccsUsageHolder.updateUsage(ccsUsage);
+        }
+        counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
+        for (String knownClient : KNOWN_CLIENTS) {
+            assertThat(counts.get(knownClient), equalTo(2L));
+        }
+        // Check that new clients are not counted
+        CCSUsage.Builder builder = new CCSUsage.Builder();
+        String randomClient = randomAlphaOfLength(10);
+        builder.took(randomLongBetween(5, 10000)).setRemotesCount(1).setClient(randomClient);
+        CCSUsage ccsUsage = builder.build();
+        ccsUsageHolder.updateUsage(ccsUsage);
+        counts = ccsUsageHolder.getCCSTelemetrySnapshot().getClientCounts();
+        assertThat(counts.get(randomClient), equalTo(null));
     }
 }


### PR DESCRIPTION
Limit number of unknown clients accepted by CCS telemetry so that we don't get infinite memory requirements, since client name comes from the user-controlled header. 