### PR TITLE
Parallelise ESIntegTestCase.ensureClusterStateConsistency across multiple nodes

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -59,6 +59,7 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -1236,47 +1237,72 @@ public abstract class ESIntegTestCase extends ESTestCase {
     protected void ensureClusterStateConsistency() throws IOException {
         if (cluster() != null && cluster().size() > 0) {
             final NamedWriteableRegistry namedWriteableRegistry = cluster().getNamedWriteableRegistry();
-            final Client masterClient = client();
-            ClusterState masterClusterState = masterClient.admin().cluster().prepareState().all().get().getState();
-            byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterClusterState);
-            // remove local node reference
-            masterClusterState = ClusterState.Builder.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
-            Map<String, Object> masterStateMap = convertToMap(masterClusterState);
-            int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
-            String masterId = masterClusterState.nodes().getMasterNodeId();
+            final PlainActionFuture<Void> future = new PlainActionFuture<>();
+            final List<SubscribableListener<ClusterStateResponse>> localStates = new ArrayList<>(cluster().size());
             for (Client client : cluster().getClients()) {
-                ClusterState localClusterState = client.admin().cluster().prepareState().all().setLocal(true).get().getState();
-                byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
-                // remove local node reference
-                localClusterState = ClusterState.Builder.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
-                final Map<String, Object> localStateMap = convertToMap(localClusterState);
-                final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
-                // Check that the non-master node has the same version of the cluster state as the master and
-                // that the master node matches the master (otherwise there is no requirement for the cluster state to match)
-                if (masterClusterState.version() == localClusterState.version()
-                    && masterId.equals(localClusterState.nodes().getMasterNodeId())) {
-                    try {
-                        assertEquals("cluster state UUID does not match", masterClusterState.stateUUID(), localClusterState.stateUUID());
-                        // We cannot compare serialization bytes since serialization order of maps is not guaranteed
-                        // but we can compare serialization sizes - they should be the same
-                        assertEquals("cluster state size does not match", masterClusterStateSize, localClusterStateSize);
-                        // Compare JSON serialization
-                        assertNull(
-                            "cluster state JSON serialization does not match",
-                            differenceBetweenMapsIgnoringArrayOrder(masterStateMap, localStateMap)
-                        );
-                    } catch (final AssertionError error) {
-                        logger.error(
-                            "Cluster state from master:\n{}\nLocal cluster state:\n{}",
-                            masterClusterState.toString(),
-                            localClusterState.toString()
-                        );
-                        throw error;
-                    }
-                }
+                localStates.add(
+                    SubscribableListener.newForked(l -> client.admin().cluster().prepareState().all().setLocal(true).execute(l))
+                );
             }
+            try (RefCountingListener refCountingListener = new RefCountingListener(future)) {
+                SubscribableListener.<ClusterStateResponse>newForked(l -> client().admin().cluster().prepareState().all().execute(l))
+                    .andThenAccept(masterStateResponse -> {
+                        byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterStateResponse.getState());
+                        // remove local node reference
+                        final ClusterState masterClusterState = ClusterState.Builder.fromBytes(
+                            masterClusterStateBytes,
+                            null,
+                            namedWriteableRegistry
+                        );
+                        Map<String, Object> masterStateMap = convertToMap(masterClusterState);
+                        int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
+                        String masterId = masterClusterState.nodes().getMasterNodeId();
+                        for (SubscribableListener<ClusterStateResponse> localStateListener : localStates) {
+                            localStateListener.andThenAccept(localClusterStateResponse -> {
+                                byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterStateResponse.getState());
+                                // remove local node reference
+                                final ClusterState localClusterState = ClusterState.Builder.fromBytes(
+                                    localClusterStateBytes,
+                                    null,
+                                    namedWriteableRegistry
+                                );
+                                final Map<String, Object> localStateMap = convertToMap(localClusterState);
+                                final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
+                                // Check that the non-master node has the same version of the cluster state as the master and
+                                // that the master node matches the master (otherwise there is no requirement for the cluster state to
+                                // match)
+                                if (masterClusterState.version() == localClusterState.version()
+                                    && masterId.equals(localClusterState.nodes().getMasterNodeId())) {
+                                    try {
+                                        assertEquals(
+                                            "cluster state UUID does not match",
+                                            masterClusterState.stateUUID(),
+                                            localClusterState.stateUUID()
+                                        );
+                                        // We cannot compare serialization bytes since serialization order of maps is not guaranteed
+                                        // but we can compare serialization sizes - they should be the same
+                                        assertEquals("cluster state size does not match", masterClusterStateSize, localClusterStateSize);
+                                        // Compare JSON serialization
+                                        assertNull(
+                                            "cluster state JSON serialization does not match",
+                                            differenceBetweenMapsIgnoringArrayOrder(masterStateMap, localStateMap)
+                                        );
+                                    } catch (final AssertionError error) {
+                                        logger.error(
+                                            "Cluster state from master:\n{}\nLocal cluster state:\n{}",
+                                            masterClusterState.toString(),
+                                            localClusterState.toString()
+                                        );
+                                        throw error;
+                                    }
+                                }
+                            }).addListener(refCountingListener.acquire());
+                        }
+                    })
+                    .addListener(refCountingListener.acquire());
+            }
+            safeGet(future);
         }
-
     }
 
     protected void ensureClusterStateCanBeReadByNodeTool() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1236,73 +1236,74 @@ public abstract class ESIntegTestCase extends ESTestCase {
      */
     protected void ensureClusterStateConsistency() throws IOException {
         if (cluster() != null && cluster().size() > 0) {
-            final NamedWriteableRegistry namedWriteableRegistry = cluster().getNamedWriteableRegistry();
-            final PlainActionFuture<Void> future = new PlainActionFuture<>();
-            final List<SubscribableListener<ClusterStateResponse>> localStates = new ArrayList<>(cluster().size());
-            for (Client client : cluster().getClients()) {
-                localStates.add(
-                    SubscribableListener.newForked(l -> client.admin().cluster().prepareState().all().setLocal(true).execute(l))
-                );
-            }
-            try (RefCountingListener refCountingListener = new RefCountingListener(future)) {
-                SubscribableListener.<ClusterStateResponse>newForked(l -> client().admin().cluster().prepareState().all().execute(l))
-                    .andThenAccept(masterStateResponse -> {
-                        byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterStateResponse.getState());
-                        // remove local node reference
-                        final ClusterState masterClusterState = ClusterState.Builder.fromBytes(
-                            masterClusterStateBytes,
-                            null,
-                            namedWriteableRegistry
-                        );
-                        Map<String, Object> masterStateMap = convertToMap(masterClusterState);
-                        int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
-                        String masterId = masterClusterState.nodes().getMasterNodeId();
-                        for (SubscribableListener<ClusterStateResponse> localStateListener : localStates) {
-                            localStateListener.andThenAccept(localClusterStateResponse -> {
-                                byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterStateResponse.getState());
-                                // remove local node reference
-                                final ClusterState localClusterState = ClusterState.Builder.fromBytes(
-                                    localClusterStateBytes,
-                                    null,
-                                    namedWriteableRegistry
-                                );
-                                final Map<String, Object> localStateMap = convertToMap(localClusterState);
-                                final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
-                                // Check that the non-master node has the same version of the cluster state as the master and
-                                // that the master node matches the master (otherwise there is no requirement for the cluster state to
-                                // match)
-                                if (masterClusterState.version() == localClusterState.version()
-                                    && masterId.equals(localClusterState.nodes().getMasterNodeId())) {
-                                    try {
-                                        assertEquals(
-                                            "cluster state UUID does not match",
-                                            masterClusterState.stateUUID(),
-                                            localClusterState.stateUUID()
-                                        );
-                                        // We cannot compare serialization bytes since serialization order of maps is not guaranteed
-                                        // but we can compare serialization sizes - they should be the same
-                                        assertEquals("cluster state size does not match", masterClusterStateSize, localClusterStateSize);
-                                        // Compare JSON serialization
-                                        assertNull(
-                                            "cluster state JSON serialization does not match",
-                                            differenceBetweenMapsIgnoringArrayOrder(masterStateMap, localStateMap)
-                                        );
-                                    } catch (final AssertionError error) {
-                                        logger.error(
-                                            "Cluster state from master:\n{}\nLocal cluster state:\n{}",
-                                            masterClusterState.toString(),
-                                            localClusterState.toString()
-                                        );
-                                        throw error;
-                                    }
-                                }
-                            }).addListener(refCountingListener.acquire());
-                        }
-                    })
-                    .addListener(refCountingListener.acquire());
-            }
-            safeGet(future);
+            doEnsureClusterStateConsistency(cluster().getNamedWriteableRegistry());
         }
+    }
+
+    protected final void doEnsureClusterStateConsistency(NamedWriteableRegistry namedWriteableRegistry) {
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
+        final List<SubscribableListener<ClusterStateResponse>> localStates = new ArrayList<>(cluster().size());
+        for (Client client : cluster().getClients()) {
+            localStates.add(SubscribableListener.newForked(l -> client.admin().cluster().prepareState().all().setLocal(true).execute(l)));
+        }
+        try (RefCountingListener refCountingListener = new RefCountingListener(future)) {
+            SubscribableListener.<ClusterStateResponse>newForked(l -> client().admin().cluster().prepareState().all().execute(l))
+                .andThenAccept(masterStateResponse -> {
+                    byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterStateResponse.getState());
+                    // remove local node reference
+                    final ClusterState masterClusterState = ClusterState.Builder.fromBytes(
+                        masterClusterStateBytes,
+                        null,
+                        namedWriteableRegistry
+                    );
+                    Map<String, Object> masterStateMap = convertToMap(masterClusterState);
+                    int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
+                    String masterId = masterClusterState.nodes().getMasterNodeId();
+                    for (SubscribableListener<ClusterStateResponse> localStateListener : localStates) {
+                        localStateListener.andThenAccept(localClusterStateResponse -> {
+                            byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterStateResponse.getState());
+                            // remove local node reference
+                            final ClusterState localClusterState = ClusterState.Builder.fromBytes(
+                                localClusterStateBytes,
+                                null,
+                                namedWriteableRegistry
+                            );
+                            final Map<String, Object> localStateMap = convertToMap(localClusterState);
+                            final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
+                            // Check that the non-master node has the same version of the cluster state as the master and
+                            // that the master node matches the master (otherwise there is no requirement for the cluster state to
+                            // match)
+                            if (masterClusterState.version() == localClusterState.version()
+                                && masterId.equals(localClusterState.nodes().getMasterNodeId())) {
+                                try {
+                                    assertEquals(
+                                        "cluster state UUID does not match",
+                                        masterClusterState.stateUUID(),
+                                        localClusterState.stateUUID()
+                                    );
+                                    // We cannot compare serialization bytes since serialization order of maps is not guaranteed
+                                    // but we can compare serialization sizes - they should be the same
+                                    assertEquals("cluster state size does not match", masterClusterStateSize, localClusterStateSize);
+                                    // Compare JSON serialization
+                                    assertNull(
+                                        "cluster state JSON serialization does not match",
+                                        differenceBetweenMapsIgnoringArrayOrder(masterStateMap, localStateMap)
+                                    );
+                                } catch (final AssertionError error) {
+                                    logger.error(
+                                        "Cluster state from master:\n{}\nLocal cluster state:\n{}",
+                                        masterClusterState.toString(),
+                                        localClusterState.toString()
+                                    );
+                                    throw error;
+                                }
+                            }
+                        }).addListener(refCountingListener.acquire());
+                    }
+                })
+                .addListener(refCountingListener.acquire());
+        }
+        safeGet(future);
     }
 
     protected void ensureClusterStateCanBeReadByNodeTool() throws IOException {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -118,8 +118,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import static org.elasticsearch.test.XContentTestUtils.convertToMap;
-import static org.elasticsearch.test.XContentTestUtils.differenceBetweenMapsIgnoringArrayOrder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.monitoring.MonitoringService.ELASTICSEARCH_COLLECTION_ENABLED;
@@ -408,45 +406,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
             entries.add(
                 new NamedWriteableRegistry.Entry(AutoscalingDeciderResult.Reason.class, MlScalingReason.NAME, MlScalingReason::new)
             );
-            final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(entries);
-            ClusterState masterClusterState = clusterAdmin().prepareState().all().get().getState();
-            byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterClusterState);
-            // remove local node reference
-            masterClusterState = ClusterState.Builder.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
-            Map<String, Object> masterStateMap = convertToMap(masterClusterState);
-            int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
-            String masterId = masterClusterState.nodes().getMasterNodeId();
-            for (Client client : cluster().getClients()) {
-                ClusterState localClusterState = client.admin().cluster().prepareState().all().setLocal(true).get().getState();
-                byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
-                // remove local node reference
-                localClusterState = ClusterState.Builder.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
-                final Map<String, Object> localStateMap = convertToMap(localClusterState);
-                final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
-                // Check that the non-master node has the same version of the cluster state as the master and
-                // that the master node matches the master (otherwise there is no requirement for the cluster state to match)
-                if (masterClusterState.version() == localClusterState.version()
-                    && masterId.equals(localClusterState.nodes().getMasterNodeId())) {
-                    try {
-                        assertEquals("clusterstate UUID does not match", masterClusterState.stateUUID(), localClusterState.stateUUID());
-                        // We cannot compare serialization bytes since serialization order of maps is not guaranteed
-                        // but we can compare serialization sizes - they should be the same
-                        assertEquals("clusterstate size does not match", masterClusterStateSize, localClusterStateSize);
-                        // Compare JSON serialization
-                        assertNull(
-                            "clusterstate JSON serialization does not match",
-                            differenceBetweenMapsIgnoringArrayOrder(masterStateMap, localStateMap)
-                        );
-                    } catch (AssertionError error) {
-                        logger.error(
-                            "Cluster state from master:\n{}\nLocal cluster state:\n{}",
-                            masterClusterState.toString(),
-                            localClusterState.toString()
-                        );
-                        throw error;
-                    }
-                }
-            }
+            doEnsureClusterStateConsistency(new NamedWriteableRegistry(entries));
         }
     }
 


### PR DESCRIPTION
We can get a non-trivial speedup here but running all the nodes in parallel. This is quite helpful for end-to-end integ test performance since we run this method after effectively every test.

similar to #111744 