### PR TITLE
Unsafe future fix check

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -381,12 +381,12 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
     }
 
     // only used in assertions
-    boolean allowedExecutors(Thread thread1, Thread thread2) {
+    boolean allowedExecutors(Thread blockedThread, Thread completingThread) {
         // this should only be used to validate thread interactions, like not waiting for a future completed on the same
         // executor, hence calling it with the same thread indicates a bug in the assertion using this.
-        assert thread1 != thread2 : "only call this for different threads";
-        String thread1Name = EsExecutors.executorName(thread1);
-        String thread2Name = EsExecutors.executorName(thread2);
+        assert blockedThread != completingThread : "only call this for different threads";
+        String thread1Name = EsExecutors.executorName(blockedThread);
+        String thread2Name = EsExecutors.executorName(completingThread);
         return thread1Name == null || thread2Name == null || thread1Name.equals(thread2Name) == false;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -385,8 +385,8 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
         // this should only be used to validate thread interactions, like not waiting for a future completed on the same
         // executor, hence calling it with the same thread indicates a bug in the assertion using this.
         assert blockedThread != completingThread : "only call this for different threads";
-        String thread1Name = EsExecutors.executorName(blockedThread);
-        String thread2Name = EsExecutors.executorName(completingThread);
-        return thread1Name == null || thread2Name == null || thread1Name.equals(thread2Name) == false;
+        String blockedThreadName = EsExecutors.executorName(blockedThread);
+        String completingThreadName = EsExecutors.executorName(completingThread);
+        return blockedThreadName == null || completingThreadName == null || blockedThreadName.equals(completingThreadName) == false;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
@@ -26,14 +26,16 @@ public class UnsafePlainActionFuture<T> extends PlainActionFuture<T> {
     private final String unsafeExecutor2;
 
     /**
-     * Allow the single executor passed to be used unsafely.
+     * Allow the single executor passed to be used unsafely. This allows waiting for the future and completing the future on threads in
+     * the same executor, but only for the specific executor.
      */
     public UnsafePlainActionFuture(String unsafeExecutor) {
         this(unsafeExecutor, "__none__");
     }
 
     /**
-     * Allow both executors passed to be used unsafely.
+     * Allow both executors passed to be used unsafely. This allows waiting for the future and completing the future on threads in
+     * the same executor, but only for the two specific executors.
      */
     public UnsafePlainActionFuture(String unsafeExecutor, String unsafeExecutor2) {
         Objects.requireNonNull(unsafeExecutor);

--- a/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
@@ -45,9 +45,9 @@ public class UnsafePlainActionFuture<T> extends PlainActionFuture<T> {
     }
 
     @Override
-    boolean allowedExecutors(Thread thread1, Thread thread2) {
-        return super.allowedExecutors(thread1, thread2)
-            || unsafeExecutor.equals(EsExecutors.executorName(thread1))
-            || unsafeExecutor2.equals(EsExecutors.executorName(thread1));
+    boolean allowedExecutors(Thread blockedThread, Thread completingThread) {
+        return super.allowedExecutors(blockedThread, completingThread)
+            || unsafeExecutor.equals(EsExecutors.executorName(blockedThread))
+            || unsafeExecutor2.equals(EsExecutors.executorName(blockedThread));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/UnsafePlainActionFuture.java
@@ -25,12 +25,19 @@ public class UnsafePlainActionFuture<T> extends PlainActionFuture<T> {
     private final String unsafeExecutor;
     private final String unsafeExecutor2;
 
+    /**
+     * Allow the single executor passed to be used unsafely.
+     */
     public UnsafePlainActionFuture(String unsafeExecutor) {
-        this(unsafeExecutor, null);
+        this(unsafeExecutor, "__none__");
     }
 
+    /**
+     * Allow both executors passed to be used unsafely.
+     */
     public UnsafePlainActionFuture(String unsafeExecutor, String unsafeExecutor2) {
         Objects.requireNonNull(unsafeExecutor);
+        Objects.requireNonNull(unsafeExecutor2);
         this.unsafeExecutor = unsafeExecutor;
         this.unsafeExecutor2 = unsafeExecutor2;
     }
@@ -39,7 +46,6 @@ public class UnsafePlainActionFuture<T> extends PlainActionFuture<T> {
     boolean allowedExecutors(Thread thread1, Thread thread2) {
         return super.allowedExecutors(thread1, thread2)
             || unsafeExecutor.equals(EsExecutors.executorName(thread1))
-            || unsafeExecutor2 == null
             || unsafeExecutor2.equals(EsExecutors.executorName(thread1));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/UnsafePlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/UnsafePlainActionFutureTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class UnsafePlainActionFutureTests extends ESTestCase {
+
+    public void testOneArg() {
+        String unsafeExecutorName = "unsafe-executor";
+        String otherExecutorName = "other-executor";
+        UnsafePlainActionFuture<?> future = new UnsafePlainActionFuture<Void>(unsafeExecutorName);
+        Thread other1 = getThread(otherExecutorName);
+        Thread other2 = getThread(otherExecutorName);
+        assertFalse(future.allowedExecutors(other1, other2));
+        Thread unsafe1 = getThread(unsafeExecutorName);
+        Thread unsafe2 = getThread(unsafeExecutorName);
+        assertTrue(future.allowedExecutors(unsafe1, unsafe2));
+
+        assertTrue(future.allowedExecutors(unsafe1, other1));
+    }
+
+    public void testTwoArg() {
+        String unsafeExecutorName1 = "unsafe-executor-1";
+        String unsafeExecutorName2 = "unsafe-executor-2";
+        String otherExecutorName = "other-executor";
+        UnsafePlainActionFuture<?> future = new UnsafePlainActionFuture<Void>(unsafeExecutorName1, unsafeExecutorName2);
+        Thread other1 = getThread(otherExecutorName);
+        Thread other2 = getThread(otherExecutorName);
+        assertFalse(future.allowedExecutors(other1, other2));
+        Thread unsafe1Thread1 = getThread(unsafeExecutorName1);
+        Thread unsafe2Thread1 = getThread(unsafeExecutorName2);
+        Thread unsafe1Thread2 = getThread(unsafeExecutorName1);
+        Thread unsafe2Thread2 = getThread(unsafeExecutorName2);
+        assertTrue(future.allowedExecutors(unsafe1Thread1, unsafe1Thread2));
+        assertTrue(future.allowedExecutors(unsafe2Thread1, unsafe2Thread2));
+
+        assertTrue(future.allowedExecutors(unsafe1Thread1, unsafe2Thread2));
+        assertTrue(future.allowedExecutors(unsafe2Thread1, other1));
+        assertTrue(future.allowedExecutors(other1, unsafe2Thread2));
+    }
+
+    private static Thread getThread(String executorName) {
+        Thread t = new Thread("[" + executorName + "][]");
+        assertThat(EsExecutors.executorName(t), equalTo(executorName));
+        return t;
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/action/support/TestPlainActionFuture.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/TestPlainActionFuture.java
@@ -13,7 +13,7 @@ package org.elasticsearch.action.support;
  */
 public class TestPlainActionFuture<T> extends PlainActionFuture<T> {
     @Override
-    boolean allowedExecutors(Thread thread1, Thread thread2) {
+    boolean allowedExecutors(Thread blockedThread, Thread completingThread) {
         return true;
     }
 }


### PR DESCRIPTION
UnsafePlainActionFuture would allow any thread to do unsafe completes when using the one-arg constructor, fixed.