### PR TITLE
Json parsing exceptions should not cause 500 errors

### DIFF
--- a/docs/changelog/111548.yaml
+++ b/docs/changelog/111548.yaml
@@ -1,0 +1,6 @@
+pr: 111548
+summary: Json parsing exceptions should not cause 500 errors
+area: "Infra/Core, Search"
+type: bug
+issues:
+ - 111542

--- a/docs/changelog/111548.yaml
+++ b/docs/changelog/111548.yaml
@@ -1,6 +1,6 @@
 pr: 111548
 summary: Json parsing exceptions should not cause 500 errors
-area: "Infra/Core, Search"
+area: Infra/Core
 type: bug
 issues:
  - 111542

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -57,7 +57,8 @@ public class JsonXContentParser extends AbstractXContentParser {
         try {
             return convertToken(parser.nextToken());
         } catch (JsonEOFException e) {
-            throw new XContentEOFException(e);
+            JsonLocation location = e.getLocation();
+            throw new XContentEOFException(new XContentLocation(location.getLineNr(), location.getColumnNr()), "Unexpected end of file", e);
         } catch (JsonParseException e) {
             throw newXContentParseException(e);
         }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
@@ -7,7 +7,6 @@
  */
 
 package org.elasticsearch.xcontent;
-
 public class XContentEOFException extends XContentParseException {
 
     public XContentEOFException(XContentLocation location, String message, Exception cause) {

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.xcontent;
 
-import java.io.IOException;
-
 public class XContentEOFException extends XContentParseException {
 
     public XContentEOFException(XContentLocation location, String message, Exception cause) {

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
@@ -7,6 +7,7 @@
  */
 
 package org.elasticsearch.xcontent;
+
 public class XContentEOFException extends XContentParseException {
 
     public XContentEOFException(XContentLocation location, String message, Exception cause) {

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentEOFException.java
@@ -10,9 +10,9 @@ package org.elasticsearch.xcontent;
 
 import java.io.IOException;
 
-public class XContentEOFException extends IOException {
+public class XContentEOFException extends XContentParseException {
 
-    public XContentEOFException(IOException cause) {
-        super(cause);
+    public XContentEOFException(XContentLocation location, String message, Exception cause) {
+        super(location, message, cause);
     }
 }

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
@@ -114,7 +114,7 @@ setup:
 
   - match:  { responses.0.hits.total:     2  }
   - match:  { responses.1.error.root_cause.0.type: x_content_e_o_f_exception }
-  - match:  { responses.1.error.root_cause.0.reason: "/Unexpected.end.of.input/" }
+  - match:  { responses.1.error.root_cause.0.reason: "/\\[1:22\\].Unexpected.end.of.file/" }
   - match:  { responses.2.hits.total:     1  }
   - match:  { responses.3.error.root_cause.0.type: parsing_exception }
   - match:  { responses.3.error.root_cause.0.reason: "/unknown.query.\\[unknown\\]/" }

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/50_multi_search_template.yml
@@ -121,7 +121,7 @@ setup:
   - match:  { responses.4.error.root_cause.0.type: illegal_argument_exception }
   - match:  { responses.4.error.root_cause.0.reason: "[rest_total_hits_as_int] cannot be used if the tracking of total hits is not accurate, got 1" }
   - match:  { responses.0.status: 200 }
-  - match:  { responses.1.status: 500 }
+  - match:  { responses.1.status: 400 }
   - match:  { responses.2.status: 200 }
   - match:  { responses.3.status: 400 }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/XContentUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/XContentUtilsTests.java
@@ -103,8 +103,7 @@ public class XContentUtilsTests extends ESTestCase {
                 XContentEOFException.class,
                 () -> XContentUtils.positionParserAtTokenAfterField(parser, missingField, errorFormat)
             );
-
-            assertThat(exception.getMessage(), containsString("Unexpected end-of-input"));
+            assertThat(exception.getMessage(), containsString("[4:1] Unexpected end of file"));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
@@ -309,8 +309,8 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
-
-        assertThat(thrownException.getMessage(), containsString("expected close marker for Array (start marker at"));
+        assertThat(thrownException.getMessage(), containsString("[5:1] Unexpected end of file"));
+        assertThat(thrownException.getCause().getMessage(), containsString("expected close marker for Array (start marker at"));
     }
 
     public void testFails_ResponseIsInvalidJson_MissingField() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/XContentRecordReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/XContentRecordReader.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.job.process.autodetect.writer;
 
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.xcontent.XContentEOFException;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/XContentRecordReader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/XContentRecordReader.java
@@ -196,7 +196,7 @@ class XContentRecordReader {
     protected XContentParser.Token tryNextTokenOrReadToEndOnError() throws IOException {
         try {
             return parser.nextToken();
-        } catch (XContentEOFException | XContentParseException e) {
+        } catch (XContentParseException e) {
             logger.warn("Attempting to recover from malformed JSON data.", e);
             for (int i = 0; i <= nestedLevel; ++i) {
                 readToEndOfObject();
@@ -217,7 +217,7 @@ class XContentRecordReader {
         do {
             try {
                 token = parser.nextToken();
-            } catch (XContentEOFException | XContentParseException e) {
+            } catch (XContentParseException e) {
                 ++errorCounter;
                 if (errorCounter >= PARSE_ERRORS_LIMIT) {
                     logger.error("Failed to recover from malformed JSON data.", e);


### PR DESCRIPTION
Currently we wrap JsonEOFException from advancing the json parser into our own XContentEOFException, but this has the drawback that is results in 500 errors on the client side. Instead this should be 400 errors. We should throw XContentParseException instead like we e.g. already to in the "nextFieldName" method or elsewhere in JsonXContentParser.

Closes #111542
