### PR TITLE
[ESQL] basic sorting tests for date nanos

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
@@ -7,6 +7,24 @@ millis:date              | nanos:date_nanos
 2023-10-23T13:55:01.543Z | 2023-10-23T13:55:01.543123456Z
 ;
 
+sort by nanos
+required_capability: date_nanos_type
+
+FROM date_nanos | SORT nanos DESC | KEEP millis, nanos | LIMIT 1;
+
+millis:date              | nanos:date_nanos
+2023-10-23T13:55:01.543Z | 2023-10-23T13:55:01.543123456Z
+;
+
+sort by nanos asc
+required_capability: date_nanos_type
+
+FROM date_nanos | WHERE millis > "2020-02-02" | SORT nanos ASC | KEEP millis, nanos | LIMIT 1;
+
+millis:date              | nanos:date_nanos
+2023-10-23T12:15:03.360Z | 2023-10-23T12:15:03.360103847Z
+;
+
 mv_max on date nanos
 required_capability: date_nanos_type
 


### PR DESCRIPTION
Pretty trivial PR here, just adding some basic tests for sorting on date nanos.  As expected, this just works so no code change is required to support it.  We probably want some more testing for this later, but this at least demonstrates that it works for now.