### PR TITLE
Improve search failure classification 

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -671,8 +671,4 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         }
 
     }
-
-    // TODO: implement the following tests:
-    // - scenarios with remotes not allowed to be skipped
-    // - various search failure reasons
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -42,6 +42,10 @@ public class CCSUsageTelemetry {
         SUCCESS("success"),
         REMOTES_UNAVAILABLE("remotes_unavailable"),
         CANCELED("canceled"),
+        NOT_FOUND("not_found"),
+        TIMEOUT("timeout"),
+        CORRUPTION("corruption"),
+        SECURITY("security"),
         // May be helpful if there's a lot of other reasons, and it may be hard to calculate the unknowns for some clients.
         UNKNOWN("other");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -43,7 +43,7 @@ public class CCSUsageTelemetry {
         REMOTES_UNAVAILABLE("remotes_unavailable"),
         CANCELED("canceled"),
         // May be helpful if there's a lot of other reasons, and it may be hard to calculate the unknowns for some clients.
-        UNKNOWN("unknown");
+        UNKNOWN("other");
 
         private final String name;
 


### PR DESCRIPTION
This implements search failure classification by looking up sets of exception classes in the cause chain. 

Also adds more failure tests. 