### PR TITLE
Add one missing test case to SystemIndexMappingUpdateServiceTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
@@ -208,8 +208,18 @@ public class SystemIndexMappingUpdateServiceTests extends ESTestCase {
         );
     }
 
-    // TODO[wrb]: add test where we have the old mappings version but not the new one
-    // Is this where we "placeholder" a "distant future" version string?
+    /**
+     * Check that the manager will try to upgrade indices when we have the old mappings version but not the new one
+     */
+    public void testManagerProcessesIndicesWithOldMappingsVersion() {
+        assertThat(
+            SystemIndexMappingUpdateService.getUpgradeStatus(
+                markShardsAvailable(createClusterState(Strings.toString(getMappings("1.0.0", null)))),
+                DESCRIPTOR
+            ),
+            equalTo(UpgradeStatus.NEEDS_MAPPINGS_UPDATE)
+        );
+    }
 
     /**
      * Check that the manager will try to upgrade indices where their mappings are out-of-date.


### PR DESCRIPTION
We opened https://github.com/elastic/elasticsearch/issues/101158 a while ago to check we are covering all Watcher system index mappings version update scenarios.

As discussed in https://github.com/elastic/elasticsearch/issues/100282#issuecomment-1781303951, `SystemIndexMappingUpdateServiceIT#testSystemIndexManagerUpgradesMappings` already cover the test muted in https://github.com/elastic/elasticsearch/issues/100282, as Watcher relies fully on the system index mappings management.

I added a missing test in `SystemIndexMappingUpdateServiceTests` to cover a missing case, but that's it.

Closes https://github.com/elastic/elasticsearch/issues/101158