### PR TITLE
New injector

### DIFF
--- a/libs/nalbind/build.gradle
+++ b/libs/nalbind/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
+
+dependencies {
+  compileOnly project(':libs:elasticsearch-logging')
+
+  testImplementation(project(":test:framework")) {
+    exclude group: 'org.elasticsearch', module: 'elasticsearch-nalbind'
+  }
+}
+
+tasks.named('forbiddenApisMain').configure {
+  // x-content does not depend on server
+  // TODO: Need to decide how we want to handle for forbidden signatures with the changes to core
+  replaceSignatureFiles 'jdk-signatures'
+}
+
+tasks.named("thirdPartyAudit").configure {
+  ignoreMissingClasses(
+  )
+}
+

--- a/libs/nalbind/src/main/java/module-info.java
+++ b/libs/nalbind/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.elasticsearch.nalbind {
+    exports org.elasticsearch.nalbind.api;
+    exports org.elasticsearch.nalbind.injector;
+    exports org.elasticsearch.nalbind.exceptions;
+
+    requires org.elasticsearch.logging;
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/api/Actual.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/api/Actual.java
@@ -1,0 +1,25 @@
+package org.elasticsearch.nalbind.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks an injected parameter to indicate that it must not be proxied.
+ * This allows methods to be called on the object, and methods like
+ * <code>getClass</code>, as well as identity comparison, will all work as expected.
+ * <p>
+ * Establishes an initialization ordering dependency: the injected object
+ * must be initialized first.
+ * <p>
+ * Without this annotation, the injected object may actually be a proxy,
+ * to be initialized later.
+ * The upside of proxies is that there's no problem with circular dependencies,
+ * but the downside is that methods cannot be called on the injected object.
+ */
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface Actual {
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/api/AutoInjectable.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/api/AutoInjectable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a type to be discovered by the auto-injection scan.
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface AutoInjectable {
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/api/Inject.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/api/Inject.java
@@ -1,0 +1,15 @@
+package org.elasticsearch.nalbind.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates a constructor to be called by the injector.
+ */
+@Target(CONSTRUCTOR)
+@Retention(RUNTIME)
+public @interface Inject {
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/CyclicDependencyException.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/CyclicDependencyException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.exceptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CyclicDependencyException extends InjectionConfigurationException {
+    public final List<String> dependencySteps = new ArrayList<>();
+
+    public CyclicDependencyException(String s) {
+        super(s);
+        dependencySteps.add(s);
+    }
+
+    public CyclicDependencyException(String message, Throwable cause) {
+        super(message, cause);
+        dependencySteps.add(message);
+    }
+
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/InjectionConfigurationException.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/InjectionConfigurationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.exceptions;
+
+public class InjectionConfigurationException extends IllegalStateException {
+    public InjectionConfigurationException(String s) {
+        super(s);
+    }
+
+    public InjectionConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InjectionConfigurationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/InjectionExecutionException.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/InjectionExecutionException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.exceptions;
+
+/**
+ * Indicates a bug in the injector; usually an invalid plan. These should never be thrown if the injector is working correctly.
+ */
+public class InjectionExecutionException extends IllegalStateException {
+    public InjectionExecutionException(String s) {
+        super(s);
+    }
+
+    public InjectionExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/UnresolvedProxyException.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/exceptions/UnresolvedProxyException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.exceptions;
+
+/**
+ *
+ */
+public class UnresolvedProxyException extends IllegalStateException {
+    public UnresolvedProxyException(String s) {
+        super(s);
+    }
+
+    public UnresolvedProxyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/Injector.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/Injector.java
@@ -1,0 +1,366 @@
+package org.elasticsearch.nalbind.injector;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.nalbind.exceptions.CyclicDependencyException;
+import org.elasticsearch.nalbind.api.Inject;
+import org.elasticsearch.nalbind.exceptions.InjectionConfigurationException;
+import org.elasticsearch.nalbind.injector.spec.AliasSpec;
+import org.elasticsearch.nalbind.injector.spec.AmbiguousSpec;
+import org.elasticsearch.nalbind.injector.spec.ExistingInstanceSpec;
+import org.elasticsearch.nalbind.injector.spec.InjectionModifiers;
+import org.elasticsearch.nalbind.injector.spec.InjectionSpec;
+import org.elasticsearch.nalbind.injector.spec.MethodHandleSpec;
+import org.elasticsearch.nalbind.injector.spec.ParameterSpec;
+import org.elasticsearch.nalbind.injector.spec.UnambiguousSpec;
+import org.elasticsearch.nalbind.injector.step.InjectionStep;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * The main object for dependency injection.
+ * <p>
+ * Allows the user to specify the requirements, then call {@link #inject} to create an object plus all its dependencies.
+ * <p>
+ * <em>Implementation note</em>: this class itself contains logic for <em>specifying</em> the injection requirements;
+ * the actual injection operations are performed in other classes like {@link Planner}, {@link PlanInterpreter}, and {@link ProxyPool}.
+ */
+public final class Injector {
+    private final Set<Class<?>> classesToInstantiate;
+    private final Map<Class<?>, Object> existingInstances;
+    private final MethodHandles.Lookup lookup;
+    private final ProxyPool proxyPool = new ProxyPool();
+
+    Injector(Collection<Class<?>> classesToInstantiate, Map<Class<?>, Object> existingInstances, MethodHandles.Lookup lookup) {
+        this.classesToInstantiate = new LinkedHashSet<>(classesToInstantiate);
+        this.existingInstances = existingInstances;
+        this.lookup = lookup;
+    }
+
+    public static Injector create(MethodHandles.Lookup lookup) {
+        return new Injector(new LinkedHashSet<>(), new LinkedHashMap<>(), lookup);
+    }
+
+    /**
+     * Instructs the injector to instantiate <code>classToProcess</code>
+     * in accordance with whatever annotations may be present on that class.
+     * <p>
+     * There are only three ways the injector can find out that it must instantiate some class:
+     * <ol>
+     *     <li>
+     *         This method (which is also used to implement {@link org.elasticsearch.nalbind.api.AutoInjectable @Autoinjectable})
+     *     </li>
+     *     <li>
+     *         The parameter passed to {@link #inject}
+     *     </li>
+     *     <li>
+     *         A constructor parameter of some other class being instantiated,
+     *         having exactly the right class (not a supertype)
+     *     </li>
+     * </ol>
+     *
+     * @return <code>this</code>
+     */
+    public Injector addClass(Class<?> classToProcess) {
+        this.classesToInstantiate.add(classToProcess);
+        return this;
+    }
+
+    /**
+     * Equivalent to multiple chained calls to {@link #addClass}.
+     */
+    public Injector addClasses(Class<?>... classesToProcess) {
+        return addClasses(Arrays.asList(classesToProcess));
+    }
+
+    /**
+     * Equivalent to multiple chained calls to {@link #addClass}.
+     */
+    public Injector addClasses(Collection<Class<?>> classesToProcess) {
+        this.classesToInstantiate.addAll(classesToProcess);
+        return this;
+    }
+
+    /**
+     * Equivalent to {@link #addInstance addInstance(object.getClass(), object)}.
+     */
+    public <T> Injector addInstance(T object) {
+        @SuppressWarnings("unchecked")
+        Class<? super T> aClass = (Class<? super T>) object.getClass();
+        return addInstance(aClass, object);
+    }
+
+    /**
+     * Equivalent to multiple calls to {@link #addInstance(Object)}.
+     */
+    public Injector addInstances(Object... objects) {
+        for (var x : objects) {
+            addInstance(x);
+        }
+        return this;
+    }
+
+    /**
+     * Equivalent to multiple calls to {@link #addInstance(Object)}.
+     */
+    public Injector addInstances(Iterable<?> objects) {
+        for (var x : objects) {
+            addInstance(x);
+        }
+        return this;
+    }
+
+    /**
+     * Indicates that <code>object</code> is to be injected for parameters of type <code>type</code>.
+     * The given object is treated as though it had been instantiated by the injector.
+     */
+    public <T> Injector addInstance(Class<? super T> type, T object) {
+        Object existing = this.existingInstances.put(type, object);
+        if (existing != null) {
+            throw new IllegalStateException("There's already an object for " + type);
+        }
+        return this;
+    }
+
+    /**
+     * For each "component" (getter) <em>c</em> of a {@link Record}, calls {@link #addInstance(Class, Object)} to register the
+     * value with the component's declared type.
+     */
+    public <T> Injector addRecordContents(Record r) {
+        for (var c: r.getClass().getRecordComponents()) {
+            try {
+                @SuppressWarnings("unchecked")
+                Class<T> type = (Class<T>) c.getType();
+                addInstance(type, type.cast(lookup.unreflect(c.getAccessor()).invoke(r)));
+            } catch (Throwable e) {
+                throw new InjectionConfigurationException("Unable to read record component " + c, e);
+            }
+        }
+        return this;
+    }
+
+    public void inject() {
+        doInjection();
+    }
+
+    /**
+     * @param resultType The type of object to return.
+     *                   Can't be a list; if you want a list, wrap it in a record.
+     */
+    public <T> T inject(Class<T> resultType) {
+        ensureClassIsSpecified(resultType);
+        return doInjection().theOnlyInstance(resultType);
+    }
+
+    /**
+     * Like {@link #inject(Class)} but can return multiple result objects
+     * @return {@link Map} whose keys are all the requested <code>resultTypes</code> and whose values are all the instances of those types.
+     */
+    public Map<Class<?>, List<?>> inject(Collection<? extends Class<?>> resultTypes) {
+        resultTypes.forEach(this::ensureClassIsSpecified);
+        PlanInterpreter i = doInjection();
+        return resultTypes.stream()
+            .collect(toMap(c->c, i::getInstances));
+    }
+
+    private <T> void ensureClassIsSpecified(Class<T> resultType) {
+        if (false == (existingInstances.containsKey(resultType) || classesToInstantiate.contains(resultType))) {
+            classesToInstantiate.add(resultType);
+        }
+    }
+
+    private PlanInterpreter doInjection() {
+        LOGGER.debug("Starting injection");
+        Map<Class<?>, InjectionSpec> specMap = specMap(existingInstances, classesToInstantiate, lookup);
+        PlanInterpreter interpreter = new PlanInterpreter(existingInstances, proxyPool);
+        interpreter.executePlan(injectionPlan(classesToInstantiate, specMap));
+        LOGGER.debug("Done injection");
+        return interpreter;
+    }
+
+    /**
+     * Finds an {@link InjectionSpec} for every class the injector is capable of injecting.
+     * <p>
+     * We do this once the injector is fully configured, with all calls to {@link #addClass} and {@link #addInstance} finished,
+     * so that we can easily build the complete picture of how injection should occur.
+     * <p>
+     * This is not part of the planning process; it's just discovering all the things
+     * the injector needs to know about. This logic isn't concerned with ordering, though it can detect dependency cycles.
+     *
+     * @return an {@link InjectionSpec} for every class the injector is capable of injecting.
+     *
+     * @param lookup is used to find {@link MethodHandle}s for constructors.
+     */
+    private static Map<Class<?>, InjectionSpec> specMap(
+        Map<Class<?>, Object> existingInstances,
+        Set<Class<?>> classesToInstantiate,
+        MethodHandles.Lookup lookup
+    ) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Classes to instantiate: {}", classesToInstantiate.stream().map(Class::getSimpleName).toList());
+        }
+
+        Queue<ParameterSpec> queue = classesToInstantiate.stream()
+            .map(Injector::syntheticParameterSpec)
+            .collect(toCollection(ArrayDeque::new));
+        Map<Class<?>, InjectionSpec> specsByClass = new LinkedHashMap<>();
+        existingInstances.forEach((type, obj) -> {
+            registerSpec(new ExistingInstanceSpec(type, obj), specsByClass);
+            aliasSuperinterfaces(type, type, specsByClass);
+        });
+        Set<Class<?>> checklist = new HashSet<>();
+
+        ParameterSpec p;
+        while ((p = queue.poll()) != null) {
+            Class<?> c = p.injectableType();
+            InjectionSpec existingResult = specsByClass.get(c);
+            if (existingResult != null) {
+                LOGGER.trace("Spec for {} already exists", c.getSimpleName());
+                continue;
+            }
+
+            // At this point, we know we'll need to create a MethodHandleSpec
+
+            if (checklist.add(c)) {
+                Constructor<?> constructor = getSuitableConstructorIfAny(c);
+                if (constructor == null) {
+                    throw new InjectionConfigurationException("No suitable constructor for " + c);
+                }
+
+                LOGGER.trace("Inspecting parameters for constructor: {}", constructor);
+                for (var parameter: constructor.getParameters()) {
+                    ParameterSpec ps = ParameterSpec.from(parameter);
+                    LOGGER.trace("Enqueue {}", parameter);
+                    queue.add(ps);
+                }
+
+                MethodHandle ctorHandle;
+                try {
+                    ctorHandle = lookup.unreflectConstructor(constructor);
+                } catch (IllegalAccessException e) {
+                    // Uh oh. Try setAccessible
+                    constructor.setAccessible(true);
+                    try {
+                        ctorHandle = lookup.unreflectConstructor(constructor);
+                    } catch (IllegalAccessException ex) {
+                        throw new InjectionConfigurationException(e);
+                    }
+                }
+
+                List<ParameterSpec> parameters = Stream.of(constructor.getParameters())
+                    .map(ParameterSpec::from)
+                    .toList();
+
+                registerSpec(
+                    new MethodHandleSpec(constructor.getDeclaringClass(), ctorHandle, parameters),
+                    specsByClass
+                );
+                aliasSuperinterfaces(c, c, specsByClass);
+                for (Class<?> superclass = c.getSuperclass(); superclass != Object.class; superclass = superclass.getSuperclass()) {
+                    if (Modifier.isAbstract(superclass.getModifiers())) {
+                        registerSpec(new AliasSpec(superclass, c), specsByClass);
+                    } else {
+                        LOGGER.trace("Not aliasing {} to concrete superclass {}", c.getSimpleName(), superclass.getSimpleName());
+                    }
+                    aliasSuperinterfaces(superclass, c, specsByClass);
+                }
+            } else {
+                throw new CyclicDependencyException("Cycle detected");
+            }
+        }
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Specs: {}", specsByClass.values().stream()
+                .filter(s -> s instanceof UnambiguousSpec)
+                .map(Object::toString)
+                .collect(joining("\n\t", "\n\t", "")));
+        }
+        return specsByClass;
+    }
+
+    /**
+     * For the classes we've been explicitly asked to inject,
+     * pretend there's some massive method taking all of them as parameters
+     */
+    private static ParameterSpec syntheticParameterSpec(Class<?> c) {
+        return new ParameterSpec("synthetic_" + c.getSimpleName(), c, c, InjectionModifiers.NONE);
+    }
+
+    private static Constructor<?> getSuitableConstructorIfAny(Class<?> type) {
+        var constructors = Stream.of(type.getDeclaredConstructors()).filter(not(Constructor::isSynthetic)).toList();
+        if (constructors.size() == 1) {
+            return constructors.get(0);
+        }
+        var injectConstructors = constructors.stream().filter(c -> c.isAnnotationPresent(Inject.class)).toList();
+        if (injectConstructors.size() == 1) {
+            return injectConstructors.get(0);
+        }
+        LOGGER.trace("No suitable constructor for {}", type);
+        return null;
+    }
+
+    /**
+     * When creating <code>specsByClass</code>, we compute a kind of "inheritance closure"
+     * in the sense that, for each class <code>C</code>, we not only add an entry for <code>C</code>,
+     * but we also add {@link AliasSpec} entries for all abstract supertypes.
+     * <p>
+     * This method is part of the recursion that achieves this.
+     */
+    private static void aliasSuperinterfaces(Class<?> classToScan, Class<?> classToAlias, Map<Class<?>, InjectionSpec> specsByClass) {
+        for (var i : classToScan.getInterfaces()) {
+            registerSpec(new AliasSpec(i, classToAlias), specsByClass);
+            aliasSuperinterfaces(i, classToAlias, specsByClass);
+        }
+    }
+
+    private static void registerSpec(InjectionSpec spec, Map<Class<?>, InjectionSpec> specsByClass) {
+        Class<?> requestedType = spec.requestedType();
+        var existing = specsByClass.put(requestedType, spec);
+        if (existing == null || existing.equals(spec)) {
+            LOGGER.trace("Register spec: {}", spec);
+        } else {
+            AmbiguousSpec ambiguousSpec = new AmbiguousSpec(requestedType, spec, existing);
+            LOGGER.trace("Ambiguity discovered for {}", requestedType);
+            specsByClass.put(requestedType, ambiguousSpec);
+        }
+    }
+
+    private List<InjectionStep> injectionPlan(Set<Class<?>> requiredClasses, Map<Class<?>, InjectionSpec> specsByClass) {
+        // TODO: Cycle detection and reporting. Use SCCs
+        LOGGER.trace("Constructing instantiation plan");
+        Set<Class<?>> allParameterTypes = new HashSet<>();
+        specsByClass.values().forEach(spec -> {
+            if (spec instanceof MethodHandleSpec m) {
+                m.parameters().stream()
+                    .map(ParameterSpec::injectableType)
+                    .forEachOrdered(allParameterTypes::add);
+            }
+        });
+
+        var plan = new Planner(specsByClass, requiredClasses, allParameterTypes).injectionPlan();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Injection plan: {}", plan.stream().map(Object::toString).collect(joining("\n\t", "\n\t", "")));
+        }
+        return plan;
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(Injector.class);
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/PlanInterpreter.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/PlanInterpreter.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.nalbind.exceptions.InjectionConfigurationException;
+import org.elasticsearch.nalbind.exceptions.InjectionExecutionException;
+import org.elasticsearch.nalbind.exceptions.UnresolvedProxyException;
+import org.elasticsearch.nalbind.injector.spec.MethodHandleSpec;
+import org.elasticsearch.nalbind.injector.spec.ParameterSpec;
+import org.elasticsearch.nalbind.injector.step.InjectionStep;
+import org.elasticsearch.nalbind.injector.step.InstantiateStep;
+import org.elasticsearch.nalbind.injector.step.ListProxyCreateStep;
+import org.elasticsearch.nalbind.injector.step.ListProxyResolveStep;
+import org.elasticsearch.nalbind.injector.step.RollUpStep;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.nalbind.injector.spec.InjectionModifiers.LIST;
+
+/**
+ * Performs the actual injection operations by running the {@link InjectionStep}s.
+ * <p>
+ * The intent is that this logic is as simple as possible so that we don't run complex injection
+ * logic alongside the user-supplied constructor logic. All the injector complexity is already
+ * supposed to have happened in the planning phase. In particular, no injection-related errors
+ * are supposed to be detected during execution; they should be detected during planning and validation.
+ * All exceptions thrown during execution are supposed to be caused by user-supplied code.
+ *
+ * <p>
+ * <strong>Execution model</strong>:
+ * The state of the injector during injection comprises a map from classes to lists of objects.
+ * Before any steps execute, the map is pre-populated by object instances added via
+ * {@link Injector#addInstance(Class, Object) Injector.addInstance},
+ * and then the steps begin to execute, reading and writing from this map.
+ * Some steps create objects and add them to this map; others manipulate the map itself.
+ * In addition to the map of instances, there is also a {@link ProxyPool} used to manage
+ * list proxies; some steps create, use, or resolve proxies via the pool.
+ */
+final class PlanInterpreter {
+    private final Map<Class<?>, List<Object>> instances = new LinkedHashMap<>();
+    private final ProxyPool proxyPool;
+
+    PlanInterpreter(Map<Class<?>, Object> existingInstances, ProxyPool proxyPool) {
+        existingInstances.forEach(this::addInstance);
+        this.proxyPool = proxyPool;
+    }
+
+    /**
+     * Main entry point. Contains the implementation logic for each {@link InjectionStep}.
+     */
+    void executePlan(List<InjectionStep> plan) {
+        AtomicInteger numConstructorCalls = new AtomicInteger(0);
+        plan.forEach(step -> {
+            if (step instanceof InstantiateStep i) {
+                MethodHandleSpec spec = i.spec();
+                LOGGER.trace("Instantiating {}", spec.requestedType().getSimpleName());
+                addInstance(spec.requestedType(), instantiate(spec));
+                numConstructorCalls.incrementAndGet();
+            } else if (step instanceof RollUpStep r) {
+                var requestedType = r.requestedType();
+                var subtype = r.subtype();
+                LOGGER.trace("Rolling up {} into {}", subtype.getSimpleName(), requestedType.getSimpleName());
+                addInstances(requestedType, instances.getOrDefault(subtype, emptyList()));
+            } else if (step instanceof ListProxyCreateStep s) {
+                if (proxyPool.putNewListProxy(s.elementType()) != null) {
+                    throw new InjectionExecutionException("Two proxies for " + s.elementType());
+                }
+            } else if (step instanceof ListProxyResolveStep s) {
+                Class<?> elementType = s.elementType();
+                proxyPool.resolveListProxy(elementType, this.instances.getOrDefault(elementType, emptyList()));
+            } else {
+                // TODO: switch patterns would make this unnecessary
+                throw new InjectionExecutionException("Unexpected step type: " + step.getClass().getSimpleName());
+            }
+        });
+        LOGGER.debug("Instantiated {} objects", numConstructorCalls.get());
+    }
+
+    /**
+     * @return the list element corresponding to instances.get(type).get(0),
+     * assuming that instances.get(type) has exactly one element.
+     * @throws InjectionExecutionException if instances.get(type) does not have exactly one element
+     */
+    public <T> T theOnlyInstance(Class<T> type) {
+        List<Object> candidates = getInstances(type);
+        if (candidates.size() == 1) {
+            return type.cast(candidates.get(0));
+        }
+
+        throw new InjectionConfigurationException(
+            "No unique object of type "
+                + type.getSimpleName()
+                + ": "
+                + candidates.stream().map(x -> x.getClass().getSimpleName()).toList()
+        );
+    }
+
+    /**
+     * @return The objects currently associated with <code>type</code>.
+     * Note that this is not <em>necessarily</em> all the instances of <code>type</code> that were ever instantiated,
+     * unless the appropriate {@link RollUpStep}s have run.
+     * It can also include objects that we didn't instantiate, but were included in the <code>existingInstances</code>
+     * passed in this object's constructor.
+     */
+    public <T> List<Object> getInstances(Class<T> type) {
+        return instances.getOrDefault(type, emptyList());
+    }
+
+    private void addInstance(Class<?> requestedType, Object instance) {
+        instances.computeIfAbsent(requestedType, __ -> new ArrayList<>()).add(requestedType.cast(instance));
+    }
+
+    private void addInstances(Class<?> requestedType, Collection<?> c) {
+        instances.computeIfAbsent(requestedType, __ -> new ArrayList<>()).addAll(c);
+    }
+
+    /**
+     * @throws IllegalStateException if the <code>MethodHandle</code> throws.
+     * This isn't a {@link InjectionExecutionException} because it's not an injector bug.
+     */
+    private Object instantiate(MethodHandleSpec spec) {
+        Object[] args = spec.parameters().stream().map(this::parameterValue).toArray();
+        try {
+            return spec.methodHandle().invokeWithArguments(args);
+        } catch (UnresolvedProxyException e) {
+            // This exception is descriptive enough already. Catching it and wrapping it here
+            // only makes the stack trace a little more complex for no benefit.
+            throw e;
+        } catch (Throwable e) {
+            throw new IllegalStateException("Unexpected exception while instantiating {}" + spec, e);
+        }
+    }
+
+    private Object parameterValue(ParameterSpec parameterSpec) {
+        if (parameterSpec.modifiers().contains(LIST)) {
+            return proxyPool.theProxyFor(parameterSpec.injectableType());
+        } else {
+            return theOnlyInstance(parameterSpec.formalType());
+        }
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(PlanInterpreter.class);
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/Planner.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/Planner.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.nalbind.exceptions.InjectionConfigurationException;
+import org.elasticsearch.nalbind.injector.spec.AliasSpec;
+import org.elasticsearch.nalbind.injector.spec.AmbiguousSpec;
+import org.elasticsearch.nalbind.injector.spec.ExistingInstanceSpec;
+import org.elasticsearch.nalbind.injector.spec.InjectionSpec;
+import org.elasticsearch.nalbind.injector.spec.MethodHandleSpec;
+import org.elasticsearch.nalbind.injector.step.InjectionStep;
+import org.elasticsearch.nalbind.injector.step.InstantiateStep;
+import org.elasticsearch.nalbind.injector.step.ListProxyCreateStep;
+import org.elasticsearch.nalbind.injector.step.ListProxyResolveStep;
+import org.elasticsearch.nalbind.injector.step.RollUpStep;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSet;
+import static org.elasticsearch.nalbind.injector.spec.InjectionModifiers.LIST;
+
+/**
+ * <em>Evolution note</em>: the intent is to plan one domain/subsystem at a time.
+ */
+final class Planner {
+    final List<InjectionStep> plan;
+    final Queue<Class<?>> queue;
+    final Map<Class<?>, InjectionSpec> specsByClass;
+    final Set<Class<?>> requiredTypes; // The injector's job is to ensure there is an instance of these; this is like the "root set"
+    final Set<Class<?>> allParameterTypes; // All the injectable types in all dependencies (recursively) of all required types
+    final Set<InjectionSpec> startedPlanning;
+    final Set<InjectionSpec> finishedPlanning;
+    final Set<Class<?>> alreadyProxied;
+
+    /**
+     * @param specsByClass an {@link InjectionSpec} indicating how each class should be injected
+     * @param requiredTypes the classes of which we need instances
+     * @param allParameterTypes the classes that appear as the type of any parameter of any constructor we might call
+     */
+    Planner(Map<Class<?>, InjectionSpec> specsByClass, Set<Class<?>> requiredTypes, Set<Class<?>> allParameterTypes) {
+        this.requiredTypes = requiredTypes;
+        this.plan = new ArrayList<>();
+        this.specsByClass = unmodifiableMap(specsByClass);
+        this.allParameterTypes = unmodifiableSet(allParameterTypes);
+        this.startedPlanning = new HashSet<>();
+        this.finishedPlanning = new HashSet<>();
+        this.alreadyProxied = new HashSet<>();
+
+        // Evolution note: this was a queue because we anticipated cases where the planner needs
+        // to put items at the end rather than recursing. If that never turns out to be necessary,
+        // this could be simplified away.
+        this.queue = new ArrayDeque<>(requiredTypes);
+    }
+
+    /**
+     * Intended to be called once.
+     * <p>
+     * Note that not all proxies are resolved once this plan has been executed.
+     * <p>
+     *
+     * <em>Evolution note</em>: in a world with multiple domains/subsystems,
+     * it will become necessary to defer proxy resolution until after other plans
+     * have been executed, because they could create additional objects that ought
+     * to be included in the proxies created by this plan.
+     *
+     * @return the {@link InjectionStep} objects listed in execution order.
+     */
+    List<InjectionStep> injectionPlan() {
+        Class<?> c;
+        while ((c = queue.poll()) != null) {
+            planForClass(c, 0);
+        }
+        planProxyResolution(unresolvedProxies());
+        return plan;
+    }
+
+    /**
+     * An analysis that scans the current plan and finds proxies that are created but never resolved.
+     *
+     * @return the element types for list proxies that aren't resolved in the current plan
+     */
+    private Collection<Class<?>> unresolvedProxies() {
+        Set<Class<?>> result = new LinkedHashSet<>();
+        for (InjectionStep step : plan) {
+            if (step instanceof ListProxyCreateStep s) {
+                result.add(s.elementType());
+            } else if (step instanceof ListProxyResolveStep s) {
+                result.remove(s.elementType());
+            }
+        }
+        return result;
+    }
+
+    private void planProxyResolution(Collection<Class<?>> proxiesToResolve) {
+        LOGGER.trace("Resolving {} remaining proxies", proxiesToResolve.size());
+        proxiesToResolve.forEach(elementType -> rollUpAndResolveListProxy(elementType, 0, ""));
+    }
+
+    /**
+     * Recursive procedure that determines what effect <code>requestedClass</code>
+     * should have on the plan under construction.
+     *
+     * @param depth is used just for indenting the logs
+     */
+    private void planForClass(Class<?> requestedClass, int depth) {
+        InjectionSpec spec = specsByClass.get(requestedClass);
+        if (spec == null) {
+            throw new InjectionConfigurationException("Cannot instantiate " + requestedClass);
+        }
+        planForSpec(spec, depth);
+    }
+
+    private void planForSpec(InjectionSpec spec, int depth) {
+        String indent;
+        if (LOGGER.isTraceEnabled()) {
+            indent = "\t".repeat(depth);
+        } else {
+            indent = null;
+        }
+
+        if (finishedPlanning.contains(spec)) {
+            LOGGER.trace("{}Already planned {}", indent, spec);
+            return;
+        }
+
+        LOGGER.trace("{}Planning for {}", indent, spec);
+        if (startedPlanning.add(spec) == false) {
+            throw new InjectionConfigurationException("Cyclic dependency involving " + spec);
+        }
+
+        if (spec instanceof MethodHandleSpec m) {
+            for (var p : m.parameters()) {
+                if (p.canBeProxied()) {
+                    if (alreadyProxied.add(p.injectableType())) {
+                        addStep(new ListProxyCreateStep(p.injectableType()), indent);
+                    } else {
+                        LOGGER.trace("{}- Use existing proxy for {}", indent, p);
+                    }
+                } else {
+                    LOGGER.trace("{}- Recursing into {} for actual parameter {}", indent, p.injectableType(), p);
+                    planForClass(p.injectableType(), depth + 1);
+                    if (p.modifiers().contains(LIST)) {
+                        rollUpAndResolveListProxy(p.injectableType(), depth, indent);
+                    }
+                }
+            }
+            addStep(new InstantiateStep(m), indent);
+        } else if (spec instanceof AliasSpec a) {
+            LOGGER.trace("{}- Recursing into subtype for {}", indent, a);
+            planForClass(a.subtype(), depth + 1);
+            if (allParameterTypes.contains(a.requestedType()) == false) {
+                // Could be an opportunity for optimization here.
+                // The _only_ reason we need these unused aliases is in case
+                // somebody asks for one directly from the injector; they are
+                // not needed otherwise.
+                // If we change the injector setup so the user must specify
+                // which types they'll pull directly, we could skip these.
+                LOGGER.trace("{}- Planning unused {}", indent, a);
+            }
+            addStep(new RollUpStep(a.requestedType(), a.subtype()), indent);
+        } else if (spec instanceof ExistingInstanceSpec e) {
+            LOGGER.trace("{}- Plan {}", indent, e);
+            // Nothing to do. The injector will already have the required object.
+        } else if (spec instanceof AmbiguousSpec a) {
+            if (requiredTypes.contains(a.requestedType())) {
+                throw new InjectionConfigurationException("Ambiguous injection spec for required type: " + a);
+            } else {
+                // Nobody could validly ask for an instance of an ambiguous class, so
+                // this must be a class we encountered as a List.
+                // Ensure we generate the necessary rollups to ensure the list has all the right objects.
+                LOGGER.trace("{}- Processing candidates for {}", indent, a.requestedType());
+                a.candidates().forEach(candidate -> planForSpec(candidate, depth + 1));
+            }
+        }
+
+        finishedPlanning.add(spec);
+    }
+
+    private void addStep(InjectionStep newStep, String indent) {
+        LOGGER.trace("{}- Add step {}", indent, newStep);
+        plan.add(newStep);
+    }
+
+    private void rollUpAndResolveListProxy(Class<?> elementType, int depth, String indent) {
+        LOGGER.trace("{}- Roll up and resolve {}", indent, elementType);
+        planForClass(elementType, depth + 1);
+        addStep(new ListProxyResolveStep(elementType), indent);
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(Planner.class);
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/ProxyPool.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/ProxyPool.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.nalbind.exceptions.InjectionConfigurationException;
+import org.elasticsearch.nalbind.exceptions.UnresolvedProxyException;
+
+import java.util.AbstractList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Proxies generally have a lifetime that is not bound to any one injection plan,
+ * and objects from multiple injectors/plans must be grouped into the same list.
+ */
+class ProxyPool {
+    private final Map<Class<?>, List<?>> proxyInstances = new LinkedHashMap<>();
+    private final Map<Class<?>, ProxyPool.ProxyInfo<? extends List<?>>> unresolvedListProxies = new LinkedHashMap<>();
+
+    private record ProxyInfo<T>(Class<T> interfaceType, T proxyObject, Consumer<T> setter) {}
+
+    List<?> theProxyFor(Class<?> elementType) {
+        List<?> result = proxyInstances.get(elementType);
+        if (result == null) {
+            throw new InjectionConfigurationException("No proxy for " + elementType.getSimpleName());
+        } else {
+            return result;
+        }
+    }
+
+    /**
+     * @return the existing proxy, or null if none
+     */
+    public <T> List<T> putNewListProxy(Class<T> elementType) {
+        LOGGER.trace("Creating list proxy for {}", elementType.getSimpleName());
+        ProxyPool.ProxyInfo<List<T>> proxyInfo = generateListProxyFor(elementType);
+        unresolvedListProxies.put(elementType, proxyInfo);
+        return proxyInfo.interfaceType().cast(proxyInstances.put(elementType, proxyInfo.proxyObject()));
+    }
+
+    /**
+     * <em>Evolution note</em>: when we have multiple domains/subsystems, we'll actually need to resolve
+     * proxies to contain all instances from all subsystems. But that's a tomorrow problem.
+     */
+    public void resolveListProxy(Class<?> elementType, List<Object> instances) {
+        resolveListProxy(elementType, instances, requireNonNull(unresolvedListProxies.remove(elementType)));
+    }
+
+    /**
+     * Extracting this method helps us convince the Java type system that are generics are kosher.
+     */
+    private static <L extends List<?>> void resolveListProxy(Class<?> elementType, List<Object> instances, ProxyInfo<L> p) {
+        L List = p.interfaceType().cast(instances);
+        LOGGER.trace("- {}: {} instances", elementType.getSimpleName(), List.size());
+        p.setter().accept(List);
+    }
+
+    private <T> ProxyInfo<List<T>> generateListProxyFor(Class<T> elementType) {
+        AtomicReference<List<T>> delegate = new AtomicReference<>(null);
+        return new ProxyInfo<>(listClass(), new ListProxy<>(delegate, elementType), delegate::set);
+    }
+
+    // TODO: A more performant proxy
+    private static final class ListProxy<T> extends AbstractList<T> {
+
+        private final AtomicReference<List<T>> delegate;
+        private final Class<T> elementType;
+
+        ListProxy(AtomicReference<List<T>> delegate, Class<T> elementType) {
+            this.delegate = delegate;
+            this.elementType = elementType;
+        }
+
+        @Override
+        public T get(int index) {
+            return delegate().get(index);
+        }
+
+        @Override
+        public int size() {
+            return delegate().size();
+        }
+
+        private List<T> delegate() {
+            List<T> result = delegate.get();
+            if (result == null) {
+                throw new UnresolvedProxyException(
+                    "Missing @Actual annotation; cannot call method on injected List during object construction. " +
+                        "Element type is " + elementType);
+            } else {
+                return result;
+            }
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private <T> Class<List<T>> listClass() {
+        return (Class<List<T>>)(Class)List.class;
+    }
+
+    private static final Logger LOGGER = LogManager.getLogger(ProxyInfo.class);
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/AliasSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/AliasSpec.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+/**
+ * Indicates that a type should be injected as though the requester had asked for some subtype instead.
+ */
+public record AliasSpec(Class<?> requestedType, Class<?> subtype) implements UnambiguousSpec {}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/AmbiguousSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/AmbiguousSpec.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+import java.util.stream.Stream;
+
+/**
+ * Indicates that there are multiple ways to inject a given type.
+ *
+ * <p>
+ * This is an error only if some type attempts to inject {@link #requestedType()},
+ * because there is no single best object of that type.
+ *
+ * <p>
+ * This is arranged as a tree so it can be instantiated in constant time;
+ * if there are more than two candidates, than {@link #option1} and/or {@link #option2}
+ * will themselves be an {@link AmbiguousSpec}.
+ */
+public record AmbiguousSpec(Class<?> requestedType, InjectionSpec option1, InjectionSpec option2) implements InjectionSpec {
+    public Stream<UnambiguousSpec> candidates() {
+        return specStream(this);
+    }
+
+    private static Stream<UnambiguousSpec> specStream(InjectionSpec spec) {
+        if (spec instanceof AmbiguousSpec a) {
+            return Stream.concat(specStream(a.option1()), specStream(a.option2()));
+        } else {
+            return Stream.of((UnambiguousSpec) spec);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AmbiguousSpec{" +
+            "requestedType=" + requestedType +
+            ", some options: " + candidates().limit(4).toList() +
+            '}';
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/ExistingInstanceSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/ExistingInstanceSpec.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+public record ExistingInstanceSpec(Class<?> requestedType, Object instance)
+    implements UnambiguousSpec {
+    @Override
+    public String toString() {
+        // Don't call instance.toString; who knows what that will return
+        return "ExistingInstanceSpec[" + "requestedType=" + requestedType + ']';
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/InjectionModifiers.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/InjectionModifiers.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+import static java.util.EnumSet.noneOf;
+
+public enum InjectionModifiers {
+    /**
+     * Indicates a proxy object is unacceptable; must inject the object itself.
+     * This creates a hard creation-order constraint between the objects.
+     * Non-list parameters are always <code>ACTUAL</code> regardless of whether
+     * they use the {@link org.elasticsearch.nalbind.api.Actual @Actual} annotation.
+     *
+     * @see org.elasticsearch.nalbind.api.Actual
+     */
+    ACTUAL,
+
+    /**
+     * Indicates we should inject a {@link List} of all instances of some class, instead of a single object.
+     * Allows for a one-to-many relationship.
+     * Objects are listed in creation order.
+     */
+    LIST,
+    ;
+
+    public static final Set<InjectionModifiers> NONE = unmodifiableSet(noneOf(InjectionModifiers.class));
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/InjectionSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/InjectionSpec.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+public sealed interface InjectionSpec permits AmbiguousSpec, UnambiguousSpec {
+    Class<?> requestedType();
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/MethodHandleSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/MethodHandleSpec.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Indicates that a type should be instantiated by calling the given {@link java.lang.invoke.MethodHandle}.
+ * <p>
+ * <em>Design note</em>: the intent is that the semantics are fully specified by this record,
+ * and no additional reflection logic is required to determine how the object should be injected.
+ * Roughly speaking: all the reflection should be finished, and the results should be stored in this object.
+ */
+public record MethodHandleSpec(
+    Class<?> requestedType,
+    MethodHandle methodHandle,
+    List<ParameterSpec> parameters
+) implements UnambiguousSpec {
+    public MethodHandleSpec {
+        assert Objects.equals(
+            methodHandle.type().parameterList(),
+            parameters.stream().map(ParameterSpec::formalType).toList()
+        ): "MethodHandle parameter types must match the supplied parameter info; "
+            + methodHandle.type().parameterList() + " vs " + parameters;
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/ParameterSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/ParameterSpec.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+import org.elasticsearch.nalbind.api.Actual;
+
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.nalbind.injector.spec.InjectionModifiers.ACTUAL;
+import static org.elasticsearch.nalbind.injector.spec.InjectionModifiers.LIST;
+
+/**
+ * Captures the pertinent info required to inject one of the arguments of a constructor.
+ * @param name is for troubleshooting; it's not strictly needed
+ * @param formalType is the declared class of the parameter; for lists, this would be {@link List}
+ * @param injectableType is the target type of the injection dependency; for lists, this would be the list element type
+ */
+public record ParameterSpec(
+    String name,
+    Class<?> formalType,
+    Class<?> injectableType,
+    Set<InjectionModifiers> modifiers
+) {
+    public static ParameterSpec from(Parameter parameter) {
+        EnumSet<InjectionModifiers> modifiers = EnumSet.noneOf(InjectionModifiers.class);
+        Class<?> formalType = parameter.getType();
+        Class<?> requiredType;
+        if (List.class.equals(formalType)) {
+            var pt = (ParameterizedType)parameter.getParameterizedType();
+            requiredType = rawClass(pt.getActualTypeArguments()[0]);
+            modifiers.add(LIST);
+        } else {
+            requiredType = formalType;
+        }
+        if (parameter.isAnnotationPresent(Actual.class) || (parameter.getType().isInterface() == false)) {
+            modifiers.add(ACTUAL);
+        }
+        return new ParameterSpec(parameter.getName(), formalType, requiredType, modifiers);
+    }
+
+    private static Class<?> rawClass(Type sourceType) {
+        if (sourceType instanceof ParameterizedType pt) {
+            return (Class<?>) pt.getRawType();
+        } else {
+            return (Class<?>) sourceType;
+        }
+    }
+
+    public boolean canBeProxied() {
+        return LIST_THAT_IS_NOT_ACTUAL.equals(modifiers);
+    }
+
+    private static final EnumSet<InjectionModifiers> LIST_THAT_IS_NOT_ACTUAL = EnumSet.of(LIST);
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/UnambiguousSpec.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/UnambiguousSpec.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.spec;
+
+public sealed interface UnambiguousSpec extends InjectionSpec permits AliasSpec, ExistingInstanceSpec, MethodHandleSpec {}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/package-info.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/spec/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Objects that describe the means by which an object instance is created for (or associated with) some given type.
+ * <p>
+ * The hierarchy is rooted at {@link org.elasticsearch.nalbind.injector.spec.InjectionSpec}.
+ * <p>
+ * Differs from {@link org.elasticsearch.nalbind.injector.step.InjectionStep InjectionStep} in that:
+ *
+ * <ul>
+ *     <li>
+ *         this describes the requirements, while <code>InjectionStep</code> describes the solution
+ *     </li>
+ *     <li>
+ *         this is declarative, while <code>InjectionStep</code> is imperative
+ *     </li>
+ * </ul>
+ */
+package org.elasticsearch.nalbind.injector.spec;

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/InjectionStep.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/InjectionStep.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.step;
+
+public sealed interface InjectionStep permits
+    InstanceSupplyingStep,
+    ListProxyCreateStep,
+    ListProxyResolveStep
+{ }

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/InstanceSupplyingStep.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/InstanceSupplyingStep.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.step;
+
+/**
+ * An {@link InjectionStep} that causes an object to be available
+ * for subsequent steps to look up by a particular requested type.
+ * <p>
+ * There is no requirement that the object in question be the only one associated
+ * with the given type; however, it is invalid to request injection of an object
+ * using a type that has more than one object associated with it.
+ */
+public sealed interface InstanceSupplyingStep extends InjectionStep permits
+    InstantiateStep,
+    RollUpStep
+{
+    /**
+     * Subsequent steps can find the object by looking it up under this type.
+     */
+    Class<?> requestedType();
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/InstantiateStep.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/InstantiateStep.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.step;
+
+import org.elasticsearch.nalbind.injector.spec.MethodHandleSpec;
+
+/**
+ * Constructs a new object by invoking a {@link java.lang.invoke.MethodHandle}
+ * as specified by a given {@link MethodHandleSpec}.
+ */
+public record InstantiateStep(
+    MethodHandleSpec spec
+) implements InstanceSupplyingStep {
+    @Override
+    public Class<?> requestedType() {
+        return spec.requestedType();
+    }
+}

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/ListProxyCreateStep.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/ListProxyCreateStep.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.step;
+
+/**
+ * Creates a proxy for lists of the given type.
+ * Subsequent steps that inject such a list will receive the proxy
+ * unless it is resolved first via a {@link ListProxyResolveStep}.
+ * The proxy will throw exceptions if it is used before it is resolved.
+ */
+public record ListProxyCreateStep(
+    Class<?> elementType
+) implements InjectionStep { }

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/ListProxyResolveStep.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/ListProxyResolveStep.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.step;
+
+/**
+ * Causes the proxy for the given list to become usable.
+ * This is mandatory if the list is to be injected using {@link org.elasticsearch.nalbind.api.Actual}.
+ * It is an error for there to be any subsequent {@link InstanceSupplyingStep}s for
+ * the {@link #elementType}, because it's too late to add them to the list.
+ */
+public record ListProxyResolveStep(
+    Class<?> elementType
+) implements InjectionStep { }

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/RollUpStep.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/RollUpStep.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector.step;
+
+/**
+ * Performs the paperwork associated with inheritance.
+ * Causes all objects already associated with <code>subtype</code> also to be
+ * associated with <code>requestedType</code>.
+ * Subsequent steps that request the latter will find the former.
+ * Lists of the latter will include instances of the former.
+ *
+ * <p>
+ * Note that this is not a permanent "link" between the types.
+ * It is more like a copy operation, but we avoid the name <code>CopyStep</code>
+ * because that might imply that the objects are being copied,
+ * while actually it's only metadata getting copied.
+ */
+public record RollUpStep(
+   Class<?> requestedType,
+   Class<?> subtype
+) implements InstanceSupplyingStep { }

--- a/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/package-info.java
+++ b/libs/nalbind/src/main/java/org/elasticsearch/nalbind/injector/step/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Objects that describe one operation to be performed by the <code>PlanInterpreter</code>.
+ * Injection is achieved by executing the steps in order.
+ * <p>
+ * See <code>PlanInterpreter</code> for more details on the execution model.
+ */
+package org.elasticsearch.nalbind.injector.step;

--- a/libs/nalbind/src/test/java/org/elasticsearch/example/module1/Module1ServiceImpl.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/example/module1/Module1ServiceImpl.java
@@ -1,0 +1,21 @@
+package org.elasticsearch.example.module1;
+
+import org.elasticsearch.example.module1.api.Module1Listener;
+import org.elasticsearch.example.module1.api.Module1Service;
+import org.elasticsearch.nalbind.api.Inject;
+
+import java.util.List;
+
+public class Module1ServiceImpl implements Module1Service {
+    final List<Module1Listener> listeners;
+
+    @Inject
+    public Module1ServiceImpl(List<Module1Listener> listeners) {
+        this.listeners = listeners;
+    }
+
+    @Override
+    public String greeting() {
+        return "Hello from " + getClass().getSimpleName() + " to my " + listeners.size() + " listeners";
+    }
+}

--- a/libs/nalbind/src/test/java/org/elasticsearch/example/module1/api/Module1Listener.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/example/module1/api/Module1Listener.java
@@ -1,0 +1,5 @@
+package org.elasticsearch.example.module1.api;
+
+public interface Module1Listener {
+    void yo();
+}

--- a/libs/nalbind/src/test/java/org/elasticsearch/example/module1/api/Module1Service.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/example/module1/api/Module1Service.java
@@ -1,0 +1,5 @@
+package org.elasticsearch.example.module1.api;
+
+public interface Module1Service {
+    String greeting();
+}

--- a/libs/nalbind/src/test/java/org/elasticsearch/example/module2/Module2ServiceImpl.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/example/module2/Module2ServiceImpl.java
@@ -1,0 +1,29 @@
+package org.elasticsearch.example.module2;
+
+import org.elasticsearch.example.module1.api.Module1Listener;
+import org.elasticsearch.example.module1.api.Module1Service;
+import org.elasticsearch.example.module2.api.Module2Service;
+import org.elasticsearch.nalbind.api.Inject;
+
+public class Module2ServiceImpl implements Module2Service, Module1Listener {
+    private final Module1Service module1Service;
+
+    public Module2ServiceImpl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    public Module2ServiceImpl(Module1Service module1Service) {
+        this.module1Service = module1Service;
+    }
+
+    @Override
+    public String statusReport() {
+        return "Module1Service: " + module1Service.greeting();
+    }
+
+    @Override
+    public void yo() {
+        System.out.println("Yo!");
+    }
+}

--- a/libs/nalbind/src/test/java/org/elasticsearch/example/module2/api/Module2Service.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/example/module2/api/Module2Service.java
@@ -1,0 +1,5 @@
+package org.elasticsearch.example.module2.api;
+
+public interface Module2Service {
+    String statusReport();
+}

--- a/libs/nalbind/src/test/java/org/elasticsearch/nalbind/injector/InjectorTests.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/nalbind/injector/InjectorTests.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nalbind.injector;
+
+import org.elasticsearch.example.module1.Module1ServiceImpl;
+import org.elasticsearch.example.module2.Module2ServiceImpl;
+import org.elasticsearch.example.module2.api.Module2Service;
+import org.elasticsearch.nalbind.api.Actual;
+import org.elasticsearch.nalbind.exceptions.InjectionConfigurationException;
+import org.elasticsearch.nalbind.exceptions.UnresolvedProxyException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.testSupport.InjectorTestSupport;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Set;
+
+@TestLogging(value="org.elasticsearch.nalbind:TRACE", reason="Debugging")
+public class InjectorTests extends ESTestCase {
+
+    public void testBasicFunctionality() {
+        Module2Service module2Service = Injector.create(MethodHandles.lookup())
+            .addClasses(Module1ServiceImpl.class, Module2ServiceImpl.class)
+            .inject(Module2Service.class);
+        assertEquals("Module1Service: Hello from Module1ServiceImpl to my 1 listeners", module2Service.statusReport());
+    }
+
+    public void testInaccessible() {
+        var injector = Injector.create(MethodHandles.lookup());
+        Class<?> c = new InjectorTestSupport().addLocalClassToInjector(injector);
+        Object object = injector.inject(c);
+        assertTrue(c.isInstance(object));
+    }
+
+    public void testInjectionOfRecordComponents() {
+        record First(){}
+        record Second(First first){}
+        record Third(First first, Second second){}
+        record ExistingInstances(First first, Second second){}
+
+        var first = new First();
+        var second = new Second(first);
+        Injector injector = Injector.create(MethodHandles.lookup()).addRecordContents(new ExistingInstances(first, second));
+        Third third = injector.inject(Third.class);
+        assertSame(first, third.first);
+        assertSame(second, third.second);
+    }
+
+    public void testInjectionOfLists() {
+        Injector injector = Injector.create(MethodHandles.lookup()).addClasses(GoodService.class, ActualService.class, Component1.class);
+        record InjectedStuff(GoodService goodService, ActualService actualService, Component1 component1) {}
+        InjectedStuff injectedStuff = injector.inject(InjectedStuff.class);
+        assertEquals(List.of(injectedStuff.component1), injectedStuff.goodService.components());
+        assertEquals(List.of(injectedStuff.component1), injectedStuff.actualService.components());
+        assertSame(injectedStuff.component1, injectedStuff.goodService.components().get(0));
+        assertSame(injectedStuff.component1, injectedStuff.actualService.components().get(0));
+    }
+
+    public void testInjectionOfMultipleLists() {
+        Injector injector = Injector.create(MethodHandles.lookup()).addClass(MultiService.class);
+        record InjectedStuff(MultiService multiService, Component1 component1, Component2 component2) {}
+        var injectedStuff = injector.inject(InjectedStuff.class);
+        assertEquals(List.of(injectedStuff.component1), injectedStuff.multiService.component1s);
+        assertEquals(List.of(injectedStuff.component2), injectedStuff.multiService.component2s);
+        assertSame(injectedStuff.component1, injectedStuff.multiService.component1s.get(0));
+        assertSame(injectedStuff.component2, injectedStuff.multiService.component2s.get(0));
+    }
+
+    public void testMultipleResultsMap() {
+        Injector injector = Injector.create(MethodHandles.lookup()).addClasses(Service1.class, Component3.class);
+        var resultMap = injector.inject(List.of(Service1.class, Component3.class));
+        assertEquals(Set.of(Service1.class, Component3.class), resultMap.keySet());
+        assertEquals(1, resultMap.get(Service1.class).size());
+        assertEquals(1, resultMap.get(Component3.class).size());
+        Service1 service1 = (Service1) resultMap.get(Service1.class).get(0);
+        Component3 component3 = (Component3) resultMap.get(Component3.class).get(0);
+        assertSame(service1, component3.service1());
+    }
+
+    public void testSupertypeList() {
+        interface Listener {}
+        record Service(List<Listener> listeners) {}
+        record SomeListener() implements Listener {}
+
+        Service service = Injector.create(MethodHandles.lookup()).addInstance(this).addClass(SomeListener.class).inject(Service.class);
+        assertEquals(1, service.listeners.size());
+    }
+
+    public void testMutualInjectionViaList() {
+        interface Listener {}
+        record Service(List<Listener> listeners) {}
+        record SomeListener(Service service) implements Listener {}
+
+        record InjectedStuff(Service service, SomeListener listener){}
+
+        InjectedStuff injected = Injector.create(MethodHandles.lookup()).addClass(SomeListener.class).inject(InjectedStuff.class);
+        assertEquals(List.of(injected.listener), injected.service.listeners());
+        assertSame(injected.listener, injected.service.listeners().get(0));
+        assertSame(injected.service, injected.listener.service);
+    }
+
+    /**
+     * In most cases, if there are two objects that are instances of a class, that's ambiguous.
+     * However, if a concrete (non-abstract) superclass is configured directly, that is not ambiguous:
+     * the instance of that superclass takes precedence over any instances of any subclasses.
+     */
+    public void testOverrideAlias() {
+        class Superclass {}
+        class Subclass extends Superclass {}
+
+        assertEquals(Superclass.class, Injector.create(MethodHandles.lookup())
+            .addClasses(Superclass.class, Subclass.class) // Superclass first
+            .inject(Superclass.class)
+            .getClass());
+        assertEquals(Superclass.class, Injector.create(MethodHandles.lookup())
+            .addClasses(Subclass.class, Superclass.class) // Subclass first
+            .inject(Superclass.class)
+            .getClass());
+        assertEquals(Superclass.class, Injector.create(MethodHandles.lookup())
+            .addClasses(Subclass.class)
+            .inject(Superclass.class) // Superclass is not mentioned until here
+            .getClass());
+    }
+
+    //
+    // Sad paths
+    //
+
+    public void testBadUseOfListProxy() {
+        Injector injector = Injector.create(MethodHandles.lookup()).addClasses(BadService.class, Component1.class);
+        // Note that this throws IllegalStateException rather than InjectionConfigurationException because the problem occurs in user code
+        assertThrows(UnresolvedProxyException.class, injector::inject);
+    }
+
+    public void testBadInterfaceClass() {
+        assertThrows(InjectionConfigurationException.class, () ->
+            Injector.create(MethodHandles.lookup()).addClass(Listener.class).inject());
+    }
+
+    public void testBadUnknownType() {
+        interface Supertype{}
+        record Service(Supertype supertype) {}
+
+        // Injector knows only about Service, discovers Supertype, but can't find any subtypes
+        Injector injector = Injector.create(MethodHandles.lookup()).addClass(Service.class);
+
+        assertThrows(IllegalStateException.class, injector::inject);
+    }
+
+    public void testBadCircularDependency() {
+        assertThrows(InjectionConfigurationException.class, () -> {
+            Injector.create(MethodHandles.lookup()).addClasses(Circular1.class, Circular2.class).inject();
+        });
+    }
+
+    /**
+     * For this one, we don't explicitly tell the injector about the classes involved in the cycle;
+     * it finds them on its own.
+     */
+    public void testBadCircularDependencyViaParameter() {
+        record UsesCircular1(Circular1 circular1){}
+        assertThrows(InjectionConfigurationException.class, () -> {
+            Injector.create(MethodHandles.lookup()).addClass(UsesCircular1.class).inject();
+        });
+    }
+
+    public void testBadCircularDependencyViaSupertype() {
+        interface Service1 {}
+        record Service2(Service1 service1){}
+        record Service3(Service2 service2) implements Service1 {}
+        assertThrows(InjectionConfigurationException.class, () -> {
+            Injector.create(MethodHandles.lookup()).addClasses(Service2.class, Service3.class).inject();
+        });
+    }
+
+    public void testBadCircularDependencyViaList() {
+        interface Listener {}
+        record Service(@Actual List<Listener> listeners) {}
+        record Whoops(Service service) implements Listener {}
+
+        assertThrows(InjectionConfigurationException.class, () -> {
+            Injector.create(MethodHandles.lookup()).addClasses(Whoops.class).inject();
+        });
+    }
+
+    public void testBadListenerAfterListIsResolved() {
+
+    }
+
+    // Common injectable things
+
+    public record Service1() { }
+
+    public interface Listener{}
+
+    public record Component1() implements Listener {}
+
+    public record Component2(Component1 component1) {}
+
+    public record Component3(Service1 service1) {}
+
+    public record GoodService(List<Component1> components) { }
+
+    public record BadService(List<Component1> components) {
+        public BadService {
+            // Shouldn't be using the component list here!
+            assert components.isEmpty() == false;
+        }
+    }
+
+    public record ActualService(@Actual List<Component1> components) {
+        public ActualService {
+            assert components.isEmpty() == false;
+        }
+    }
+
+    public record MultiService(List<Component1> component1s, List<Component2> component2s) { }
+
+    record Circular1(Circular2 service2) {}
+    record Circular2(Circular1 service2) {}
+
+}

--- a/libs/nalbind/src/test/java/org/elasticsearch/testSupport/InjectorTestSupport.java
+++ b/libs/nalbind/src/test/java/org/elasticsearch/testSupport/InjectorTestSupport.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.testSupport;
+
+import org.elasticsearch.nalbind.injector.Injector;
+
+public class InjectorTestSupport {
+    public Class<?> addLocalClassToInjector(Injector injector) {
+        record LocalClass(){}
+        injector.addClass(LocalClass.class);
+        return LocalClass.class;
+    }
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   api project(':libs:elasticsearch-x-content')
   api project(":libs:elasticsearch-geo")
   api project(":libs:elasticsearch-lz4")
+  api project(":libs:elasticsearch-nalbind")
   api project(":libs:elasticsearch-plugin-api")
   api project(":libs:elasticsearch-plugin-analysis-api")
   api project(':libs:elasticsearch-grok')

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -55,6 +55,7 @@ module org.elasticsearch.server {
     requires org.apache.lucene.queryparser;
     requires org.apache.lucene.sandbox;
     requires org.apache.lucene.suggest;
+    requires org.elasticsearch.nalbind;
 
     exports org.elasticsearch;
     exports org.elasticsearch.action;

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -210,9 +210,11 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -225,6 +227,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Collections.newSetFromMap;
+import static java.util.function.Predicate.not;
 import static org.elasticsearch.core.Types.forciblyCast;
 
 /**
@@ -865,7 +869,32 @@ class NodeConstruction {
             documentParsingProvider
         );
 
-        Collection<?> pluginComponents = pluginsService.flatMap(p -> p.createComponents(pluginServices)).toList();
+        Collection<?> pluginComponents = pluginsService.flatMap(plugin -> {
+            Collection<?> allItems = plugin.createComponents(pluginServices);
+            List<?> componentObjects = allItems.stream().filter(not(x -> x instanceof Class<?>)).toList();
+            List<? extends Class<?>> classes = allItems.stream().filter(x -> x instanceof Class<?>).map(x -> (Class<?>) x).toList();
+
+            // Then, injection
+            Collection<?> componentsFromInjector;
+            if (classes.isEmpty()) {
+                componentsFromInjector = Set.of();
+            } else {
+                logger.info("NALBIND - doing component injection for " + plugin.getClass().getSimpleName());
+                var injector = org.elasticsearch.nalbind.injector.Injector.create(MethodHandles.lookup());
+                injector.addInstances(componentObjects);
+                injector.addRecordContents(pluginServices);
+                var resultMap = injector.inject(classes);
+                // For now, assume we want all components added to the Guice injector
+                var distinctObjects = newSetFromMap(new IdentityHashMap<>());
+                resultMap.values().forEach(distinctObjects::addAll);
+                componentsFromInjector = distinctObjects;
+            }
+
+            // Return both
+            return Stream.of(componentObjects, componentsFromInjector)
+                .flatMap(Collection::stream)
+                .toList();
+        }).toList();
 
         var terminationHandlers = pluginsService.loadServiceProviders(TerminationHandlerProvider.class)
             .stream()

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -62,6 +62,12 @@ grant codeBase "${codebase.elasticsearch-core}" {
   permission java.lang.RuntimePermission "getClassLoader";
 };
 
+//grant codeBase "${codebase.elasticsearch-nalbind}" {
+grant {
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+};
+
 grant codeBase "${codebase.elasticsearch-cli}" {
   // we don't actually use write, but it is needed to get the entire property map
   permission java.util.PropertyPermission "*", "read,write";

--- a/x-pack/plugin/downsample/build.gradle
+++ b/x-pack/plugin/downsample/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   compileOnly project(path: xpackModule('mapper-aggregate-metric'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(xpackModule('ccr'))
+  compileOnly project(':libs:elasticsearch-nalbind')
 }
 
 addQaCheckDependencies(project)

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
@@ -137,6 +137,6 @@ public class Downsample extends Plugin implements ActionPlugin, PersistentTaskPl
 
     @Override
     public Collection<?> createComponents(PluginServices services) {
-        return List.of(new DownsampleMetrics(services.telemetryProvider().getMeterRegistry()));
+        return List.of(DownsampleMetrics.class);
     }
 }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.downsample;
 
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.nalbind.api.Inject;
+import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 
 import java.io.IOException;
@@ -38,6 +40,11 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
 
     public DownsampleMetrics(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
+    }
+
+    @Inject
+    public DownsampleMetrics(TelemetryProvider telemetryProvider) {
+        this(telemetryProvider.getMeterRegistry());
     }
 
     @Override


### PR DESCRIPTION
A new homegrown injector with the provisional name of "nalbind".

### Features
- Relatively simple codebase that we own
- Injection of `List` proxies aids in registering listeners/callbacks
- Separate planning and execution phases report all configuration errors before any object instantiation begins
  - Also should help facilitate rapid experimentation/evolution of the injector
- Thoughtful logging
  - `debug` is useful if you want to know what the injector did; you won't drown in detail
  - `trace` is useful if you think the injector might have a bug and want to understand how the sausage was made

### Annotations
- The familiar `@Inject` annotation marks which constructor the injector should call
- A `List` parameter can be annotated with `@Actual` to indicate the constructor cannot tolerate a list proxy
  - For cases where the constructor itself must check the size or contents of the list

### The name
> Noun _nalbinding_
> 
> A fabric creation technique predating knitting and crochet, involving passing the full length of the working thread through each loop, and with separate lengths pieced together during the process.

The intent is that, once we're no longer using Guice, we can remove Guice from the code, and then this injector will become the _only_ injector, at which point the name "nalbind" can go away if we want.
