### PR TITLE
NodesShutdownMetadata#isNodeMarkedForRemoval utility method

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -126,6 +126,14 @@ public class NodesShutdownMetadata implements Metadata.Custom {
     }
 
     /**
+     * Checks if the provided node is scheduled for being permanently removed from the cluster.
+     */
+    public boolean isNodeMarkedForRemoval(String nodeId) {
+        var singleNodeShutdownMetadata = get(nodeId);
+        return singleNodeShutdownMetadata != null && singleNodeShutdownMetadata.getType().isRemovalType();
+    }
+
+    /**
      * Add or update the shutdown metadata for a single node.
      * @param nodeShutdownMetadata The single node shutdown metadata to add or update.
      * @return A new {@link NodesShutdownMetadata} that reflects the updated value.

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
@@ -134,16 +134,19 @@ public class NodesShutdownMetadataTests extends ChunkedToXContentDiffableSeriali
                     Map.of("thenode", builder.setType(type).setGracePeriod(TimeValue.ONE_MINUTE).build())
                 );
                 assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(true));
+                assertThat(metadata.isNodeMarkedForRemoval("anotherNode"), is(false));
             }
             case REMOVE -> {
                 var metadata = new NodesShutdownMetadata(Map.of("thenode", builder.setType(type).build()));
                 assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(true));
+                assertThat(metadata.isNodeMarkedForRemoval("anotherNode"), is(false));
             }
             case REPLACE -> {
                 var metadata = new NodesShutdownMetadata(
                     Map.of("thenode", builder.setType(type).setTargetNodeName("newnodecoming").build())
                 );
                 assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(true));
+                assertThat(metadata.isNodeMarkedForRemoval("anotherNode"), is(false));
             }
             case RESTART -> {
                 var metadata = new NodesShutdownMetadata(Map.of("thenode", builder.setType(type).build()));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -119,6 +120,36 @@ public class NodesShutdownMetadataTests extends ChunkedToXContentDiffableSeriali
         out = new BytesStreamOutput();
         metadata.writeTo(out);
         assertThat(new SingleNodeShutdownMetadata(out.bytes().streamInput()).getType(), equalTo(SingleNodeShutdownMetadata.Type.SIGTERM));
+    }
+
+    public void testIsNodeMarkedForRemoval() {
+        SingleNodeShutdownMetadata.Type type;
+        SingleNodeShutdownMetadata.Builder builder = SingleNodeShutdownMetadata.builder()
+            .setNodeId("myid")
+            .setReason("myReason")
+            .setStartedAtMillis(0L);
+        switch (type = randomFrom(SingleNodeShutdownMetadata.Type.values())) {
+            case SIGTERM -> {
+                var metadata = new NodesShutdownMetadata(
+                    Map.of("thenode", builder.setType(type).setGracePeriod(TimeValue.ONE_MINUTE).build())
+                );
+                assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(true));
+            }
+            case REMOVE -> {
+                var metadata = new NodesShutdownMetadata(Map.of("thenode", builder.setType(type).build()));
+                assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(true));
+            }
+            case REPLACE -> {
+                var metadata = new NodesShutdownMetadata(
+                    Map.of("thenode", builder.setType(type).setTargetNodeName("newnodecoming").build())
+                );
+                assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(true));
+            }
+            case RESTART -> {
+                var metadata = new NodesShutdownMetadata(Map.of("thenode", builder.setType(type).build()));
+                assertThat(metadata.isNodeMarkedForRemoval("thenode"), is(false));
+            }
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
@@ -125,7 +125,7 @@ public class NodesShutdownMetadataTests extends ChunkedToXContentDiffableSeriali
     public void testIsNodeMarkedForRemoval() {
         SingleNodeShutdownMetadata.Type type;
         SingleNodeShutdownMetadata.Builder builder = SingleNodeShutdownMetadata.builder()
-            .setNodeId("myid")
+            .setNodeId("thenode")
             .setReason("myReason")
             .setStartedAtMillis(0L);
         switch (type = randomFrom(SingleNodeShutdownMetadata.Type.values())) {


### PR DESCRIPTION
This adds an `isNodeMarkedForRemoval` convenience method so we can test if a node is marked for being permanently removed from the cluster.
