### PR TITLE
ESQL: Make scaled_float test less precise

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -231,7 +231,8 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
     private Matcher<Double> scaledFloatMatcher(double scalingFactor, double d) {
         long encoded = Math.round(d * scalingFactor);
         double decoded = encoded / scalingFactor;
-        return closeTo(decoded, Math.ulp(decoded));
+        // We can lose a little more the ulp in the round trip.
+        return closeTo(decoded, Math.ulp(decoded) * 2);
     }
 
     public void testBoolean() throws IOException {


### PR DESCRIPTION
We can lose a tiny bit more data in scaled_float than we thought. That's just how scaled_float cuts.

Closes #108011
