### PR TITLE
[8.15] Skip LOOKUP/INLINESTATS cases unless on snapshot (#111755)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -181,16 +181,18 @@ public class VerifierTests extends ESTestCase {
             error("from test* | stats values(multi_typed)", analyzer)
         );
 
-        // LOOKUP with unsupported type
-        assertEquals(
-            "1:41: column type mismatch, table column was [integer] and original column was [unsupported]",
-            error("from test* | lookup int_number_names on int", analyzer)
-        );
-        // LOOKUP with multi-typed field
-        assertEquals(
-            "1:44: column type mismatch, table column was [double] and original column was [unsupported]",
-            error("from test* | lookup double_number_names on double", analyzer)
-        );
+        if (Build.current().isSnapshot()) {
+            // LOOKUP with unsupported type
+            assertEquals(
+                "1:41: column type mismatch, table column was [integer] and original column was [unsupported]",
+                error("from test* | lookup int_number_names on int", analyzer)
+            );
+            // LOOKUP with multi-typed field
+            assertEquals(
+                "1:44: column type mismatch, table column was [double] and original column was [unsupported]",
+                error("from test* | lookup double_number_names on double", analyzer)
+            );
+        }
 
         assertEquals(
             "1:24: Cannot use field [unsupported] with unsupported type [flattened]",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Skip LOOKUP/INLINESTATS cases unless on snapshot (#111755)](https://github.com/elastic/elasticsearch/pull/111755)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)