### PR TITLE
CCS telemetry concurrency model

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -19,7 +19,6 @@ import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Res
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.WILDCARD_FEATURE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class CCSUsageTelemetryTests extends ESTestCase {
 
@@ -73,7 +72,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             // Expect it to be within 1% of the actual value
             assertThat(snapshot.getTook().avg(), closeTo(took1));
-            assertThat(snapshot.getTook().max(), lessThanOrEqualTo(took1));
+            assertThat(snapshot.getTook().max(), closeTo(took1));
             if (minimizeRoundTrips) {
                 assertThat(snapshot.getTookMrtTrue().count(), equalTo(1L));
                 assertThat(snapshot.getTookMrtTrue().avg(), greaterThan(0L));

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -4,19 +4,19 @@
     "success" : 20,
     "skipped" : 5,
     "took" : {
-      "max" : 1988,
+      "max" : 1991,
       "avg" : 1496,
-      "p90" : 1892
+      "p90" : 1895
     },
     "took_mrt_true" : {
-      "max" : 9952,
-      "avg" : 7466,
-      "p90" : 9440
+      "max" : 9983,
+      "avg" : 7476,
+      "p90" : 9471
     },
     "took_mrt_false" : {
-      "max" : 19904,
-      "avg" : 14932,
-      "p90" : 18880
+      "max" : 19967,
+      "avg" : 14952,
+      "p90" : 18943
     },
     "remotes_per_search_max" : 6,
     "remotes_per_search_avg" : 7.89,
@@ -40,18 +40,18 @@
         "total" : 100,
         "skipped" : 22,
         "took" : {
-          "max" : 3976,
+          "max" : 3983,
           "avg" : 2992,
-          "p90" : 3784
+          "p90" : 3791
         }
       },
       "remote2" : {
         "total" : 300,
         "skipped" : 42,
         "took" : {
-          "max" : 993280,
-          "avg" : 747480,
-          "p90" : 944128
+          "max" : 995327,
+          "avg" : 747531,
+          "p90" : 946175
         }
       }
     }


### PR DESCRIPTION
This ensures that CCS telemetry collection is safe when used concurrently, and adds a test to verify it. 

Note that CCSUsageTelemetry is thread-safe, but the snapshot is not (for modification) since snapshots are going to be aggregated in a single thread. 