### PR TITLE
Save syscalls in Checkpoint.read

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
@@ -15,17 +15,15 @@ import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IOContext;
-import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.elasticsearch.common.io.Channels;
+import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -166,20 +164,19 @@ final class Checkpoint {
     }
 
     public static Checkpoint read(Path path) throws IOException {
-        try (Directory dir = new NIOFSDirectory(path.getParent())) {
-            try (IndexInput indexInput = dir.openInput(path.getFileName().toString(), IOContext.DEFAULT)) {
-                // We checksum the entire file before we even go and parse it. If it's corrupted we barf right here.
-                CodecUtil.checksumEntireFile(indexInput);
-                final int fileVersion = CodecUtil.checkHeader(indexInput, CHECKPOINT_CODEC, VERSION_LUCENE_8, CURRENT_VERSION);
-                assert fileVersion == VERSION_LUCENE_8 || fileVersion == CURRENT_VERSION;
-                assert indexInput.length() == V4_FILE_SIZE : indexInput.length();
-                if (fileVersion == CURRENT_VERSION) {
-                    return Checkpoint.readCheckpointV4(indexInput);
-                }
-                return readCheckpointV3(indexInput);
-            } catch (CorruptIndexException | NoSuchFileException | IndexFormatTooOldException | IndexFormatTooNewException e) {
-                throw new TranslogCorruptedException(path.toString(), e);
+        final byte[] bytes = Files.readAllBytes(path);
+        try (ByteArrayIndexInput indexInput = new ByteArrayIndexInput(path.toString(), bytes, 0, bytes.length)) {
+            // We checksum the entire file before we even go and parse it. If it's corrupted we barf right here.
+            CodecUtil.checksumEntireFile(indexInput);
+            final int fileVersion = CodecUtil.checkHeader(indexInput, CHECKPOINT_CODEC, VERSION_LUCENE_8, CURRENT_VERSION);
+            assert fileVersion == VERSION_LUCENE_8 || fileVersion == CURRENT_VERSION;
+            assert indexInput.length() == V4_FILE_SIZE : indexInput.length();
+            if (fileVersion == CURRENT_VERSION) {
+                return Checkpoint.readCheckpointV4(indexInput);
             }
+            return readCheckpointV3(indexInput);
+        } catch (CorruptIndexException | NoSuchFileException | IndexFormatTooOldException | IndexFormatTooNewException e) {
+            throw new TranslogCorruptedException(path.toString(), e);
         }
     }
 


### PR DESCRIPTION
No need to use a real directory here. We use a plain channel for writing, we can do the same for reading since the checkpoints are tiny. This is mostly helpful in saving hundreds of seconds in syscalls in internal cluster tests.
