### PR TITLE
[8.15] [Bugfix] Add accessDeclaredMembers permission for ObjectMapper to work. (#111285)

### DIFF
--- a/docs/changelog/111285.yaml
+++ b/docs/changelog/111285.yaml
@@ -1,0 +1,5 @@
+pr: 111285
+summary: "[Bugfix] Add `accessDeclaredMembers` permission to allow search application templates to parse floats"
+area: Relevance
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/52_search_application_render_query.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/52_search_application_render_query.yml
@@ -221,6 +221,36 @@ teardown:
   }
 
 ---
+"Render query for search application with floats":
+
+  - do:
+      search_application.render_query:
+        name: test-search-application-with-list
+        body:
+          params:
+            query_string: value3
+            text_fields:
+              - name: field1
+                boost: 1.2
+              - name: field2
+                boost: 2.3
+              - name: field3
+                boost: 3
+
+  - match: {
+    query: {
+      multi_match: {
+        query: "value3",
+        fields: [
+          "field1^1.2",
+          "field2^2.3",
+          "field3^3.0"
+        ]
+      }
+    }
+  }
+
+---
 "Render query for search application - not found":
 
   - do:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/TemplateParamValidator.java
@@ -15,11 +15,14 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -28,6 +31,9 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -79,7 +85,21 @@ public class TemplateParamValidator implements ToXContentObject, Writeable {
     }
 
     public void validate(Map<String, Object> templateParams) throws ValidationException {
-        validateWithSchema(this.jsonSchema, OBJECT_MAPPER.valueToTree(templateParams));
+
+        JsonNode secondParam = null;
+        try {
+            SpecialPermission.check();
+            secondParam = AccessController.doPrivileged((PrivilegedExceptionAction<JsonNode>) () -> {
+                return OBJECT_MAPPER.valueToTree(templateParams);
+            });
+        } catch (PrivilegedActionException e) {
+            throw new ElasticsearchStatusException(
+                "failed to convert parameters while validating",
+                RestStatus.INTERNAL_SERVER_ERROR,
+                e.getCause()
+            );
+        }
+        validateWithSchema(this.jsonSchema, secondParam);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/ent-search/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,4 @@
+grant {
+  // needed for Jackson ObjectMapper to parse floats
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+};

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/TemplateParamValidatorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/TemplateParamValidatorTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.search;
+
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TemplateParamValidatorTests extends ESTestCase {
+
+    public void testValidateThrowsWhenSchemaDontMatch() {
+        Map<String, Object> failingParams = new HashMap<>();
+        failingParams.put("fail", null);
+        TemplateParamValidator validator = new TemplateParamValidator(
+            "{\"properties\":{\"title_boost\":{\"type\":\"number\"},\"additionalProperties\":false},\"required\":[\"query_string\"]}"
+        );
+
+        assertThrows(ValidationException.class, () -> validator.validate(failingParams));
+
+    }
+
+    public void testValidateWithFloats() {
+        Map<String, Object> passingParams = new HashMap<>();
+        passingParams.put("title_boost", 1.0f);
+        passingParams.put("query_string", "query_string");
+        TemplateParamValidator validator = new TemplateParamValidator(
+            "{\"properties\":{\"title_boost\":{\"type\":\"number\"},\"additionalProperties\":false},\"required\":[\"query_string\"]}"
+        );
+        // This shouldn't throw
+        // We don't have nice assertions for this in JUnit 4
+        validator.validate(passingParams);
+    }
+
+}


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [Bugfix] Add accessDeclaredMembers permission for ObjectMapper to work. (#111285)