### PR TITLE
[8.15] Document manual steps in ILM delete phase (#111734)

### DIFF
--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -15,6 +15,18 @@ Deletes the searchable snapshot created in a previous phase.
 Defaults to `true`.
 This option is applicable when the <<ilm-searchable-snapshot,searchable
 snapshot>> action is used in any previous phase.
++
+If you set this option to `false`, use the <<delete-snapshot-api,Delete
+snapshots API>> to remove {search-snaps} from your snapshot repository when
+they are no longer needed.
++
+If you manually delete an index before the {ilm-cap} delete phase runs, then
+{ilm-init} will not delete the underlying {search-snap}. Use the
+<<delete-snapshot-api,Delete snapshots API>> to remove the {search-snap} from
+your snapshot repository when it is no longer needed.
++
+See <<searchable-snapshots-reliability,Reliability of {search-snaps}>> for
+further information about deleting {search-snaps}.
 
 WARNING: If a policy with a searchable snapshot action is applied on an existing searchable snapshot index,
 the snapshot backing this index will NOT be deleted because it was not created by this policy. If you want


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Document manual steps in ILM delete phase (#111734)