### PR TITLE
Do not execute `preallocate` tests on encrypted storage

### DIFF
--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/PreallocateTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/PreallocateTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess;
 
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -17,8 +18,14 @@ import java.util.OptionalLong;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PreallocateTests extends ESTestCase {
-    public void testPreallocate() throws IOException {
+
+    @Before
+    public void setup() {
         assumeFalse("no preallocate on windows", System.getProperty("os.name").startsWith("Windows"));
+        assumeFalse("preallocate not supported on encrypted block devices", "encryption-at-rest".equals(System.getenv("BUILDKITE_LABEL")));
+    }
+
+    public void testPreallocate() throws IOException {
         Path file = createTempFile();
         long size = 1024 * 1024; // 1 MB
         var nativeAccess = NativeAccess.instance();
@@ -29,7 +36,6 @@ public class PreallocateTests extends ESTestCase {
     }
 
     public void testPreallocateNonExistingFile() {
-        assumeFalse("no preallocate on windows", System.getProperty("os.name").startsWith("Windows"));
         Path file = createTempDir().resolve("intermediate-dir").resolve("test-preallocate");
         long size = 1024 * 1024; // 1 MB
         var nativeAccess = NativeAccess.instance();
@@ -40,7 +46,6 @@ public class PreallocateTests extends ESTestCase {
     }
 
     public void testPreallocateNonExistingDirectory() {
-        assumeFalse("no preallocate on windows", System.getProperty("os.name").startsWith("Windows"));
         Path file = createTempDir().resolve("intermediate-dir").resolve("test-preallocate");
         long size = 1024 * 1024; // 1 MB
         var nativeAccess = NativeAccess.instance();

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -74,9 +74,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.common.CacheFileTests
   method: testCacheFileCreatedAsSparseFile
   issue: https://github.com/elastic/elasticsearch/issues/110801
-- class: org.elasticsearch.nativeaccess.PreallocateTests
-  method: testPreallocate
-  issue: https://github.com/elastic/elasticsearch/issues/110948
 - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
   method: testSystemPropertyDisabled
   issue: https://github.com/elastic/elasticsearch/issues/110949


### PR DESCRIPTION
Our CI has a `encrypt-at-rest` [periodic task](https://github.com/elastic/elasticsearch/blob/46f941c9f637ddf174653c68d5c609cfc857ac75/.buildkite/pipelines/periodic.yml#L713)  that runs the usual tests, but inside a dm-crypt volume (instead of a regular filesystem).

We recently added/fixed how preallocate works, calling native functions; however, these tests fail for encryption-at-rest command, because `fallocate` is not supported on encrypted block devices.

Most of ES should continue to work unchanged with or without encryption on the volume - this low-level function is a special case; since we missed some errors in the past, we explicitly want to test preallocate is working via the native function (and does not use the fallback). But on encrypted disks, it will always be the fallback, as the function is not supported by the OS.

This PR excludes these tests from running during `encrypt-at-rest` 

Closes https://github.com/elastic/elasticsearch/issues/111615
Closes https://github.com/elastic/elasticsearch/issues/111616
