### PR TITLE
Expose shard field stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -4080,7 +4080,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         @Override
         public void afterRefresh(boolean didRefresh) {
             if (shardFieldStats == null || didRefresh) {
-                try (var searcher = getEngine().acquireSearcher("shard_field_stats", Engine.SearcherScope.INTERNAL, Function.identity())) {
+                try (var searcher = getEngine().acquireSearcher("shard_field_stats", Engine.SearcherScope.INTERNAL)) {
                     int numSegments = 0;
                     int totalFields = 0;
                     for (LeafReaderContext leaf : searcher.getLeafContexts()) {

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.shard;
+
+/**
+ * A per shard stats including the number of segments and total fields across those segments.
+ * These stats should be recomputed whenever the shard is refreshed.
+ *
+ * @param numSegments the number of segments
+ * @param totalFields the total number of fields across the segments
+ */
+public record ShardFieldStats(int numSegments, int totalFields) {
+
+}


### PR DESCRIPTION
Previously, we returned the number of segments and the total number of fields in those segments in NodeMappingStats (see #111123). However, the total number of fields returned in that PR might be very inaccurate for indices having large mappings but only a small number of actual fields.

This change returns a more accurate total number of fields using the Lucene FieldInfos from those segments. Since we need to acquire a searcher to compute this stats, we opt to compute it after a shard is refreshed and cache the result.

I will try to revert the change introduced in #111123.

Relates #111123