### PR TITLE
[ESQL] Capability gate match command tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.analysis;
 import org.elasticsearch.Build;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
 import org.elasticsearch.xpack.esql.parser.QueryParam;
@@ -663,6 +664,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testMatchCommand() throws Exception {
+        assumeTrue("skipping because MATCH_COMMAND is not enabled", EsqlCapabilities.Cap.MATCH_COMMAND.isEnabled());
         assertEquals("1:24: MATCH cannot be used after LIMIT", error("from test | limit 10 | match \"Anna\""));
         assertEquals("1:13: MATCH cannot be used after SHOW", error("show info | match \"8.16.0\""));
         assertEquals("1:17: MATCH cannot be used after ROW", error("row a= \"Anna\" | match \"Anna\""));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.EsqlTestUtils.TestSearchStats;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
@@ -384,6 +385,7 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
      *       \_EsQueryExec[test], indexMode[standard], query[{"query_string":{"query":"\"last_name: Smith\""
      */
     public void testMatchCommand() {
+        assumeTrue("skipping because MATCH_COMMAND is not enabled", EsqlCapabilities.Cap.MATCH_COMMAND.isEnabled());
         var plan = plannerOptimizer.plan("""
             from test
             | match "last_name: Smith"
@@ -412,6 +414,7 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
      *          }]
      */
     public void testMatchCommandWithWhereClause() {
+        assumeTrue("skipping because MATCH_COMMAND is not enabled", EsqlCapabilities.Cap.MATCH_COMMAND.isEnabled());
         var plan = plannerOptimizer.plan("""
             from test
             | where emp_no > 10010
@@ -444,6 +447,7 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
      *          sort[[FieldSort[field=emp_no{f}#3, direction=ASC, nulls=LAST]]]
      */
     public void testMatchCommandWithMultipleMatches() {
+        assumeTrue("skipping because MATCH_COMMAND is not enabled", EsqlCapabilities.Cap.MATCH_COMMAND.isEnabled());
         var plan = plannerOptimizer.plan("""
             from test
             | match "last_name: Smith"


### PR DESCRIPTION
Some of the Match command tests were failing against the release build.  This should disable them when the capability is not enabled.

These two test commands fail on main right prior to this PR:

```shell
./gradlew ":x-pack:plugin:esql:test" --tests "org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizerTests.testMatchCommandWithMultipleMatches {default}" -Dtests.seed=FDBFBB17E32C40EB -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false" -Dtests.locale=en -Dtests.timezone=Etc/UTC -Druntime.java=22 -Dlicense.key="x-pack/license-tools/src/test/resources/public.key"
```
(as you can see from the delta, there are a couple of others failing in `LocalPhysicalPlanOptimizerTests`; sorry for not pasting all the repro lines.)

```shell
./gradlew ":x-pack:plugin:esql:test" --tests "org.elasticsearch.xpack.esql.analysis.VerifierTests.testMatchCommand" -Dtests.seed=FDBFBB17E32C40EB -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false" -Dtests.locale=en -Dtests.timezone=Etc/UTC -Druntime.java=22 -Dlicense.key="x-pack/license-tools/src/test/resources/public.key"
```

