### PR TITLE
[8.15] Include license key property in reproduction lines for release builds (#111693)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -178,11 +178,13 @@ public class ReproduceInfoPrinter extends RunListener {
             if (System.getProperty("tests.jvm.argline") != null && System.getProperty("tests.jvm.argline").isEmpty() == false) {
                 appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");
             }
+            if (Boolean.parseBoolean(System.getProperty("build.snapshot", "true")) == false) {
+                appendOpt("license.key", "x-pack/license-tools/src/test/resources/public.key");
+            }
             appendOpt("tests.locale", Locale.getDefault().toLanguageTag());
             appendOpt("tests.timezone", TimeZone.getDefault().getID());
             appendOpt("tests.distribution", System.getProperty("tests.distribution"));
             appendOpt("runtime.java", Integer.toString(Runtime.version().feature()));
-            appendOpt("license.key", System.getProperty("licence.key"));
             appendOpt(ESTestCase.FIPS_SYSPROP, System.getProperty(ESTestCase.FIPS_SYSPROP));
             return this;
         }


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Include license key property in reproduction lines for release builds (#111693)