### PR TITLE
ESQL: Fix verification for missing non-wildcard index

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
@@ -8,7 +8,9 @@ package org.elasticsearch.xpack.esql.index;
 
 import org.elasticsearch.core.Nullable;
 
+import java.util.Collection;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public final class IndexResolution {
     public static IndexResolution valid(EsIndex index) {
@@ -21,9 +23,12 @@ public final class IndexResolution {
         return new IndexResolution(null, invalid);
     }
 
-    public static IndexResolution notFound(String name) {
-        Objects.requireNonNull(name, "name must not be null");
-        return invalid("Unknown index [" + name + "]");
+    public static IndexResolution notFound(Collection<String> missingNames) {
+        Objects.requireNonNull(missingNames, "missingNames must not be null");
+
+        String errorMessageStart = missingNames.size() == 1 ? "Unknown index [" : "Unknown indices [";
+        String missingNamesConcatenated = missingNames.stream().collect(Collectors.joining(", "));
+        return invalid(errorMessageStart + missingNamesConcatenated + "]");
     }
 
     private final EsIndex index;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -96,8 +96,9 @@ public class IndexResolver {
             return IndexResolution.notFound(Arrays.stream(indexPatterns).toList());
         }
 
-        // We allow no found indices in wildcards (if there's at least 1 found index), but indices with no wildcard need to be found.
+        // We allow no found indices in wildcards (if there's at least 1 found index), but indices with no wildcard need to be present.
         // TODO: for CCQ may need to strip `the_cluster_name:`.
+        // TODO: timeseries, aliased indices, rollovers
         List<String> nonWildcardIndices = Arrays.stream(indexPatterns).filter(pattern -> pattern.contains("*") == false).toList();
         if (nonWildcardIndices.isEmpty() == false) {
             Set<String> actuallyFoundIndices = fieldCapsResponse.getIndexResponses()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2103,7 +2103,7 @@ public class AnalyzerTests extends ESTestCase {
     private static LogicalPlan analyzeWithEmptyFieldCapsResponse(String query) throws IOException {
         List<FieldCapabilitiesIndexResponse> idxResponses = List.of(new FieldCapabilitiesIndexResponse("idx", "idx", Map.of(), true));
         FieldCapabilitiesResponse caps = new FieldCapabilitiesResponse(idxResponses, List.of());
-        IndexResolution resolution = new IndexResolver(null).mergedMappings("test*", caps);
+        IndexResolution resolution = new IndexResolver(null).mergedMappings("test*", new String[] { "test*" }, caps);
         var analyzer = analyzer(resolution, TEST_VERIFIER, configuration(query));
         return analyze(query, analyzer);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -52,7 +52,7 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
 
         FieldCapabilitiesResponse caps = new FieldCapabilitiesResponse(idxResponses, List.of());
         // IndexResolver uses EsqlDataTypeRegistry directly
-        IndexResolution resolution = new IndexResolver(null).mergedMappings("idx-*", caps);
+        IndexResolution resolution = new IndexResolver(null).mergedMappings("idx-*", new String[] { "idx-*" }, caps);
         EsField f = resolution.get().mapping().get(field);
         assertThat(f.getDataType(), equalTo(expected));
     }


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/111712

Until recently, ESQL queries were invalid when a non-wildcard index name in the `FROM` command did not correspond to an existing index; e.g. if there was an index `index1` but no index `index2`, the query `FROM index1, index2` would respond with an `IndexNotFoundException`.

https://github.com/elastic/elasticsearch/pull/109483 enabled aliased indexes in `FROM` but somehow now the query from above is treated as valid.

I think that, rather than relying on an `IndexNotFoundException` being thrown when _I think_ the `EsqlResolveFieldsAction` is handled, we should throw a `ValidationException` in the `IndexResolver` - which is what we also do when there are no matching indices for a given `FROM` command.