### PR TITLE
Fixing potential OOME in HistoryIntegrationTest.testThatHistoryIsTruncated()

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -271,7 +271,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         }
         {
             /*
-             * The input for this watch is 500 MB, much bigger than the configured 100 KB of HistoryStore's MAX_HISTORY_SIZE_SETTING. So we
+             * The input for this watch is 500 KB, much bigger than the configured 100 KB of HistoryStore's MAX_HISTORY_SIZE_SETTING. So we
              * expect to see its history record truncated before being stored.
              */
             new PutWatchRequestBuilder(client()).setId("test_watch_large")

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.watcher.test.integration;
 
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchResponse;
 import org.elasticsearch.search.SearchHit;
@@ -52,6 +53,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put("xpack.watcher.max.history.record.size", "100kb") // used for testThatHistoryIsTruncated()
+            .build();
+    }
 
     // issue: https://github.com/elastic/x-plugins/issues/2338
     public void testThatHistoryIsWrittenWithChainedInput() throws Exception {
@@ -232,13 +242,13 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
     public void testThatHistoryIsTruncated() throws Exception {
         {
             /*
-             * The input for this watch is 1 MB, smaller than the 10 MB default of HistoryStore's MAX_HISTORY_SIZE_SETTING. So we do not
-             * expect its history record to be truncated.
+             * The input for this watch is 20 KB, smaller than the configured 100 KB of HistoryStore's MAX_HISTORY_SIZE_SETTING. So we do
+             * not expect its history record to be truncated.
              */
             new PutWatchRequestBuilder(client()).setId("test_watch_small")
                 .setSource(
                     watchBuilder().trigger(schedule(interval(5, IntervalSchedule.Interval.Unit.HOURS)))
-                        .input(simpleInput("foo", randomAlphaOfLength((int) ByteSizeValue.ofMb(1).getBytes())))
+                        .input(simpleInput("foo", randomAlphaOfLength((int) ByteSizeValue.ofKb(20).getBytes())))
                         .addAction("_logger", loggingAction("#### randomLogging"))
                 )
                 .get();
@@ -261,13 +271,13 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         }
         {
             /*
-             * The input for this watch is 20 MB, much bigger than the 10 MB default of HistoryStore's MAX_HISTORY_SIZE_SETTING. So we
+             * The input for this watch is 500 MB, much bigger than the configured 100 KB of HistoryStore's MAX_HISTORY_SIZE_SETTING. So we
              * expect to see its history record truncated before being stored.
              */
             new PutWatchRequestBuilder(client()).setId("test_watch_large")
                 .setSource(
                     watchBuilder().trigger(schedule(interval(5, IntervalSchedule.Interval.Unit.HOURS)))
-                        .input(simpleInput("foo", randomAlphaOfLength((int) ByteSizeValue.ofMb(20).getBytes())))
+                        .input(simpleInput("foo", randomAlphaOfLength((int) ByteSizeValue.ofKb(500).getBytes())))
                         .addAction("_logger", loggingAction("#### randomLogging"))
                 )
                 .get();

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -613,6 +613,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         settings.add(SETTING_BULK_CONCURRENT_REQUESTS);
         settings.add(SETTING_BULK_FLUSH_INTERVAL);
         settings.add(SETTING_BULK_SIZE);
+        settings.add(HistoryStore.MAX_HISTORY_SIZE_SETTING);
 
         // notification services
         settings.addAll(SlackService.getSettings());


### PR DESCRIPTION
HistoryIntegrationTest.testThatHistoryIsTruncated() sometimes results in an OutOfMemoryError. This happens when the cluster is started with multiple nodes and the test is using a 512 MB heap. The 20 MB watch gets stored as byte arrays several times, and it winds up being just enough to push us over the top.
This change uses a lower configured value for `xpack.watcher.max.history.record.size` in the test instead (which is good, because it also showed that that setting was not exposed in the plugin).
Closes #111530