### PR TITLE
ESQL: Fix serialization during can_match

### DIFF
--- a/docs/changelog/111779.yaml
+++ b/docs/changelog/111779.yaml
@@ -1,0 +1,7 @@
+pr: 111779
+summary: "ESQL: Fix serialization during `can_match`"
+area: ES|QL
+type: bug
+issues:
+ - 111701
+ - 111726

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/Source.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/Source.java
@@ -51,6 +51,21 @@ public final class Source implements Writeable {
         return new Source(new Location(line, charPositionInLine), text);
     }
 
+    /**
+     * Read the components of a {@link Source} and throw it away, returning
+     * {@link Source#EMPTY}. Use this when you will never use the {@link Source}
+     * and there is no chance of getting a {@link PlanStreamInput}.
+     */
+    public static Source readEmpty(StreamInput in) throws IOException {
+        if (in.readBoolean() == false) {
+            return EMPTY;
+        }
+        in.readInt();
+        in.readInt();
+        in.readInt();
+        return Source.EMPTY;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (this == EMPTY) {

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/tree/SourceTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/tree/SourceTests.java
@@ -6,13 +6,17 @@
  */
 package org.elasticsearch.xpack.esql.core.tree;
 
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.equalTo;
 
 public class SourceTests extends ESTestCase {
     public static Source randomSource() {
@@ -41,5 +45,17 @@ public class SourceTests extends ESTestCase {
             l -> new Source(l.source().getLineNumber(), l.source().getColumnNumber() - 1, l.text()),
             SourceTests::mutate
         );
+    }
+
+    public void testReadEmpty() throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            randomSource().writeTo(out);
+            int test = randomInt();
+            out.writeInt(test);
+            try (StreamInput in = out.bytes().streamInput()) {
+                assertThat(Source.readEmpty(in), equalTo(Source.EMPTY));
+                assertThat(in.readInt(), equalTo(test));
+            }
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -107,7 +107,15 @@ public class SingleValueQuery extends Query {
             this.next = in.readNamedWriteable(QueryBuilder.class);
             this.field = in.readString();
             if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_SINGLE_VALUE_QUERY_SOURCE)) {
-                this.source = Source.readFrom((PlanStreamInput) in);
+                if (in instanceof PlanStreamInput psi) {
+                    this.source = Source.readFrom(psi);
+                } else {
+                    /*
+                     * For things like CanMatch we serialize without the Source. But we
+                     * don't use it, so that's ok.
+                     */
+                    this.source = Source.readEmpty(in);
+                }
             } else if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
                 this.source = readOldSource(in);
             } else {


### PR DESCRIPTION
This fixes that serialization of the `SingleValueQuery` during the `can_match` phase.

Closes #111726
Closes #111701
