### PR TITLE
[8.14] [DOCS] Fix elasticsearch-py helpers page link (#111789)

### DIFF
--- a/docs/reference/search/search-your-data/paginate-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/paginate-search-results.asciidoc
@@ -362,7 +362,7 @@ Perl::
 
 Python::
 
-    See https://elasticsearch-py.readthedocs.io/en/[elasticsearch.helpers.*]
+    See https://elasticsearch-py.readthedocs.io/en/stable/helpers.html[elasticsearch.helpers.*]
 
 JavaScript::
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Fix elasticsearch-py helpers page link (#111789)