### PR TITLE
[8.15] LTR documentation - Remove tech preview note. (#111803)

### DIFF
--- a/docs/reference/search/search-your-data/learning-to-rank-model-training.asciidoc
+++ b/docs/reference/search/search-your-data/learning-to-rank-model-training.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Deploy and manage LTR models</titleabbrev>
 ++++
 
-preview::["The Learning To Rank feature is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but this feature is not subject to the support SLA of official GA features."]
-
 NOTE: This feature was introduced in version 8.12.0 and is only available to certain subscription levels.
 For more information, see {subscriptions}.
 

--- a/docs/reference/search/search-your-data/learning-to-rank-search-usage.asciidoc
+++ b/docs/reference/search/search-your-data/learning-to-rank-search-usage.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Search using LTR</titleabbrev>
 ++++
 
-preview::["The Learning To Rank feature is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but this feature is not subject to the support SLA of official GA features."]
-
 NOTE: This feature was introduced in version 8.12.0 and is only available to certain subscription levels.
 For more information, see {subscriptions}.
 

--- a/docs/reference/search/search-your-data/learning-to-rank.asciidoc
+++ b/docs/reference/search/search-your-data/learning-to-rank.asciidoc
@@ -1,8 +1,6 @@
 [[learning-to-rank]]
 == Learning To Rank
 
-preview::["The Learning To Rank feature is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but this feature is not subject to the support SLA of official GA features."]
-
 NOTE: This feature was introduced in version 8.12.0 and is only available to certain subscription levels.
 For more information, see {subscriptions}.
 


### PR DESCRIPTION
Backports the following commits to 8.15:
 - LTR documentation - Remove tech preview note. (#111803)