### PR TITLE
[Inference API] Backport Delete...Action pipeline check to threadpool

### DIFF
--- a/docs/changelog/111646.yaml
+++ b/docs/changelog/111646.yaml
@@ -1,0 +1,5 @@
+pr: 111646
+summary: "[Inference API] Backport Delete...Action pipeline check to threadpool"
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/111646.yaml
+++ b/docs/changelog/111646.yaml
@@ -1,5 +1,5 @@
 pr: 111646
-summary: "[Inference API] Backport Delete...Action pipeline check to threadpool"
+summary: "[Inference API] Move Delete inference checks to threadpool worker"
 area: Machine Learning
 type: bug
 issues: []


### PR DESCRIPTION
[This PR](https://github.com/elastic/elasticsearch/pull/110487) moved the pipeline check in the DeleteInferenceEndpointAction to a utility threadpool to avoid overburdening the transport thread. This change needs to be backported to v8.15.1.