### PR TITLE
Revert "[cache] Support async RangeMissingHandler callbacks (#111340)"

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -646,14 +646,13 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             // no need to allocate a new capturing lambda if the offset isn't adjusted
             return writer;
         }
-        return (channel, channelPos, streamFactory, relativePos, len, progressUpdater, completionListener) -> writer.fillCacheRange(
+        return (channel, channelPos, streamFactory, relativePos, len, progressUpdater) -> writer.fillCacheRange(
             channel,
             channelPos,
             streamFactory,
             relativePos - writeOffset,
             len,
-            progressUpdater,
-            completionListener
+            progressUpdater
         );
     }
 
@@ -988,17 +987,16 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                                 executor.execute(fillGapRunnable(gap, writer, null, refs.acquireListener()));
                             }
                         } else {
-                            var gapFillingListener = refs.acquireListener();
-                            try (var gfRefs = new RefCountingRunnable(ActionRunnable.run(gapFillingListener, streamFactory::close))) {
-                                final List<Runnable> gapFillingTasks = gaps.stream()
-                                    .map(gap -> fillGapRunnable(gap, writer, streamFactory, gfRefs.acquireListener()))
-                                    .toList();
-                                executor.execute(() -> {
+                            final List<AbstractRunnable> gapFillingTasks = gaps.stream()
+                                .map(gap -> fillGapRunnable(gap, writer, streamFactory, refs.acquireListener()))
+                                .toList();
+                            executor.execute(() -> {
+                                try (streamFactory) {
                                     // Fill the gaps in order. If a gap fails to fill for whatever reason, the task for filling the next
                                     // gap will still be executed.
                                     gapFillingTasks.forEach(Runnable::run);
-                                });
-                            }
+                                }
+                            });
                         }
                     }
                 }
@@ -1007,13 +1005,13 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             }
         }
 
-        private Runnable fillGapRunnable(
+        private AbstractRunnable fillGapRunnable(
             SparseFileTracker.Gap gap,
             RangeMissingHandler writer,
             @Nullable SourceInputStreamFactory streamFactory,
             ActionListener<Void> listener
         ) {
-            return () -> ActionListener.run(listener, l -> {
+            return ActionRunnable.run(listener.delegateResponse((l, e) -> failGapAndListener(gap, l, e)), () -> {
                 var ioRef = io;
                 assert regionOwners.get(ioRef) == CacheFileRegion.this;
                 assert CacheFileRegion.this.hasReferences() : CacheFileRegion.this;
@@ -1024,15 +1022,10 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                     streamFactory,
                     start,
                     Math.toIntExact(gap.end() - start),
-                    progress -> gap.onProgress(start + progress),
-                    l.<Void>map(unused -> {
-                        assert regionOwners.get(ioRef) == CacheFileRegion.this;
-                        assert CacheFileRegion.this.hasReferences() : CacheFileRegion.this;
-                        writeCount.increment();
-                        gap.onCompletion();
-                        return null;
-                    }).delegateResponse((delegate, e) -> failGapAndListener(gap, delegate, e))
+                    progress -> gap.onProgress(start + progress)
                 );
+                writeCount.increment();
+                gap.onCompletion();
             });
         }
 
@@ -1120,23 +1113,12 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                     SourceInputStreamFactory streamFactory,
                     int relativePos,
                     int length,
-                    IntConsumer progressUpdater,
-                    ActionListener<Void> completionListener
+                    IntConsumer progressUpdater
                 ) throws IOException {
-                    writer.fillCacheRange(
-                        channel,
-                        channelPos,
-                        streamFactory,
-                        relativePos,
-                        length,
-                        progressUpdater,
-                        completionListener.map(unused -> {
-                            var elapsedTime = TimeUnit.NANOSECONDS.toMillis(relativeTimeInNanosSupplier.getAsLong() - startTime);
-                            blobCacheMetrics.getCacheMissLoadTimes().record(elapsedTime);
-                            blobCacheMetrics.getCacheMissCounter().increment();
-                            return null;
-                        })
-                    );
+                    writer.fillCacheRange(channel, channelPos, streamFactory, relativePos, length, progressUpdater);
+                    var elapsedTime = TimeUnit.NANOSECONDS.toMillis(relativeTimeInNanosSupplier.getAsLong() - startTime);
+                    SharedBlobCacheService.this.blobCacheMetrics.getCacheMissLoadTimes().record(elapsedTime);
+                    SharedBlobCacheService.this.blobCacheMetrics.getCacheMissCounter().increment();
                 }
             };
             if (rangeToRead.isEmpty()) {
@@ -1229,18 +1211,9 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                         SourceInputStreamFactory streamFactory,
                         int relativePos,
                         int len,
-                        IntConsumer progressUpdater,
-                        ActionListener<Void> completionListener
+                        IntConsumer progressUpdater
                     ) throws IOException {
-                        delegate.fillCacheRange(
-                            channel,
-                            channelPos,
-                            streamFactory,
-                            relativePos - writeOffset,
-                            len,
-                            progressUpdater,
-                            completionListener
-                        );
+                        delegate.fillCacheRange(channel, channelPos, streamFactory, relativePos - writeOffset, len, progressUpdater);
                     }
                 };
             }
@@ -1253,25 +1226,14 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                         SourceInputStreamFactory streamFactory,
                         int relativePos,
                         int len,
-                        IntConsumer progressUpdater,
-                        ActionListener<Void> completionListener
+                        IntConsumer progressUpdater
                     ) throws IOException {
                         assert assertValidRegionAndLength(fileRegion, channelPos, len);
-                        delegate.fillCacheRange(
-                            channel,
-                            channelPos,
-                            streamFactory,
-                            relativePos,
-                            len,
-                            progressUpdater,
-                            Assertions.ENABLED ? ActionListener.runBefore(completionListener, () -> {
-                                assert regionOwners.get(fileRegion.io) == fileRegion
-                                    : "File chunk [" + fileRegion.regionKey + "] no longer owns IO [" + fileRegion.io + "]";
-                            }) : completionListener
-                        );
+                        delegate.fillCacheRange(channel, channelPos, streamFactory, relativePos, len, progressUpdater);
+                        assert regionOwners.get(fileRegion.io) == fileRegion
+                            : "File chunk [" + fileRegion.regionKey + "] no longer owns IO [" + fileRegion.io + "]";
                     }
                 };
-
             }
             return adjustedWriter;
         }
@@ -1358,7 +1320,6 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
          * @param length of data to fetch
          * @param progressUpdater consumer to invoke with the number of copied bytes as they are written in cache.
          *                        This is used to notify waiting readers that data become available in cache.
-         * @param completionListener listener that has to be called when the callback method completes
          */
         void fillCacheRange(
             SharedBytes.IO channel,
@@ -1366,8 +1327,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             @Nullable SourceInputStreamFactory streamFactory,
             int relativePos,
             int length,
-            IntConsumer progressUpdater,
-            ActionListener<Void> completionListener
+            IntConsumer progressUpdater
         ) throws IOException;
     }
 
@@ -1379,9 +1339,9 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         /**
          * Create the input stream at the specified position.
          * @param relativePos the relative position in the remote storage to read from.
-         * @param listener listener for the input stream ready to be read from.
+         * @return the input stream ready to be read from.
          */
-        void create(int relativePos, ActionListener<InputStream> listener) throws IOException;
+        InputStream create(int relativePos) throws IOException;
     }
 
     private abstract static class DelegatingRangeMissingHandler implements RangeMissingHandler {
@@ -1403,10 +1363,9 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             SourceInputStreamFactory streamFactory,
             int relativePos,
             int length,
-            IntConsumer progressUpdater,
-            ActionListener<Void> completionListener
+            IntConsumer progressUpdater
         ) throws IOException {
-            delegate.fillCacheRange(channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener);
+            delegate.fillCacheRange(channel, channelPos, streamFactory, relativePos, length, progressUpdater);
         }
     }
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -335,7 +335,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         NodeEnvironment environment,
         Settings settings,
         ThreadPool threadPool,
-        Executor ioExecutor,
+        String ioExecutor,
         BlobCacheMetrics blobCacheMetrics
     ) {
         this(environment, settings, threadPool, ioExecutor, blobCacheMetrics, System::nanoTime);
@@ -345,12 +345,12 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         NodeEnvironment environment,
         Settings settings,
         ThreadPool threadPool,
-        Executor ioExecutor,
+        String ioExecutor,
         BlobCacheMetrics blobCacheMetrics,
         LongSupplier relativeTimeInNanosSupplier
     ) {
         this.threadPool = threadPool;
-        this.ioExecutor = ioExecutor;
+        this.ioExecutor = threadPool.executor(ioExecutor);
         long totalFsSize;
         try {
             totalFsSize = FsProbe.getTotal(Environment.getFileStore(environment.nodeDataPaths()[0]));

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.StoppableExecutorServiceWrapper;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.TestEnvironment;
@@ -71,13 +70,6 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
 
     private static long size(long numPages) {
         return numPages * SharedBytes.PAGE_SIZE;
-    }
-
-    private static <E extends Exception> void completeWith(ActionListener<Void> listener, CheckedRunnable<E> runnable) {
-        ActionListener.completeWith(listener, () -> {
-            runnable.run();
-            return null;
-        });
     }
 
     public void testBasicEviction() throws IOException {
@@ -123,10 +115,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 ByteRange.of(0L, 1L),
                 ByteRange.of(0L, 1L),
                 (channel, channelPos, relativePos, length) -> 1,
-                (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                    completionListener,
-                    () -> progressUpdater.accept(length)
-                ),
+                (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
                 taskQueue.getThreadPool().generic(),
                 bytesReadFuture
             );
@@ -563,14 +552,11 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 cacheService.maybeFetchFullEntry(
                     cacheKey,
                     size,
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> {
-                            assert streamFactory == null : streamFactory;
-                            bytesRead.addAndGet(-length);
-                            progressUpdater.accept(length);
-                        }
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                        assert streamFactory == null : streamFactory;
+                        bytesRead.addAndGet(-length);
+                        progressUpdater.accept(length);
+                    },
                     bulkExecutor,
                     future
                 );
@@ -584,15 +570,9 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 // a download that would use up all regions should not run
                 final var cacheKey = generateCacheKey();
                 assertEquals(2, cacheService.freeRegionCount());
-                var configured = cacheService.maybeFetchFullEntry(
-                    cacheKey,
-                    size(500),
-                    (ch, chPos, streamFactory, relPos, len, update, completionListener) -> completeWith(completionListener, () -> {
-                        throw new AssertionError("Should never reach here");
-                    }),
-                    bulkExecutor,
-                    ActionListener.noop()
-                );
+                var configured = cacheService.maybeFetchFullEntry(cacheKey, size(500), (ch, chPos, streamFactory, relPos, len, update) -> {
+                    throw new AssertionError("Should never reach here");
+                }, bulkExecutor, ActionListener.noop());
                 assertFalse(configured);
                 assertEquals(2, cacheService.freeRegionCount());
             }
@@ -633,14 +613,9 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             (ActionListener<Void> listener) -> cacheService.maybeFetchFullEntry(
                                 cacheKey,
                                 size,
-                                (
-                                    channel,
-                                    channelPos,
-                                    streamFactory,
-                                    relativePos,
-                                    length,
-                                    progressUpdater,
-                                    completionListener) -> completeWith(completionListener, () -> progressUpdater.accept(length)),
+                                (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> progressUpdater.accept(
+                                    length
+                                ),
                                 bulkExecutor,
                                 listener
                             )
@@ -884,10 +859,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 var entry = cacheService.get(cacheKey, regionSize, 0);
                 entry.populate(
                     ByteRange.of(0L, regionSize),
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> progressUpdater.accept(length)
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
                     taskQueue.getThreadPool().generic(),
                     ActionListener.noop()
                 );
@@ -982,14 +954,11 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     cacheKey,
                     0,
                     blobLength,
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> {
-                            assert streamFactory == null : streamFactory;
-                            bytesRead.addAndGet(length);
-                            progressUpdater.accept(length);
-                        }
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                        assert streamFactory == null : streamFactory;
+                        bytesRead.addAndGet(length);
+                        progressUpdater.accept(length);
+                    },
                     bulkExecutor,
                     future
                 );
@@ -1016,14 +985,11 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                         cacheKey,
                         region,
                         blobLength,
-                        (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                            completionListener,
-                            () -> {
-                                assert streamFactory == null : streamFactory;
-                                bytesRead.addAndGet(length);
-                                progressUpdater.accept(length);
-                            }
-                        ),
+                        (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                            assert streamFactory == null : streamFactory;
+                            bytesRead.addAndGet(length);
+                            progressUpdater.accept(length);
+                        },
                         bulkExecutor,
                         listener
                     );
@@ -1044,12 +1010,9 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     cacheKey,
                     randomIntBetween(0, 10),
                     randomLongBetween(1L, regionSize),
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> {
-                            throw new AssertionError("should not be executed");
-                        }
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                        throw new AssertionError("should not be executed");
+                    },
                     bulkExecutor,
                     future
                 );
@@ -1069,14 +1032,11 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     cacheKey,
                     0,
                     blobLength,
-                    (channel, channelPos, ignore, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> {
-                            assert ignore == null : ignore;
-                            bytesRead.addAndGet(length);
-                            progressUpdater.accept(length);
-                        }
-                    ),
+                    (channel, channelPos, ignore, relativePos, length, progressUpdater) -> {
+                        assert ignore == null : ignore;
+                        bytesRead.addAndGet(length);
+                        progressUpdater.accept(length);
+                    },
                     bulkExecutor,
                     future
                 );
@@ -1150,15 +1110,12 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     region,
                     range,
                     blobLength,
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> {
-                            assertThat(range.start() + relativePos, equalTo(cacheService.getRegionStart(region) + regionRange.start()));
-                            assertThat(channelPos, equalTo(Math.toIntExact(regionRange.start())));
-                            assertThat(length, equalTo(Math.toIntExact(regionRange.length())));
-                            bytesCopied.addAndGet(length);
-                        }
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                        assertThat(range.start() + relativePos, equalTo(cacheService.getRegionStart(region) + regionRange.start()));
+                        assertThat(channelPos, equalTo(Math.toIntExact(regionRange.start())));
+                        assertThat(length, equalTo(Math.toIntExact(regionRange.length())));
+                        bytesCopied.addAndGet(length);
+                    },
                     bulkExecutor,
                     future
                 );
@@ -1193,10 +1150,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                         region,
                         ByteRange.of(0L, blobLength),
                         blobLength,
-                        (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                            completionListener,
-                            () -> bytesCopied.addAndGet(length)
-                        ),
+                        (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> bytesCopied.addAndGet(length),
                         bulkExecutor,
                         listener
                     );
@@ -1219,12 +1173,9 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     randomIntBetween(0, 10),
                     ByteRange.of(0L, blobLength),
                     blobLength,
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> {
-                            throw new AssertionError("should not be executed");
-                        }
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                        throw new AssertionError("should not be executed");
+                    },
                     bulkExecutor,
                     future
                 );
@@ -1245,10 +1196,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     0,
                     ByteRange.of(0L, blobLength),
                     blobLength,
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> bytesCopied.addAndGet(length)
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> bytesCopied.addAndGet(length),
                     bulkExecutor,
                     future
                 );
@@ -1289,18 +1237,10 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             var entry = cacheService.get(cacheKey, blobLength, 0);
             AtomicLong bytesWritten = new AtomicLong(0L);
             final PlainActionFuture<Boolean> future1 = new PlainActionFuture<>();
-            entry.populate(
-                ByteRange.of(0, regionSize - 1),
-                (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                    completionListener,
-                    () -> {
-                        bytesWritten.addAndGet(length);
-                        progressUpdater.accept(length);
-                    }
-                ),
-                taskQueue.getThreadPool().generic(),
-                future1
-            );
+            entry.populate(ByteRange.of(0, regionSize - 1), (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                bytesWritten.addAndGet(length);
+                progressUpdater.accept(length);
+            }, taskQueue.getThreadPool().generic(), future1);
 
             assertThat(future1.isDone(), is(false));
             assertThat(taskQueue.hasRunnableTasks(), is(true));
@@ -1308,34 +1248,18 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             // start populating the second region
             entry = cacheService.get(cacheKey, blobLength, 1);
             final PlainActionFuture<Boolean> future2 = new PlainActionFuture<>();
-            entry.populate(
-                ByteRange.of(0, regionSize - 1),
-                (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                    completionListener,
-                    () -> {
-                        bytesWritten.addAndGet(length);
-                        progressUpdater.accept(length);
-                    }
-                ),
-                taskQueue.getThreadPool().generic(),
-                future2
-            );
+            entry.populate(ByteRange.of(0, regionSize - 1), (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                bytesWritten.addAndGet(length);
+                progressUpdater.accept(length);
+            }, taskQueue.getThreadPool().generic(), future2);
 
             // start populating again the first region, listener should be called immediately
             entry = cacheService.get(cacheKey, blobLength, 0);
             final PlainActionFuture<Boolean> future3 = new PlainActionFuture<>();
-            entry.populate(
-                ByteRange.of(0, regionSize - 1),
-                (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                    completionListener,
-                    () -> {
-                        bytesWritten.addAndGet(length);
-                        progressUpdater.accept(length);
-                    }
-                ),
-                taskQueue.getThreadPool().generic(),
-                future3
-            );
+            entry.populate(ByteRange.of(0, regionSize - 1), (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> {
+                bytesWritten.addAndGet(length);
+                progressUpdater.accept(length);
+            }, taskQueue.getThreadPool().generic(), future3);
 
             assertThat(future3.isDone(), is(true));
             var written = future3.get(10L, TimeUnit.SECONDS);
@@ -1453,10 +1377,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     range,
                     range,
                     (channel, channelPos, relativePos, length) -> length,
-                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater, completionListener) -> completeWith(
-                        completionListener,
-                        () -> progressUpdater.accept(length)
-                    ),
+                    (channel, channelPos, streamFactory, relativePos, length, progressUpdater) -> progressUpdater.accept(length),
                     EsExecutors.DIRECT_EXECUTOR_SERVICE,
                     future
                 );
@@ -1473,8 +1394,8 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             final var factoryClosed = new AtomicBoolean(false);
             final var dummyStreamFactory = new SourceInputStreamFactory() {
                 @Override
-                public void create(int relativePos, ActionListener<InputStream> listener) {
-                    listener.onResponse(null);
+                public InputStream create(int relativePos) {
+                    return null;
                 }
 
                 @Override
@@ -1499,20 +1420,17 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                     SourceInputStreamFactory streamFactory,
                     int relativePos,
                     int length,
-                    IntConsumer progressUpdater,
-                    ActionListener<Void> completion
+                    IntConsumer progressUpdater
                 ) throws IOException {
-                    completeWith(completion, () -> {
-                        if (invocationCounter.incrementAndGet() == 1) {
-                            final Thread witness = invocationThread.compareAndExchange(null, Thread.currentThread());
-                            assertThat(witness, nullValue());
-                        } else {
-                            assertThat(invocationThread.get(), sameInstance(Thread.currentThread()));
-                        }
-                        assertThat(streamFactory, sameInstance(dummyStreamFactory));
-                        assertThat(position.getAndSet(relativePos), lessThan(relativePos));
-                        progressUpdater.accept(length);
-                    });
+                    if (invocationCounter.incrementAndGet() == 1) {
+                        final Thread witness = invocationThread.compareAndExchange(null, Thread.currentThread());
+                        assertThat(witness, nullValue());
+                    } else {
+                        assertThat(invocationThread.get(), sameInstance(Thread.currentThread()));
+                    }
+                    assertThat(streamFactory, sameInstance(dummyStreamFactory));
+                    assertThat(position.getAndSet(relativePos), lessThan(relativePos));
+                    progressUpdater.accept(length);
                 }
             };
 

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -86,7 +86,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -164,7 +164,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -208,7 +208,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -242,7 +242,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -276,7 +276,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -384,7 +384,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -459,7 +459,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 threadPool,
-                threadPool.executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -539,7 +539,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 threadPool,
-                threadPool.executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -598,7 +598,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 threadPool,
-                threadPool.executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -801,7 +801,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -819,7 +819,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -844,7 +844,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -939,7 +939,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 threadPool,
-                threadPool.executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -1077,7 +1077,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 threadPool,
-                threadPool.executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -1226,7 +1226,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {
@@ -1318,7 +1318,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
-                taskQueue.getThreadPool().executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             ) {
                 @Override
@@ -1359,7 +1359,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 environment,
                 settings,
                 threadPool,
-                threadPool.executor(ThreadPool.Names.GENERIC),
+                ThreadPool.Names.GENERIC,
                 BlobCacheMetrics.NOOP
             )
         ) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -331,7 +331,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
                 nodeEnvironment,
                 settings,
                 threadPool,
-                threadPool.executor(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME),
+                SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
                 new BlobCacheMetrics(services.telemetryProvider().getMeterRegistry())
             );
             this.frozenCacheService.set(sharedBlobCacheService);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.blobcache.BlobCacheUtils;
 import org.elasticsearch.blobcache.common.ByteBufferReference;
 import org.elasticsearch.blobcache.common.ByteRange;
@@ -147,38 +146,32 @@ public final class FrozenIndexInput extends MetadataCachingIndexInput {
                 final int read = SharedBytes.readCacheFile(channel, pos, relativePos, len, byteBufferReference);
                 stats.addCachedBytesRead(read);
                 return read;
-            },
-                (channel, channelPos, streamFactory, relativePos, len, progressUpdater, completionListener) -> ActionListener.completeWith(
-                    completionListener,
-                    () -> {
-                        assert streamFactory == null : streamFactory;
-                        final long startTimeNanos = stats.currentTimeNanos();
-                        try (InputStream input = openInputStreamFromBlobStore(rangeToWrite.start() + relativePos, len)) {
-                            assert ThreadPool.assertCurrentThreadPool(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
-                            logger.trace(
-                                "{}: writing channel {} pos {} length {} (details: {})",
-                                fileInfo.physicalName(),
-                                channelPos,
-                                relativePos,
-                                len,
-                                cacheFile
-                            );
-                            SharedBytes.copyToCacheFileAligned(
-                                channel,
-                                input,
-                                channelPos,
-                                relativePos,
-                                len,
-                                progressUpdater,
-                                writeBuffer.get().clear()
-                            );
-                            final long endTimeNanos = stats.currentTimeNanos();
-                            stats.addCachedBytesWritten(len, endTimeNanos - startTimeNanos);
-                            return null;
-                        }
-                    }
-                )
-            );
+            }, (channel, channelPos, streamFactory, relativePos, len, progressUpdater) -> {
+                assert streamFactory == null : streamFactory;
+                final long startTimeNanos = stats.currentTimeNanos();
+                try (InputStream input = openInputStreamFromBlobStore(rangeToWrite.start() + relativePos, len)) {
+                    assert ThreadPool.assertCurrentThreadPool(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
+                    logger.trace(
+                        "{}: writing channel {} pos {} length {} (details: {})",
+                        fileInfo.physicalName(),
+                        channelPos,
+                        relativePos,
+                        len,
+                        cacheFile
+                    );
+                    SharedBytes.copyToCacheFileAligned(
+                        channel,
+                        input,
+                        channelPos,
+                        relativePos,
+                        len,
+                        progressUpdater,
+                        writeBuffer.get().clear()
+                    );
+                    final long endTimeNanos = stats.currentTimeNanos();
+                    stats.addCachedBytesWritten(len, endTimeNanos - startTimeNanos);
+                }
+            });
             assert bytesRead == length : bytesRead + " vs " + length;
             byteBufferReference.finish(bytesRead);
         } finally {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -144,7 +144,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
             nodeEnvironment,
             Settings.EMPTY,
             threadPool,
-            threadPool.executor(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME),
+            SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
             BlobCacheMetrics.NOOP
         );
     }
@@ -167,7 +167,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
             singlePathNodeEnvironment,
             cacheSettings.build(),
             threadPool,
-            threadPool.executor(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME),
+            SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
             BlobCacheMetrics.NOOP
         );
     }
@@ -192,7 +192,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
                 .put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), cacheRangeSize)
                 .build(),
             threadPool,
-            threadPool.executor(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME),
+            SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
             BlobCacheMetrics.NOOP
         );
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -111,7 +111,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
                 nodeEnvironment,
                 settings,
                 threadPool,
-                threadPool.executor(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME),
+                SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
                 BlobCacheMetrics.NOOP
             );
             CacheService cacheService = randomCacheService();


### PR DESCRIPTION
Also 

* Revert "Give executor to cache instead of string #111711"