### PR TITLE
Convert data stream global retention to record

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
@@ -344,12 +344,12 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
             new DataStreamFactoryRetention() {
                 @Override
                 public TimeValue getMaxRetention() {
-                    return globalRetention.getMaxRetention();
+                    return globalRetention.maxRetention();
                 }
 
                 @Override
                 public TimeValue getDefaultRetention() {
-                    return globalRetention.getDefaultRetention();
+                    return globalRetention.defaultRetention();
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetention.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetention.java
@@ -14,36 +14,24 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.NodeFeature;
-import org.elasticsearch.xcontent.ParseField;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * A cluster state entry that contains global retention settings that are configurable by the user. These settings include:
  * - default retention, applied on any data stream managed by DSL that does not have an explicit retention defined
  * - max retention, applied on every data stream managed by DSL
  */
-public final class DataStreamGlobalRetention implements Writeable {
+public record DataStreamGlobalRetention(@Nullable TimeValue defaultRetention, @Nullable TimeValue maxRetention) implements Writeable {
 
     public static final String TYPE = "data-stream-global-retention";
 
     public static final NodeFeature GLOBAL_RETENTION = new NodeFeature("data_stream.lifecycle.global_retention");
-
-    public static final ParseField DEFAULT_RETENTION_FIELD = new ParseField("default_retention");
-    public static final ParseField MAX_RETENTION_FIELD = new ParseField("max_retention");
-
-    public static final DataStreamGlobalRetention EMPTY = new DataStreamGlobalRetention(null, null);
     public static final TimeValue MIN_RETENTION_VALUE = TimeValue.timeValueSeconds(10);
-
-    @Nullable
-    private final TimeValue defaultRetention;
-    @Nullable
-    private final TimeValue maxRetention;
 
     /**
      * @param defaultRetention the default retention or null if it's undefined
-     * @param maxRetention the max retention or null if it's undefined
+     * @param maxRetention     the max retention or null if it's undefined
      * @throws IllegalArgumentException when the default retention is greater than the max retention.
      */
     public DataStreamGlobalRetention(TimeValue defaultRetention, TimeValue maxRetention) {
@@ -75,29 +63,6 @@ public final class DataStreamGlobalRetention implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalTimeValue(defaultRetention);
         out.writeOptionalTimeValue(maxRetention);
-    }
-
-    @Nullable
-    public TimeValue getDefaultRetention() {
-        return defaultRetention;
-    }
-
-    @Nullable
-    public TimeValue getMaxRetention() {
-        return maxRetention;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DataStreamGlobalRetention that = (DataStreamGlobalRetention) o;
-        return Objects.equals(defaultRetention, that.defaultRetention) && Objects.equals(maxRetention, that.maxRetention);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(defaultRetention, maxRetention);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -174,12 +174,12 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
             return Tuple.tuple(dataStreamRetention, RetentionSource.DATA_STREAM_CONFIGURATION);
         }
         if (dataStreamRetention == null) {
-            return globalRetention.getDefaultRetention() != null
-                ? Tuple.tuple(globalRetention.getDefaultRetention(), RetentionSource.DEFAULT_GLOBAL_RETENTION)
-                : Tuple.tuple(globalRetention.getMaxRetention(), RetentionSource.MAX_GLOBAL_RETENTION);
+            return globalRetention.defaultRetention() != null
+                ? Tuple.tuple(globalRetention.defaultRetention(), RetentionSource.DEFAULT_GLOBAL_RETENTION)
+                : Tuple.tuple(globalRetention.maxRetention(), RetentionSource.MAX_GLOBAL_RETENTION);
         }
-        if (globalRetention.getMaxRetention() != null && globalRetention.getMaxRetention().getMillis() < dataStreamRetention.getMillis()) {
-            return Tuple.tuple(globalRetention.getMaxRetention(), RetentionSource.MAX_GLOBAL_RETENTION);
+        if (globalRetention.maxRetention() != null && globalRetention.maxRetention().getMillis() < dataStreamRetention.getMillis()) {
+            return Tuple.tuple(globalRetention.maxRetention(), RetentionSource.MAX_GLOBAL_RETENTION);
         } else {
             return Tuple.tuple(dataStreamRetention, RetentionSource.DATA_STREAM_CONFIGURATION);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionProviderTests.java
@@ -23,8 +23,8 @@ public class DataStreamGlobalRetentionProviderTests extends ESTestCase {
         DataStreamGlobalRetentionProvider resolver = new DataStreamGlobalRetentionProvider(factoryRetention);
         DataStreamGlobalRetention globalRetention = resolver.provide();
         assertThat(globalRetention, notNullValue());
-        assertThat(globalRetention.getDefaultRetention(), equalTo(factoryRetention.getDefaultRetention()));
-        assertThat(globalRetention.getMaxRetention(), equalTo(factoryRetention.getMaxRetention()));
+        assertThat(globalRetention.defaultRetention(), equalTo(factoryRetention.getDefaultRetention()));
+        assertThat(globalRetention.maxRetention(), equalTo(factoryRetention.getMaxRetention()));
     }
 
     private static DataStreamFactoryRetention randomNonEmptyFactoryRetention() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionTests.java
@@ -26,8 +26,8 @@ public class DataStreamGlobalRetentionTests extends AbstractWireSerializingTestC
 
     @Override
     protected DataStreamGlobalRetention mutateInstance(DataStreamGlobalRetention instance) {
-        var defaultRetention = instance.getDefaultRetention();
-        var maxRetention = instance.getMaxRetention();
+        var defaultRetention = instance.defaultRetention();
+        var maxRetention = instance.maxRetention();
         switch (randomInt(1)) {
             case 0 -> {
                 defaultRetention = randomValueOtherThan(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -135,7 +135,7 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
             } else {
                 assertThat(serialized, containsString("data_retention"));
             }
-            boolean globalRetentionIsNotNull = globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null;
+            boolean globalRetentionIsNotNull = globalRetention.defaultRetention() != null || globalRetention.maxRetention() != null;
             boolean configuredLifeCycleIsNotNull = lifecycle.getDataRetention() != null && lifecycle.getDataRetention().value() != null;
             if (lifecycle.isEnabled() && (globalRetentionIsNotNull || configuredLifeCycleIsNotNull)) {
                 assertThat(serialized, containsString("effective_retention"));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
@@ -92,7 +92,7 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
             responseHeaders.get("Warning").get(0),
             containsString(
                 "Not providing a retention is not allowed for this project. The default retention of ["
-                    + globalRetention.getDefaultRetention().getStringRep()
+                    + globalRetention.defaultRetention().getStringRep()
                     + "] will be applied."
             )
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1901,7 +1901,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             // We check that even if there was no retention provided by the user, the global retention applies
             assertThat(serialized, not(containsString("data_retention")));
             if (dataStream.isSystem() == false
-                && (globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null)) {
+                && (globalRetention.defaultRetention() != null || globalRetention.maxRetention() != null)) {
                 assertThat(serialized, containsString("effective_retention"));
             } else {
                 assertThat(serialized, not(containsString("effective_retention")));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1900,8 +1900,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             }
             // We check that even if there was no retention provided by the user, the global retention applies
             assertThat(serialized, not(containsString("data_retention")));
-            if (dataStream.isSystem() == false
-                && (globalRetention.defaultRetention() != null || globalRetention.maxRetention() != null)) {
+            if (dataStream.isSystem() == false && (globalRetention.defaultRetention() != null || globalRetention.maxRetention() != null)) {
                 assertThat(serialized, containsString("effective_retention"));
             } else {
                 assertThat(serialized, not(containsString("effective_retention")));


### PR DESCRIPTION
In this refactoring PR we convert the global retention class to a record.