### PR TITLE
[7.17] Fix typo for the Reset Features API (#111731)

### DIFF
--- a/docs/reference/features/apis/features-apis.asciidoc
+++ b/docs/reference/features/apis/features-apis.asciidoc
@@ -7,7 +7,7 @@ by Elasticsearch and Elasticsearch plugins.
 [discrete]
 === Features APIs
 * <<get-features-api,Get Features API>>
-* <<reset-features-api,Rest Features API>>
+* <<reset-features-api,Reset Features API>>
 
 include::get-features-api.asciidoc[]
 include::reset-features-api.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix typo for the Reset Features API (#111731)