### PR TITLE
[DOCS] Highlights auto-chunking in intro of semantic text

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -7,8 +7,8 @@
 
 beta[]
 
-The `semantic_text` field type automatically generates embeddings for text
-content using an inference endpoint.
+The `semantic_text` field type automatically generates embeddings for text content using an inference endpoint.
+Long passages are <<auto-text-chunking, automatically chunked>> to smaller sections to enable the processing of larger corpuses of text.
 
 The `semantic_text` field type specifies an inference endpoint identifier that will be used to generate embeddings.
 You can create the inference endpoint by using the <<put-inference-api>>.


### PR DESCRIPTION
## Overview

This PR highlights the auto-chunking capabilities of semantic text in the intro. As auto-chunking is advertised heavily on different channels, informing the user early on the page makes sense.

### Preview

[semantic_text](https://elasticsearch_bk_111836.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-text.html)