### PR TITLE
Rename streamContent/Separator to bulkContent/Separator

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/cbor/CborXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/cbor/CborXContentImpl.java
@@ -63,8 +63,8 @@ public final class CborXContentImpl implements XContent {
     }
 
     @Override
-    public byte streamSeparator() {
-        throw new XContentParseException("cbor does not support stream parsing...");
+    public byte bulkSeparator() {
+        throw new XContentParseException("cbor does not support bulk parsing...");
     }
 
     @Override

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
@@ -65,7 +65,7 @@ public class JsonXContentImpl implements XContent {
     }
 
     @Override
-    public byte streamSeparator() {
+    public byte bulkSeparator() {
         return '\n';
     }
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/smile/SmileXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/smile/SmileXContentImpl.java
@@ -65,7 +65,7 @@ public final class SmileXContentImpl implements XContent {
     }
 
     @Override
-    public byte streamSeparator() {
+    public byte bulkSeparator() {
         return (byte) 0xFF;
     }
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/yaml/YamlXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/yaml/YamlXContentImpl.java
@@ -61,8 +61,8 @@ public final class YamlXContentImpl implements XContent {
     }
 
     @Override
-    public byte streamSeparator() {
-        throw new UnsupportedOperationException("yaml does not support stream parsing...");
+    public byte bulkSeparator() {
+        throw new UnsupportedOperationException("yaml does not support bulk parsing...");
     }
 
     @Override

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContent.java
@@ -24,7 +24,7 @@ public interface XContent {
      */
     XContentType type();
 
-    byte streamSeparator();
+    byte bulkSeparator();
 
     @Deprecated
     boolean detectContent(byte[] bytes, int offset, int length);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateRequest.java
@@ -142,12 +142,12 @@ public class MultiSearchTemplateRequest extends ActionRequest implements Composi
                 MultiSearchRequest.writeSearchRequestParams(searchRequest, xContentBuilder);
                 BytesReference.bytes(xContentBuilder).writeTo(output);
             }
-            output.write(xContent.streamSeparator());
+            output.write(xContent.bulkSeparator());
             try (XContentBuilder xContentBuilder = XContentBuilder.builder(xContent)) {
                 templateRequest.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
                 BytesReference.bytes(xContentBuilder).writeTo(output);
             }
-            output.write(xContent.streamSeparator());
+            output.write(xContent.bulkSeparator());
         }
         return output.toByteArray();
     }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -94,7 +94,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
     }
 
     @Override
-    public boolean supportsContentStream() {
+    public boolean supportsBulkContent() {
         return true;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -139,7 +139,7 @@ public final class BulkRequestParser {
         XContent xContent = xContentType.xContent();
         int line = 0;
         int from = 0;
-        byte marker = xContent.streamSeparator();
+        byte marker = xContent.bulkSeparator();
         // Bulk requests can contain a lot of repeated strings for the index, pipeline and routing parameters. This map is used to
         // deduplicate duplicate strings parsed for these parameters. While it does not prevent instantiating the duplicate strings, it
         // reduces their lifetime to the lifetime of this parse call instead of the lifetime of the full bulk request.

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -206,7 +206,7 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
         TriFunction<String, Object, SearchRequest, Boolean> extraParamParser
     ) throws IOException {
         int from = 0;
-        byte marker = xContent.streamSeparator();
+        byte marker = xContent.bulkSeparator();
         while (true) {
             int nextMarker = findNextMarker(marker, from, data);
             if (nextMarker == -1) {
@@ -343,7 +343,7 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                 writeSearchRequestParams(request, xContentBuilder);
                 BytesReference.bytes(xContentBuilder).writeTo(output);
             }
-            output.write(xContent.streamSeparator());
+            output.write(xContent.bulkSeparator());
             try (XContentBuilder xContentBuilder = XContentBuilder.builder(xContent)) {
                 if (request.source() != null) {
                     request.source().toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
@@ -353,7 +353,7 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                 }
                 BytesReference.bytes(xContentBuilder).writeTo(output);
             }
-            output.write(xContent.streamSeparator());
+            output.write(xContent.bulkSeparator());
         }
         return output.toByteArray();
     }

--- a/server/src/main/java/org/elasticsearch/rest/FilterRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/FilterRestHandler.java
@@ -48,8 +48,8 @@ public abstract class FilterRestHandler implements RestHandler {
     }
 
     @Override
-    public boolean supportsContentStream() {
-        return delegate.supportsContentStream();
+    public boolean supportsBulkContent() {
+        return delegate.supportsBulkContent();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -432,7 +432,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
             }
             final XContentType xContentType = request.getXContentType();
             // TODO consider refactoring to handler.supportsContentStream(xContentType). It is only used with JSON and SMILE
-            if (handler.supportsContentStream()
+            if (handler.supportsBulkContent()
                 && XContentType.JSON != xContentType.canonical()
                 && XContentType.SMILE != xContentType.canonical()) {
                 channel.sendResponse(

--- a/server/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -39,11 +39,11 @@ public interface RestHandler {
     }
 
     /**
-     * Indicates if the RestHandler supports content as a stream. A stream would be multiple objects delineated by
-     * {@link XContent#streamSeparator()}. If a handler returns true this will affect the types of content that can be sent to
-     * this endpoint.
+     * Indicates if the RestHandler supports content as a bulk. A bulk would be multiple objects
+     * delineated by {@link XContent#bulkSeparator()}. If a handler returns true this will affect
+     * the types of content that can be sent to this endpoint.
      */
-    default boolean supportsContentStream() {
+    default boolean supportsBulkContent() {
         return false;
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -39,7 +39,7 @@ public interface RestHandler {
     }
 
     /**
-     * Indicates if the RestHandler supports content as a bulk. A bulk would be multiple objects
+     * Indicates if the RestHandler supports bulk content. A bulk request contains multiple objects
      * delineated by {@link XContent#bulkSeparator()}. If a handler returns true this will affect
      * the types of content that can be sent to this endpoint.
      */

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -101,7 +101,7 @@ public class RestBulkAction extends BaseRestHandler {
     }
 
     @Override
-    public boolean supportsContentStream() {
+    public boolean supportsBulkContent() {
         return true;
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -209,7 +209,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
     }
 
     @Override
-    public boolean supportsContentStream() {
+    public boolean supportsBulkContent() {
         return true;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
@@ -290,13 +290,13 @@ public class BulkRequestTests extends ESTestCase {
                 builder.endObject();
                 builder.endObject();
             }
-            out.write(xContentType.xContent().streamSeparator());
+            out.write(xContentType.xContent().bulkSeparator());
             try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, out)) {
                 builder.startObject();
                 builder.field("field", "value");
                 builder.endObject();
             }
-            out.write(xContentType.xContent().streamSeparator());
+            out.write(xContentType.xContent().bulkSeparator());
             data = out.bytes();
         }
 
@@ -327,7 +327,7 @@ public class BulkRequestTests extends ESTestCase {
                 builder.endObject();
                 builder.endObject();
             }
-            out.write(xContentType.xContent().streamSeparator());
+            out.write(xContentType.xContent().bulkSeparator());
             try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, out)) {
                 builder.startObject();
                 builder.startObject("doc").endObject();
@@ -338,7 +338,7 @@ public class BulkRequestTests extends ESTestCase {
                 builder.field("upsert", values);
                 builder.endObject();
             }
-            out.write(xContentType.xContent().streamSeparator());
+            out.write(xContentType.xContent().bulkSeparator());
             data = out.bytes();
         }
         BulkRequest bulkRequest = new BulkRequest();

--- a/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -155,17 +155,17 @@ public class DeprecationRestHandlerTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> DeprecationRestHandler.requireValidHeader(blank));
     }
 
-    public void testSupportsContentStreamTrue() {
-        when(handler.supportsContentStream()).thenReturn(true);
+    public void testSupportsBulkContentTrue() {
+        when(handler.supportsBulkContent()).thenReturn(true);
         assertTrue(
-            new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, deprecationLogger, false).supportsContentStream()
+            new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, deprecationLogger, false).supportsBulkContent()
         );
     }
 
-    public void testSupportsContentStreamFalse() {
-        when(handler.supportsContentStream()).thenReturn(false);
+    public void testSupportsBulkContentFalse() {
+        when(handler.supportsBulkContent()).thenReturn(false);
         assertFalse(
-            new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, deprecationLogger, false).supportsContentStream()
+            new DeprecationRestHandler(handler, METHOD, PATH, null, deprecationMessage, deprecationLogger, false).supportsBulkContent()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -598,7 +598,7 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public boolean supportsContentStream() {
+            public boolean supportsBulkContent() {
                 return true;
             }
         });
@@ -637,7 +637,7 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public boolean supportsContentStream() {
+            public boolean supportsBulkContent() {
                 return true;
             }
         });
@@ -662,7 +662,7 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public boolean supportsContentStream() {
+            public boolean supportsBulkContent() {
                 return true;
             }
         });
@@ -688,7 +688,7 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public boolean supportsContentStream() {
+            public boolean supportsBulkContent() {
                 return true;
             }
         });
@@ -713,7 +713,7 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public boolean supportsContentStream() {
+            public boolean supportsBulkContent() {
                 return true;
             }
         });

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -200,7 +200,7 @@ public class ClientYamlTestExecutionContext {
                 for (int i = bytesRef.offset; i < bytesRef.length; i++) {
                     bytes[position++] = bytesRef.bytes[i];
                 }
-                bytes[position++] = xContentType.xContent().streamSeparator();
+                bytes[position++] = xContentType.xContent().bulkSeparator();
             }
             return new ByteArrayEntity(bytes, ContentType.create(xContentType.mediaTypeWithoutParameters(), StandardCharsets.UTF_8));
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/JsonDataToProcessWriter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/JsonDataToProcessWriter.java
@@ -91,7 +91,7 @@ public class JsonDataToProcessWriter extends AbstractDataToProcessWriter {
 
     private void writeSmileXContent(CategorizationAnalyzer categorizationAnalyzer, InputStream inputStream) throws IOException {
         while (true) {
-            byte[] nextObject = findNextObject(XContentType.SMILE.xContent().streamSeparator(), inputStream);
+            byte[] nextObject = findNextObject(XContentType.SMILE.xContent().bulkSeparator(), inputStream);
             if (nextObject.length == 0) {
                 break;
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/output/NormalizerResultHandler.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/output/NormalizerResultHandler.java
@@ -57,7 +57,7 @@ public class NormalizerResultHandler {
     }
 
     private BytesReference parseResults(XContent xContent, BytesReference bytesRef) throws IOException {
-        byte marker = xContent.streamSeparator();
+        byte marker = xContent.bulkSeparator();
         int from = 0;
         while (true) {
             int nextMarker = findNextMarker(marker, bytesRef, from);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandler.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandler.java
@@ -236,7 +236,7 @@ public class CppLogMessageHandler implements Closeable {
     }
 
     private BytesReference parseMessages(XContent xContent, BytesReference bytesRef) {
-        byte marker = xContent.streamSeparator();
+        byte marker = xContent.bulkSeparator();
         int from = 0;
         while (true) {
             int nextMarker = findNextMarker(marker, bytesRef, from);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestPostDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestPostDataAction.java
@@ -53,7 +53,7 @@ public class RestPostDataAction extends BaseRestHandler {
     }
 
     @Override
-    public boolean supportsContentStream() {
+    public boolean supportsBulkContent() {
         return true;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/JsonDataToProcessWriterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/writer/JsonDataToProcessWriterTests.java
@@ -373,7 +373,7 @@ public class JsonDataToProcessWriterTests extends ESTestCase {
         xsonGen.writeStringField("value", "1.0");
         xsonGen.writeEndObject();
         xsonGen.close();
-        xsonOs.writeByte(XContentType.SMILE.xContent().streamSeparator());
+        xsonOs.writeByte(XContentType.SMILE.xContent().bulkSeparator());
 
         xsonGen = XContentFactory.xContent(XContentType.SMILE).createGenerator(xsonOs);
         xsonGen.writeStartObject();
@@ -382,7 +382,7 @@ public class JsonDataToProcessWriterTests extends ESTestCase {
         xsonGen.writeStringField("value", "2.0");
         xsonGen.writeEndObject();
         xsonGen.flush();
-        xsonOs.writeByte(XContentType.SMILE.xContent().streamSeparator());
+        xsonOs.writeByte(XContentType.SMILE.xContent().bulkSeparator());
 
         InputStream inputStream = new ByteArrayInputStream(BytesReference.toBytes(xsonOs.bytes()));
         JsonDataToProcessWriter writer = createWriter();

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExportBulk.java
@@ -176,7 +176,7 @@ class HttpExportBulk extends ExportBulk {
         }
 
         // Adds action metadata line bulk separator
-        out.write(xContent.streamSeparator());
+        out.write(xContent.bulkSeparator());
 
         // Adds the source of the monitoring document
         try (XContentBuilder builder = new XContentBuilder(xContent, out)) {
@@ -184,7 +184,7 @@ class HttpExportBulk extends ExportBulk {
         }
 
         // Adds final bulk separator
-        out.write(xContent.streamSeparator());
+        out.write(xContent.bulkSeparator());
 
         logger.trace("http exporter [{}] - added index request [index={}, id={}, monitoring data type={}]", name, index, id, doc.getType());
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkAction.java
@@ -102,7 +102,7 @@ public class RestMonitoringBulkAction extends BaseRestHandler {
     }
 
     @Override
-    public boolean supportsContentStream() {
+    public boolean supportsBulkContent() {
         return true;
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkRequestTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkRequestTests.java
@@ -105,16 +105,16 @@ public class MonitoringBulkRequestTests extends ESTestCase {
                 builder.endObject();
 
                 builder.flush();
-                content.write(xContentType.xContent().streamSeparator());
+                content.write(xContentType.xContent().bulkSeparator());
 
                 sources[i] = RandomObjects.randomSource(random(), xContentType);
                 BytesRef bytes = sources[i].toBytesRef();
                 content.write(bytes.bytes, bytes.offset, bytes.length);
 
-                content.write(xContentType.xContent().streamSeparator());
+                content.write(xContentType.xContent().bulkSeparator());
             }
 
-            content.write(xContentType.xContent().streamSeparator());
+            content.write(xContentType.xContent().bulkSeparator());
         }
 
         final MonitoredSystem system = randomFrom(MonitoredSystem.values());
@@ -146,7 +146,7 @@ public class MonitoringBulkRequestTests extends ESTestCase {
         final int totalDocs = nbDocs + nbEmptyDocs;
 
         final XContentType xContentType = XContentType.JSON;
-        final byte separator = xContentType.xContent().streamSeparator();
+        final byte separator = xContentType.xContent().bulkSeparator();
 
         final BytesStreamOutput content = new BytesStreamOutput();
         try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, content)) {
@@ -192,7 +192,7 @@ public class MonitoringBulkRequestTests extends ESTestCase {
         final String indexName = randomAlphaOfLength(10);
 
         final XContentType xContentType = XContentType.JSON;
-        final byte separator = xContentType.xContent().streamSeparator();
+        final byte separator = xContentType.xContent().bulkSeparator();
 
         final BytesStreamOutput content = new BytesStreamOutput();
         try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType, content)) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringBulkActionTests.java
@@ -45,9 +45,9 @@ public class RestMonitoringBulkActionTests extends ESTestCase {
         assertThat(action.getName(), is("monitoring_bulk"));
     }
 
-    public void testSupportsContentStream() {
+    public void testSupportsBulkContent() {
         // if you change this, it's a very breaking change for Monitoring
-        assertThat(action.supportsContentStream(), is(true));
+        assertThat(action.supportsBulkContent(), is(true));
     }
 
     public void testMissingSystemId() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/rest/action/RestMonitoringMigrateAlertsActionTests.java
@@ -35,7 +35,7 @@ public class RestMonitoringMigrateAlertsActionTests extends ESTestCase {
     }
 
     public void testSupportsContentStream() {
-        assertThat(action.supportsContentStream(), is(false));
+        assertThat(action.supportsBulkContent(), is(false));
     }
 
     public void testRestActionCompletion() throws Exception {

--- a/x-pack/qa/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
+++ b/x-pack/qa/runtime-fields/src/main/java/org/elasticsearch/xpack/runtimefields/test/CoreTestTranslater.java
@@ -341,7 +341,7 @@ public abstract class CoreTestTranslater {
                     try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, bos)) {
                         b.map(body);
                     }
-                    bos.write(JsonXContent.jsonXContent.streamSeparator());
+                    bos.write(JsonXContent.jsonXContent.bulkSeparator());
                 }
                 List<IndexRequest> indexRequests = new ArrayList<>();
                 new BulkRequestParser(false, RestApiVersion.current()).parse(


### PR DESCRIPTION
Rename `xContent.streamSeparator()` and `RestHandler.supportsStreamContent()`
to `xContent.bulkSeparator()` and `RestHandler.supportsBulkContent()`.

I want to reserve use of "supportsStreamContent" for current work in HTTP layer
to [support incremental content handling](https://github.com/elastic/elasticsearch/pull/111438) besides fully aggregated byte buffers.
`supportsStreamContent` would indicate that handler can parse chunks of http content
as they arrive.