### PR TITLE
Fix SearchServiceTests not waiting for scroll clear

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -1548,7 +1548,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
 
         ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
         clearScrollRequest.setScrollIds(clearScrollIds);
-        client().clearScroll(clearScrollRequest);
+        client().clearScroll(clearScrollRequest).get();
 
         for (int i = 0; i < clearScrollIds.size(); i++) {
             client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)).get().decRef();


### PR DESCRIPTION
We were not waiting on the response here but assume the scrolls are cleared in the following lines. This worked as long as the transport action wasn't forking but is broken now that we fork to generic. Fixed by just waiting.

closes #111529
