### PR TITLE
[8.14] Update paginate-search-results.asciidoc (#111565)

### DIFF
--- a/docs/reference/search/search-your-data/paginate-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/paginate-search-results.asciidoc
@@ -362,7 +362,7 @@ Perl::
 
 Python::
 
-    See https://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
+    See https://elasticsearch-py.readthedocs.io/en/[elasticsearch.helpers.*]
 
 JavaScript::
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Update paginate-search-results.asciidoc (#111565)