### PR TITLE
(Doc+) cluster.routing.allocation.enable effects going forward

### DIFF
--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -15,7 +15,7 @@ Enable or disable allocation for specific kinds of shards:
 * `new_primaries` -   Allows shard allocation only for primary shards for new indices.
 * `none` -            No shard allocations of any kind are allowed for any indices.
 
-This setting does not affect currently allocated shards, but future allocations. 
+This setting only affects future allocations, and does not re-allocate or un-allocate currently allocated shards.
 It also does not affect the recovery of local primary shards when
 restarting a node. A restarted node that has a copy of an unassigned primary
 shard will recover that primary immediately, assuming that its allocation id matches

--- a/docs/reference/modules/cluster/shards_allocation.asciidoc
+++ b/docs/reference/modules/cluster/shards_allocation.asciidoc
@@ -15,7 +15,8 @@ Enable or disable allocation for specific kinds of shards:
 * `new_primaries` -   Allows shard allocation only for primary shards for new indices.
 * `none` -            No shard allocations of any kind are allowed for any indices.
 
-This setting does not affect the recovery of local primary shards when
+This setting does not affect currently allocated shards, but future allocations. 
+It also does not affect the recovery of local primary shards when
 restarting a node. A restarted node that has a copy of an unassigned primary
 shard will recover that primary immediately, assuming that its allocation id matches
 one of the active allocation ids in the cluster state.


### PR DESCRIPTION
Noting setting e.g.  `cluster.routing.allocation.enable: primaries` ([doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-cluster.html#cluster-shard-allocation-settings)) does not de-allocate existing replicas. Instead this setting affects allocations going forward.