### PR TITLE
Fix LogsDB challenge test

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.greaterThan;
 public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChallengeRestTest {
     private final int numShards = randomBoolean() ? randomIntBetween(2, 5) : 0;
     private final int numReplicas = randomBoolean() ? randomIntBetween(1, 3) : 0;
+    private final boolean fullyDynamicMapping = randomBoolean();
 
     public StandardVersusLogsIndexModeChallengeRestIT() {
         super("standard-apache-baseline", "logs-apache-contender", "baseline-template", "contender-template", 101, 101);
@@ -57,7 +58,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
 
     @Override
     public void baselineMappings(XContentBuilder builder) throws IOException {
-        if (randomBoolean()) {
+        if (fullyDynamicMapping == false) {
             builder.startObject()
                 .startObject("properties")
 
@@ -108,7 +109,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         builder.startObject();
         builder.field("subobjects", false);
 
-        if (randomBoolean()) {
+        if (fullyDynamicMapping == false) {
             builder.startObject("properties")
 
                 .startObject("@timestamp")

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceMatcher.java
@@ -136,8 +136,21 @@ public class SourceMatcher extends GenericEqualsMatcher<List<Map<String, Object>
         }
 
         var expectedFieldMapping = expectedNormalizedMapping.get(fieldName);
-        if (expectedFieldMapping == null || Objects.equals(actualFieldType, expectedFieldMapping.get("type")) == false) {
-            throw new IllegalStateException("Field type of a leaf field [" + fieldName + "] differs between expected and actual mapping");
+        if (expectedFieldMapping == null) {
+            throw new IllegalStateException("Leaf field [" + fieldName + "] is present in actual mapping but absent in expected mapping");
+        } else {
+            var expectedFieldType = expectedFieldMapping.get("type");
+            if (Objects.equals(actualFieldType, expectedFieldType) == false) {
+                throw new IllegalStateException(
+                    "Leaf field ["
+                        + fieldName
+                        + "] has type ["
+                        + actualFieldType
+                        + "] in actual mapping but a different type ["
+                        + expectedFieldType
+                        + "] in expected mapping"
+                );
+            }
         }
 
         var fieldSpecificMatcher = fieldSpecificMatchers.get(actualFieldType);

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -137,9 +137,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.analysis.VerifierTests
   method: testMatchCommand
   issue: https://github.com/elastic/elasticsearch/issues/111661
-- class: org.elasticsearch.datastreams.logsdb.qa.StandardVersusLogsIndexModeChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/111664
 
 # Examples:
 #


### PR DESCRIPTION
This is a follow-up from #111568. It doesn't really make sense to compare dynamic mapping of standard mode with static mapping of logsdb mode.

Closes #111666.
Closes #111664.