### PR TITLE
LogsDB QA tests - add mapping parameters generation

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
@@ -17,11 +17,13 @@ import org.elasticsearch.logsdb.datageneration.datasource.DataSourceHandler;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.logsdb.datageneration.fields.PredefinedField;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -30,39 +32,57 @@ import java.util.List;
  */
 public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends StandardVersusLogsIndexModeChallengeRestIT {
     private final boolean fullyDynamicMapping;
+    private final boolean subobjectsDisabled;
 
     private final DataGenerator dataGenerator;
 
     public StandardVersusLogsIndexModeRandomDataChallengeRestIT() {
         super();
         this.fullyDynamicMapping = randomBoolean();
+        this.subobjectsDisabled = randomBoolean();
 
-        this.dataGenerator = new DataGenerator(
-            DataGeneratorSpecification.builder()
-                // Nested fields don't work with subobjects: false.
-                .withNestedFieldsLimit(0)
-                .withDataSourceHandlers(List.of(new DataSourceHandler() {
-                    // TODO enable scaled_float fields
-                    // There a difference in synthetic source (precision loss)
-                    // specific to this fields which matcher can't handle.
-                    @Override
-                    public DataSourceResponse.FieldTypeGenerator handle(DataSourceRequest.FieldTypeGenerator request) {
-                        // Unsigned long is not used with dynamic mapping
-                        // since it can initially look like long
-                        // but later fail to parse once big values arrive.
-                        // Double is not used since it maps to float with dynamic mapping
-                        // resulting in precision loss compared to original source.
-                        var excluded = fullyDynamicMapping
-                            ? List.of(FieldType.DOUBLE, FieldType.SCALED_FLOAT, FieldType.UNSIGNED_LONG)
-                            : List.of(FieldType.SCALED_FLOAT);
-                        return new DataSourceResponse.FieldTypeGenerator(
-                            () -> randomValueOtherThanMany(excluded::contains, () -> randomFrom(FieldType.values()))
-                        );
+        var specificationBuilder = DataGeneratorSpecification.builder();
+        // TODO enable nested fields when subobjects are enabled
+        // It currently hits a bug with empty nested objects
+        // Nested fields don't work with subobjects: false.
+        specificationBuilder = specificationBuilder.withNestedFieldsLimit(0);
+        this.dataGenerator = new DataGenerator(specificationBuilder.withDataSourceHandlers(List.of(new DataSourceHandler() {
+            @Override
+            public DataSourceResponse.FieldTypeGenerator handle(DataSourceRequest.FieldTypeGenerator request) {
+                // Unsigned long is not used with dynamic mapping
+                // since it can initially look like long
+                // but later fail to parse once big values arrive.
+                // Double is not used since it maps to float with dynamic mapping
+                // resulting in precision loss compared to original source.
+                var excluded = fullyDynamicMapping ? List.of(FieldType.DOUBLE, FieldType.SCALED_FLOAT, FieldType.UNSIGNED_LONG) : List.of();
+                return new DataSourceResponse.FieldTypeGenerator(
+                    () -> randomValueOtherThanMany(excluded::contains, () -> randomFrom(FieldType.values()))
+                );
+            }
+
+            public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
+                if (subobjectsDisabled == false) {
+                    // Use default behavior
+                    return null;
+                }
+
+                assert request.isNested() == false;
+
+                // "enabled: false" is not compatible with subobjects: false
+                // "runtime: false/strict/runtime" is not compatible with subobjects: false
+                return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
+                    var parameters = new HashMap<String, Object>();
+                    if (ESTestCase.randomBoolean()) {
+                        parameters.put("dynamic", "true");
                     }
-                }))
-                .withPredefinedFields(List.of(new PredefinedField("host.name", FieldType.KEYWORD)))
-                .build()
-        );
+                    if (ESTestCase.randomBoolean()) {
+                        parameters.put("enabled", "true");
+                    }
+
+                    return parameters;
+                });
+            }
+        })).withPredefinedFields(List.of(new PredefinedField("host.name", FieldType.KEYWORD))).build());
     }
 
     @Override
@@ -87,10 +107,16 @@ public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends Standa
     @Override
     public void contenderMappings(XContentBuilder builder) throws IOException {
         if (fullyDynamicMapping == false) {
-            dataGenerator.writeMapping(builder, b -> builder.field("subobjects", false));
+            if (subobjectsDisabled) {
+                dataGenerator.writeMapping(builder, b -> builder.field("subobjects", false));
+            } else {
+                dataGenerator.writeMapping(builder);
+            }
         } else {
             builder.startObject();
-            builder.field("subobjects", false);
+            if (subobjectsDisabled) {
+                builder.field("subobjects", false);
+            }
             builder.endObject();
         }
     }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/FieldSpecificMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/FieldSpecificMatcher.java
@@ -13,7 +13,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.datastreams.logsdb.qa.matchers.MatchResult;
 import org.elasticsearch.xcontent.XContentBuilder;
 
+import java.math.BigInteger;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -23,7 +25,7 @@ import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.formatEr
 import static org.elasticsearch.datastreams.logsdb.qa.matchers.Messages.prettyPrintCollections;
 
 interface FieldSpecificMatcher {
-    MatchResult match(List<Object> actual, List<Object> expected);
+    MatchResult match(List<Object> actual, List<Object> expected, Map<String, Object> actualMapping, Map<String, Object> expectedMapping);
 
     class HalfFloatMatcher implements FieldSpecificMatcher {
         private final XContentBuilder actualMappings;
@@ -44,7 +46,12 @@ interface FieldSpecificMatcher {
         }
 
         @Override
-        public MatchResult match(List<Object> actual, List<Object> expected) {
+        public MatchResult match(
+            List<Object> actual,
+            List<Object> expected,
+            Map<String, Object> actualMapping,
+            Map<String, Object> expectedMapping
+        ) {
             var actualHalfFloatBytes = normalize(actual);
             var expectedHalfFloatBytes = normalize(expected);
 
@@ -74,6 +81,146 @@ interface FieldSpecificMatcher {
                 // Based on logic in NumberFieldMapper
                 .map(HalfFloatPoint::halfFloatToSortableShort)
                 .collect(Collectors.toSet());
+        }
+    }
+
+    class ScaledFloatMatcher implements FieldSpecificMatcher {
+        private final XContentBuilder actualMappings;
+        private final Settings.Builder actualSettings;
+        private final XContentBuilder expectedMappings;
+        private final Settings.Builder expectedSettings;
+
+        ScaledFloatMatcher(
+            XContentBuilder actualMappings,
+            Settings.Builder actualSettings,
+            XContentBuilder expectedMappings,
+            Settings.Builder expectedSettings
+        ) {
+            this.actualMappings = actualMappings;
+            this.actualSettings = actualSettings;
+            this.expectedMappings = expectedMappings;
+            this.expectedSettings = expectedSettings;
+        }
+
+        @Override
+        public MatchResult match(
+            List<Object> actual,
+            List<Object> expected,
+            Map<String, Object> actualMapping,
+            Map<String, Object> expectedMapping
+        ) {
+            var scalingFactor = actualMapping.get("scaling_factor");
+            var expectedScalingFactor = expectedMapping.get("scaling_factor");
+            if (Objects.equals(scalingFactor, expectedScalingFactor) == false) {
+                throw new IllegalStateException("Scaling factor for scaled_float field does not match between actual and expected mapping");
+            }
+
+            assert scalingFactor instanceof Number;
+            var expectedNormalized = normalizeExpected(expected, ((Number) scalingFactor).doubleValue());
+            var actualNormalized = normalizeActual(actual);
+
+            return actualNormalized.equals(expectedNormalized)
+                ? MatchResult.match()
+                : MatchResult.noMatch(
+                    formatErrorMessage(
+                        actualMappings,
+                        actualSettings,
+                        expectedMappings,
+                        expectedSettings,
+                        "Values of type [scaled_float] don't match after normalization, normalized "
+                            + prettyPrintCollections(actualNormalized, expectedNormalized)
+                    )
+                );
+        }
+
+        private static Set<Double> normalizeExpected(List<Object> values, double scalingFactor) {
+            if (values == null) {
+                return Set.of();
+            }
+
+            return values.stream()
+                .filter(Objects::nonNull)
+                .map(ScaledFloatMatcher::toDouble)
+                // Based on logic in ScaledFloatFieldMapper
+                .map(v -> {
+                    var encoded = Math.round(v * scalingFactor);
+                    return encoded / scalingFactor;
+                })
+                .collect(Collectors.toSet());
+        }
+
+        private static Set<Double> normalizeActual(List<Object> values) {
+            if (values == null) {
+                return Set.of();
+            }
+
+            return values.stream().filter(Objects::nonNull).map(ScaledFloatMatcher::toDouble).collect(Collectors.toSet());
+        }
+
+        private static double toDouble(Object value) {
+            return ((Number) value).doubleValue();
+        }
+    }
+
+    class UnsignedLongMatcher implements FieldSpecificMatcher {
+        private final XContentBuilder actualMappings;
+        private final Settings.Builder actualSettings;
+        private final XContentBuilder expectedMappings;
+        private final Settings.Builder expectedSettings;
+
+        UnsignedLongMatcher(
+            XContentBuilder actualMappings,
+            Settings.Builder actualSettings,
+            XContentBuilder expectedMappings,
+            Settings.Builder expectedSettings
+        ) {
+            this.actualMappings = actualMappings;
+            this.actualSettings = actualSettings;
+            this.expectedMappings = expectedMappings;
+            this.expectedSettings = expectedSettings;
+        }
+
+        @Override
+        public MatchResult match(
+            List<Object> actual,
+            List<Object> expected,
+            Map<String, Object> actualMapping,
+            Map<String, Object> expectedMapping
+        ) {
+            var expectedNormalized = normalize(expected);
+            var actualNormalized = normalize(actual);
+
+            return actualNormalized.equals(expectedNormalized)
+                ? MatchResult.match()
+                : MatchResult.noMatch(
+                    formatErrorMessage(
+                        actualMappings,
+                        actualSettings,
+                        expectedMappings,
+                        expectedSettings,
+                        "Values of type [scaled_float] don't match after normalization, normalized "
+                            + prettyPrintCollections(actualNormalized, expectedNormalized)
+                    )
+                );
+        }
+
+        private static Set<BigInteger> normalize(List<Object> values) {
+            if (values == null) {
+                return Set.of();
+            }
+
+            return values.stream().filter(Objects::nonNull).map(UnsignedLongMatcher::toBigInteger).collect(Collectors.toSet());
+        }
+
+        private static BigInteger toBigInteger(Object value) {
+            if (value instanceof String s) {
+                return new BigInteger(s, 10);
+            }
+            if (value instanceof Long l) {
+                return BigInteger.valueOf(l);
+            }
+
+            return (BigInteger) value;
         }
     }
 }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceMatcher.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/matchers/source/SourceMatcher.java
@@ -54,7 +54,11 @@ public class SourceMatcher extends GenericEqualsMatcher<List<Map<String, Object>
 
         this.fieldSpecificMatchers = Map.of(
             "half_float",
-            new FieldSpecificMatcher.HalfFloatMatcher(actualMappings, actualSettings, expectedMappings, expectedSettings)
+            new FieldSpecificMatcher.HalfFloatMatcher(actualMappings, actualSettings, expectedMappings, expectedSettings),
+            "scaled_float",
+            new FieldSpecificMatcher.ScaledFloatMatcher(actualMappings, actualSettings, expectedMappings, expectedSettings),
+            "unsigned_long",
+            new FieldSpecificMatcher.UnsignedLongMatcher(actualMappings, actualSettings, expectedMappings, expectedSettings)
         );
     }
 
@@ -158,7 +162,7 @@ public class SourceMatcher extends GenericEqualsMatcher<List<Map<String, Object>
             return Optional.empty();
         }
 
-        MatchResult matched = fieldSpecificMatcher.match(actualValues, expectedValues);
+        MatchResult matched = fieldSpecificMatcher.match(actualValues, expectedValues, expectedFieldMapping, actualFieldMapping);
         return Optional.of(matched);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSource.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSource.java
@@ -34,6 +34,7 @@ public class DataSource {
         this.handlers.add(new DefaultPrimitiveTypesHandler());
         this.handlers.add(new DefaultWrappersHandler());
         this.handlers.add(new DefaultObjectGenerationHandler());
+        this.handlers.add(new DefaultMappingParametersHandler());
     }
 
     public <T extends DataSourceResponse> T get(DataSourceRequest<T> request) {

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceHandler.java
@@ -33,10 +33,6 @@ public interface DataSourceHandler {
         return null;
     }
 
-    default DataSourceResponse.DoubleInRangeGenerator handle(DataSourceRequest.DoubleInRangeGenerator request) {
-        return null;
-    }
-
     default DataSourceResponse.FloatGenerator handle(DataSourceRequest.FloatGenerator request) {
         return null;
     }
@@ -66,6 +62,14 @@ public interface DataSourceHandler {
     }
 
     default DataSourceResponse.ObjectArrayGenerator handle(DataSourceRequest.ObjectArrayGenerator request) {
+        return null;
+    }
+
+    default DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
+        return null;
+    }
+
+    default DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
         return null;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.logsdb.datageneration.datasource;
 
 import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 
 public interface DataSourceRequest<TResponse extends DataSourceResponse> {
     TResponse accept(DataSourceHandler handler);
@@ -45,14 +46,6 @@ public interface DataSourceRequest<TResponse extends DataSourceResponse> {
 
     record DoubleGenerator() implements DataSourceRequest<DataSourceResponse.DoubleGenerator> {
         public DataSourceResponse.DoubleGenerator accept(DataSourceHandler handler) {
-            return handler.handle(this);
-        }
-    }
-
-    record DoubleInRangeGenerator(double minExclusive, double maxExclusive)
-        implements
-            DataSourceRequest<DataSourceResponse.DoubleInRangeGenerator> {
-        public DataSourceResponse.DoubleInRangeGenerator accept(DataSourceHandler handler) {
             return handler.handle(this);
         }
     }
@@ -103,6 +96,22 @@ public interface DataSourceRequest<TResponse extends DataSourceResponse> {
 
     record ObjectArrayGenerator() implements DataSourceRequest<DataSourceResponse.ObjectArrayGenerator> {
         public DataSourceResponse.ObjectArrayGenerator accept(DataSourceHandler handler) {
+            return handler.handle(this);
+        }
+    }
+
+    record LeafMappingParametersGenerator(String fieldName, FieldType fieldType)
+        implements
+            DataSourceRequest<DataSourceResponse.LeafMappingParametersGenerator> {
+        public DataSourceResponse.LeafMappingParametersGenerator accept(DataSourceHandler handler) {
+            return handler.handle(this);
+        }
+    }
+
+    record ObjectMappingParametersGenerator(boolean isNested)
+        implements
+            DataSourceRequest<DataSourceResponse.ObjectMappingParametersGenerator> {
+        public DataSourceResponse.ObjectMappingParametersGenerator accept(DataSourceHandler handler) {
             return handler.handle(this);
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceResponse.java
@@ -10,6 +10,7 @@ package org.elasticsearch.logsdb.datageneration.datasource;
 
 import org.elasticsearch.logsdb.datageneration.FieldType;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -26,8 +27,6 @@ public interface DataSourceResponse {
     record ByteGenerator(Supplier<Byte> generator) implements DataSourceResponse {}
 
     record DoubleGenerator(Supplier<Double> generator) implements DataSourceResponse {}
-
-    record DoubleInRangeGenerator(Supplier<Double> generator) implements DataSourceResponse {}
 
     record FloatGenerator(Supplier<Float> generator) implements DataSourceResponse {}
 
@@ -52,4 +51,8 @@ public interface DataSourceResponse {
     record FieldTypeGenerator(Supplier<FieldType> generator) implements DataSourceResponse {}
 
     record ObjectArrayGenerator(Supplier<Optional<Integer>> lengthGenerator) implements DataSourceResponse {}
+
+    record LeafMappingParametersGenerator(Supplier<Map<String, Object>> mappingGenerator) implements DataSourceResponse {}
+
+    record ObjectMappingParametersGenerator(Supplier<Map<String, Object>> mappingGenerator) implements DataSourceResponse {}
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logsdb.datageneration.datasource;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class DefaultMappingParametersHandler implements DataSourceHandler {
+    @Override
+    public DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
+        return new DataSourceResponse.LeafMappingParametersGenerator(switch (request.fieldType()) {
+            case KEYWORD -> keywordMapping();
+            case LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, HALF_FLOAT -> numberMapping();
+            case UNSIGNED_LONG -> unsignedLongMapping();
+            case SCALED_FLOAT -> scaledFloatMapping();
+        });
+    }
+
+    // TODO enable doc_values: false
+    // It is disabled because it hits a bug in synthetic source.
+    private Supplier<Map<String, Object>> keywordMapping() {
+        return () -> Map.of("store", ESTestCase.randomBoolean(), "index", ESTestCase.randomBoolean());
+    }
+
+    // TODO enable doc_values: false
+    // It is disabled because it hits a bug in synthetic source.
+    private Supplier<Map<String, Object>> numberMapping() {
+        return () -> Map.of("store", ESTestCase.randomBoolean(), "index", ESTestCase.randomBoolean());
+    }
+
+    private Supplier<Map<String, Object>> unsignedLongMapping() {
+        return () -> Map.of("store", ESTestCase.randomBoolean(), "index", ESTestCase.randomBoolean());
+    }
+
+    private Supplier<Map<String, Object>> scaledFloatMapping() {
+        return () -> {
+            var scalingFactor = ESTestCase.randomFrom(10, 1000, 100000, 100.5);
+            return Map.of("scaling_factor", scalingFactor, "store", ESTestCase.randomBoolean(), "index", ESTestCase.randomBoolean());
+        };
+    }
+
+    @Override
+    public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
+        if (request.isNested()) {
+            return new DataSourceResponse.ObjectMappingParametersGenerator(
+                // TODO enable "false" and "strict"
+                // It is disabled because it hits a bug in synthetic source.
+                () -> {
+                    var parameters = new HashMap<String, Object>();
+                    if (ESTestCase.randomBoolean()) {
+                        parameters.put("dynamic", "true");
+                    }
+
+                    return parameters;
+                }
+            );
+        }
+
+        // TODO enable "enabled: false" and "dynamic: false/runtime"
+        // It is disabled because it hits a bug in synthetic source.
+        return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
+            var parameters = new HashMap<String, Object>();
+            if (ESTestCase.randomBoolean()) {
+                parameters.put("dynamic", ESTestCase.randomFrom("true", "strict"));
+            }
+            if (ESTestCase.randomBoolean()) {
+                parameters.put("enabled", "true");
+            }
+
+            return parameters;
+        });
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultPrimitiveTypesHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultPrimitiveTypesHandler.java
@@ -20,7 +20,8 @@ public class DefaultPrimitiveTypesHandler implements DataSourceHandler {
 
     @Override
     public DataSourceResponse.UnsignedLongGenerator handle(DataSourceRequest.UnsignedLongGenerator request) {
-        return new DataSourceResponse.UnsignedLongGenerator(() -> new BigInteger(64, ESTestCase.random()));
+        // TODO there is currently an issue with handling BigInteger in some synthetic source scenarios
+        return new DataSourceResponse.UnsignedLongGenerator(() -> new BigInteger(64, ESTestCase.random()).toString());
     }
 
     @Override
@@ -41,13 +42,6 @@ public class DefaultPrimitiveTypesHandler implements DataSourceHandler {
     @Override
     public DataSourceResponse.DoubleGenerator handle(DataSourceRequest.DoubleGenerator request) {
         return new DataSourceResponse.DoubleGenerator(ESTestCase::randomDouble);
-    }
-
-    @Override
-    public DataSourceResponse.DoubleInRangeGenerator handle(DataSourceRequest.DoubleInRangeGenerator request) {
-        return new DataSourceResponse.DoubleInRangeGenerator(
-            () -> ESTestCase.randomDoubleBetween(request.minExclusive(), request.maxExclusive(), false)
-        );
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/GenericSubObjectFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/GenericSubObjectFieldDataGenerator.java
@@ -49,9 +49,9 @@ public class GenericSubObjectFieldDataGenerator {
             var fieldName = generateFieldName(existingFieldNames);
 
             if (context.shouldAddObjectField()) {
-                result.add(new ChildField(fieldName, new ObjectFieldDataGenerator(context.subObject())));
+                result.add(new ChildField(fieldName, new ObjectFieldDataGenerator(context.subObject()), false));
             } else if (context.shouldAddNestedField()) {
-                result.add(new ChildField(fieldName, new NestedFieldDataGenerator(context.nestedObject())));
+                result.add(new ChildField(fieldName, new NestedFieldDataGenerator(context.nestedObject()), false));
             } else {
                 var fieldType = context.fieldTypeGenerator().generator().get();
                 result.add(leafField(fieldType, fieldName));
@@ -103,19 +103,19 @@ public class GenericSubObjectFieldDataGenerator {
 
     private ChildField leafField(FieldType type, String fieldName) {
         var generator = switch (type) {
-            case KEYWORD -> new KeywordFieldDataGenerator(context.specification().dataSource());
-            case LONG -> new LongFieldDataGenerator(context.specification().dataSource());
-            case UNSIGNED_LONG -> new UnsignedLongFieldDataGenerator(context.specification().dataSource());
-            case INTEGER -> new IntegerFieldDataGenerator(context.specification().dataSource());
-            case SHORT -> new ShortFieldDataGenerator(context.specification().dataSource());
-            case BYTE -> new ByteFieldDataGenerator(context.specification().dataSource());
-            case DOUBLE -> new DoubleFieldDataGenerator(context.specification().dataSource());
-            case FLOAT -> new FloatFieldDataGenerator(context.specification().dataSource());
-            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(context.specification().dataSource());
-            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(context.specification().dataSource());
+            case KEYWORD -> new KeywordFieldDataGenerator(fieldName, context.specification().dataSource());
+            case LONG -> new LongFieldDataGenerator(fieldName, context.specification().dataSource());
+            case UNSIGNED_LONG -> new UnsignedLongFieldDataGenerator(fieldName, context.specification().dataSource());
+            case INTEGER -> new IntegerFieldDataGenerator(fieldName, context.specification().dataSource());
+            case SHORT -> new ShortFieldDataGenerator(fieldName, context.specification().dataSource());
+            case BYTE -> new ByteFieldDataGenerator(fieldName, context.specification().dataSource());
+            case DOUBLE -> new DoubleFieldDataGenerator(fieldName, context.specification().dataSource());
+            case FLOAT -> new FloatFieldDataGenerator(fieldName, context.specification().dataSource());
+            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, context.specification().dataSource());
+            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, context.specification().dataSource());
         };
 
-        return new ChildField(fieldName, generator);
+        return new ChildField(fieldName, generator, false);
     }
 
     private String generateFieldName(Set<String> existingFields) {
@@ -128,5 +128,5 @@ public class GenericSubObjectFieldDataGenerator {
         return fieldName;
     }
 
-    record ChildField(String fieldName, FieldDataGenerator generator) {}
+    record ChildField(String fieldName, FieldDataGenerator generator, boolean dynamic) {}
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/NestedFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/NestedFieldDataGenerator.java
@@ -10,17 +10,27 @@ package org.elasticsearch.logsdb.datageneration.fields;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class NestedFieldDataGenerator implements FieldDataGenerator {
     private final Context context;
+    private final Map<String, Object> mappingParameters;
     private final List<GenericSubObjectFieldDataGenerator.ChildField> childFields;
 
     NestedFieldDataGenerator(Context context) {
         this.context = context;
+
+        this.mappingParameters = context.specification()
+            .dataSource()
+            .get(new DataSourceRequest.ObjectMappingParametersGenerator(true))
+            .mappingGenerator()
+            .get();
+
         var genericGenerator = new GenericSubObjectFieldDataGenerator(context);
         this.childFields = genericGenerator.generateChildFields();
     }
@@ -31,6 +41,10 @@ public class NestedFieldDataGenerator implements FieldDataGenerator {
             b.startObject();
 
             b.field("type", "nested");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
 
             b.startObject("properties");
             GenericSubObjectFieldDataGenerator.writeChildFieldsMapping(b, childFields);

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ByteFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ByteFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class ByteFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public ByteFieldDataGenerator(DataSource dataSource) {
+    public ByteFieldDataGenerator(String fieldName, DataSource dataSource) {
         var bytes = dataSource.get(new DataSourceRequest.ByteGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> bytes.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.BYTE))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "byte").endObject();
+        return b -> {
+            b.startObject().field("type", "byte");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/DoubleFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/DoubleFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class DoubleFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public DoubleFieldDataGenerator(DataSource dataSource) {
+    public DoubleFieldDataGenerator(String fieldName, DataSource dataSource) {
         var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> doubles.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.DOUBLE))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "double").endObject();
+        return b -> {
+            b.startObject().field("type", "double");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/HalfFloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/HalfFloatFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class HalfFloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public HalfFloatFieldDataGenerator(DataSource dataSource) {
+    public HalfFloatFieldDataGenerator(String fieldName, DataSource dataSource) {
         var halfFloats = dataSource.get(new DataSourceRequest.HalfFloatGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> halfFloats.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.HALF_FLOAT))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "half_float").endObject();
+        return b -> {
+            b.startObject().field("type", "half_float");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/IntegerFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/IntegerFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class IntegerFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public IntegerFieldDataGenerator(DataSource dataSource) {
+    public IntegerFieldDataGenerator(String fieldName, DataSource dataSource) {
         var ints = dataSource.get(new DataSourceRequest.IntegerGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> ints.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.INTEGER))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "integer").endObject();
+        return b -> {
+            b.startObject().field("type", "integer");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/KeywordFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/KeywordFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class KeywordFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public KeywordFieldDataGenerator(DataSource dataSource) {
+    public KeywordFieldDataGenerator(String fieldName, DataSource dataSource) {
         var strings = dataSource.get(new DataSourceRequest.StringGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> strings.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.KEYWORD))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "keyword").endObject();
+        return b -> {
+            b.startObject().field("type", "keyword");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/LongFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/LongFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class LongFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public LongFieldDataGenerator(DataSource dataSource) {
+    public LongFieldDataGenerator(String fieldName, DataSource dataSource) {
         var longs = dataSource.get(new DataSourceRequest.LongGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> longs.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.LONG))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "long").endObject();
+        return b -> {
+            b.startObject().field("type", "long");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ScaledFloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ScaledFloatFieldDataGenerator.java
@@ -10,31 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class ScaledFloatFieldDataGenerator implements FieldDataGenerator {
-    private final double scalingFactor;
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public ScaledFloatFieldDataGenerator(DataSource dataSource) {
-        var positiveDoubles = dataSource.get(new DataSourceRequest.DoubleInRangeGenerator(0, Double.MAX_VALUE));
-        this.scalingFactor = positiveDoubles.generator().get();
-
+    public ScaledFloatFieldDataGenerator(String fieldName, DataSource dataSource) {
         var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> doubles.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.SCALED_FLOAT))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "scaled_float").field("scaling_factor", scalingFactor).endObject();
+        return b -> {
+            b.startObject().field("type", "scaled_float");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/UnsignedLongFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/UnsignedLongFieldDataGenerator.java
@@ -10,27 +10,41 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class UnsignedLongFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
+    private final Map<String, Object> mappingParameters;
 
-    public UnsignedLongFieldDataGenerator(DataSource dataSource) {
+    public UnsignedLongFieldDataGenerator(String fieldName, DataSource dataSource) {
         var unsignedLongs = dataSource.get(new DataSourceRequest.UnsignedLongGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> unsignedLongs.generator().get());
+        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.UNSIGNED_LONG))
+            .mappingGenerator()
+            .get();
     }
 
     @Override
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-        return b -> b.startObject().field("type", "unsigned_long").endObject();
+        return b -> {
+            b.startObject().field("type", "unsigned_long");
+
+            for (var entry : mappingParameters.entrySet()) {
+                b.field(entry.getKey(), entry.getValue());
+            }
+
+            b.endObject();
+        };
     }
 
     @Override

--- a/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/DataGeneratorSnapshotTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/logsdb/datageneration/DataGeneratorSnapshotTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class DataGeneratorSnapshotTests extends ESTestCase {
@@ -40,24 +41,31 @@ public class DataGeneratorSnapshotTests extends ESTestCase {
               "_doc" : {
                 "properties" : {
                   "f1" : {
+                    "dynamic" : "false",
                     "properties" : {
                       "f2" : {
+                        "dynamic" : "false",
                         "properties" : {
                           "f3" : {
-                            "type" : "keyword"
+                            "type" : "keyword",
+                            "store" : "true"
                           },
                           "f4" : {
-                            "type" : "long"
+                            "type" : "long",
+                            "index" : "false"
                           }
                         }
                       },
                       "f5" : {
+                        "dynamic" : "false",
                         "properties" : {
                           "f6" : {
-                            "type" : "keyword"
+                            "type" : "keyword",
+                            "store" : "true"
                           },
                           "f7" : {
-                            "type" : "long"
+                            "type" : "long",
+                            "index" : "false"
                           }
                         }
                       }
@@ -65,20 +73,25 @@ public class DataGeneratorSnapshotTests extends ESTestCase {
                   },
                   "f8" : {
                     "type" : "nested",
+                    "dynamic" : "false",
                     "properties" : {
                       "f9" : {
                         "type" : "nested",
+                        "dynamic" : "false",
                         "properties" : {
                           "f10" : {
-                            "type" : "keyword"
+                            "type" : "keyword",
+                            "store" : "true"
                           },
                           "f11" : {
-                            "type" : "long"
+                            "type" : "long",
+                            "index" : "false"
                           }
                         }
                       },
                       "f12" : {
-                        "type" : "keyword"
+                        "type" : "keyword",
+                        "store" : "true"
                       }
                     }
                   }
@@ -198,6 +211,24 @@ public class DataGeneratorSnapshotTests extends ESTestCase {
                 fieldType = FieldType.KEYWORD;
                 return FieldType.LONG;
             });
+        }
+
+        @Override
+        public DataSourceResponse.LeafMappingParametersGenerator handle(DataSourceRequest.LeafMappingParametersGenerator request) {
+            if (request.fieldType() == FieldType.KEYWORD) {
+                return new DataSourceResponse.LeafMappingParametersGenerator(() -> Map.of("store", "true"));
+            }
+
+            if (request.fieldType() == FieldType.LONG) {
+                return new DataSourceResponse.LeafMappingParametersGenerator(() -> Map.of("index", "false"));
+            }
+
+            return null;
+        }
+
+        @Override
+        public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
+            return new DataSourceResponse.ObjectMappingParametersGenerator(() -> Map.of("dynamic", "false"));
         }
     }
 


### PR DESCRIPTION
This PR adds generation of mapping parameters for leaf fields and a base for generating mapping parameters for object mappers. Next step based on this work is to add dynamic mapping.

Some of the generation is disabled due to issues i discovered while adding this functionality:
https://github.com/elastic/elasticsearch/issues/111694
#111811
#111812

