### PR TITLE
Fix potential bug in EmbeddedProviderPlugin

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -43,17 +43,16 @@ public class EmbeddedProviderExtension {
         });
 
         String manifestTaskName = "generate" + capitalName + "ProviderManifest";
-        Provider<Directory> generatedResourcesDir = project.getLayout().getBuildDirectory().dir("generated-resources");
+        Provider<Directory> generatedResourcesRoot = project.getLayout().getBuildDirectory().dir("generated-resources");
         var generateProviderManifest = project.getTasks().register(manifestTaskName, GenerateProviderManifest.class);
         generateProviderManifest.configure(t -> {
-            t.getManifestFile().set(generatedResourcesDir.map(d -> d.file("LISTING.TXT")));
+            t.getManifestFile().set(generatedResourcesRoot.map(d -> d.dir(manifestTaskName).file("LISTING.TXT")));
             t.getProviderImplClasspath().from(implConfig);
         });
-
         String implTaskName = "generate" + capitalName + "ProviderImpl";
         var generateProviderImpl = project.getTasks().register(implTaskName, Sync.class);
         generateProviderImpl.configure(t -> {
-            t.into(generatedResourcesDir);
+            t.into(generatedResourcesRoot.map(d -> d.dir(implTaskName)));
             t.into("IMPL-JARS/" + implName, spec -> {
                 spec.from(implConfig);
                 spec.from(generateProviderManifest);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/GenerateProviderManifest.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/GenerateProviderManifest.java
@@ -39,7 +39,6 @@ abstract class GenerateProviderManifest extends DefaultTask {
         File manifestFile = getManifestFile().get().getAsFile();
         manifestFile.getParentFile().mkdirs();
         FileUtils.write(manifestFile, generateManifestContent(), "UTF-8");
-        System.out.println("manifestFile = " + manifestFile + " exists = " + manifestFile.exists());
     }
 
     private String generateManifestContent() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/GenerateProviderManifest.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/GenerateProviderManifest.java
@@ -39,6 +39,7 @@ abstract class GenerateProviderManifest extends DefaultTask {
         File manifestFile = getManifestFile().get().getAsFile();
         manifestFile.getParentFile().mkdirs();
         FileUtils.write(manifestFile, generateManifestContent(), "UTF-8");
+        System.out.println("manifestFile = " + manifestFile + " exists = " + manifestFile.exists());
     }
 
     private String generateManifestContent() {


### PR DESCRIPTION
Ocassionally we see a LISTING.TXT not included in the jar. The cause seems a timing issue with sync task were target root folder is same folder as folder containing listing.txt.  