### PR TITLE
Implement CCS telemetry export as part of _cluster/stats

### DIFF
--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1307,6 +1307,142 @@ Each repository type may also include other statistics about the repositories of
 
 ====
 
+`ccs`::
+(object) Contains information relating to <<modules-cross-cluster-search, cross-cluster search>> settings and activity in the cluster.
++
+.Properties of `ccs`
+[%collapsible%open]
+=====
+
+
+`_search`:::
+(object) Contains telemetry information about the <<modules-cross-cluster-search, cross-cluster searches>> in the cluster.
++
+.Properties of `_search`
+[%collapsible%open]
+======
+`total`:::
+(integer) The total number of cross-cluster search requests that have been executed by the cluster.
+
+`success`:::
+(integer) The total number of cross-cluster search requests that have been successfully executed by the cluster.
+
+`skipped`:::
+(integer) The total number of cross-cluster search requests that had at least one remote cluster skipped.
+
+`took`:::
+(object) Contains statistics about the time taken to execute cross-cluster search requests.
++
+.Properties of `took`
+[%collapsible%open]
+=======
+`max`:::
+(integer) The maximum time taken to execute a cross-cluster search request, in milliseconds.
+
+`avg`:::
+(integer) The median time taken to execute a cross-cluster search request, in milliseconds.
+
+`p90`:::
+(integer) The 90th percentile of the time taken to execute cross-cluster search requests, in milliseconds.
+=======
+
+`took_mrt_true`::
+(object) Contains statistics about the time taken to execute cross-cluster search requests for which the
+<<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> setting was set to `true`.
++
+.Properties of `took_mrt_true`
+[%collapsible%open]
+=======
+`max`:::
+(integer) The maximum time taken to execute a cross-cluster search request, in milliseconds.
+
+`avg`:::
+(integer) The median time taken to execute a cross-cluster search request, in milliseconds.
+
+`p90`:::
+(integer) The 90th percentile of the time taken to execute cross-cluster search requests, in milliseconds.
+=======
+
+`took_mrt_false`::
+(object) Contains statistics about the time taken to execute cross-cluster search requests for which the
+<<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> setting was set to `false`.
++
+.Properties of `took_mrt_false`
+[%collapsible%open]
+=======
+`max`:::
+(integer) The maximum time taken to execute a cross-cluster search request, in milliseconds.
+
+`avg`:::
+(integer) The median time taken to execute a cross-cluster search request, in milliseconds.
+
+`p90`:::
+(integer) The 90th percentile of the time taken to execute cross-cluster search requests, in milliseconds.
+=======
+
+`remotes_per_search_max`::
+(integer) The maximum number of remote clusters that were queried in a single cross-cluster search request.
+
+`remotes_per_search_avg`::
+(integer) The average number of remote clusters that were queried in a single cross-cluster search request.
+
+`failure_reasons`::
+(object) Contains statistics about the reasons for cross-cluster search request failures.
+The keys are the failure reasons names and the values are the number of requests that failed for that reason.
+
+`features`::
+(object) Contains statistics about the features used in cross-cluster search requests. The keys are the names of the search feature,
+and the values are the number of requests that used that feature. Single request can use more than one feature
+(e.g. both `async` and `wildcard`). Known features are:
+
+* `async` - <<async-search, Async search>>
+
+* `mrt` - <<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> setting was set to `true`.
+
+* `wildcard` - <<api-multi-index,Multi-target syntax>> for indices with wildcards was used in the search request.
+
+`clients`::
+(object) Contains statistics about the clients that executed cross-cluster search requests.
+The keys are the names of the clients, and the values are the number of requests that were executed by that client.
+Only known clients (such as `kibana` or `elasticsearch`) are counted.
+
+`clusters`::
+(object) Contains statistics about the clusters that were queried in cross-cluster search requests.
+The keys are cluster names, and the values are per-cluster telemetry data.
+This also includes the local cluster itself, which uses the name `(local)`.
++
+.Properties of per-cluster data:
+[%collapsible%open]
+=======
+`total`:::
+(integer) The total number of successful (not skipped) cross-cluster search requests that were executed against this cluster.
+This may include requests where partial results were returned, but not requests in which the cluster has been skipped entirely.
+
+`skipped`:::
+(integer) The total number of cross-cluster search requests for which this cluster was skipped.
+
+`took`:::
+(object) Contains statistics about the time taken to execute requests against this cluster.
++
+.Properties of `took`
+[%collapsible%open]
+========
+`max`:::
+(integer) The maximum time taken to execute a cross-cluster search request, in milliseconds.
+
+`avg`:::
+(integer) The median time taken to execute a cross-cluster search request, in milliseconds.
+
+`p90`:::
+(integer) The 90th percentile of the time taken to execute cross-cluster search requests, in milliseconds.
+========
+
+=======
+
+======
+
+=====
+
 [[cluster-stats-api-example]]
 ==== {api-examples-title}
 
@@ -1607,7 +1743,35 @@ The API returns the following response:
    },
    "repositories": {
      ...
-   }
+   },
+   "ccs": {
+     "_search": {
+        "total": 7,
+        "success": 7,
+        "skipped": 0,
+        "took": {
+            "max": 36,
+            "avg": 20,
+            "p90": 33
+        },
+        "took_mrt_true": {
+            "max": 33,
+            "avg": 15,
+            "p90": 33
+        },
+        "took_mrt_false": {
+            "max": 36,
+            "avg": 26,
+            "p90": 36
+        },
+        "remotes_per_search_max": 3,
+        "remotes_per_search_avg": 2.0,
+        "failure_reasons": { ... },
+        "features": { ... },
+        "clients": { ... },
+        "clusters": { ... }
+     }
+  }
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"plugins": \[[^\]]*\]/"plugins": $body.$_path/]
@@ -1618,10 +1782,15 @@ The API returns the following response:
 // TESTRESPONSE[s/"packaging_types": \[[^\]]*\]/"packaging_types": $body.$_path/]
 // TESTRESPONSE[s/"snapshots": \{[^\}]*\}/"snapshots": $body.$_path/]
 // TESTRESPONSE[s/"repositories": \{[^\}]*\}/"repositories": $body.$_path/]
+// TESTRESPONSE[s/"clusters": \{[^\}]*\}/"clusters": $body.$_path/]
+// TESTRESPONSE[s/"features": \{[^\}]*\}/"features": $body.$_path/]
+// TESTRESPONSE[s/"clients": \{[^\}]*\}/"clients": $body.$_path/]
+// TESTRESPONSE[s/"failure_reasons": \{[^\}]*\}/"failure_reasons": $body.$_path/]
 // TESTRESPONSE[s/"field_types": \[[^\]]*\]/"field_types": $body.$_path/]
 // TESTRESPONSE[s/"runtime_field_types": \[[^\]]*\]/"runtime_field_types": $body.$_path/]
 // TESTRESPONSE[s/"search": \{[^\}]*\}/"search": $body.$_path/]
-// TESTRESPONSE[s/: true|false/: $body.$_path/]
+// TESTRESPONSE[s/"remotes_per_search_avg": [.0-9]+/"remotes_per_search_avg": $body.$_path/]
+// TESTRESPONSE[s/: (true|false)/: $body.$_path/]
 // TESTRESPONSE[s/: (\-)?[0-9]+/: $body.$_path/]
 // TESTRESPONSE[s/: "[^"]*"/: $body.$_path/]
 // These replacements do a few things:

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -201,6 +201,8 @@ public class TransportVersions {
     public static final TransportVersion ADD_MANAGE_ROLES_PRIVILEGE = def(8_731_00_0);
     public static final TransportVersion REPOSITORIES_TELEMETRY = def(8_732_00_0);
 
+
+    public static final TransportVersion CCS_TELEMETRY_STATS = def(8_733_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -201,7 +201,6 @@ public class TransportVersions {
     public static final TransportVersion ADD_MANAGE_ROLES_PRIVILEGE = def(8_731_00_0);
     public static final TransportVersion REPOSITORIES_TELEMETRY = def(8_732_00_0);
 
-
     public static final TransportVersion CCS_TELEMETRY_STATS = def(8_733_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -277,7 +277,7 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
      */
     public void add(CCSTelemetrySnapshot stats) {
         // This should be called in ClusterStatsResponse ctor only, so we don't need to worry about concurrency
-        if (stats.totalCount == 0) {
+        if (stats == null || stats.totalCount == 0) {
             // Just ignore the empty stats.
             // This could happen if the node is brand new or if the stats are not available, e.g. because it runs an old version.
             return;
@@ -315,7 +315,7 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
      *      "p90": 2570
      * }
      */
-    public static void publishLatency(XContentBuilder builder, String name, LongMetricValue took) throws IOException {
+    private static void publishLatency(XContentBuilder builder, String name, LongMetricValue took) throws IOException {
         builder.startObject(name);
         {
             builder.field("max", took.max());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -175,7 +175,7 @@ public class CCSUsageTelemetry {
         // The number of successful (not skipped) requests to this cluster.
         private final LongAdder count;
         private final LongAdder skippedCount;
-        // This is only over the successful requetss, skipped ones do not count here.
+        // This is only over the successful requests, skipped ones do not count here.
         private final LongMetric took;
 
         PerClusterCCSTelemetry(String clusterAlias) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsResponse.java
@@ -136,7 +136,9 @@ public class ClusterStatsResponse extends BaseNodesResponse<ClusterStatsNodeResp
         repositoryUsageStats.toXContent(builder, params);
 
         if (CCS_TELEMETRY_FEATURE_FLAG.isEnabled()) {
+            builder.startObject("ccs");
             ccsMetrics.toXContent(builder, params);
+            builder.endObject();
         }
 
         return builder;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -81,6 +81,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
     private final IndicesService indicesService;
     private final RepositoriesService repositoriesService;
     private final SearchUsageHolder searchUsageHolder;
+    private final CCSUsageTelemetry ccsUsageHolder;
 
     private final MetadataStatsCache<MappingStats> mappingStatsCache;
     private final MetadataStatsCache<AnalysisStats> analysisStatsCache;
@@ -108,6 +109,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         this.indicesService = indicesService;
         this.repositoriesService = repositoriesService;
         this.searchUsageHolder = usageService.getSearchUsageHolder();
+        this.ccsUsageHolder = usageService.getCcsUsageHolder();
         this.mappingStatsCache = new MetadataStatsCache<>(threadPool.getThreadContext(), MappingStats::of);
         this.analysisStatsCache = new MetadataStatsCache<>(threadPool.getThreadContext(), AnalysisStats::of);
     }
@@ -249,6 +251,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         final SearchUsageStats searchUsageStats = searchUsageHolder.getSearchUsageStats();
 
         final RepositoryUsageStats repositoryUsageStats = repositoriesService.getUsageStats();
+        final CCSTelemetrySnapshot ccsUsage = ccsUsageHolder.getCCSTelemetrySnapshot();
 
         return new ClusterStatsNodeResponse(
             nodeInfo.getNode(),
@@ -257,7 +260,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             nodeStats,
             shardsStats.toArray(new ShardStats[shardsStats.size()]),
             searchUsageStats,
-            repositoryUsageStats
+            repositoryUsageStats,
+            ccsUsage
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -127,7 +127,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     public static final String FROZEN_INDICES_DEPRECATION_MESSAGE = "Searching frozen indices [{}] is deprecated."
         + " Consider cold or frozen tiers in place of frozen indices. The frozen feature will be removed in a feature release.";
 
-    private static final FeatureFlag CCS_TELEMETRY_FEATURE_FLAG = new FeatureFlag("ccs_telemetry");
+    public static final FeatureFlag CCS_TELEMETRY_FEATURE_FLAG = new FeatureFlag("ccs_telemetry");
 
     /** The maximum number of shards for a single search request. */
     public static final Setting<Long> SHARD_COUNT_LIMIT_SETTING = Setting.longSetting(

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -128,7 +128,8 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
             null,
             new ShardStats[] { shardStats },
             new SearchUsageStats(),
-            RepositoryUsageStats.EMPTY
+            RepositoryUsageStats.EMPTY,
+            null
         );
 
         stats = VersionStats.of(metadata, Collections.singletonList(nodeResponse));

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -754,7 +754,38 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                   },
                   "repositories": {}
                 },
-                "repositories": {}
+                "repositories": {},
+                "ccs_telemetry": {
+                    "total": 0,
+                    "success": 0,
+                    "skipped": 0,
+                    "took": {
+                        "max": 0,
+                        "avg": 0,
+                        "p90": 0
+                    },
+                    "took_mrt_true": {
+                        "max": 0,
+                        "avg": 0,
+                        "p90": 0
+                    },
+                    "took_mrt_false": {
+                        "max": 0,
+                        "avg": 0,
+                        "p90": 0
+                    },
+                    "remotes_per_search_max": 0,
+                    "remotes_per_search_avg": 0.0,
+                    "failure_reasons": {
+                    },
+                    "features": {
+                    },
+                    "clients": {
+                    },
+                    "clusters": {
+                        "count": 0
+                    }
+                }
               },
               "cluster_state": {
                 "nodes_hash": 1314980060,

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -755,37 +755,37 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                   "repositories": {}
                 },
                 "repositories": {},
-                "ccs_telemetry": {
-                    "total": 0,
-                    "success": 0,
-                    "skipped": 0,
-                    "took": {
-                        "max": 0,
-                        "avg": 0,
-                        "p90": 0
-                    },
-                    "took_mrt_true": {
-                        "max": 0,
-                        "avg": 0,
-                        "p90": 0
-                    },
-                    "took_mrt_false": {
-                        "max": 0,
-                        "avg": 0,
-                        "p90": 0
-                    },
-                    "remotes_per_search_max": 0,
-                    "remotes_per_search_avg": 0.0,
-                    "failure_reasons": {
-                    },
-                    "features": {
-                    },
-                    "clients": {
-                    },
-                    "clusters": {
-                        "count": 0
+                "ccs": {
+                    "_search": {
+                        "total": 0,
+                        "success": 0,
+                        "skipped": 0,
+                        "took": {
+                            "max": 0,
+                            "avg": 0,
+                            "p90": 0
+                        },
+                        "took_mrt_true": {
+                            "max": 0,
+                            "avg": 0,
+                            "p90": 0
+                        },
+                        "took_mrt_false": {
+                            "max": 0,
+                            "avg": 0,
+                            "p90": 0
+                        },
+                        "remotes_per_search_max": 0,
+                        "remotes_per_search_avg": 0.0,
+                        "failure_reasons": {
+                        },
+                        "features": {
+                        },
+                        "clients": {
+                        },
+                        "clusters": {}
                     }
-                }
+                  }
               },
               "cluster_state": {
                 "nodes_hash": 1314980060,


### PR DESCRIPTION
Adds "ccs_telemetry" item to the cluster stats output. 

TODO: tests