### PR TITLE
[8.15] Forward port v8.14.3 release notes (#110629)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.15.0>>
+* <<release-notes-8.14.3>>
 * <<release-notes-8.14.2>>
 * <<release-notes-8.14.1>>
 * <<release-notes-8.14.0>>
@@ -69,7 +70,11 @@ This section summarizes the changes in each release.
 
 --
 
+<<<<<<< HEAD
 include::release-notes/8.15.0.asciidoc[]
+=======
+include::release-notes/8.14.3.asciidoc[]
+>>>>>>> b6110d1abad (Update docs for v8.14.3 release (#110629))
 include::release-notes/8.14.2.asciidoc[]
 include::release-notes/8.14.1.asciidoc[]
 include::release-notes/8.14.0.asciidoc[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -70,11 +70,8 @@ This section summarizes the changes in each release.
 
 --
 
-<<<<<<< HEAD
 include::release-notes/8.15.0.asciidoc[]
-=======
 include::release-notes/8.14.3.asciidoc[]
->>>>>>> b6110d1abad (Update docs for v8.14.3 release (#110629))
 include::release-notes/8.14.2.asciidoc[]
 include::release-notes/8.14.1.asciidoc[]
 include::release-notes/8.14.0.asciidoc[]

--- a/docs/reference/release-notes/8.14.3.asciidoc
+++ b/docs/reference/release-notes/8.14.3.asciidoc
@@ -1,0 +1,24 @@
+[[release-notes-8.14.3]]
+== {es} version 8.14.3
+
+coming[8.14.3]
+
+Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
+
+[[bug-8.14.3]]
+[float]
+=== Bug fixes
+
+Cluster Coordination::
+* Ensure tasks preserve versions in `MasterService` {es-pull}109850[#109850]
+
+ES|QL::
+* Introduce compute listener {es-pull}110400[#110400]
+
+Mapping::
+* Automatically adjust `ignore_malformed` only for the @timestamp {es-pull}109948[#109948]
+
+TSDB::
+* Disallow index.time_series.end_time setting from being set or updated in normal indices {es-pull}110268[#110268] (issue: {es-issue}110265[#110265])
+
+

--- a/docs/reference/release-notes/8.14.3.asciidoc
+++ b/docs/reference/release-notes/8.14.3.asciidoc
@@ -3,6 +3,15 @@
 
 
 Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
+[[known-issues-8.14.3]]
+[float]
+=== Known issues
+* When upgrading clusters from version 8.11.4 or earlier, if your cluster contains non-master-eligible nodes,
+information about the new functionality of these upgraded nodes may not be registered properly with the master node.
+This can lead to some new functionality added since 8.12.0 not being accessible on the upgraded cluster.
+If your cluster is running on ECK 2.12.1 and above, this may cause problems with finalizing the upgrade.
+To resolve this issue, perform a rolling restart on the non-master-eligible nodes once all Elasticsearch nodes
+are upgraded. This issue is fixed in 8.15.0.
 
 [[bug-8.14.3]]
 [float]

--- a/docs/reference/release-notes/8.14.3.asciidoc
+++ b/docs/reference/release-notes/8.14.3.asciidoc
@@ -1,7 +1,6 @@
 [[release-notes-8.14.3]]
 == {es} version 8.14.3
 
-coming[8.14.3]
 
 Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
 

--- a/docs/reference/release-notes/8.14.3.asciidoc
+++ b/docs/reference/release-notes/8.14.3.asciidoc
@@ -3,6 +3,7 @@
 
 
 Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
+
 [[known-issues-8.14.3]]
 [float]
 === Known issues


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.14` to `8.15`:
 - [Update docs for v8.14.3 release (#110629)](https://github.com/elastic/elasticsearch/pull/110629)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)