### PR TITLE
Add back warning to not remove inference id in semantic_text for 8.15

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -52,8 +52,8 @@ Use the <<put-inference-api>> to create the endpoint.
 The `inference_id` will not be validated when the mapping is created, but when documents are ingested into the index.
 When the first document is indexed, the `inference_id` will be used to generate underlying indexing structures for the field.
 
-WARNING: Removing an {infer}  endpoint will cause ingestion of documents and semantic queries to fail on indices that define `semantic_text` fields with that {infer}  endpoint as their `inference_id`.
-Please check that {infer}  endpoints are not used in `semantic_text` fields before removal.
+WARNING: Removing an {infer}  endpoint will cause ingestion of documents and semantic queries to fail on indices that define `semantic_text` fields with that {infer} endpoint as their `inference_id`.
+Before removal, check if {infer} endpoints are used in `semantic_text` fields.
 
 [discrete]
 [[auto-text-chunking]]

--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -52,8 +52,8 @@ Use the <<put-inference-api>> to create the endpoint.
 The `inference_id` will not be validated when the mapping is created, but when documents are ingested into the index.
 When the first document is indexed, the `inference_id` will be used to generate underlying indexing structures for the field.
 
-WARNING: Removing an {infer} endpoint will cause ingestion of documents and semantic queries to fail on indices that define `semantic_text` fields with that {infer} endpoint as their `inference_id`.
-Trying to <<delete-inference-api,delete an {infer} endpoint>> that is used on a `semantic_text` field will result in an error.
+WARNING: Removing an {infer}  endpoint will cause ingestion of documents and semantic queries to fail on indices that define `semantic_text` fields with that {infer}  endpoint as their `inference_id`.
+Please check that {infer}  endpoints are not used in `semantic_text` fields before removal.
 
 [discrete]
 [[auto-text-chunking]]
@@ -123,8 +123,8 @@ types and create an ingest pipeline with an
 <<inference-processor, {infer} processor>> to generate the embeddings.
 <<semantic-search-inference,This tutorial>> walks you through the process. In
 these cases - when you use `sparse_vector` or `dense_vector` field types instead
-of the `semantic_text` field type to customize indexing - using the 
-<<query-dsl-semantic-query,`semantic_query`>> is not supported for querying the 
+of the `semantic_text` field type to customize indexing - using the
+<<query-dsl-semantic-query,`semantic_query`>> is not supported for querying the
 field data.
 
 


### PR DESCRIPTION
This partially reverts commit 836b4a5bb2c535a4fb82335a1343ab0f0e928d97 in this PR: https://github.com/elastic/elasticsearch/pull/111329

In 8.15, there will be no prevention of deleting inference ids used in semantic_text - that will be added for 8.16.

