### PR TITLE
Force using the last centroid during merging

### DIFF
--- a/docs/changelog/111644.yaml
+++ b/docs/changelog/111644.yaml
@@ -1,0 +1,6 @@
+pr: 111644
+summary: Force using the last centroid during merging
+area: Aggregations
+type: bug
+issues:
+ - 111065

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
@@ -92,7 +92,7 @@ public class MergingDigest extends AbstractTDigest {
     private final int[] order;
 
     // if true, alternate upward and downward merge passes
-    public boolean useAlternatingSort = true;
+    public boolean useAlternatingSort = false;
     // if true, use higher working value of compression during construction, then reduce on presentation
     public boolean useTwoLevelCompression = true;
 
@@ -302,8 +302,12 @@ public class MergingDigest extends AbstractTDigest {
                 addThis = projectedW <= wLimit;
             }
             if (i == 1 || i == incomingCount - 1) {
-                // force last centroid to never merge
+                // force first and last centroid to never merge
                 addThis = false;
+            }
+            if (lastUsedCell == mean.length - 1) {
+                // use the last centroid, there's no more
+                addThis = true;
             }
 
             if (addThis) {

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
@@ -153,9 +153,12 @@ public class MergingDigestTests extends TDigestTests {
     }
 
     public void testLargeInputSmallCompression() {
-        TDigest td = TDigest.createMergingDigest(10);
+        MergingDigest td = new MergingDigest(10);
         for (int i = 0; i < 10_000_000; i++) {
             td.add(between(0, 3_600_000));
         }
+        assertTrue(td.centroidCount() < 100);
+        assertTrue(td.quantile(0.00001) < 100_000);
+        assertTrue(td.quantile(0.99999) > 3_000_000);
     }
 }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
@@ -151,4 +151,11 @@ public class MergingDigestTests extends TDigestTests {
             i++;
         }
     }
+
+    public void testLargeInputSmallCompression() {
+        TDigest td = TDigest.createMergingDigest(10);
+        for(int i = 0; i < 10_000_000; i++) {
+            td.add(between(0, 3_600_000));
+        }
+    }
 }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
@@ -154,7 +154,7 @@ public class MergingDigestTests extends TDigestTests {
 
     public void testLargeInputSmallCompression() {
         TDigest td = TDigest.createMergingDigest(10);
-        for(int i = 0; i < 10_000_000; i++) {
+        for (int i = 0; i < 10_000_000; i++) {
             td.add(between(0, 3_600_000));
         }
     }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/TDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/TDigestTests.java
@@ -152,7 +152,7 @@ public abstract class TDigestTests extends ESTestCase {
         hist2.compress();
         double x1 = hist1.quantile(0.5);
         double x2 = hist2.quantile(0.5);
-        assertEquals(Dist.quantile(0.5, data), x1, 0.2);
+        assertEquals(Dist.quantile(0.5, data), x1, 0.25);
         assertEquals(x1, x2, 0.01);
     }
 


### PR DESCRIPTION
The MergingDigest uses pre-allocated arrays for constant memory footprint and improved performance. Points get added to an intermediate buffer that gets merged to the canonical arrays of means and weights (constituting the centroids). During merging, the values in the latter arrays get updated with the merged values. However, the current logic may try to update a value after the array bound, for values in the very low or very high percentiles. This PR fixes this.

Fixes #111065 