### PR TITLE
ESQL: Drop an unneeded feature flag check

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -394,34 +394,18 @@ public enum DataType {
      * Supported types that can be contained in a block.
      */
     public static boolean isRepresentable(DataType t) {
-        if (EsqlCorePlugin.DATE_NANOS_FEATURE_FLAG.isEnabled()) {
-            return t != OBJECT
-                && t != UNSUPPORTED
-                && t != DATE_PERIOD
-                && t != TIME_DURATION
-                && t != BYTE
-                && t != SHORT
-                && t != FLOAT
-                && t != SCALED_FLOAT
-                && t != SOURCE
-                && t != HALF_FLOAT
-                && t != PARTIAL_AGG
-                && t.isCounter() == false;
-        } else {
-            return t != OBJECT
-                && t != UNSUPPORTED
-                && t != DATE_PERIOD
-                && t != DATE_NANOS
-                && t != TIME_DURATION
-                && t != BYTE
-                && t != SHORT
-                && t != FLOAT
-                && t != SCALED_FLOAT
-                && t != SOURCE
-                && t != HALF_FLOAT
-                && t != PARTIAL_AGG
-                && t.isCounter() == false;
-        }
+        return t != OBJECT
+            && t != UNSUPPORTED
+            && t != DATE_PERIOD
+            && t != TIME_DURATION
+            && t != BYTE
+            && t != SHORT
+            && t != FLOAT
+            && t != SCALED_FLOAT
+            && t != SOURCE
+            && t != HALF_FLOAT
+            && t != PARTIAL_AGG
+            && t.isCounter() == false;
     }
 
     public static boolean isSpatialPoint(DataType t) {


### PR DESCRIPTION
When checking if a type is `representable` we were excluding `DATE_NANOS` if it's feature flag was disabled. But we don't have to do it - nothing checks that or needs it.
