### PR TITLE
LogsDB qa tests - add specific matcher for source

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -188,7 +188,8 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
             .size(numberOfDocuments);
 
-        final MatchResult matchResult = Matcher.mappings(getContenderMappings(), getBaselineMappings())
+        final MatchResult matchResult = Matcher.matchSource()
+            .mappings(getContenderMappings(), getBaselineMappings())
             .settings(getContenderSettings(), getBaselineSettings())
             .expected(getQueryHits(queryBaseline(searchSourceBuilder)))
             .ignoringSort(true)
@@ -208,7 +209,8 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.termQuery("method", "put"))
             .size(numberOfDocuments);
 
-        final MatchResult matchResult = Matcher.mappings(getContenderMappings(), getBaselineMappings())
+        final MatchResult matchResult = Matcher.matchSource()
+            .mappings(getContenderMappings(), getBaselineMappings())
             .settings(getContenderSettings(), getBaselineSettings())
             .expected(getQueryHits(queryBaseline(searchSourceBuilder)))
             .ignoringSort(true)
@@ -324,5 +326,4 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         var contenderResponseBody = entityAsMap(tuple.v2());
         assertThat("errors in contender bulk response:\n " + contenderResponseBody, contenderResponseBody.get("errors"), equalTo(false));
     }
-
 }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.xcontent.XContentFactory;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * Challenge test (see {@link StandardVersusLogsIndexModeChallengeRestIT}) that uses randomly generated
@@ -42,26 +41,7 @@ public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends Standa
             DataGeneratorSpecification.builder()
                 // Nested fields don't work with subobjects: false.
                 .withNestedFieldsLimit(0)
-                // TODO increase depth of objects
-                // Currently matching fails because in synthetic source all fields are flat (given that we have subobjects: false)
-                // but stored source is identical to original document which has nested structure.
-                .withMaxObjectDepth(0)
                 .withDataSourceHandlers(List.of(new DataSourceHandler() {
-                    // TODO enable null values
-                    // Matcher does not handle nulls currently
-                    @Override
-                    public DataSourceResponse.NullWrapper handle(DataSourceRequest.NullWrapper request) {
-                        return new DataSourceResponse.NullWrapper(Function.identity());
-                    }
-
-                    // TODO enable arrays
-                    // List matcher currently does not apply matching logic recursively
-                    // and equality check fails because arrays are sorted in synthetic source.
-                    @Override
-                    public DataSourceResponse.ArrayWrapper handle(DataSourceRequest.ArrayWrapper request) {
-                        return new DataSourceResponse.ArrayWrapper(Function.identity());
-                    }
-
                     // TODO enable scaled_float fields
                     // There a difference in synthetic source (precision loss)
                     // specific to this fields which matcher can't handle.

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ArrayEqualMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ArrayEqualMatcher.java
@@ -14,7 +14,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.util.Arrays;
 import java.util.List;
 
-class ArrayEqualMatcher extends EqualMatcher<Object[]> {
+import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.prettyPrintArrays;
+
+class ArrayEqualMatcher extends GenericEqualsMatcher<Object[]> {
     ArrayEqualMatcher(
         final XContentBuilder actualMappings,
         final Settings.Builder actualSettings,

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/EqualMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/EqualMatcher.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.List;
 
-class EqualMatcher<T> extends Matcher {
+public class EqualMatcher<T> extends Matcher {
     protected final XContentBuilder actualMappings;
     protected final Settings.Builder actualSettings;
     protected final XContentBuilder expectedMappings;
@@ -22,7 +22,7 @@ class EqualMatcher<T> extends Matcher {
     protected final T expected;
     protected final boolean ignoringSort;
 
-    EqualMatcher(
+    protected EqualMatcher(
         XContentBuilder actualMappings,
         Settings.Builder actualSettings,
         XContentBuilder expectedMappings,

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/GenericEqualsMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/GenericEqualsMatcher.java
@@ -13,7 +13,9 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.List;
 
-public class EqualMatcher<T> extends Matcher {
+import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.formatErrorMessage;
+
+public class GenericEqualsMatcher<T> extends Matcher {
     protected final XContentBuilder actualMappings;
     protected final Settings.Builder actualSettings;
     protected final XContentBuilder expectedMappings;
@@ -22,7 +24,7 @@ public class EqualMatcher<T> extends Matcher {
     protected final T expected;
     protected final boolean ignoringSort;
 
-    protected EqualMatcher(
+    protected GenericEqualsMatcher(
         XContentBuilder actualMappings,
         Settings.Builder actualSettings,
         XContentBuilder expectedMappings,

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ListEqualMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ListEqualMatcher.java
@@ -13,7 +13,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.List;
 
-public class ListEqualMatcher extends EqualMatcher<List<?>> {
+import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.formatErrorMessage;
+import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.prettyPrintCollections;
+
+public class ListEqualMatcher extends GenericEqualsMatcher<List<?>> {
     public ListEqualMatcher(
         final XContentBuilder actualMappings,
         final Settings.Builder actualSettings,
@@ -40,7 +43,7 @@ public class ListEqualMatcher extends EqualMatcher<List<?>> {
                     actualSettings,
                     expectedMappings,
                     expectedSettings,
-                    "List lengths do no match, " + prettyPrintLists(actualList, expectedList)
+                    "List lengths do no match, " + prettyPrintCollections(actualList, expectedList)
                 )
             );
         }
@@ -53,7 +56,7 @@ public class ListEqualMatcher extends EqualMatcher<List<?>> {
                         actualSettings,
                         expectedMappings,
                         expectedSettings,
-                        "Lists do not match when ignoring sort order, " + prettyPrintLists(actualList, expectedList)
+                        "Lists do not match when ignoring sort order, " + prettyPrintCollections(actualList, expectedList)
                     )
                 );
         } else {
@@ -65,7 +68,7 @@ public class ListEqualMatcher extends EqualMatcher<List<?>> {
                         actualSettings,
                         expectedMappings,
                         expectedSettings,
-                        "Lists do not match exactly, " + prettyPrintLists(actualList, expectedList)
+                        "Lists do not match exactly, " + prettyPrintCollections(actualList, expectedList)
                     )
                 );
         }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ListEqualMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ListEqualMatcher.java
@@ -13,8 +13,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.util.List;
 
-class ListEqualMatcher extends EqualMatcher<List<?>> {
-    ListEqualMatcher(
+public class ListEqualMatcher extends EqualMatcher<List<?>> {
+    public ListEqualMatcher(
         final XContentBuilder actualMappings,
         final Settings.Builder actualSettings,
         final XContentBuilder expectedMappings,

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/Matcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/Matcher.java
@@ -8,15 +8,12 @@
 
 package org.elasticsearch.datastreams.logsdb.qa.matchers;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.datastreams.logsdb.qa.matchers.source.SourceMatcher;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * A base class to be used for the matching logic when comparing query results.
@@ -76,8 +73,15 @@ public abstract class Matcher {
 
         @Override
         public MatchResult isEqualTo(T actual) {
-            return new EqualMatcher<>(actualMappings, actualSettings, expectedMappings, expectedSettings, actual, expected, ignoringSort)
-                .match();
+            return new GenericEqualsMatcher<>(
+                actualMappings,
+                actualSettings,
+                expectedMappings,
+                expectedSettings,
+                actual,
+                expected,
+                ignoringSort
+            ).match();
         }
 
         @Override
@@ -142,41 +146,5 @@ public abstract class Matcher {
             this.expected = expected;
             return this;
         }
-    }
-
-    protected static String formatErrorMessage(
-        final XContentBuilder actualMappings,
-        final Settings.Builder actualSettings,
-        final XContentBuilder expectedMappings,
-        final Settings.Builder expectedSettings,
-        final String errorMessage
-    ) {
-        return "Error ["
-            + errorMessage
-            + "] "
-            + "actual mappings ["
-            + Strings.toString(actualMappings)
-            + "] "
-            + "actual settings ["
-            + Strings.toString(actualSettings.build())
-            + "] "
-            + "expected mappings ["
-            + Strings.toString(expectedMappings)
-            + "] "
-            + "expected settings ["
-            + Strings.toString(expectedSettings.build())
-            + "] ";
-    }
-
-    protected static String prettyPrintArrays(final Object[] actualArray, final Object[] expectedArray) {
-        return "actual: " + prettyPrintList(Arrays.asList(actualArray)) + ", expected: " + prettyPrintList(Arrays.asList(expectedArray));
-    }
-
-    protected static <T> String prettyPrintLists(final List<T> actualList, final List<T> expectedList) {
-        return "actual: " + prettyPrintList(actualList) + ", expected: " + prettyPrintList(expectedList);
-    }
-
-    private static <T> String prettyPrintList(final List<T> list) {
-        return "[" + list.stream().map(Object::toString).collect(Collectors.joining(", ")) + "]";
     }
 }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/Messages.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/Messages.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa.matchers;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class Messages {
+    public static String formatErrorMessage(
+        final XContentBuilder actualMappings,
+        final Settings.Builder actualSettings,
+        final XContentBuilder expectedMappings,
+        final Settings.Builder expectedSettings,
+        final String errorMessage
+    ) {
+        return "Error ["
+            + errorMessage
+            + "] "
+            + "actual mappings ["
+            + Strings.toString(actualMappings)
+            + "] "
+            + "actual settings ["
+            + Strings.toString(actualSettings.build())
+            + "] "
+            + "expected mappings ["
+            + Strings.toString(expectedMappings)
+            + "] "
+            + "expected settings ["
+            + Strings.toString(expectedSettings.build())
+            + "] ";
+    }
+
+    public static String prettyPrintArrays(final Object[] actualArray, final Object[] expectedArray) {
+        return "actual: "
+            + prettyPrintCollection(Arrays.asList(actualArray))
+            + ", expected: "
+            + prettyPrintCollection(Arrays.asList(expectedArray));
+    }
+
+    public static <T> String prettyPrintCollections(final Collection<T> actualList, final Collection<T> expectedList) {
+        return "actual: " + prettyPrintCollection(actualList) + ", expected: " + prettyPrintCollection(expectedList);
+    }
+
+    private static <T> String prettyPrintCollection(final Collection<T> list) {
+        return "[" + list.stream().map(Object::toString).collect(Collectors.joining(", ")) + "]";
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ObjectMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/ObjectMatcher.java
@@ -11,7 +11,9 @@ package org.elasticsearch.datastreams.logsdb.qa.matchers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-public class ObjectMatcher extends EqualMatcher<Object> {
+import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.formatErrorMessage;
+
+public class ObjectMatcher extends GenericEqualsMatcher<Object> {
     ObjectMatcher(
         final XContentBuilder actualMappings,
         final Settings.Builder actualSettings,

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/FieldSpecificMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/FieldSpecificMatcher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa.matchers.source;
+
+import org.apache.lucene.sandbox.document.HalfFloatPoint;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public interface FieldSpecificMatcher {
+    boolean match(List<Object> actual, List<Object> expected);
+
+    class HalfFloatMatcher implements FieldSpecificMatcher {
+        public boolean match(List<Object> actual, List<Object> expected) {
+            var actualHalfFloatBytes = normalize(actual);
+            var expectedHalfFloatBytes = normalize(expected);
+
+            return actualHalfFloatBytes.equals(expectedHalfFloatBytes);
+        }
+
+        private static Set<Short> normalize(List<Object> values) {
+            if (values == null) {
+                return Set.of();
+            }
+
+            Function<Object, Float> toFloat = (o) -> o instanceof Number n ? n.floatValue() : Float.parseFloat((String) o);
+            return values.stream()
+                .filter(Objects::nonNull)
+                .map(toFloat)
+                // Based on logic in NumberFieldMapper
+                .map(HalfFloatPoint::halfFloatToSortableShort)
+                .collect(Collectors.toSet());
+        }
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/MappingTransforms.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/MappingTransforms.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa.matchers.source;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class MappingTransforms {
+    /**
+     * Normalize mapping to have the same structure as normalized source and enable field mapping lookup.
+     * Similar to {@link SourceTransforms#normalize(Map)} but needs to get rid of intermediate nodes
+     * and collect results into a different data structure.
+     *
+     * @param map
+     * @return
+     */
+    public static Map<String, Map<String, Object>> normalizeMapping(Map<String, Object> map) {
+        var flattened = new HashMap<String, Map<String, Object>>();
+
+        descend(null, map, flattened);
+
+        return flattened;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void descend(String pathFromRoot, Map<String, Object> currentLevel, Map<String, Map<String, Object>> flattened) {
+        for (var entry : currentLevel.entrySet()) {
+            if (entry.getKey().equals("_doc") || entry.getKey().equals("properties")) {
+                descend(pathFromRoot, (Map<String, Object>) entry.getValue(), flattened);
+            } else {
+                if (entry.getValue() instanceof Map<?, ?> map) {
+                    var pathToField = pathFromRoot == null ? entry.getKey() : pathFromRoot + "." + entry.getKey();
+                    descend(pathToField, (Map<String, Object>) map, flattened);
+                } else {
+                    if (pathFromRoot == null) {
+                        // Ignore top level mapping parameters for now
+                        continue;
+                    }
+
+                    flattened.putIfAbsent(pathFromRoot, new HashMap<>());
+                    flattened.get(pathFromRoot).put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/MappingTransforms.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/MappingTransforms.java
@@ -17,8 +17,8 @@ class MappingTransforms {
      * Similar to {@link SourceTransforms#normalize(Map)} but needs to get rid of intermediate nodes
      * and collect results into a different data structure.
      *
-     * @param map
-     * @return
+     * @param map raw mapping document converted to map
+     * @return map from normalized field name (like a.b.c) to a map of mapping parameters (like type)
      */
     public static Map<String, Map<String, Object>> normalizeMapping(Map<String, Object> map) {
         var flattened = new HashMap<String, Map<String, Object>>();
@@ -43,8 +43,7 @@ class MappingTransforms {
                         continue;
                     }
 
-                    flattened.putIfAbsent(pathFromRoot, new HashMap<>());
-                    flattened.get(pathFromRoot).put(entry.getKey(), entry.getValue());
+                    flattened.computeIfAbsent(pathFromRoot, k -> new HashMap<>()).put(entry.getKey(), entry.getValue());
                 }
             }
         }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceMatcher.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa.matchers.source;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.FormatNames;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.datastreams.logsdb.qa.matchers.EqualMatcher;
+import org.elasticsearch.datastreams.logsdb.qa.matchers.ListEqualMatcher;
+import org.elasticsearch.datastreams.logsdb.qa.matchers.MatchResult;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class SourceMatcher extends EqualMatcher<List<Map<String, Object>>> {
+    private final Map<String, Map<String, Object>> actualNormalizedMapping;
+    private final Map<String, Map<String, Object>> expectedNormalizedMapping;
+
+    private final Map<String, FieldSpecificMatcher> fieldSpecificMatchers;
+
+    public SourceMatcher(
+        final XContentBuilder actualMappings,
+        final Settings.Builder actualSettings,
+        final XContentBuilder expectedMappings,
+        final Settings.Builder expectedSettings,
+        final List<Map<String, Object>> actual,
+        final List<Map<String, Object>> expected,
+        final boolean ignoringSort
+    ) {
+        super(actualMappings, actualSettings, expectedMappings, expectedSettings, actual, expected, ignoringSort);
+
+        var actualMappingAsMap = XContentHelper.convertToMap(BytesReference.bytes(actualMappings), false, actualMappings.contentType())
+            .v2();
+        this.actualNormalizedMapping = MappingTransforms.normalizeMapping(actualMappingAsMap);
+
+        var expectedMappingAsMap = XContentHelper.convertToMap(BytesReference.bytes(expectedMappings), false, actualMappings.contentType())
+            .v2();
+        this.expectedNormalizedMapping = MappingTransforms.normalizeMapping(expectedMappingAsMap);
+
+        this.fieldSpecificMatchers = Map.of("half_float", new FieldSpecificMatcher.HalfFloatMatcher());
+    }
+
+    public MatchResult match() {
+        if (actual.size() != expected.size()) {
+            return MatchResult.noMatch(
+                formatErrorMessage(
+                    actualMappings,
+                    actualSettings,
+                    expectedMappings,
+                    expectedSettings,
+                    "Number of documents does not match, " + prettyPrintLists(actual, expected)
+                )
+            );
+        }
+
+        var sortedAndFlattenedActual = actual.stream()
+            .sorted(Comparator.comparing((Map<String, Object> m) -> parseTimestampToEpochMillis(m.get("@timestamp"))))
+            .map(SourceTransforms::normalize)
+            .toList();
+        var sortedAndFlattenedExpected = expected.stream()
+            .sorted(Comparator.comparing((Map<String, Object> m) -> parseTimestampToEpochMillis(m.get("@timestamp"))))
+            .map(SourceTransforms::normalize)
+            .toList();
+
+        for (int i = 0; i < sortedAndFlattenedActual.size(); i++) {
+            var actual = sortedAndFlattenedActual.get(i);
+            var expected = sortedAndFlattenedExpected.get(i);
+
+            var result = compareSource(actual, expected);
+            if (result.isMatch() == false) {
+                return result;
+            }
+        }
+
+        return MatchResult.match();
+    }
+
+    private MatchResult compareSource(Map<String, List<Object>> actual, Map<String, List<Object>> expected) {
+        for (var expectedFieldEntry : expected.entrySet()) {
+            var name = expectedFieldEntry.getKey();
+
+            var actualValues = actual.get(name);
+            var expectedValues = expectedFieldEntry.getValue();
+
+            MatchResult fieldMatch = matchWithFieldSpecificMatcher(name, actualValues, expectedValues).orElseGet(
+                () -> matchWithGenericMatcher(actualValues, expectedValues)
+            );
+
+            if (fieldMatch.isMatch() == false) {
+                var message = "Source documents don't match for field [" + name + "]: " + fieldMatch.getMessage();
+                return MatchResult.noMatch(message);
+            }
+        }
+
+        return MatchResult.match();
+    }
+
+    private Optional<MatchResult> matchWithFieldSpecificMatcher(String fieldName, List<Object> actualValues, List<Object> expectedValues) {
+        var actualFieldMapping = actualNormalizedMapping.get(fieldName);
+        if (actualFieldMapping == null) {
+            // Dynamic mapping, nothing to do
+            return Optional.empty();
+        }
+
+        var actualFieldType = (String) actualFieldMapping.get("type");
+        if (actualFieldType == null) {
+            throw new IllegalStateException("Field type is missing from leaf field mapping parameters");
+        }
+
+        var expectedFieldMapping = expectedNormalizedMapping.get(fieldName);
+        if (expectedFieldMapping == null || Objects.equals(actualFieldType, expectedFieldMapping.get("type")) == false) {
+            throw new IllegalStateException("Field type of a leaf field differs between expected and actual mapping");
+        }
+
+        var fieldSpecificMatcher = fieldSpecificMatchers.get(actualFieldType);
+        if (fieldSpecificMatcher == null) {
+            return Optional.empty();
+        }
+
+        boolean matched = fieldSpecificMatcher.match(actualValues, expectedValues);
+        return Optional.of(
+            matched
+                ? MatchResult.match()
+                : MatchResult.noMatch(
+                    formatErrorMessage(
+                        actualMappings,
+                        actualSettings,
+                        expectedMappings,
+                        expectedSettings,
+                        "Source documents don't match for field ["
+                            + fieldName
+                            + "], of type ["
+                            + actualFieldType
+                            + "], "
+                            + prettyPrintLists(actualValues, expectedValues)
+                    )
+                )
+        );
+    }
+
+    private MatchResult matchWithGenericMatcher(List<Object> actualValues, List<Object> expectedValues) {
+        var genericListMatcher = new ListEqualMatcher(
+            actualMappings,
+            actualSettings,
+            expectedMappings,
+            expectedSettings,
+            SourceTransforms.normalizeValues(actualValues),
+            SourceTransforms.normalizeValues(expectedValues),
+            true
+        );
+
+        return genericListMatcher.match();
+    }
+
+    // We could look up the format from mapping eventually.
+    private static long parseTimestampToEpochMillis(Object timestamp) {
+        return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).parseMillis((String) timestamp);
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceTransforms.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceTransforms.java
@@ -66,8 +66,7 @@ class SourceTransforms {
         if (currentField instanceof Map<?, ?> map) {
             descend(pathToCurrentField, (Map<String, Object>) map, flattened);
         } else {
-            flattened.putIfAbsent(pathToCurrentField, new ArrayList<>());
-            flattened.get(pathToCurrentField).add(currentField);
+            flattened.computeIfAbsent(pathToCurrentField, k -> new ArrayList<>()).add(currentField);
         }
     }
 }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceTransforms.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceTransforms.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa.matchers.source;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+class SourceTransforms {
+    /**
+     * This preprocessing step makes it easier to match the document using a unified structure.
+     * It performs following modifications:
+     * <ul>
+     * <li> Flattens all nested maps into top level map with full field path as key (e.g. "a.b.c.d") </li>
+     * <li> Transforms all field values to arrays of length >= 1 </li>
+     * </ul>
+     * <p>
+     * It also makes it possible to work with subobjects: false/auto settings.
+     *
+     * @return flattened map
+     */
+    public static Map<String, List<Object>> normalize(Map<String, Object> map) {
+        var flattened = new HashMap<String, List<Object>>();
+
+        descend(null, map, flattened);
+
+        return flattened;
+    }
+
+    public static <T> List<T> normalizeValues(List<T> values) {
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        // Synthetic source modifications:
+        // * null values are not present
+        // * duplicates are removed
+        return new ArrayList<>(values.stream().filter(v -> v != null && Objects.equals(v, "null") == false).collect(Collectors.toSet()));
+    }
+
+    private static void descend(String pathFromRoot, Map<String, Object> currentLevel, Map<String, List<Object>> flattened) {
+        for (var entry : currentLevel.entrySet()) {
+            var pathToCurrentField = pathFromRoot == null ? entry.getKey() : pathFromRoot + "." + entry.getKey();
+            if (entry.getValue() instanceof List<?> list) {
+                for (var fieldValue : list) {
+                    handleField(pathToCurrentField, fieldValue, flattened);
+                }
+            } else {
+                handleField(pathToCurrentField, entry.getValue(), flattened);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void handleField(String pathToCurrentField, Object currentField, Map<String, List<Object>> flattened) {
+        if (currentField instanceof Map<?, ?> map) {
+            descend(pathToCurrentField, (Map<String, Object>) map, flattened);
+        } else {
+            flattened.putIfAbsent(pathToCurrentField, new ArrayList<>());
+            flattened.get(pathToCurrentField).add(currentField);
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultPrimitiveTypesHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultPrimitiveTypesHandler.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.logsdb.datageneration.datasource;
 
-import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.elasticsearch.test.ESTestCase;
 
 import java.math.BigInteger;
@@ -58,13 +57,8 @@ public class DefaultPrimitiveTypesHandler implements DataSourceHandler {
 
     @Override
     public DataSourceResponse.HalfFloatGenerator handle(DataSourceRequest.HalfFloatGenerator request) {
-        // This trick taken from NumberFieldMapper reduces precision of float to actual half float precision.
-        // We do this to avoid getting tripped on values in synthetic source having reduced precision but
-        // values in stored source having full float precision.
-        // This can be removed with a more lenient matcher.
-        return new DataSourceResponse.HalfFloatGenerator(
-            () -> HalfFloatPoint.sortableShortToHalfFloat(HalfFloatPoint.halfFloatToSortableShort(ESTestCase.randomFloat()))
-        );
+        // All floats are accepted but stored precision is reduced.
+        return new DataSourceResponse.HalfFloatGenerator(ESTestCase::randomFloat);
     }
 
     @Override


### PR DESCRIPTION
This PR adds a new matcher that specifically handles source of documents. We need a special implementation due to complex structure of source document (multiple layers of documents) and differences between synthetic and stored source. 

Such differences in theory could be expressed in generic terms (e.g. add a parameter to ignore nulls to list matcher) but i think this is simpler. Moreover as i discovered previously we need special matchers for some fields due to field-specific differences in synthetic source. To do that we would need a special code path anyway.