### PR TITLE
ESQL: Migrate some PhysicalPlan to NamedWriteable

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -106,10 +106,10 @@ public final class PlanNamedTypes {
     public static List<PlanNameRegistry.Entry> namedTypeEntries() {
         List<PlanNameRegistry.Entry> declared = List.of(
             // Physical Plan Nodes
-            of(PhysicalPlan.class, AggregateExec.class, PlanNamedTypes::writeAggregateExec, PlanNamedTypes::readAggregateExec),
-            of(PhysicalPlan.class, DissectExec.class, PlanNamedTypes::writeDissectExec, PlanNamedTypes::readDissectExec),
+            of(PhysicalPlan.class, AggregateExec.ENTRY),
+            of(PhysicalPlan.class, DissectExec.ENTRY),
             of(PhysicalPlan.class, EsQueryExec.class, PlanNamedTypes::writeEsQueryExec, PlanNamedTypes::readEsQueryExec),
-            of(PhysicalPlan.class, EsSourceExec.class, PlanNamedTypes::writeEsSourceExec, PlanNamedTypes::readEsSourceExec),
+            of(PhysicalPlan.class, EsSourceExec.ENTRY),
             of(PhysicalPlan.class, EvalExec.class, PlanNamedTypes::writeEvalExec, PlanNamedTypes::readEvalExec),
             of(PhysicalPlan.class, EnrichExec.class, PlanNamedTypes::writeEnrichExec, PlanNamedTypes::readEnrichExec),
             of(PhysicalPlan.class, ExchangeExec.class, PlanNamedTypes::writeExchangeExec, PlanNamedTypes::readExchangeExec),
@@ -156,44 +156,6 @@ public final class PlanNamedTypes {
     }
 
     // -- physical plan nodes
-    static AggregateExec readAggregateExec(PlanStreamInput in) throws IOException {
-        return new AggregateExec(
-            Source.readFrom(in),
-            in.readPhysicalPlanNode(),
-            in.readNamedWriteableCollectionAsList(Expression.class),
-            in.readNamedWriteableCollectionAsList(NamedExpression.class),
-            in.readEnum(AggregateExec.Mode.class),
-            in.readOptionalVInt()
-        );
-    }
-
-    static void writeAggregateExec(PlanStreamOutput out, AggregateExec aggregateExec) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writePhysicalPlanNode(aggregateExec.child());
-        out.writeNamedWriteableCollection(aggregateExec.groupings());
-        out.writeNamedWriteableCollection(aggregateExec.aggregates());
-        out.writeEnum(aggregateExec.getMode());
-        out.writeOptionalVInt(aggregateExec.estimatedRowSize());
-    }
-
-    static DissectExec readDissectExec(PlanStreamInput in) throws IOException {
-        return new DissectExec(
-            Source.readFrom(in),
-            in.readPhysicalPlanNode(),
-            in.readNamedWriteable(Expression.class),
-            Dissect.Parser.readFrom(in),
-            in.readNamedWriteableCollectionAsList(Attribute.class)
-        );
-    }
-
-    static void writeDissectExec(PlanStreamOutput out, DissectExec dissectExec) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writePhysicalPlanNode(dissectExec.child());
-        out.writeNamedWriteable(dissectExec.inputExpression());
-        dissectExec.parser().writeTo(out);
-        out.writeNamedWriteableCollection(dissectExec.extractedFields());
-    }
-
     static EsQueryExec readEsQueryExec(PlanStreamInput in) throws IOException {
         return new EsQueryExec(
             Source.readFrom(in),
@@ -217,24 +179,6 @@ public final class PlanNamedTypes {
         out.writeOptionalNamedWriteable(esQueryExec.limit());
         out.writeOptionalCollection(esQueryExec.sorts(), writerFromPlanWriter(PlanNamedTypes::writeFieldSort));
         out.writeOptionalInt(esQueryExec.estimatedRowSize());
-    }
-
-    static EsSourceExec readEsSourceExec(PlanStreamInput in) throws IOException {
-        return new EsSourceExec(
-            Source.readFrom(in),
-            new EsIndex(in),
-            in.readNamedWriteableCollectionAsList(Attribute.class),
-            in.readOptionalNamedWriteable(QueryBuilder.class),
-            readIndexMode(in)
-        );
-    }
-
-    static void writeEsSourceExec(PlanStreamOutput out, EsSourceExec esSourceExec) throws IOException {
-        Source.EMPTY.writeTo(out);
-        esSourceExec.index().writeTo(out);
-        out.writeNamedWriteableCollection(esSourceExec.output());
-        out.writeOptionalNamedWriteable(esSourceExec.query());
-        writeIndexMode(out, esSourceExec.indexMode());
     }
 
     public static IndexMode readIndexMode(StreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExec.java
@@ -7,17 +7,29 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 public class AggregateExec extends UnaryExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "AggregateExec",
+        AggregateExec::new
+    );
+
     private final List<? extends Expression> groupings;
     private final List<? extends NamedExpression> aggregates;
 
@@ -48,6 +60,32 @@ public class AggregateExec extends UnaryExec implements EstimatesRowSize {
         this.aggregates = aggregates;
         this.mode = mode;
         this.estimatedRowSize = estimatedRowSize;
+    }
+
+    private AggregateExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            ((PlanStreamInput) in).readPhysicalPlanNode(),
+            in.readNamedWriteableCollectionAsList(Expression.class),
+            in.readNamedWriteableCollectionAsList(NamedExpression.class),
+            in.readEnum(AggregateExec.Mode.class),
+            in.readOptionalVInt()
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
+        out.writeNamedWriteableCollection(groupings());
+        out.writeNamedWriteableCollection(aggregates());
+        out.writeEnum(getMode());
+        out.writeOptionalVInt(estimatedRowSize());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.QueryPlan;
@@ -21,6 +22,9 @@ import java.util.List;
  * PhysicalPlan = take Delta, DEN to SJC, then SJC to SFO
  */
 public abstract class PhysicalPlan extends QueryPlan<PhysicalPlan> {
+    public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(AggregateExec.ENTRY, DissectExec.ENTRY, EsSourceExec.ENTRY);
+    }
 
     public PhysicalPlan(Source source, List<PhysicalPlan> children) {
         super(source, children);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
-import org.elasticsearch.dissect.DissectParser;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -37,7 +36,7 @@ public class AggregateSerializationTests extends AbstractLogicalPlanSerializatio
         return new Aggregate(source, child, aggregateType, groupings, aggregates);
     }
 
-    private static List<? extends NamedExpression> randomAggregates() {
+    public static List<? extends NamedExpression> randomAggregates() {
         int size = between(1, 5);
         List<NamedExpression> result = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -58,12 +57,6 @@ public class AggregateSerializationTests extends AbstractLogicalPlanSerializatio
             result.add(new Alias(randomSource(), randomAlphaOfLength(5), agg));
         }
         return result;
-    }
-
-    private static Dissect.Parser randomParser() {
-        String suffix = randomAlphaOfLength(5);
-        String pattern = "%{b} %{c}" + suffix;
-        return new Dissect.Parser(pattern, ",", new DissectParser(pattern, ","));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/DissectSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/DissectSerializationTests.java
@@ -27,7 +27,7 @@ public class DissectSerializationTests extends AbstractLogicalPlanSerializationT
         return new Dissect(source, child, input, parser, extracted);
     }
 
-    private static Dissect.Parser randomParser() {
+    public static Dissect.Parser randomParser() {
         String suffix = randomAlphaOfLength(5);
         String pattern = "%{b} %{c}" + suffix;
         return new Dissect.Parser(pattern, ",", new DissectParser(pattern, ","));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Node;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.plan.AbstractNodeSerializationTests;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.plan.physical.AggregateExecSerializationTests.randomAggregateExec;
+import static org.elasticsearch.xpack.esql.plan.physical.DissectExecSerializationTests.randomDissectExec;
+import static org.elasticsearch.xpack.esql.plan.physical.EsSourceExecSerializationTests.randomEsSourceExec;
+
+public abstract class AbstractPhysicalPlanSerializationTests<T extends PhysicalPlan> extends AbstractNodeSerializationTests<T> {
+    public static PhysicalPlan randomChild(int depth) {
+        if (randomBoolean() && depth < 4) {
+            // TODO more random options
+            return randomBoolean() ? randomDissectExec(depth + 1) : randomAggregateExec(depth + 1);
+        }
+        return randomEsSourceExec();
+    }
+
+    public static Integer randomEstimatedRowSize() {
+        return randomBoolean() ? null : between(0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    protected final NamedWriteableRegistry getNamedWriteableRegistry() {
+        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
+        entries.addAll(PhysicalPlan.getNamedWriteables());
+        entries.addAll(AggregateFunction.getNamedWriteables());
+        entries.addAll(Expression.getNamedWriteables());
+        entries.addAll(Attribute.getNamedWriteables());
+        entries.addAll(EsField.getNamedWriteables());
+        entries.addAll(Block.getNamedWriteables());
+        entries.addAll(NamedExpression.getNamedWriteables());
+        entries.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedWriteables());
+        return new NamedWriteableRegistry(entries);
+    }
+
+    @Override
+    protected final Class<? extends Node<?>> categoryClass() {
+        return PhysicalPlan.class;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AggregateExecSerializationTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.AggregateSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
+
+public class AggregateExecSerializationTests extends AbstractPhysicalPlanSerializationTests<AggregateExec> {
+    public static AggregateExec randomAggregateExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        List<Expression> groupings = randomFieldAttributes(0, 5, false).stream().map(a -> (Expression) a).toList();
+        List<? extends NamedExpression> aggregates = AggregateSerializationTests.randomAggregates();
+        AggregateExec.Mode mode = randomFrom(AggregateExec.Mode.values());
+        Integer estimatedRowSize = randomEstimatedRowSize();
+        return new AggregateExec(source, child, groupings, aggregates, mode, estimatedRowSize);
+    }
+
+    @Override
+    protected AggregateExec createTestInstance() {
+        return randomAggregateExec(0);
+    }
+
+    @Override
+    protected AggregateExec mutateInstance(AggregateExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        List<? extends Expression> groupings = instance.groupings();
+        List<? extends NamedExpression> aggregates = instance.aggregates();
+        AggregateExec.Mode mode = instance.getMode();
+        Integer estimatedRowSize = instance.estimatedRowSize();
+        switch (between(0, 4)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> groupings = randomValueOtherThan(groupings, () -> randomFieldAttributes(0, 5, false));
+            case 2 -> aggregates = randomValueOtherThan(aggregates, AggregateSerializationTests::randomAggregates);
+            case 3 -> mode = randomValueOtherThan(mode, () -> randomFrom(AggregateExec.Mode.values()));
+            case 4 -> estimatedRowSize = randomValueOtherThan(
+                estimatedRowSize,
+                AbstractPhysicalPlanSerializationTests::randomEstimatedRowSize
+            );
+            default -> throw new IllegalStateException();
+        }
+        return new AggregateExec(instance.source(), child, groupings, aggregates, mode, estimatedRowSize);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/DissectExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/DissectExecSerializationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.plan.logical.Dissect;
+import org.elasticsearch.xpack.esql.plan.logical.DissectSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
+
+public class DissectExecSerializationTests extends AbstractPhysicalPlanSerializationTests<DissectExec> {
+    public static DissectExec randomDissectExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        Expression inputExpression = FieldAttributeTests.createFieldAttribute(1, false);
+        Dissect.Parser parser = DissectSerializationTests.randomParser();
+        List<Attribute> extracted = randomFieldAttributes(0, 4, false);
+        return new DissectExec(source, child, inputExpression, parser, extracted);
+    }
+
+    @Override
+    protected DissectExec createTestInstance() {
+        return randomDissectExec(0);
+    }
+
+    @Override
+    protected DissectExec mutateInstance(DissectExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        Expression inputExpression = FieldAttributeTests.createFieldAttribute(1, false);
+        Dissect.Parser parser = DissectSerializationTests.randomParser();
+        List<Attribute> extracted = randomFieldAttributes(0, 4, false);
+        switch (between(0, 3)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> inputExpression = randomValueOtherThan(inputExpression, () -> FieldAttributeTests.createFieldAttribute(1, false));
+            case 2 -> parser = randomValueOtherThan(parser, DissectSerializationTests::randomParser);
+            case 3 -> extracted = randomValueOtherThan(extracted, () -> randomFieldAttributes(0, 4, false));
+            default -> throw new IllegalStateException();
+        }
+        return new DissectExec(instance.source(), child, inputExpression, parser, extracted);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExecSerializationTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.index.EsIndexSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
+
+public class EsSourceExecSerializationTests extends AbstractPhysicalPlanSerializationTests<EsSourceExec> {
+    public static EsSourceExec randomEsSourceExec() {
+        Source source = randomSource();
+        EsIndex index = EsIndexSerializationTests.randomEsIndex();
+        List<Attribute> attributes = randomFieldAttributes(1, 10, false);
+        QueryBuilder query = new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5));
+        IndexMode indexMode = randomFrom(IndexMode.values());
+        return new EsSourceExec(source, index, attributes, query, indexMode);
+    }
+
+    @Override
+    protected EsSourceExec createTestInstance() {
+        return randomEsSourceExec();
+    }
+
+    @Override
+    protected EsSourceExec mutateInstance(EsSourceExec instance) throws IOException {
+        EsIndex index = instance.index();
+        List<Attribute> attributes = instance.output();
+        QueryBuilder query = instance.query();
+        IndexMode indexMode = instance.indexMode();
+        switch (between(0, 3)) {
+            case 0 -> index = randomValueOtherThan(index, EsIndexSerializationTests::randomEsIndex);
+            case 1 -> attributes = randomValueOtherThan(attributes, () -> randomFieldAttributes(1, 10, false));
+            case 2 -> query = randomValueOtherThan(query, () -> new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+            case 3 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
+            default -> throw new IllegalStateException();
+        }
+        return new EsSourceExec(instance.source(), index, attributes, query, indexMode);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}


### PR DESCRIPTION
This migrates a couple of our `PhysicalPlan` subclasses to `NamedWriteable` to line up with the serialization used by the rest of Elasticsearch.
