### PR TITLE
Adding Field caps support for Semantic Text

### DIFF
--- a/docs/changelog/111809.yaml
+++ b/docs/changelog/111809.yaml
@@ -1,5 +1,5 @@
 pr: 111809
-summary: Adding Field caps support for Semantic Text
-area: Relevance
+summary: Add Field caps support for Semantic Text
+area: Mapping
 type: enhancement
 issues: []

--- a/docs/changelog/111809.yaml
+++ b/docs/changelog/111809.yaml
@@ -1,0 +1,5 @@
+pr: 111809
+summary: Adding Field caps support for Semantic Text
+area: Relevance
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 restResources {
   restApi {
-    include '_common', 'bulk', 'indices', 'inference', 'index', 'get', 'update', 'reindex', 'search'
+    include '_common', 'bulk', 'indices', 'inference', 'index', 'get', 'update', 'reindex', 'search', 'field_caps'
   }
 }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.mapper;
 
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
@@ -320,7 +321,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             IndexVersion indexVersionCreated,
             Map<String, String> meta
         ) {
-            super(name, false, false, false, TextSearchInfo.NONE, meta);
+            super(name, true, false, false, TextSearchInfo.NONE, meta);
             this.inferenceId = inferenceId;
             this.modelSettings = modelSettings;
             this.inferenceField = inferenceField;
@@ -381,6 +382,11 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
             throw new IllegalArgumentException("[semantic_text] fields do not support sorting, scripting or aggregating");
+        }
+
+        @Override
+        public final boolean fieldHasValue(FieldInfos fieldInfos) {
+            return fieldInfos.fieldInfo(getEmbeddingsFieldName(name())) != null;
         }
 
         public QueryBuilder semanticQuery(InferenceResults inferenceResults, float boost, String queryName) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -385,7 +385,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         }
 
         @Override
-        public final boolean fieldHasValue(FieldInfos fieldInfos) {
+        public boolean fieldHasValue(FieldInfos fieldInfos) {
             return fieldInfos.fieldInfo(getEmbeddingsFieldName(name())) != null;
         }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -135,7 +135,14 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     @Override
     public MappedFieldType getMappedFieldType() {
-        return new SemanticTextFieldMapper.SemanticTextFieldType("field", "fake-inference-id", null, null, IndexVersion.current(), Map.of());
+        return new SemanticTextFieldMapper.SemanticTextFieldType(
+            "field",
+            "fake-inference-id",
+            null,
+            null,
+            IndexVersion.current(),
+            Map.of()
+        );
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.inference.mapper;
 
 import org.apache.lucene.document.FeatureField;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -63,6 +65,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
@@ -130,6 +133,18 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         throw new AssumptionViolatedException("not supported");
     }
 
+    @Override
+    public MappedFieldType getMappedFieldType() {
+        return new SemanticTextFieldMapper.SemanticTextFieldType("field", "fake-inference-id", null, null, IndexVersion.current(), Map.of());
+    }
+
+    @Override
+    protected void assertSearchable(MappedFieldType fieldType) {
+        assertThat(fieldType, instanceOf(SemanticTextFieldMapper.SemanticTextFieldType.class));
+        assertTrue(fieldType.isIndexed());
+        assertTrue(fieldType.isSearchable());
+    }
+
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());
@@ -139,6 +154,13 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
         // No indexable fields
         assertTrue(fields.isEmpty());
+    }
+
+    @Override
+    public void testFieldHasValue() {
+        MappedFieldType fieldType = getMappedFieldType();
+        FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { getFieldInfoWithName(getEmbeddingsFieldName("field")) });
+        assertTrue(fieldType.fieldHasValue(fieldInfos));
     }
 
     public void testInferenceIdNotPresent() {

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -64,62 +64,7 @@ setup:
   - length: { "test-index.mappings.properties.sparse_field": 3 }
 
 ---
-"Field caps set include_empty_field to false with sparse embedding":
-
-  - requires:
-      cluster_features: "gte_v8.16.0"
-      reason: field_caps support for semantic_text added in 8.16.0
-
-  - do:
-      field_caps:
-        include_empty_fields: false
-        index: test-index
-        fields: "*"
-
-  - match: { indices: [ "test-index" ] }
-  - is_false: fields.sparse_field
-  - is_false: fields.dense_field
-
-  - do:
-      index:
-        index: test-index
-        id: doc_1
-        body:
-          sparse_field:
-            text: "these are not the droids you're looking for. He's free to go around"
-            inference:
-              inference_id: sparse-inference-id
-              model_settings:
-                task_type: sparse_embedding
-              chunks:
-                - text: "these are not the droids you're looking for"
-                  embeddings:
-                    feature_0: 1.0
-                    feature_1: 2.0
-                    feature_2: 3.0
-                    feature_3: 4.0
-                - text: "He's free to go around"
-                  embeddings:
-                    feature_4: 0.1
-                    feature_5: 0.2
-                    feature_6: 0.3
-                    feature_7: 0.4
-        refresh: true
-
-  - do:
-      field_caps:
-        include_empty_fields: false
-        index: test-index
-        fields: "*"
-
-  - match: { indices: [ "test-index" ] }
-  - is_true: fields.sparse_field
-  - is_false: fields.dense_field
-
-  - match: { fields.sparse_field.semantic_text.searchable: true }
-
----
-"Field caps set include_empty_field to true with sparse embedding":
+"Field caps with sparse embedding":
 
   - requires:
       cluster_features: "gte_v8.16.0"
@@ -132,8 +77,18 @@ setup:
         fields: "*"
 
   - match: { indices: [ "test-index" ] }
-  - is_true: fields.sparse_field
-  - is_true: fields.dense_field
+  - exists: fields.sparse_field
+  - exists: fields.dense_field
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - not_exists: fields.sparse_field
+  - not_exists: fields.dense_field
 
   - do:
       index:
@@ -168,11 +123,21 @@ setup:
         fields: "*"
 
   - match: { indices: [ "test-index" ] }
-  - is_true: fields.sparse_field
-  - is_true: fields.dense_field
-
+  - exists: fields.sparse_field
+  - exists: fields.dense_field
   - match: { fields.sparse_field.semantic_text.searchable: true }
   - match: { fields.dense_field.semantic_text.searchable: true }
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - exists: fields.sparse_field
+  - not_exists: fields.dense_field
+  - match: { fields.sparse_field.semantic_text.searchable: true }
 
 ---
 "Indexes dense vector document":
@@ -217,57 +182,7 @@ setup:
   - length: { "test-index.mappings.properties.dense_field": 3 }
 
 ---
-"Field caps set include_empty_field to false with text embedding":
-
-  - requires:
-      cluster_features: "gte_v8.16.0"
-      reason: field_caps support for semantic_text added in 8.16.0
-
-  - do:
-      field_caps:
-        include_empty_fields: false
-        index: test-index
-        fields: "*"
-
-  - match: { indices: [ "test-index" ] }
-  - is_false: fields.sparse_field
-  - is_false: fields.dense_field
-
-  - do:
-      index:
-        index: test-index
-        id: doc_2
-        body:
-          dense_field:
-            text: "these are not the droids you're looking for. He's free to go around"
-            inference:
-              inference_id: dense-inference-id
-              model_settings:
-                task_type: text_embedding
-                dimensions: 4
-                similarity: cosine
-                element_type: float
-              chunks:
-                - text: "these are not the droids you're looking for"
-                  embeddings: [ 0.04673296958208084, -0.03237321600317955, -0.02543032355606556, 0.056035321205854416 ]
-                - text: "He's free to go around"
-                  embeddings: [ 0.00641461368650198, -0.0016253676731139421, -0.05126338079571724, 0.053438711911439896 ]
-        refresh: true
-
-  - do:
-      field_caps:
-        include_empty_fields: false
-        index: test-index
-        fields: "*"
-
-  - match: { indices: [ "test-index" ] }
-  - is_false: fields.sparse_field
-  - is_true: fields.dense_field
-
-  - match: { fields.dense_field.semantic_text.searchable: true }
-
----
-"Field caps set include_empty_field to true with text embedding":
+"Field caps with text embedding":
 
   - requires:
       cluster_features: "gte_v8.16.0"
@@ -280,8 +195,18 @@ setup:
         fields: "*"
 
   - match: { indices: [ "test-index" ] }
-  - is_true: fields.sparse_field
-  - is_true: fields.dense_field
+  - exists: fields.sparse_field
+  - exists: fields.dense_field
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - not_exists: fields.sparse_field
+  - not_exists: fields.dense_field
 
   - do:
       index:
@@ -311,11 +236,21 @@ setup:
         fields: "*"
 
   - match: { indices: [ "test-index" ] }
-  - is_true: fields.sparse_field
-  - is_true: fields.dense_field
-
-  - match: { fields.dense_field.semantic_text.searchable: true }
+  - exists: fields.sparse_field
+  - exists: fields.dense_field
   - match: { fields.sparse_field.semantic_text.searchable: true }
+  - match: { fields.dense_field.semantic_text.searchable: true }
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - not_exists: fields.sparse_field
+  - exists: fields.dense_field
+  - match: { fields.dense_field.semantic_text.searchable: true }
 
 ---
 "Can't be used as a multifield":

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -64,6 +64,60 @@ setup:
   - length: { "test-index.mappings.properties.sparse_field": 3 }
 
 ---
+"Add field_caps support for semantic_text field types with sparse embedding":
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_false: fields.sparse_field
+  - is_false: fields.dense_field
+
+  - do:
+      index:
+        index: test-index
+        id: doc_1
+        body:
+          sparse_field:
+            text: "these are not the droids you're looking for. He's free to go around"
+            inference:
+              inference_id: sparse-inference-id
+              model_settings:
+                task_type: sparse_embedding
+              chunks:
+                - text: "these are not the droids you're looking for"
+                  embeddings:
+                    feature_0: 1.0
+                    feature_1: 2.0
+                    feature_2: 3.0
+                    feature_3: 4.0
+                - text: "He's free to go around"
+                  embeddings:
+                    feature_4: 0.1
+                    feature_5: 0.2
+                    feature_6: 0.3
+                    feature_7: 0.4
+
+  - do:
+      indices.refresh:
+        index: [ test-index ]
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_true: fields.sparse_field
+  - is_false: fields.dense_field
+
+  - match: { fields.sparse_field.semantic_text.searchable: true }
+
+---
 "Indexes dense vector document":
 
   # Checks mapping is not updated until first doc arrives
@@ -104,6 +158,55 @@ setup:
   - match: { "test-index.mappings.properties.dense_field.inference_id": dense-inference-id }
   - match: { "test-index.mappings.properties.dense_field.model_settings.task_type": text_embedding }
   - length: { "test-index.mappings.properties.dense_field": 3 }
+
+---
+"Add field_caps support for semantic_text field types with text embedding":
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_false: fields.sparse_field
+  - is_false: fields.dense_field
+
+  - do:
+      index:
+        index: test-index
+        id: doc_2
+        body:
+          dense_field:
+            text: "these are not the droids you're looking for. He's free to go around"
+            inference:
+              inference_id: dense-inference-id
+              model_settings:
+                task_type: text_embedding
+                dimensions: 4
+                similarity: cosine
+                element_type: float
+              chunks:
+                - text: "these are not the droids you're looking for"
+                  embeddings: [ 0.04673296958208084, -0.03237321600317955, -0.02543032355606556, 0.056035321205854416 ]
+                - text: "He's free to go around"
+                  embeddings: [ 0.00641461368650198, -0.0016253676731139421, -0.05126338079571724, 0.053438711911439896 ]
+
+  - do:
+      indices.refresh:
+        index: [ test-index ]
+
+  - do:
+      field_caps:
+        include_empty_fields: false
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_false: fields.sparse_field
+  - is_true: fields.dense_field
+
+  - match: { fields.dense_field.semantic_text.searchable: true }
 
 ---
 "Can't be used as a multifield":

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -64,7 +64,11 @@ setup:
   - length: { "test-index.mappings.properties.sparse_field": 3 }
 
 ---
-"Add field_caps support for semantic_text field types with sparse embedding":
+"Field caps set include_empty_field to false with sparse embedding":
+
+  - requires:
+      cluster_features: "gte_v8.16.0"
+      reason: field_caps support for semantic_text added in 8.16.0
 
   - do:
       field_caps:
@@ -100,10 +104,7 @@ setup:
                     feature_5: 0.2
                     feature_6: 0.3
                     feature_7: 0.4
-
-  - do:
-      indices.refresh:
-        index: [ test-index ]
+        refresh: true
 
   - do:
       field_caps:
@@ -116,6 +117,62 @@ setup:
   - is_false: fields.dense_field
 
   - match: { fields.sparse_field.semantic_text.searchable: true }
+
+---
+"Field caps set include_empty_field to true with sparse embedding":
+
+  - requires:
+      cluster_features: "gte_v8.16.0"
+      reason: field_caps support for semantic_text added in 8.16.0
+
+  - do:
+      field_caps:
+        include_empty_fields: true
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_true: fields.sparse_field
+  - is_true: fields.dense_field
+
+  - do:
+      index:
+        index: test-index
+        id: doc_1
+        body:
+          sparse_field:
+            text: "these are not the droids you're looking for. He's free to go around"
+            inference:
+              inference_id: sparse-inference-id
+              model_settings:
+                task_type: sparse_embedding
+              chunks:
+                - text: "these are not the droids you're looking for"
+                  embeddings:
+                    feature_0: 1.0
+                    feature_1: 2.0
+                    feature_2: 3.0
+                    feature_3: 4.0
+                - text: "He's free to go around"
+                  embeddings:
+                    feature_4: 0.1
+                    feature_5: 0.2
+                    feature_6: 0.3
+                    feature_7: 0.4
+        refresh: true
+
+  - do:
+      field_caps:
+        include_empty_fields: true
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_true: fields.sparse_field
+  - is_true: fields.dense_field
+
+  - match: { fields.sparse_field.semantic_text.searchable: true }
+  - match: { fields.dense_field.semantic_text.searchable: true }
 
 ---
 "Indexes dense vector document":
@@ -160,7 +217,11 @@ setup:
   - length: { "test-index.mappings.properties.dense_field": 3 }
 
 ---
-"Add field_caps support for semantic_text field types with text embedding":
+"Field caps set include_empty_field to false with text embedding":
+
+  - requires:
+      cluster_features: "gte_v8.16.0"
+      reason: field_caps support for semantic_text added in 8.16.0
 
   - do:
       field_caps:
@@ -191,10 +252,7 @@ setup:
                   embeddings: [ 0.04673296958208084, -0.03237321600317955, -0.02543032355606556, 0.056035321205854416 ]
                 - text: "He's free to go around"
                   embeddings: [ 0.00641461368650198, -0.0016253676731139421, -0.05126338079571724, 0.053438711911439896 ]
-
-  - do:
-      indices.refresh:
-        index: [ test-index ]
+        refresh: true
 
   - do:
       field_caps:
@@ -207,6 +265,57 @@ setup:
   - is_true: fields.dense_field
 
   - match: { fields.dense_field.semantic_text.searchable: true }
+
+---
+"Field caps set include_empty_field to true with text embedding":
+
+  - requires:
+      cluster_features: "gte_v8.16.0"
+      reason: field_caps support for semantic_text added in 8.16.0
+
+  - do:
+      field_caps:
+        include_empty_fields: true
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_true: fields.sparse_field
+  - is_true: fields.dense_field
+
+  - do:
+      index:
+        index: test-index
+        id: doc_2
+        body:
+          dense_field:
+            text: "these are not the droids you're looking for. He's free to go around"
+            inference:
+              inference_id: dense-inference-id
+              model_settings:
+                task_type: text_embedding
+                dimensions: 4
+                similarity: cosine
+                element_type: float
+              chunks:
+                - text: "these are not the droids you're looking for"
+                  embeddings: [ 0.04673296958208084, -0.03237321600317955, -0.02543032355606556, 0.056035321205854416 ]
+                - text: "He's free to go around"
+                  embeddings: [ 0.00641461368650198, -0.0016253676731139421, -0.05126338079571724, 0.053438711911439896 ]
+        refresh: true
+
+  - do:
+      field_caps:
+        include_empty_fields: true
+        index: test-index
+        fields: "*"
+
+  - match: { indices: [ "test-index" ] }
+  - is_true: fields.sparse_field
+  - is_true: fields.dense_field
+
+  - match: { fields.dense_field.semantic_text.searchable: true }
+  - match: { fields.sparse_field.semantic_text.searchable: true }
 
 ---
 "Can't be used as a multifield":


### PR DESCRIPTION
Adding `field_caps` support for Semantic text field type.

Setup:
```
PUT _inference/sparse_embedding/my-elser-model
{
  "service": "elser",
  "service_settings": {
    "num_allocations": 1,
    "num_threads": 1
  },
  "task_settings": {}
}

PUT test-sparse
{
    "mappings": {
        "properties": {
            "test_field": {
                "type": "semantic_text",
                "inference_id": "my-elser-model"
            },
            "non_infer_field": {
                "type": "text"
            }
        }
    }
}

PUT test-sparse/_doc/doc1
{
    "test_field": "these are not the droids you're looking for. He's free to go around"
}
```

Now, Querying with the Semantic field with `include_empty_fields` to `false`, does not return the semantic field even if the field has value. 

```
GET /_field_caps?fields=test_field&include_empty_fields=false
```

will produce something like this:
```
...,
"fields": {}
```

After apply the changes in this PR, We will be able to get the desired output.

Query
```
GET /_field_caps?fields=test_field&include_empty_fields=false
```

result:
```
"fields": {
    "test_field": {
      "semantic_text": {
        "type": "semantic_text",
        "metadata_field": false,
        "searchable": true,
        "aggregatable": false
      }
    }
  }
```






