### PR TITLE
ESQL: Migrate logical plan to NamedWriteable

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/index/EsIndex.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/index/EsIndex.java
@@ -6,13 +6,17 @@
  */
 package org.elasticsearch.xpack.esql.core.index;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public class EsIndex {
+public class EsIndex implements Writeable {
 
     private final String name;
     private final Map<String, EsField> mapping;
@@ -28,6 +32,22 @@ public class EsIndex {
         this.name = name;
         this.mapping = mapping;
         this.concreteIndices = concreteIndices;
+    }
+
+    @SuppressWarnings("unchecked")
+    public EsIndex(StreamInput in) throws IOException {
+        this(
+            in.readString(),
+            in.readImmutableMap(StreamInput::readString, i -> i.readNamedWriteable(EsField.class)),
+            (Set<String>) in.readGenericValue()
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name());
+        out.writeMap(mapping(), StreamOutput::writeNamedWriteable);
+        out.writeGenericValue(concreteIndices());
     }
 
     public String name() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -7,18 +7,14 @@
 
 package org.elasticsearch.xpack.esql.io.stream;
 
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.util.iterable.Iterables;
-import org.elasticsearch.dissect.DissectParser;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.transport.RemoteClusterAware;
-import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -27,10 +23,8 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.Order;
 import org.elasticsearch.xpack.esql.core.index.EsIndex;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
-import org.elasticsearch.xpack.esql.plan.logical.Dissect.Parser;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
@@ -140,22 +134,22 @@ public final class PlanNamedTypes {
             of(PhysicalPlan.class, ShowExec.class, PlanNamedTypes::writeShowExec, PlanNamedTypes::readShowExec),
             of(PhysicalPlan.class, TopNExec.class, PlanNamedTypes::writeTopNExec, PlanNamedTypes::readTopNExec),
             // Logical Plan Nodes - a subset of plans that end up being actually serialized
-            of(LogicalPlan.class, Aggregate.class, Aggregate::writeAggregate, Aggregate::new),
-            of(LogicalPlan.class, Dissect.class, PlanNamedTypes::writeDissect, PlanNamedTypes::readDissect),
-            of(LogicalPlan.class, EsRelation.class, PlanNamedTypes::writeEsRelation, PlanNamedTypes::readEsRelation),
-            of(LogicalPlan.class, Eval.class, PlanNamedTypes::writeEval, PlanNamedTypes::readEval),
-            of(LogicalPlan.class, Enrich.class, PlanNamedTypes::writeEnrich, PlanNamedTypes::readEnrich),
-            of(LogicalPlan.class, EsqlProject.class, PlanNamedTypes::writeEsqlProject, PlanNamedTypes::readEsqlProject),
-            of(LogicalPlan.class, Filter.class, PlanNamedTypes::writeFilter, PlanNamedTypes::readFilter),
-            of(LogicalPlan.class, Grok.class, PlanNamedTypes::writeGrok, PlanNamedTypes::readGrok),
-            of(LogicalPlan.class, InlineStats.class, (PlanStreamOutput out, InlineStats v) -> v.writeTo(out), InlineStats::new),
+            of(LogicalPlan.class, Aggregate.ENTRY),
+            of(LogicalPlan.class, Dissect.ENTRY),
+            of(LogicalPlan.class, EsRelation.ENTRY),
+            of(LogicalPlan.class, Eval.ENTRY),
+            of(LogicalPlan.class, Enrich.ENTRY),
+            of(LogicalPlan.class, EsqlProject.ENTRY),
+            of(LogicalPlan.class, Filter.ENTRY),
+            of(LogicalPlan.class, Grok.ENTRY),
+            of(LogicalPlan.class, InlineStats.ENTRY),
             of(LogicalPlan.class, Join.ENTRY),
-            of(LogicalPlan.class, Limit.class, PlanNamedTypes::writeLimit, PlanNamedTypes::readLimit),
+            of(LogicalPlan.class, Limit.ENTRY),
             of(LogicalPlan.class, LocalRelation.ENTRY),
             of(LogicalPlan.class, Lookup.ENTRY),
-            of(LogicalPlan.class, MvExpand.class, PlanNamedTypes::writeMvExpand, PlanNamedTypes::readMvExpand),
-            of(LogicalPlan.class, OrderBy.class, PlanNamedTypes::writeOrderBy, PlanNamedTypes::readOrderBy),
-            of(LogicalPlan.class, Project.class, PlanNamedTypes::writeProject, PlanNamedTypes::readProject),
+            of(LogicalPlan.class, MvExpand.ENTRY),
+            of(LogicalPlan.class, OrderBy.ENTRY),
+            of(LogicalPlan.class, Project.ENTRY),
             of(LogicalPlan.class, TopN.ENTRY)
         );
         return declared;
@@ -187,7 +181,7 @@ public final class PlanNamedTypes {
             Source.readFrom(in),
             in.readPhysicalPlanNode(),
             in.readNamedWriteable(Expression.class),
-            readDissectParser(in),
+            Dissect.Parser.readFrom(in),
             in.readNamedWriteableCollectionAsList(Attribute.class)
         );
     }
@@ -196,14 +190,14 @@ public final class PlanNamedTypes {
         Source.EMPTY.writeTo(out);
         out.writePhysicalPlanNode(dissectExec.child());
         out.writeNamedWriteable(dissectExec.inputExpression());
-        writeDissectParser(out, dissectExec.parser());
+        dissectExec.parser().writeTo(out);
         out.writeNamedWriteableCollection(dissectExec.extractedFields());
     }
 
     static EsQueryExec readEsQueryExec(PlanStreamInput in) throws IOException {
         return new EsQueryExec(
             Source.readFrom(in),
-            readEsIndex(in),
+            new EsIndex(in),
             readIndexMode(in),
             in.readNamedWriteableCollectionAsList(Attribute.class),
             in.readOptionalNamedWriteable(QueryBuilder.class),
@@ -216,7 +210,7 @@ public final class PlanNamedTypes {
     static void writeEsQueryExec(PlanStreamOutput out, EsQueryExec esQueryExec) throws IOException {
         assert esQueryExec.children().size() == 0;
         Source.EMPTY.writeTo(out);
-        writeEsIndex(out, esQueryExec.index());
+        esQueryExec.index().writeTo(out);
         writeIndexMode(out, esQueryExec.indexMode());
         out.writeNamedWriteableCollection(esQueryExec.output());
         out.writeOptionalNamedWriteable(esQueryExec.query());
@@ -228,7 +222,7 @@ public final class PlanNamedTypes {
     static EsSourceExec readEsSourceExec(PlanStreamInput in) throws IOException {
         return new EsSourceExec(
             Source.readFrom(in),
-            readEsIndex(in),
+            new EsIndex(in),
             in.readNamedWriteableCollectionAsList(Attribute.class),
             in.readOptionalNamedWriteable(QueryBuilder.class),
             readIndexMode(in)
@@ -237,13 +231,13 @@ public final class PlanNamedTypes {
 
     static void writeEsSourceExec(PlanStreamOutput out, EsSourceExec esSourceExec) throws IOException {
         Source.EMPTY.writeTo(out);
-        writeEsIndex(out, esSourceExec.index());
+        esSourceExec.index().writeTo(out);
         out.writeNamedWriteableCollection(esSourceExec.output());
         out.writeOptionalNamedWriteable(esSourceExec.query());
         writeIndexMode(out, esSourceExec.indexMode());
     }
 
-    static IndexMode readIndexMode(StreamInput in) throws IOException {
+    public static IndexMode readIndexMode(StreamInput in) throws IOException {
         if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_ADD_INDEX_MODE_TO_SOURCE)) {
             return IndexMode.fromString(in.readString());
         } else {
@@ -251,7 +245,7 @@ public final class PlanNamedTypes {
         }
     }
 
-    static void writeIndexMode(StreamOutput out, IndexMode indexMode) throws IOException {
+    public static void writeIndexMode(StreamOutput out, IndexMode indexMode) throws IOException {
         if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_ADD_INDEX_MODE_TO_SOURCE)) {
             out.writeString(indexMode.getName());
         } else if (indexMode != IndexMode.STANDARD) {
@@ -283,7 +277,7 @@ public final class PlanNamedTypes {
             concreteIndices = in.readMap(StreamInput::readString, StreamInput::readString);
         } else {
             mode = Enrich.Mode.ANY;
-            EsIndex esIndex = readEsIndex(in);
+            EsIndex esIndex = new EsIndex(in);
             if (esIndex.concreteIndices().size() != 1) {
                 throw new IllegalStateException("expected a single concrete enrich index; got " + esIndex.concreteIndices());
             }
@@ -317,7 +311,7 @@ public final class PlanNamedTypes {
         } else {
             if (enrich.concreteIndices().keySet().equals(Set.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY))) {
                 String concreteIndex = enrich.concreteIndices().get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                writeEsIndex(out, new EsIndex(concreteIndex, Map.of(), Set.of(concreteIndex)));
+                new EsIndex(concreteIndex, Map.of(), Set.of(concreteIndex)).writeTo(out);
             } else {
                 throw new IllegalStateException("expected a single concrete enrich index; got " + enrich.concreteIndices());
             }
@@ -389,7 +383,7 @@ public final class PlanNamedTypes {
     static FragmentExec readFragmentExec(PlanStreamInput in) throws IOException {
         return new FragmentExec(
             Source.readFrom(in),
-            in.readLogicalPlanNode(),
+            in.readNamedWriteable(LogicalPlan.class),
             in.readOptionalNamedWriteable(QueryBuilder.class),
             in.readOptionalVInt(),
             in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0) ? in.readOptionalPhysicalPlanNode() : null
@@ -398,7 +392,7 @@ public final class PlanNamedTypes {
 
     static void writeFragmentExec(PlanStreamOutput out, FragmentExec fragmentExec) throws IOException {
         Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(fragmentExec.fragment());
+        out.writeNamedWriteable(fragmentExec.fragment());
         out.writeOptionalNamedWriteable(fragmentExec.esFilter());
         out.writeOptionalVInt(fragmentExec.estimatedRowSize());
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
@@ -522,232 +516,6 @@ public final class PlanNamedTypes {
         out.writeOptionalVInt(topNExec.estimatedRowSize());
     }
 
-    static Dissect readDissect(PlanStreamInput in) throws IOException {
-        return new Dissect(
-            Source.readFrom(in),
-            in.readLogicalPlanNode(),
-            in.readNamedWriteable(Expression.class),
-            readDissectParser(in),
-            in.readNamedWriteableCollectionAsList(Attribute.class)
-        );
-    }
-
-    static void writeDissect(PlanStreamOutput out, Dissect dissect) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(dissect.child());
-        out.writeNamedWriteable(dissect.input());
-        writeDissectParser(out, dissect.parser());
-        out.writeNamedWriteableCollection(dissect.extractedFields());
-    }
-
-    static EsRelation readEsRelation(PlanStreamInput in) throws IOException {
-        Source source = Source.readFrom(in);
-        EsIndex esIndex = readEsIndex(in);
-        List<Attribute> attributes = in.readNamedWriteableCollectionAsList(Attribute.class);
-        if (supportingEsSourceOptions(in.getTransportVersion())) {
-            readEsSourceOptions(in); // consume optional strings sent by remote
-        }
-        final IndexMode indexMode = readIndexMode(in);
-        boolean frozen = in.readBoolean();
-        return new EsRelation(source, esIndex, attributes, indexMode, frozen);
-    }
-
-    static void writeEsRelation(PlanStreamOutput out, EsRelation relation) throws IOException {
-        assert relation.children().size() == 0;
-        Source.EMPTY.writeTo(out);
-        writeEsIndex(out, relation.index());
-        out.writeNamedWriteableCollection(relation.output());
-        if (supportingEsSourceOptions(out.getTransportVersion())) {
-            writeEsSourceOptions(out); // write (null) string fillers expected by remote
-        }
-        writeIndexMode(out, relation.indexMode());
-        out.writeBoolean(relation.frozen());
-    }
-
-    private static boolean supportingEsSourceOptions(TransportVersion version) {
-        return version.onOrAfter(TransportVersions.V_8_14_0) && version.before(TransportVersions.ESQL_REMOVE_ES_SOURCE_OPTIONS);
-    }
-
-    private static void readEsSourceOptions(PlanStreamInput in) throws IOException {
-        // allowNoIndices
-        in.readOptionalString();
-        // ignoreUnavailable
-        in.readOptionalString();
-        // preference
-        in.readOptionalString();
-    }
-
-    private static void writeEsSourceOptions(PlanStreamOutput out) throws IOException {
-        // allowNoIndices
-        out.writeOptionalString(null);
-        // ignoreUnavailable
-        out.writeOptionalString(null);
-        // preference
-        out.writeOptionalString(null);
-    }
-
-    static Eval readEval(PlanStreamInput in) throws IOException {
-        return new Eval(Source.readFrom(in), in.readLogicalPlanNode(), in.readCollectionAsList(Alias::new));
-    }
-
-    static void writeEval(PlanStreamOutput out, Eval eval) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(eval.child());
-        out.writeCollection(eval.fields());
-    }
-
-    static Enrich readEnrich(PlanStreamInput in) throws IOException {
-        Enrich.Mode mode = Enrich.Mode.ANY;
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
-            mode = in.readEnum(Enrich.Mode.class);
-        }
-        final Source source = Source.readFrom(in);
-        final LogicalPlan child = in.readLogicalPlanNode();
-        final Expression policyName = in.readNamedWriteable(Expression.class);
-        final NamedExpression matchField = in.readNamedWriteable(NamedExpression.class);
-        if (in.getTransportVersion().before(TransportVersions.V_8_13_0)) {
-            in.readString(); // discard the old policy name
-        }
-        final EnrichPolicy policy = new EnrichPolicy(in);
-        final Map<String, String> concreteIndices;
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
-            concreteIndices = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            EsIndex esIndex = readEsIndex(in);
-            if (esIndex.concreteIndices().size() > 1) {
-                throw new IllegalStateException("expected a single enrich index; got " + esIndex);
-            }
-            concreteIndices = Map.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, Iterables.get(esIndex.concreteIndices(), 0));
-        }
-        return new Enrich(
-            source,
-            child,
-            mode,
-            policyName,
-            matchField,
-            policy,
-            concreteIndices,
-            in.readNamedWriteableCollectionAsList(NamedExpression.class)
-        );
-    }
-
-    static void writeEnrich(PlanStreamOutput out, Enrich enrich) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
-            out.writeEnum(enrich.mode());
-        }
-
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(enrich.child());
-        out.writeNamedWriteable(enrich.policyName());
-        out.writeNamedWriteable(enrich.matchField());
-        if (out.getTransportVersion().before(TransportVersions.V_8_13_0)) {
-            out.writeString(BytesRefs.toString(enrich.policyName().fold())); // old policy name
-        }
-        enrich.policy().writeTo(out);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
-            out.writeMap(enrich.concreteIndices(), StreamOutput::writeString, StreamOutput::writeString);
-        } else {
-            Map<String, String> concreteIndices = enrich.concreteIndices();
-            if (concreteIndices.keySet().equals(Set.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY))) {
-                String enrichIndex = concreteIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                EsIndex esIndex = new EsIndex(enrichIndex, Map.of(), Set.of(enrichIndex));
-                writeEsIndex(out, esIndex);
-            } else {
-                throw new IllegalStateException("expected a single enrich index; got " + concreteIndices);
-            }
-        }
-        out.writeNamedWriteableCollection(enrich.enrichFields());
-    }
-
-    static EsqlProject readEsqlProject(PlanStreamInput in) throws IOException {
-        return new EsqlProject(Source.readFrom(in), in.readLogicalPlanNode(), in.readNamedWriteableCollectionAsList(NamedExpression.class));
-    }
-
-    static void writeEsqlProject(PlanStreamOutput out, EsqlProject project) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(project.child());
-        out.writeNamedWriteableCollection(project.projections());
-    }
-
-    static Filter readFilter(PlanStreamInput in) throws IOException {
-        return new Filter(Source.readFrom(in), in.readLogicalPlanNode(), in.readNamedWriteable(Expression.class));
-    }
-
-    static void writeFilter(PlanStreamOutput out, Filter filter) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(filter.child());
-        out.writeNamedWriteable(filter.condition());
-    }
-
-    static Grok readGrok(PlanStreamInput in) throws IOException {
-        Source source;
-        return new Grok(
-            source = Source.readFrom(in),
-            in.readLogicalPlanNode(),
-            in.readNamedWriteable(Expression.class),
-            Grok.pattern(source, in.readString()),
-            in.readNamedWriteableCollectionAsList(Attribute.class)
-        );
-    }
-
-    static void writeGrok(PlanStreamOutput out, Grok grok) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(grok.child());
-        out.writeNamedWriteable(grok.input());
-        out.writeString(grok.parser().pattern());
-        out.writeNamedWriteableCollection(grok.extractedFields());
-    }
-
-    static Limit readLimit(PlanStreamInput in) throws IOException {
-        return new Limit(Source.readFrom(in), in.readNamedWriteable(Expression.class), in.readLogicalPlanNode());
-    }
-
-    static void writeLimit(PlanStreamOutput out, Limit limit) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeNamedWriteable(limit.limit());
-        out.writeLogicalPlanNode(limit.child());
-    }
-
-    static MvExpand readMvExpand(PlanStreamInput in) throws IOException {
-        return new MvExpand(
-            Source.readFrom(in),
-            in.readLogicalPlanNode(),
-            in.readNamedWriteable(NamedExpression.class),
-            in.readNamedWriteable(Attribute.class)
-        );
-    }
-
-    static void writeMvExpand(PlanStreamOutput out, MvExpand mvExpand) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(mvExpand.child());
-        out.writeNamedWriteable(mvExpand.target());
-        out.writeNamedWriteable(mvExpand.expanded());
-    }
-
-    static OrderBy readOrderBy(PlanStreamInput in) throws IOException {
-        return new OrderBy(
-            Source.readFrom(in),
-            in.readLogicalPlanNode(),
-            in.readCollectionAsList(org.elasticsearch.xpack.esql.expression.Order::new)
-        );
-    }
-
-    static void writeOrderBy(PlanStreamOutput out, OrderBy order) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(order.child());
-        out.writeCollection(order.order());
-    }
-
-    static Project readProject(PlanStreamInput in) throws IOException {
-        return new Project(Source.readFrom(in), in.readLogicalPlanNode(), in.readNamedWriteableCollectionAsList(NamedExpression.class));
-    }
-
-    static void writeProject(PlanStreamOutput out, Project project) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(project.child());
-        out.writeNamedWriteableCollection(project.projections());
-    }
-
     // -- ancillary supporting classes of plan nodes, etc
 
     static EsQueryExec.FieldSort readFieldSort(PlanStreamInput in) throws IOException {
@@ -762,31 +530,5 @@ public final class PlanNamedTypes {
         fieldSort.field().writeTo(out);
         out.writeEnum(fieldSort.direction());
         out.writeEnum(fieldSort.nulls());
-    }
-
-    @SuppressWarnings("unchecked")
-    static EsIndex readEsIndex(PlanStreamInput in) throws IOException {
-        return new EsIndex(
-            in.readString(),
-            in.readImmutableMap(StreamInput::readString, i -> i.readNamedWriteable(EsField.class)),
-            (Set<String>) in.readGenericValue()
-        );
-    }
-
-    static void writeEsIndex(PlanStreamOutput out, EsIndex esIndex) throws IOException {
-        out.writeString(esIndex.name());
-        out.writeMap(esIndex.mapping(), StreamOutput::writeNamedWriteable);
-        out.writeGenericValue(esIndex.concreteIndices());
-    }
-
-    static Parser readDissectParser(PlanStreamInput in) throws IOException {
-        String pattern = in.readString();
-        String appendSeparator = in.readString();
-        return new Parser(pattern, appendSeparator, new DissectParser(pattern, appendSeparator));
-    }
-
-    static void writeDissectParser(PlanStreamOutput out, Parser dissectParser) throws IOException {
-        out.writeString(dissectParser.pattern());
-        out.writeString(dissectParser.appendSeparator());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
@@ -30,7 +30,6 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanNamedReader;
 import org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanReader;
-import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 
@@ -83,10 +82,6 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput
         this.registry = registry;
         this.configuration = configuration;
         this.nameIdFunction = new NameIdMapper();
-    }
-
-    public LogicalPlan readLogicalPlanNode() throws IOException {
-        return readNamed(LogicalPlan.class);
     }
 
     public PhysicalPlan readPhysicalPlanNode() throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutput.java
@@ -23,8 +23,6 @@ import org.elasticsearch.xpack.esql.Column;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanWriter;
-import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 
@@ -96,11 +94,6 @@ public final class PlanStreamOutput extends StreamOutput implements org.elastics
             }
         }
         this.maxSerializedAttributes = maxSerializedAttributes;
-    }
-
-    public void writeLogicalPlanNode(LogicalPlan logicalPlan) throws IOException {
-        assert logicalPlan.children().size() <= 1 || (logicalPlan instanceof Join && logicalPlan.children().size() == 2);
-        writeNamed(LogicalPlan.class, logicalPlan);
     }
 
     public void writePhysicalPlanNode(PhysicalPlan physicalPlan) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.esql.plan.logical;
 
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
@@ -17,7 +18,6 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,6 +27,12 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
 public class Aggregate extends UnaryPlan implements Stats {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        LogicalPlan.class,
+        "Aggregate",
+        Aggregate::new
+    );
+
     public enum AggregateType {
         STANDARD,
         // include metrics aggregates such as rates
@@ -67,22 +73,28 @@ public class Aggregate extends UnaryPlan implements Stats {
         this.aggregates = aggregates;
     }
 
-    public Aggregate(PlanStreamInput in) throws IOException {
+    public Aggregate(StreamInput in) throws IOException {
         this(
-            Source.readFrom(in),
-            in.readLogicalPlanNode(),
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(LogicalPlan.class),
             AggregateType.readType(in),
             in.readNamedWriteableCollectionAsList(Expression.class),
             in.readNamedWriteableCollectionAsList(NamedExpression.class)
         );
     }
 
-    public static void writeAggregate(PlanStreamOutput out, Aggregate aggregate) throws IOException {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
-        out.writeLogicalPlanNode(aggregate.child());
-        AggregateType.writeType(out, aggregate.aggregateType());
-        out.writeNamedWriteableCollection(aggregate.groupings);
-        out.writeNamedWriteableCollection(aggregate.aggregates());
+        out.writeNamedWriteable(child());
+        AggregateType.writeType(out, aggregateType());
+        out.writeNamedWriteableCollection(groupings);
+        out.writeNamedWriteableCollection(aggregates());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Dissect.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Dissect.java
@@ -7,6 +7,10 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.dissect.DissectParser;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -14,15 +18,30 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class Dissect extends RegexExtract {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Dissect", Dissect::new);
+
     private final Parser parser;
 
-    public record Parser(String pattern, String appendSeparator, DissectParser parser) {
+    public record Parser(String pattern, String appendSeparator, DissectParser parser) implements Writeable {
+        public static Parser readFrom(StreamInput in) throws IOException {
+            String pattern = in.readString();
+            String appendSeparator = in.readString();
+            return new Parser(pattern, appendSeparator, new DissectParser(pattern, appendSeparator));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(pattern());
+            out.writeString(appendSeparator());
+        }
 
         public List<Attribute> keyAttributes(Source src) {
             List<Attribute> keys = new ArrayList<>();
@@ -54,6 +73,30 @@ public class Dissect extends RegexExtract {
     public Dissect(Source source, LogicalPlan child, Expression input, Parser parser, List<Attribute> extracted) {
         super(source, child, input, extracted);
         this.parser = parser;
+    }
+
+    private Dissect(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(LogicalPlan.class),
+            in.readNamedWriteable(Expression.class),
+            Parser.readFrom(in),
+            in.readNamedWriteableCollectionAsList(Attribute.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(input());
+        parser.writeTo(out);
+        out.writeNamedWriteableCollection(extractedFields());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Drop.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Drop.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -21,6 +22,16 @@ public class Drop extends UnaryPlan {
     public Drop(Source source, LogicalPlan child, List<NamedExpression> removals) {
         super(source, child);
         this.removals = removals;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     public List<NamedExpression> removals() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
@@ -7,7 +7,14 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
@@ -17,20 +24,30 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.index.EsIndex;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.core.expression.Expressions.asAttributes;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
 public class Enrich extends UnaryPlan implements GeneratingPlan<Enrich> {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        LogicalPlan.class,
+        "Enrich",
+        Enrich::readFrom
+    );
+
     private final Expression policyName;
     private final NamedExpression matchField;
     private final EnrichPolicy policy;
@@ -78,6 +95,75 @@ public class Enrich extends UnaryPlan implements GeneratingPlan<Enrich> {
         this.policy = policy;
         this.concreteIndices = concreteIndices;
         this.enrichFields = enrichFields;
+    }
+
+    private static Enrich readFrom(StreamInput in) throws IOException {
+        Enrich.Mode mode = Enrich.Mode.ANY;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
+            mode = in.readEnum(Enrich.Mode.class);
+        }
+        final Source source = Source.readFrom((PlanStreamInput) in);
+        final LogicalPlan child = in.readNamedWriteable(LogicalPlan.class);
+        final Expression policyName = in.readNamedWriteable(Expression.class);
+        final NamedExpression matchField = in.readNamedWriteable(NamedExpression.class);
+        if (in.getTransportVersion().before(TransportVersions.V_8_13_0)) {
+            in.readString(); // discard the old policy name
+        }
+        final EnrichPolicy policy = new EnrichPolicy(in);
+        final Map<String, String> concreteIndices;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
+            concreteIndices = in.readMap(StreamInput::readString, StreamInput::readString);
+        } else {
+            EsIndex esIndex = new EsIndex(in);
+            if (esIndex.concreteIndices().size() > 1) {
+                throw new IllegalStateException("expected a single enrich index; got " + esIndex);
+            }
+            concreteIndices = Map.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, Iterables.get(esIndex.concreteIndices(), 0));
+        }
+        return new Enrich(
+            source,
+            child,
+            mode,
+            policyName,
+            matchField,
+            policy,
+            concreteIndices,
+            in.readNamedWriteableCollectionAsList(NamedExpression.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
+            out.writeEnum(mode());
+        }
+
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(policyName());
+        out.writeNamedWriteable(matchField());
+        if (out.getTransportVersion().before(TransportVersions.V_8_13_0)) {
+            out.writeString(BytesRefs.toString(policyName().fold())); // old policy name
+        }
+        policy().writeTo(out);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
+            out.writeMap(concreteIndices(), StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            Map<String, String> concreteIndices = concreteIndices();
+            if (concreteIndices.keySet().equals(Set.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY))) {
+                String enrichIndex = concreteIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+                EsIndex esIndex = new EsIndex(enrichIndex, Map.of(), Set.of(enrichIndex));
+                esIndex.writeTo(out);
+            } else {
+                throw new IllegalStateException("expected a single enrich index; got " + concreteIndices);
+            }
+        }
+        out.writeNamedWriteableCollection(enrichFields());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public NamedExpression matchField() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -6,6 +6,11 @@
  */
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -14,7 +19,10 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.io.stream.PlanNamedTypes;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +30,11 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 public class EsRelation extends LeafPlan {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        LogicalPlan.class,
+        "EsRelation",
+        EsRelation::readFrom
+    );
 
     private final EsIndex index;
     private final List<Attribute> attrs;
@@ -42,6 +55,45 @@ public class EsRelation extends LeafPlan {
         this.attrs = attributes;
         this.indexMode = indexMode;
         this.frozen = frozen;
+    }
+
+    private static EsRelation readFrom(StreamInput in) throws IOException {
+        Source source = Source.readFrom((PlanStreamInput) in);
+        EsIndex esIndex = new EsIndex(in);
+        List<Attribute> attributes = in.readNamedWriteableCollectionAsList(Attribute.class);
+        if (supportingEsSourceOptions(in.getTransportVersion())) {
+            // We don't do anything with these strings
+            in.readOptionalString();
+            in.readOptionalString();
+            in.readOptionalString();
+        }
+        IndexMode indexMode = PlanNamedTypes.readIndexMode(in);
+        boolean frozen = in.readBoolean();
+        return new EsRelation(source, esIndex, attributes, indexMode, frozen);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        index().writeTo(out);
+        out.writeNamedWriteableCollection(output());
+        if (supportingEsSourceOptions(out.getTransportVersion())) {
+            // write (null) string fillers expected by remote
+            out.writeOptionalString(null);
+            out.writeOptionalString(null);
+            out.writeOptionalString(null);
+        }
+        PlanNamedTypes.writeIndexMode(out, indexMode());
+        out.writeBoolean(frozen());
+    }
+
+    private static boolean supportingEsSourceOptions(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_14_0) && version.before(TransportVersions.ESQL_REMOVE_ES_SOURCE_OPTIONS);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -15,8 +18,10 @@ import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -25,6 +30,7 @@ import static org.elasticsearch.xpack.esql.core.expression.Expressions.asAttribu
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
 public class Eval extends UnaryPlan implements GeneratingPlan<Eval> {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Eval", Eval::new);
 
     private final List<Alias> fields;
     private List<Attribute> lazyOutput;
@@ -32,6 +38,22 @@ public class Eval extends UnaryPlan implements GeneratingPlan<Eval> {
     public Eval(Source source, LogicalPlan child, List<Alias> fields) {
         super(source, child);
         this.fields = fields;
+    }
+
+    private Eval(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(LogicalPlan.class), in.readCollectionAsList(Alias::new));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeCollection(fields());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public List<Alias> fields() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Explain.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Explain.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -28,6 +29,16 @@ public class Explain extends LeafPlan {
     public Explain(Source source, LogicalPlan query) {
         super(source);
         this.query = query;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     // TODO: implement again

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Filter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Filter.java
@@ -6,10 +6,15 @@
  */
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -18,12 +23,29 @@ import java.util.Objects;
  * {@code Filter} has a "condition" Expression that does the filtering.
  */
 public class Filter extends UnaryPlan {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Filter", Filter::new);
 
     private final Expression condition;
 
     public Filter(Source source, LogicalPlan child, Expression condition) {
         super(source, child);
         this.condition = condition;
+    }
+
+    private Filter(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(LogicalPlan.class), in.readNamedWriteable(Expression.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(condition());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/InlineStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/InlineStats.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinType;
@@ -51,7 +50,7 @@ import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutp
  */
 public class InlineStats extends UnaryPlan implements NamedWriteable, Phased, Stats {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
-        InlineStats.class,
+        LogicalPlan.class,
         "InlineStats",
         InlineStats::new
     );
@@ -69,7 +68,7 @@ public class InlineStats extends UnaryPlan implements NamedWriteable, Phased, St
     public InlineStats(StreamInput in) throws IOException {
         this(
             Source.readFrom((PlanStreamInput) in),
-            ((PlanStreamInput) in).readLogicalPlanNode(),
+            in.readNamedWriteable(LogicalPlan.class),
             in.readNamedWriteableCollectionAsList(Expression.class),
             in.readNamedWriteableCollectionAsList(NamedExpression.class)
         );
@@ -78,7 +77,7 @@ public class InlineStats extends UnaryPlan implements NamedWriteable, Phased, St
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
-        ((PlanStreamOutput) out).writeLogicalPlanNode(child());
+        out.writeNamedWriteable(child());
         out.writeNamedWriteableCollection(groupings);
         out.writeNamedWriteableCollection(aggregates);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Limit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Limit.java
@@ -6,19 +6,41 @@
  */
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.Objects;
 
 public class Limit extends UnaryPlan {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Limit", Limit::new);
 
     private final Expression limit;
 
     public Limit(Source source, Expression limit, LogicalPlan child) {
         super(source, child);
         this.limit = limit;
+    }
+
+    private Limit(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(Expression.class), in.readNamedWriteable(LogicalPlan.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(limit());
+        out.writeNamedWriteable(child());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/LogicalPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/LogicalPlan.java
@@ -7,15 +7,14 @@
 package org.elasticsearch.xpack.esql.plan.logical;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvable;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.plan.QueryPlan;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
+import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -24,7 +23,25 @@ import java.util.List;
  */
 public abstract class LogicalPlan extends QueryPlan<LogicalPlan> implements Resolvable {
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return List.of(LocalRelation.ENTRY, Lookup.ENTRY, Join.ENTRY, TopN.ENTRY);
+        return List.of(
+            Aggregate.ENTRY,
+            Dissect.ENTRY,
+            Enrich.ENTRY,
+            EsRelation.ENTRY,
+            EsqlProject.ENTRY,
+            Eval.ENTRY,
+            Filter.ENTRY,
+            Grok.ENTRY,
+            InlineStats.ENTRY,
+            LocalRelation.ENTRY,
+            Limit.ENTRY,
+            Lookup.ENTRY,
+            MvExpand.ENTRY,
+            Join.ENTRY,
+            OrderBy.ENTRY,
+            Project.ENTRY,
+            TopN.ENTRY
+        );
     }
 
     /**
@@ -43,17 +60,6 @@ public abstract class LogicalPlan extends QueryPlan<LogicalPlan> implements Reso
 
     public LogicalPlan(Source source, List<LogicalPlan> children) {
         super(source, children);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        // TODO remove when all PhysicalPlans are migrated to NamedWriteable
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String getWriteableName() {
-        throw new UnsupportedOperationException();
     }
 
     public boolean preAnalyzed() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Lookup.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Lookup.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinType;
@@ -59,7 +58,7 @@ public class Lookup extends UnaryPlan {
     }
 
     public Lookup(StreamInput in) throws IOException {
-        super(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readLogicalPlanNode());
+        super(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(LogicalPlan.class));
         this.tableName = in.readNamedWriteable(Expression.class);
         this.matchFields = in.readNamedWriteableCollectionAsList(Attribute.class);
         this.localRelation = in.readBoolean() ? new LocalRelation(in) : null;
@@ -68,7 +67,7 @@ public class Lookup extends UnaryPlan {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
-        ((PlanStreamOutput) out).writeLogicalPlanNode(child());
+        out.writeNamedWriteable(child());
         out.writeNamedWriteable(tableName);
         out.writeNamedWriteableCollection(matchFields);
         if (localRelation == null) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/OrderBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/OrderBy.java
@@ -6,21 +6,47 @@
  */
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 public class OrderBy extends UnaryPlan {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "OrderBy", OrderBy::new);
 
     private final List<Order> order;
 
     public OrderBy(Source source, LogicalPlan child, List<Order> order) {
         super(source, child);
         this.order = order;
+    }
+
+    private OrderBy(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(LogicalPlan.class),
+            in.readCollectionAsList(org.elasticsearch.xpack.esql.expression.Order::new)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeCollection(order());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.analysis.Analyzer.ResolveRefs;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -26,6 +27,16 @@ public class Rename extends UnaryPlan {
     public Rename(Source source, LogicalPlan child, List<Alias> renamings) {
         super(source, child);
         this.renamings = renamings;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     public List<Alias> renamings() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Row.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Row.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -24,6 +25,16 @@ public class Row extends LeafPlan {
     public Row(Source source, List<Alias> fields) {
         super(source);
         this.fields = fields;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     public List<Alias> fields() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TopN.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,7 +36,7 @@ public class TopN extends UnaryPlan {
     private TopN(StreamInput in) throws IOException {
         this(
             Source.readFrom((PlanStreamInput) in),
-            ((PlanStreamInput) in).readLogicalPlanNode(),
+            in.readNamedWriteable(LogicalPlan.class),
             in.readCollectionAsList(Order::new),
             in.readNamedWriteable(Expression.class)
         );
@@ -46,7 +45,7 @@ public class TopN extends UnaryPlan {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         Source.EMPTY.writeTo(out);
-        ((PlanStreamOutput) out).writeLogicalPlanNode(child());
+        out.writeNamedWriteable(child());
         out.writeCollection(order);
         out.writeNamedWriteable(limit);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.capabilities.Unresolvable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -44,6 +45,16 @@ public class UnresolvedRelation extends LeafPlan implements Unresolvable {
         this.metadataFields = metadataFields;
         this.indexMode = indexMode;
         this.unresolvedMsg = unresolvedMessage == null ? "Unknown index [" + table.index() + "]" : unresolvedMessage;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.BinaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
@@ -56,19 +55,15 @@ public class Join extends BinaryPlan {
     }
 
     public Join(StreamInput in) throws IOException {
-        super(
-            Source.readFrom((PlanStreamInput) in),
-            ((PlanStreamInput) in).readLogicalPlanNode(),
-            ((PlanStreamInput) in).readLogicalPlanNode()
-        );
+        super(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(LogicalPlan.class), in.readNamedWriteable(LogicalPlan.class));
         this.config = new JoinConfig(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
-        ((PlanStreamOutput) out).writeLogicalPlanNode(left());
-        ((PlanStreamOutput) out).writeLogicalPlanNode(right());
+        out.writeNamedWriteable(left());
+        out.writeNamedWriteable(right());
         config.writeTo(out);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/local/EsqlProject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/local/EsqlProject.java
@@ -7,19 +7,49 @@
 
 package org.elasticsearch.xpack.esql.plan.logical.local;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 
+import java.io.IOException;
 import java.util.List;
 
 public class EsqlProject extends Project {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        LogicalPlan.class,
+        "EsqlProject",
+        EsqlProject::new
+    );
 
     public EsqlProject(Source source, LogicalPlan child, List<? extends NamedExpression> projections) {
         super(source, child, projections);
+    }
+
+    public EsqlProject(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(LogicalPlan.class),
+            in.readNamedWriteableCollectionAsList(NamedExpression.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteableCollection(projections());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/meta/MetaFunctions.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/meta/MetaFunctions.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.plan.logical.meta;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -41,6 +42,16 @@ public class MetaFunctions extends LeafPlan {
         for (var name : List.of("optionalArgs", "variadic", "isAggregation")) {
             attributes.add(new ReferenceAttribute(Source.EMPTY, name, BOOLEAN));
         }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/show/ShowInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/show/ShowInfo.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.plan.logical.show;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Build;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -32,6 +33,16 @@ public class ShowInfo extends LeafPlan {
         for (var name : List.of("version", "date", "hash")) {
             attributes.add(new ReferenceAttribute(Source.EMPTY, name, KEYWORD));
         }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -66,6 +66,7 @@ import org.elasticsearch.xpack.esql.execution.PlanExecutor;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.querydsl.query.SingleValueQuery;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 import org.elasticsearch.xpack.esql.type.MultiTypeEsField;
@@ -200,6 +201,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
         entries.add(MultiTypeEsField.ENTRY); // TODO combine with EsField.getNamedWriteables() once these are in the same module
         entries.addAll(EsqlScalarFunction.getNamedWriteables());
         entries.addAll(AggregateFunction.getNamedWriteables());
+        entries.addAll(LogicalPlan.getNamedWriteables());
         return entries;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/SerializationTestUtils.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/SerializationTestUtils.java
@@ -63,7 +63,7 @@ public class SerializationTestUtils {
     }
 
     public static void assertSerialization(LogicalPlan plan) {
-        var deserPlan = serializeDeserialize(plan, PlanStreamOutput::writeLogicalPlanNode, PlanStreamInput::readLogicalPlanNode);
+        var deserPlan = serializeDeserialize(plan, PlanStreamOutput::writeNamedWriteable, in -> in.readNamedWriteable(LogicalPlan.class));
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(plan, unused -> deserPlan);
     }
 
@@ -128,6 +128,7 @@ public class SerializationTestUtils {
         entries.addAll(EsqlScalarFunction.getNamedWriteables());
         entries.addAll(AggregateFunction.getNamedWriteables());
         entries.addAll(Block.getNamedWriteables());
+        entries.addAll(LogicalPlan.getNamedWriteables());
         return new NamedWriteableRegistry(entries);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/AliasTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/AliasTests.java
@@ -32,8 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.in;
 
 public class AliasTests extends AbstractWireTestCase<Alias> {
-    @Override
-    protected Alias createTestInstance() {
+    public static Alias randomAlias() {
         Source source = SourceTests.randomSource();
         String name = randomAlphaOfLength(5);
         String qualifier = randomBoolean() ? null : randomAlphaOfLength(3);
@@ -41,6 +40,11 @@ public class AliasTests extends AbstractWireTestCase<Alias> {
         Expression child = ReferenceAttributeTests.randomReferenceAttribute();
         boolean synthetic = randomBoolean();
         return new Alias(source, name, qualifier, child, new NameId(), synthetic);
+    }
+
+    @Override
+    protected Alias createTestInstance() {
+        return randomAlias();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexSerializationTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.index;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.esql.core.index.EsIndex;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.core.type.EsFieldTests;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class EsIndexSerializationTests extends AbstractWireSerializingTestCase<EsIndex> {
+    public static EsIndex randomEsIndex() {
+        String name = randomAlphaOfLength(5);
+        Map<String, EsField> mapping = randomMapping();
+        Set<String> concreteIndices = randomConcreteIndices();
+        return new EsIndex(name, mapping, concreteIndices);
+    }
+
+    private static Map<String, EsField> randomMapping() {
+        int size = between(0, 10);
+        Map<String, EsField> result = new HashMap<>(size);
+        while (result.size() < size) {
+            result.put(randomAlphaOfLength(5), EsFieldTests.randomAnyEsField(1));
+        }
+        return result;
+    }
+
+    private static Set<String> randomConcreteIndices() {
+        int size = between(0, 10);
+        Set<String> result = new HashSet<>(size);
+        while (result.size() < size) {
+            result.add(randomAlphaOfLength(5));
+        }
+        return result;
+    }
+
+    @Override
+    protected Writeable.Reader<EsIndex> instanceReader() {
+        return EsIndex::new;
+    }
+
+    @Override
+    protected EsIndex createTestInstance() {
+        return randomEsIndex();
+    }
+
+    @Override
+    protected EsIndex mutateInstance(EsIndex instance) throws IOException {
+        String name = instance.name();
+        Map<String, EsField> mapping = randomMapping();
+        Set<String> concreteIndices = randomConcreteIndices();
+        switch (between(0, 2)) {
+            case 0 -> name = randomValueOtherThan(name, () -> randomAlphaOfLength(5));
+            case 1 -> mapping = randomValueOtherThan(mapping, EsIndexSerializationTests::randomMapping);
+            case 2 -> concreteIndices = randomValueOtherThan(concreteIndices, EsIndexSerializationTests::randomConcreteIndices);
+            default -> throw new IllegalArgumentException();
+        }
+        return new EsIndex(name, mapping, concreteIndices);
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(EsField.getNamedWriteables());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -12,8 +12,6 @@ import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.dissect.DissectParser;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
@@ -23,7 +21,6 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
-import org.elasticsearch.xpack.esql.core.index.EsIndex;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
@@ -88,12 +85,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
-import static org.elasticsearch.xpack.esql.SerializationTestUtils.serializeDeserialize;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PlanNamedTypesTests extends ESTestCase {
@@ -202,86 +196,6 @@ public class PlanNamedTypesTests extends ESTestCase {
         PlanNamedTypes.writeFieldSort(out, orig);
         var deser = PlanNamedTypes.readFieldSort(planStreamInput(bso));
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testEsIndexSimple() throws IOException {
-        var orig = new EsIndex("test*", Map.of("first_name", new KeywordEsField("first_name")), Set.of("test1", "test2"));
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeEsIndex(out, orig);
-        var deser = PlanNamedTypes.readEsIndex(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testDissectParserSimple() throws IOException {
-        String pattern = "%{b} %{c}";
-        var orig = new Dissect.Parser(pattern, ",", new DissectParser(pattern, ","));
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeDissectParser(out, orig);
-        var deser = PlanNamedTypes.readDissectParser(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testEsRelation() throws IOException {
-        var orig = new EsRelation(
-            Source.EMPTY,
-            randomEsIndex(),
-            List.of(randomFieldAttribute()),
-            randomFrom(IndexMode.values()),
-            randomBoolean()
-        );
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeEsRelation(out, orig);
-        var deser = PlanNamedTypes.readEsRelation(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testEsqlProject() throws IOException {
-        var orig = new EsqlProject(
-            Source.EMPTY,
-            new EsRelation(Source.EMPTY, randomEsIndex(), List.of(randomFieldAttribute()), randomFrom(IndexMode.values()), randomBoolean()),
-            List.of(randomFieldAttribute())
-        );
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeEsqlProject(out, orig);
-        var deser = PlanNamedTypes.readEsqlProject(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testMvExpand() throws IOException {
-        var esRelation = new EsRelation(
-            Source.EMPTY,
-            randomEsIndex(),
-            List.of(randomFieldAttribute()),
-            randomFrom(IndexMode.values()),
-            randomBoolean()
-        );
-        var orig = new MvExpand(Source.EMPTY, esRelation, randomFieldAttribute(), randomFieldAttribute());
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeMvExpand(out, orig);
-        var deser = PlanNamedTypes.readMvExpand(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    private static <T> void assertNamedType(Class<T> type, T origObj) {
-        var deserObj = serializeDeserialize(origObj, (o, v) -> o.writeNamed(type, origObj), i -> i.readNamed(type));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(origObj, unused -> deserObj);
-    }
-
-    static EsIndex randomEsIndex() {
-        Set<String> concreteIndices = new TreeSet<>();
-        while (concreteIndices.size() < 2) {
-            concreteIndices.add(randomAlphaOfLengthBetween(1, 25));
-        }
-        return new EsIndex(
-            randomAlphaOfLengthBetween(1, 25),
-            Map.of(randomAlphaOfLengthBetween(1, 25), randomKeywordEsField()),
-            concreteIndices
-        );
     }
 
     static FieldAttribute randomFieldAttributeOrNull() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInputTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInputTests.java
@@ -138,8 +138,8 @@ public class PlanStreamInputTests extends ESTestCase {
             LogicalPlan planIn = analyze(query);
             LogicalPlan planOut = serializeDeserialize(
                 planIn,
-                PlanStreamOutput::writeLogicalPlanNode,
-                PlanStreamInput::readLogicalPlanNode,
+                PlanStreamOutput::writeNamedWriteable,
+                in -> in.readNamedWriteable(LogicalPlan.class),
                 config
             );
             assertThat(planIn, equalTo(planOut));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
@@ -226,6 +227,16 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         public MockFieldAttributeCommand(Source source, LogicalPlan child, FieldAttribute field) {
             super(source, child);
             this.field = field;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {
+            throw new UnsupportedOperationException("not serialized");
+        }
+
+        @Override
+        public String getWriteableName() {
+            throw new UnsupportedOperationException("not serialized");
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AbstractLogicalPlanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AbstractLogicalPlanSerializationTests.java
@@ -11,9 +11,11 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.plan.AbstractNodeSerializationTests;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelationSerializationTests;
 
@@ -26,8 +28,7 @@ public abstract class AbstractLogicalPlanSerializationTests<T extends LogicalPla
             // TODO more random options
             return LookupSerializationTests.randomLookup(depth + 1);
         }
-        // TODO more random options
-        return LocalRelationSerializationTests.randomLocalRelation();
+        return randomBoolean() ? EsRelationSerializationTests.randomEsRelation() : LocalRelationSerializationTests.randomLocalRelation();
     }
 
     public static List<Attribute> randomFieldAttributes(int min, int max, boolean onlyRepresentable) {
@@ -38,10 +39,12 @@ public abstract class AbstractLogicalPlanSerializationTests<T extends LogicalPla
     protected final NamedWriteableRegistry getNamedWriteableRegistry() {
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
         entries.addAll(LogicalPlan.getNamedWriteables());
+        entries.addAll(AggregateFunction.getNamedWriteables());
         entries.addAll(Expression.getNamedWriteables());
         entries.addAll(Attribute.getNamedWriteables());
         entries.addAll(EsField.getNamedWriteables());
         entries.addAll(Block.getNamedWriteables());
+        entries.addAll(NamedExpression.getNamedWriteables());
         return new NamedWriteableRegistry(entries);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.dissect.DissectParser;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Top;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateSerializationTests extends AbstractLogicalPlanSerializationTests<Aggregate> {
+    @Override
+    protected Aggregate createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        Aggregate.AggregateType aggregateType = randomFrom(Aggregate.AggregateType.values());
+        List<Expression> groupings = randomFieldAttributes(0, 5, false).stream().map(a -> (Expression) a).toList();
+        List<? extends NamedExpression> aggregates = randomAggregates();
+        return new Aggregate(source, child, aggregateType, groupings, aggregates);
+    }
+
+    private static List<? extends NamedExpression> randomAggregates() {
+        int size = between(1, 5);
+        List<NamedExpression> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            Expression agg = switch (between(0, 5)) {
+                case 0 -> new Max(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                case 1 -> new Min(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                case 2 -> new Count(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                case 3 -> new Top(
+                    randomSource(),
+                    FieldAttributeTests.createFieldAttribute(1, true),
+                    new Literal(randomSource(), between(1, 5), DataType.INTEGER),
+                    new Literal(randomSource(), randomFrom("ASC", "DESC"), DataType.KEYWORD)
+                );
+                case 4 -> new Values(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                case 5 -> new Sum(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                default -> throw new IllegalArgumentException();
+            };
+            result.add(new Alias(randomSource(), randomAlphaOfLength(5), agg));
+        }
+        return result;
+    }
+
+    private static Dissect.Parser randomParser() {
+        String suffix = randomAlphaOfLength(5);
+        String pattern = "%{b} %{c}" + suffix;
+        return new Dissect.Parser(pattern, ",", new DissectParser(pattern, ","));
+    }
+
+    @Override
+    protected Aggregate mutateInstance(Aggregate instance) throws IOException {
+        LogicalPlan child = instance.child();
+        Aggregate.AggregateType aggregateType = instance.aggregateType();
+        List<Expression> groupings = instance.groupings();
+        List<? extends NamedExpression> aggregates = instance.aggregates();
+        switch (between(0, 3)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> aggregateType = randomValueOtherThan(aggregateType, () -> randomFrom(Aggregate.AggregateType.values()));
+            case 2 -> groupings = randomValueOtherThan(
+                groupings,
+                () -> randomFieldAttributes(0, 5, false).stream().map(a -> (Expression) a).toList()
+            );
+            case 3 -> aggregates = randomValueOtherThan(aggregates, AggregateSerializationTests::randomAggregates);
+        }
+        return new Aggregate(instance.source(), child, aggregateType, groupings, aggregates);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/DissectSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/DissectSerializationTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.dissect.DissectParser;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DissectSerializationTests extends AbstractLogicalPlanSerializationTests<Dissect> {
+    @Override
+    protected Dissect createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        Expression input = FieldAttributeTests.createFieldAttribute(1, false);
+        Dissect.Parser parser = randomParser();
+        List<Attribute> extracted = randomFieldAttributes(0, 4, false);
+        return new Dissect(source, child, input, parser, extracted);
+    }
+
+    private static Dissect.Parser randomParser() {
+        String suffix = randomAlphaOfLength(5);
+        String pattern = "%{b} %{c}" + suffix;
+        return new Dissect.Parser(pattern, ",", new DissectParser(pattern, ","));
+    }
+
+    @Override
+    protected Dissect mutateInstance(Dissect instance) throws IOException {
+        LogicalPlan child = instance.child();
+        Expression input = instance.input();
+        Dissect.Parser parser = randomParser();
+        List<Attribute> extracted = randomFieldAttributes(0, 4, false);
+        switch (between(0, 3)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> input = randomValueOtherThan(input, () -> FieldAttributeTests.createFieldAttribute(1, false));
+            case 2 -> parser = randomValueOtherThan(parser, DissectSerializationTests::randomParser);
+            case 3 -> extracted = randomValueOtherThan(extracted, () -> randomFieldAttributes(0, 4, false));
+        }
+        return new Dissect(instance.source(), child, input, parser, extracted);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EnrichSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EnrichSerializationTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EnrichSerializationTests extends AbstractLogicalPlanSerializationTests<Enrich> {
+    @Override
+    protected Enrich createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        Enrich.Mode mode = randomFrom(Enrich.Mode.values());
+        Expression policyName = randomPolicyName();
+        NamedExpression matchField = FieldAttributeTests.createFieldAttribute(1, false);
+        EnrichPolicy policy = randomEnrichPolicy();
+        Map<String, String> concreteIndices = randomConcreteIndices();
+        List<NamedExpression> enrichFields = randomFieldAttributes(0, 10, false).stream().map(f -> (NamedExpression) f).toList();
+        return new Enrich(source, child, mode, policyName, matchField, policy, concreteIndices, enrichFields);
+    }
+
+    private static Expression randomPolicyName() {
+        return new Literal(randomSource(), randomAlphaOfLength(5), DataType.KEYWORD);
+    }
+
+    private static EnrichPolicy randomEnrichPolicy() {
+        String type = randomFrom(EnrichPolicy.SUPPORTED_POLICY_TYPES);
+        EnrichPolicy.QuerySource query = randomBoolean() ? randomQuerySource() : null;
+        List<String> indices = randomList(0, 5, () -> randomAlphaOfLength(5));
+        String matchField = randomAlphaOfLength(5);
+        List<String> enrichFields = randomList(0, 5, () -> randomAlphaOfLength(5));
+        return new EnrichPolicy(type, query, indices, matchField, enrichFields);
+    }
+
+    private static EnrichPolicy.QuerySource randomQuerySource() {
+        QueryBuilder queryBuilder = randomBoolean()
+            ? new MatchAllQueryBuilder()
+            : new TermQueryBuilder(randomAlphaOfLength(4), randomAlphaOfLength(4));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON, out)) {
+            XContentBuilder content = queryBuilder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
+            content.flush();
+            return new EnrichPolicy.QuerySource(new BytesArray(out.toByteArray()), content.contentType());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, String> randomConcreteIndices() {
+        int size = between(0, 5);
+        Map<String, String> result = new HashMap<>();
+        while (result.size() < size) {
+            result.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
+        }
+        return result;
+    }
+
+    @Override
+    protected Enrich mutateInstance(Enrich instance) throws IOException {
+        Source source = instance.source();
+        LogicalPlan child = instance.child();
+        Enrich.Mode mode = instance.mode();
+        Expression policyName = instance.policyName();
+        NamedExpression matchField = instance.matchField();
+        EnrichPolicy policy = instance.policy();
+        Map<String, String> concreteIndices = instance.concreteIndices();
+        List<NamedExpression> enrichFields = instance.enrichFields();
+        switch (between(0, 6)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> mode = randomValueOtherThan(mode, () -> randomFrom(Enrich.Mode.values()));
+            case 2 -> policyName = randomValueOtherThan(policyName, EnrichSerializationTests::randomPolicyName);
+            case 3 -> matchField = randomValueOtherThan(matchField, () -> FieldAttributeTests.createFieldAttribute(1, false));
+            case 4 -> policy = randomValueOtherThan(policy, EnrichSerializationTests::randomEnrichPolicy);
+            case 5 -> concreteIndices = randomValueOtherThan(concreteIndices, EnrichSerializationTests::randomConcreteIndices);
+            case 6 -> enrichFields = randomValueOtherThan(
+                enrichFields,
+                () -> randomFieldAttributes(0, 10, false).stream().map(f -> (NamedExpression) f).toList()
+            );
+            default -> throw new IllegalArgumentException();
+        }
+        return new Enrich(source, child, mode, policyName, matchField, policy, concreteIndices, enrichFields);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EsRelationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EsRelationSerializationTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.index.EsIndex;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.index.EsIndexSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EsRelationSerializationTests extends AbstractLogicalPlanSerializationTests<EsRelation> {
+    public static EsRelation randomEsRelation() {
+        Source source = randomSource();
+        EsIndex index = EsIndexSerializationTests.randomEsIndex();
+        List<Attribute> attributes = randomFieldAttributes(0, 10, false);
+        IndexMode indexMode = randomFrom(IndexMode.values());
+        boolean frozen = randomBoolean();
+        return new EsRelation(source, index, attributes, indexMode, frozen);
+    }
+
+    @Override
+    protected EsRelation createTestInstance() {
+        return randomEsRelation();
+    }
+
+    @Override
+    protected EsRelation mutateInstance(EsRelation instance) throws IOException {
+        EsIndex index = instance.index();
+        List<Attribute> attributes = instance.output();
+        IndexMode indexMode = instance.indexMode();
+        boolean frozen = instance.frozen();
+        switch (between(0, 3)) {
+            case 0 -> index = randomValueOtherThan(index, EsIndexSerializationTests::randomEsIndex);
+            case 1 -> attributes = randomValueOtherThan(attributes, () -> randomFieldAttributes(0, 10, false));
+            case 2 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
+            case 3 -> frozen = false == frozen;
+            default -> throw new IllegalArgumentException();
+        }
+        return new EsRelation(instance.source(), index, attributes, indexMode, frozen);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EvalSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/EvalSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AliasTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EvalSerializationTests extends AbstractLogicalPlanSerializationTests<Eval> {
+    @Override
+    protected Eval createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        List<Alias> fields = randomList(0, 10, AliasTests::randomAlias);
+        return new Eval(source, child, fields);
+    }
+
+    @Override
+    protected Eval mutateInstance(Eval instance) throws IOException {
+        LogicalPlan child = instance.child();
+        List<Alias> fields = instance.fields();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            fields = randomValueOtherThan(fields, () -> randomList(0, 10, AliasTests::randomAlias));
+        }
+        return new Eval(instance.source(), child, fields);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/FilterSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/FilterSerializationTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+
+import java.io.IOException;
+
+public class FilterSerializationTests extends AbstractLogicalPlanSerializationTests<Filter> {
+    @Override
+    protected Filter createTestInstance() {
+        LogicalPlan child = randomChild(0);
+        Expression condition = FieldAttributeTests.createFieldAttribute(3, false);
+        return new Filter(randomSource(), child, condition);
+    }
+
+    @Override
+    protected Filter mutateInstance(Filter instance) throws IOException {
+        LogicalPlan child = instance.child();
+        Expression condition = instance.condition();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            condition = randomValueOtherThan(condition, () -> FieldAttributeTests.createFieldAttribute(3, false));
+        }
+        return new Filter(instance.source(), child, condition);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokSerializationTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.expression.function.ReferenceAttributeTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class GrokSerializationTests extends AbstractLogicalPlanSerializationTests<Grok> {
+    @Override
+    protected Grok createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        Expression inputExpr = FieldAttributeTests.createFieldAttribute(3, false);
+        String pattern = randomAlphaOfLength(5);
+        List<Attribute> extracted = randomList(1, 10, ReferenceAttributeTests::randomReferenceAttribute);
+        return new Grok(source, child, inputExpr, Grok.pattern(source, pattern), extracted);
+    }
+
+    @Override
+    protected Grok mutateInstance(Grok instance) throws IOException {
+        LogicalPlan child = instance.child();
+        Expression inputExpr = instance.input();
+        String pattern = instance.parser().pattern();
+        List<Attribute> extracted = instance.extractedFields();
+        switch (between(0, 2)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> inputExpr = randomValueOtherThan(inputExpr, () -> FieldAttributeTests.createFieldAttribute(0, false));
+            case 2 -> pattern = randomValueOtherThan(pattern, () -> randomAlphaOfLength(5));
+        }
+        return new Grok(instance.source(), child, inputExpr, Grok.pattern(instance.source(), pattern), extracted);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/InlineStatsSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/InlineStatsSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+public class InlineStatsSerializationTests extends AbstractLogicalPlanSerializationTests<InlineStats> {
+    @Override
+    protected InlineStats createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        List<Expression> groupings = randomFieldAttributes(0, 5, false).stream().map(a -> (Expression) a).toList();
+        List<? extends NamedExpression> aggregates = randomFieldAttributes(0, 5, false).stream().map(a -> (NamedExpression) a).toList();
+        return new InlineStats(source, child, groupings, aggregates);
+    }
+
+    @Override
+    protected InlineStats mutateInstance(InlineStats instance) throws IOException {
+        LogicalPlan child = instance.child();
+        List<Expression> groupings = instance.groupings();
+        List<? extends NamedExpression> aggregates = instance.aggregates();
+        switch (between(0, 2)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> groupings = randomValueOtherThan(
+                groupings,
+                () -> randomFieldAttributes(0, 5, false).stream().map(a -> (Expression) a).toList()
+            );
+            case 2 -> aggregates = randomValueOtherThan(
+                aggregates,
+                () -> randomFieldAttributes(0, 5, false).stream().map(a -> (NamedExpression) a).toList()
+            );
+        }
+        return new InlineStats(instance.source(), child, groupings, aggregates);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/LimitSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/LimitSerializationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+
+import java.io.IOException;
+
+public class LimitSerializationTests extends AbstractLogicalPlanSerializationTests<Limit> {
+    @Override
+    protected Limit createTestInstance() {
+        Source source = randomSource();
+        Expression limit = FieldAttributeTests.createFieldAttribute(0, false);
+        LogicalPlan child = randomChild(0);
+        return new Limit(source, limit, child);
+    }
+
+    @Override
+    protected Limit mutateInstance(Limit instance) throws IOException {
+        Expression limit = instance.limit();
+        LogicalPlan child = instance.child();
+        if (randomBoolean()) {
+            limit = randomValueOtherThan(limit, () -> FieldAttributeTests.createFieldAttribute(0, false));
+        } else {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        }
+        return new Limit(instance.source(), limit, child);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/MvExpandSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/MvExpandSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.expression.function.ReferenceAttributeTests;
+
+import java.io.IOException;
+
+public class MvExpandSerializationTests extends AbstractLogicalPlanSerializationTests<MvExpand> {
+    @Override
+    protected MvExpand createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        NamedExpression target = FieldAttributeTests.createFieldAttribute(0, false);
+        Attribute expanded = ReferenceAttributeTests.randomReferenceAttribute();
+        return new MvExpand(source, child, target, expanded);
+    }
+
+    @Override
+    protected MvExpand mutateInstance(MvExpand instance) throws IOException {
+        LogicalPlan child = instance.child();
+        NamedExpression target = instance.target();
+        Attribute expanded = instance.expanded();
+        switch (between(0, 2)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> target = randomValueOtherThan(target, () -> FieldAttributeTests.createFieldAttribute(0, false));
+            case 2 -> expanded = randomValueOtherThan(expanded, ReferenceAttributeTests::randomReferenceAttribute);
+        }
+        return new MvExpand(instance.source(), child, target, expanded);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/OrderBySerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/OrderBySerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.OrderSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class OrderBySerializationTests extends AbstractLogicalPlanSerializationTests<OrderBy> {
+    @Override
+    protected OrderBy createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        List<Order> orders = randomList(1, 10, OrderSerializationTests::randomOrder);
+        return new OrderBy(source, child, orders);
+    }
+
+    @Override
+    protected OrderBy mutateInstance(OrderBy instance) throws IOException {
+        LogicalPlan child = instance.child();
+        List<Order> orders = instance.order();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            orders = randomValueOtherThan(orders, () -> randomList(1, 10, OrderSerializationTests::randomOrder));
+        }
+        return new OrderBy(instance.source(), child, orders);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/PhasedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/PhasedTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
@@ -19,6 +20,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -93,6 +95,16 @@ public class PhasedTests extends ESTestCase {
     public class Dummy extends UnaryPlan implements Phased {
         Dummy(Source source, LogicalPlan child) {
             super(source, child);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            throw new UnsupportedOperationException("not serialized");
+        }
+
+        @Override
+        public String getWriteableName() {
+            throw new UnsupportedOperationException("not serialized");
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ProjectSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ProjectSerializationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ProjectSerializationTests extends AbstractLogicalPlanSerializationTests<Project> {
+    @Override
+    protected Project createTestInstance() {
+        Source source = randomSource();
+        LogicalPlan child = randomChild(0);
+        List<? extends NamedExpression> projections = randomFieldAttributes(0, 10, false);
+        return new Project(source, child, projections);
+    }
+
+    @Override
+    protected Project mutateInstance(Project instance) throws IOException {
+        LogicalPlan child = instance.child();
+        List<? extends NamedExpression> projections = instance.projections();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            projections = randomValueOtherThan(projections, () -> randomFieldAttributes(0, 10, false));
+        }
+        return new Project(instance.source(), child, projections);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/local/EsqlProjectSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/local/EsqlProjectSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical.local;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EsqlProjectSerializationTests extends AbstractLogicalPlanSerializationTests<EsqlProject> {
+    @Override
+    protected EsqlProject createTestInstance() {
+        LogicalPlan child = randomChild(0);
+        List<Attribute> projections = randomFieldAttributes(1, 10, false);
+        return new EsqlProject(randomSource(), child, projections);
+    }
+
+    @Override
+    protected EsqlProject mutateInstance(EsqlProject instance) throws IOException {
+        LogicalPlan child = instance.child();
+        List<? extends NamedExpression> projections = instance.projections();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            projections = randomValueOtherThan(projections, () -> randomFieldAttributes(1, 10, false));
+        }
+        return new EsqlProject(instance.source(), child, projections);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}


### PR DESCRIPTION
This migrates all of `LogicalPlan` to `NamedWriteable` to line up with the way the rest of ES serializes things.
