### PR TITLE
Properly handle filters on TextSimilarityRank retriever

### DIFF
--- a/docs/changelog/111673.yaml
+++ b/docs/changelog/111673.yaml
@@ -1,0 +1,5 @@
+pr: 111673
+summary: Properly handle filters on `TextSimilarityRank` retriever
+area: Ranking
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -101,6 +101,7 @@ public class TextSimilarityRankRetrieverBuilder extends RetrieverBuilder {
 
     @Override
     public void extractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder, boolean compoundUsed) {
+        retrieverBuilder.getPreFilterQueryBuilders().addAll(preFilterQueryBuilders);
         retrieverBuilder.extractToSearchSourceBuilder(searchSourceBuilder, compoundUsed);
 
         // Combining with other rank builder (such as RRF) is not supported yet

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -29,6 +29,8 @@ setup:
                 type: text
               topic:
                 type: keyword
+              subtopic:
+                type: keyword
 
   - do:
       index:
@@ -37,6 +39,7 @@ setup:
         body:
           text: "As seen from Earth, a solar eclipse happens when the Moon is directly between the Earth and the Sun."
           topic: ["science"]
+          subtopic: ["technology"]
         refresh: true
 
   - do:
@@ -46,6 +49,7 @@ setup:
         body:
           text: "The phases of the Moon come from the position of the Moon relative to the Earth and Sun."
           topic: ["science"]
+          subtopic: ["astronomy"]
         refresh: true
 
   - do:
@@ -88,3 +92,35 @@ setup:
   - match: { hits.hits.1._id: "doc_1" }
   - match: { hits.hits.1._rank: 2 }
   - close_to: { hits.hits.1._score: { value: 0.2, error: 0.001 } }
+
+---
+"Simple text similarity rank retriever and filtering":
+
+  - do:
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          fields: [ "text", "topic" ]
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    term:
+                      topic: "science"
+              filter:
+                term:
+                  subtopic: "technology"
+              rank_window_size: 10
+              inference_id: my-rerank-model
+              inference_text: "How often does the moon hide the sun?"
+              field: text
+          size: 10
+
+  - match: { hits.total.value : 1 }
+  - length: { hits.hits: 1 }
+
+  - match: { hits.hits.0._id: "doc_1" }
+  - match: { hits.hits.0._rank: 1 }
+  - close_to: { hits.hits.0._score: { value: 0.2, error: 0.001 } }


### PR DESCRIPTION
Currently, the `filter` specified  in  `TextSimilarityRank` retriever is ignored, so in this PR we account for that by propagating all top-level filters to the nested retriever, just before extracting it to `source`. 