### PR TITLE
ESQL: Unmute MATCH command tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -122,18 +122,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.integration.ModelRegistryIT
   method: testGetModel
   issue: https://github.com/elastic/elasticsearch/issues/111570
-- class: org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizerTests
-  method: testMatchCommandWithWhereClause {default}
-  issue: https://github.com/elastic/elasticsearch/issues/111658
-- class: org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizerTests
-  method: testMatchCommand {default}
-  issue: https://github.com/elastic/elasticsearch/issues/111659
-- class: org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizerTests
-  method: testMatchCommandWithMultipleMatches {default}
-  issue: https://github.com/elastic/elasticsearch/issues/111660
-- class: org.elasticsearch.xpack.esql.analysis.VerifierTests
-  method: testMatchCommand
-  issue: https://github.com/elastic/elasticsearch/issues/111661
 - class: org.elasticsearch.rest.ChunkedZipResponseIT
   method: testAbort
   issue: https://github.com/elastic/elasticsearch/issues/111698


### PR DESCRIPTION
These were [fixed](https://github.com/elastic/elasticsearch/pull/111657) by @not-napoleon, but CI caught them in the meantime and muted them nonetheless.