### PR TITLE
Check the scale before converting xcontent long values, rather than the absolute value

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
@@ -151,11 +151,8 @@ public abstract class AbstractXContentParser implements XContentParser {
 
     protected abstract int doIntValue() throws IOException;
 
-    private static BigInteger LONG_MAX_VALUE_AS_BIGINTEGER = BigInteger.valueOf(Long.MAX_VALUE);
-    private static BigInteger LONG_MIN_VALUE_AS_BIGINTEGER = BigInteger.valueOf(Long.MIN_VALUE);
-    // weak bounds on the BigDecimal representation to allow for coercion
-    private static BigDecimal BIGDECIMAL_GREATER_THAN_LONG_MAX_VALUE = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
-    private static BigDecimal BIGDECIMAL_LESS_THAN_LONG_MIN_VALUE = BigDecimal.valueOf(Long.MIN_VALUE).subtract(BigDecimal.ONE);
+    private static final BigInteger LONG_MAX_VALUE_AS_BIGINTEGER = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger LONG_MIN_VALUE_AS_BIGINTEGER = BigInteger.valueOf(Long.MIN_VALUE);
 
     /** Return the long that {@code stringValue} stores or throws an exception if the
      *  stored value cannot be converted to a long that stores the exact same
@@ -170,8 +167,8 @@ public abstract class AbstractXContentParser implements XContentParser {
         final BigInteger bigIntegerValue;
         try {
             final BigDecimal bigDecimalValue = new BigDecimal(stringValue);
-            if (bigDecimalValue.compareTo(BIGDECIMAL_GREATER_THAN_LONG_MAX_VALUE) >= 0
-                || bigDecimalValue.compareTo(BIGDECIMAL_LESS_THAN_LONG_MIN_VALUE) <= 0) {
+            // long can have a maximum of 19 digits - any more than that cannot be a long
+            if (Math.abs(bigDecimalValue.scale()) > 19) {
                 throw new IllegalArgumentException("Value [" + stringValue + "] is out of range for a long");
             }
             bigIntegerValue = coerce ? bigDecimalValue.toBigInteger() : bigDecimalValue.toBigIntegerExact();

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -78,17 +78,12 @@ public class XContentParserTests extends ESTestCase {
     public void testLongCoercion() throws IOException {
         XContentType xContentType = randomFrom(XContentType.values());
 
-        String longValue1 = "5.5";
-        String longValue2 = "5e18";
-        String longValue3 = "2e100";
-        String longValue4 = "2e-100";
-
         try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
             builder.startObject();
-            builder.field("decimal", longValue1);
-            builder.field("expInRange", longValue2);
-            builder.field("expTooBig", longValue3);
-            builder.field("expTooSmall", longValue4);
+            builder.field("decimal", "5.5");
+            builder.field("expInRange", "5e18");
+            builder.field("expTooBig", "2e100");
+            builder.field("expTooSmall", "2e-100");
             builder.endObject();
 
             try (XContentParser parser = createParser(xContentType.xContent(), BytesReference.bytes(builder))) {

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/XContentParserTests.java
@@ -109,10 +109,11 @@ public class XContentParserTests extends ESTestCase {
                 assertThat(parser.nextToken(), is(XContentParser.Token.VALUE_STRING));
                 expectThrows(IllegalArgumentException.class, parser::longValue);
 
+                // too small goes to zero
                 assertThat(parser.nextToken(), is(XContentParser.Token.FIELD_NAME));
                 assertThat(parser.currentName(), is("expTooSmall"));
                 assertThat(parser.nextToken(), is(XContentParser.Token.VALUE_STRING));
-                expectThrows(IllegalArgumentException.class, parser::longValue);
+                assertThat(parser.longValue(), equalTo(0L));
             }
         }
     }


### PR DESCRIPTION
Check the BigDecimal scale before trying to convert to a long - this is a faster check than converting to BigInteger and checking the resulting value