### PR TITLE
[DOCS] Fix elasticsearch-py helpers page link

### DIFF
--- a/docs/reference/search/search-your-data/paginate-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/paginate-search-results.asciidoc
@@ -362,7 +362,7 @@ Perl::
 
 Python::
 
-    See https://elasticsearch-py.readthedocs.io/en/[elasticsearch.helpers.*]
+    See https://elasticsearch-py.readthedocs.io/en/stable/helpers.html[elasticsearch.helpers.*]
 
 JavaScript::
 


### PR DESCRIPTION
@woodywalton fixed an issue with this link in https://github.com/elastic/elasticsearch/pull/111565. Thank you! However, I provided a wrong guidance at the time to @kderusso as I had missed that this was a link to helpers specifically. Now we link to the helpers page, while also avoiding referencing a specific version with the "stable" label.