### PR TITLE
[8.15] Wait for cluster to be more ready in REST test (#111606)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -39,7 +39,7 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
     public static final AtomicInteger NEXT_DEBUG_PORT = new AtomicInteger(5007);
 
     private static final Logger LOGGER = LogManager.getLogger(DefaultLocalClusterHandle.class);
-    private static final Duration CLUSTER_UP_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration CLUSTER_UP_TIMEOUT = Duration.ofMinutes(5);
 
     public final ForkJoinPool executor = new ForkJoinPool(
         Math.max(Runtime.getRuntime().availableProcessors(), 4),

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/WaitForHttpResource.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/WaitForHttpResource.java
@@ -56,7 +56,20 @@ public class WaitForHttpResource {
     private String password;
 
     public WaitForHttpResource(String protocol, String host, int numberOfNodes) throws MalformedURLException {
-        this(new URL(protocol + "://" + host + "/_cluster/health?wait_for_nodes=>=" + numberOfNodes + "&wait_for_status=yellow"));
+        this(
+            new URL(
+                protocol
+                    + "://"
+                    + host
+                    + "/_cluster/health"
+                    + "?wait_for_nodes=>="
+                    + numberOfNodes
+                    + "&wait_for_status=yellow"
+                    + "&wait_for_events=LANGUID"
+                    + "&wait_for_no_initializing_shards"
+                    + "&wait_for_no_relocating_shards"
+            )
+        );
     }
 
     public WaitForHttpResource(URL url) {


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Wait for cluster to be more ready in REST test (#111606)