### PR TITLE
[DOCS] Fixes the description of 'affected_resources' in health API documentation

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -204,7 +204,7 @@ for health status set `verbose` to `false` to disable the more expensive analysi
     `help_url` field.
 
 `affected_resources`::
-    (Optional, object) This field contains an object where the keys represent resource types (e.g., indices, shards), 
+    (Optional, object) An object where the keys represent resource types (for example, indices, shards), 
     and the values are lists of the specific resources affected by the issue.
 
 `help_url`::

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -204,9 +204,8 @@ for health status set `verbose` to `false` to disable the more expensive analysi
     `help_url` field.
 
 `affected_resources`::
-    (Optional, array of strings) If the root cause pertains to multiple resources in the
-    cluster (like indices, shards, nodes, etc...) this will hold all resources that this
-    diagnosis is applicable for.
+    (Optional, object) This field contains an object where the keys represent resource types (e.g., indices, shards), 
+    and the values are lists of the specific resources affected by the issue.
 
 `help_url`::
     (string) A link to the troubleshooting guide that'll fix the health problem.


### PR DESCRIPTION
## Overview

Related issue: https://github.com/elastic/elasticsearch/issues/106925

This PR updates the `affected_resources` field in the Health API documentation to accurately reflect that it returns an object mapping resource types to lists of affected items.

### Preview

[Health API](https://elasticsearch_bk_111833.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/health-api.html)
