### PR TITLE
[8.15][DOCS] Document inference API breaking change

### DIFF
--- a/docs/reference/migration/migrate_8_15.asciidoc
+++ b/docs/reference/migration/migrate_8_15.asciidoc
@@ -70,6 +70,18 @@ Use `?timeout=0` to force relevant operations to time out immediately
 instead of `?timeout=-1`
 ====
 
+[[replace_model_id_with_inference_id]]
+.Replace `model_id` with `inference_id` in GET inference API
+[%collapsible]
+====
+*Details* +
+From 8.15 onwards the <<get-inference-api>> response will return an
+`inference_id` field instead of a `model_id`.
+
+*Impact* +
+
+====
+
 
 [discrete]
 [[deprecated-8.15]]

--- a/docs/reference/migration/migrate_8_15.asciidoc
+++ b/docs/reference/migration/migrate_8_15.asciidoc
@@ -79,7 +79,8 @@ From 8.15 onwards the <<get-inference-api>> response will return an
 `inference_id` field instead of a `model_id`.
 
 *Impact* +
-
+If your application looks for the `model_id` in a GET inference API response,
+switch it to use `inference_id` instead.
 ====
 
 

--- a/docs/reference/migration/migrate_8_15.asciidoc
+++ b/docs/reference/migration/migrate_8_15.asciidoc
@@ -79,7 +79,7 @@ From 8.15 onwards the <<get-inference-api>> response will return an
 `inference_id` field instead of a `model_id`.
 
 *Impact* +
-If your application looks for the `model_id` in a GET inference API response,
+If your application uses the `model_id` in a GET inference API response,
 switch it to use `inference_id` instead.
 ====
 

--- a/docs/reference/release-notes/8.15.0.asciidoc
+++ b/docs/reference/release-notes/8.15.0.asciidoc
@@ -12,6 +12,9 @@ Also see <<breaking-changes-8.15,Breaking changes in 8.15>>.
 Cluster Coordination::
 * Interpret `?timeout=-1` as infinite ack timeout {es-pull}107675[#107675]
 
+Inference API::
+* Replace `model_id` with `inference_id` in GET inference API {es-pull}111366[#111366]
+
 Rollup::
 * Disallow new rollup jobs in clusters with no rollup usage {es-pull}108624[#108624] (issue: {es-issue}108381[#108381])
 


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch/pull/111366

This PR documents a breaking change in the inference API. The GET inference API response returns the `inference_id` field instead of the `model_id` field.

### Preview

* [8.15 release notes](https://elasticsearch_bk_111633.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.15/release-notes-8.15.0.html#breaking-8.15.0) 
* [8.15 breaking changes](https://elasticsearch_bk_111633.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.15/migrating-8.15.html)