### PR TITLE
Only emit product origin in deprecation log if present

### DIFF
--- a/docs/changelog/111683.yaml
+++ b/docs/changelog/111683.yaml
@@ -1,0 +1,6 @@
+pr: 111683
+summary: Only emit product origin in deprecation log if present
+area: Infra/Logging
+type: bug
+issues:
+ - 81757

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
@@ -63,7 +63,7 @@ public class DeprecatedMessage {
             .field("elasticsearch.event.category", category.name().toLowerCase(Locale.ROOT));
 
         if (Strings.isNullOrEmpty(xOpaqueId) == false) {
-            esLogMessage.field(X_OPAQUE_ID_FIELD_NAME, xOpaqueId)
+            esLogMessage.field(X_OPAQUE_ID_FIELD_NAME, xOpaqueId);
         }
         if (Strings.isNullOrEmpty(productOrigin) == false) {
             esLogMessage.field(ELASTIC_ORIGIN_FIELD_NAME, productOrigin);

--- a/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/DeprecatedMessage.java
@@ -62,10 +62,12 @@ public class DeprecatedMessage {
             .field(KEY_FIELD_NAME, key)
             .field("elasticsearch.event.category", category.name().toLowerCase(Locale.ROOT));
 
-        if (Strings.isNullOrEmpty(xOpaqueId)) {
-            return esLogMessage;
+        if (Strings.isNullOrEmpty(xOpaqueId) == false) {
+            esLogMessage.field(X_OPAQUE_ID_FIELD_NAME, xOpaqueId)
         }
-
-        return esLogMessage.field(X_OPAQUE_ID_FIELD_NAME, xOpaqueId).field(ELASTIC_ORIGIN_FIELD_NAME, productOrigin);
+        if (Strings.isNullOrEmpty(productOrigin) == false) {
+            esLogMessage.field(ELASTIC_ORIGIN_FIELD_NAME, productOrigin);
+        }
+        return esLogMessage;
     }
 }


### PR DESCRIPTION
The elastic product origin may not always be present when deprecation messages are emitted. This commit changes the log message created for deprecations to only emit the product origin field if it is not empty.

closes #81757