### PR TITLE
Fix `testElectionSchedulingAfterDiscoveryOutage`

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -496,6 +496,11 @@ public abstract class PeerFinder {
                             } // else this Peer has been superseded by a different instance which should be left in place
                         }
                     }
+
+                    @Override
+                    public String toString() {
+                        return "Peer#establishConnection[" + transportAddress + "]";
+                    }
                 })
             );
         }
@@ -584,6 +589,7 @@ public abstract class PeerFinder {
                 + Optional.ofNullable(probeConnectionResult.get())
                     .map(result -> result.getDiscoveryNode().descriptionWithoutAttributes())
                     .orElse("unknown")
+                + "]"
                 + (peersRequestInFlight ? " [request in flight]" : "");
         }
     }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1396,6 +1396,11 @@ public class TransportService extends AbstractLifecycleComponent
                     protected void doRun() {
                         handler.handleException(exception);
                     }
+
+                    @Override
+                    public String toString() {
+                        return "onConnectionClosed/handleException[" + handler + "]";
+                    }
                 });
             }
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -2047,7 +2047,15 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     + 4 * DEFAULT_DELAY_VARIABILITY
                     // Then a commit of the new leader's first cluster state
                     + DEFAULT_CLUSTER_STATE_UPDATE_DELAY
-                    // Then the remaining node may join
+                    // Then the remaining node may experience a disconnect (see comment in PeerFinder#closePeers) for which it is
+                    // removed from the cluster, and its fault detection must also detect its removal
+                    + Math.max(
+                        DEFAULT_CLUSTER_STATE_UPDATE_DELAY,
+                        defaultMillis(LEADER_CHECK_TIMEOUT_SETTING) * LEADER_CHECK_RETRY_COUNT_SETTING.get(Settings.EMPTY)
+                    )
+                    // then it does another round of discovery
+                    + defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING)
+                    // and finally it joins the master
                     + DEFAULT_CLUSTER_STATE_UPDATE_DELAY
             );
 


### PR DESCRIPTION
We need to wait a little longer to deal with the case that closing the
`PeerFinder` on the master triggers a disconnect, removing the third
node from the cluster, and requiring another round of discovery to
recover.

Closes #111155