### PR TITLE
Add maximum nested depth check to WKT parser

### DIFF
--- a/docs/changelog/111843.yaml
+++ b/docs/changelog/111843.yaml
@@ -1,0 +1,5 @@
+pr: 111843
+summary: Add maximum nested depth check to WKT parser
+area: Geo
+type: bug
+issues: []

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownText.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownText.java
@@ -43,6 +43,7 @@ public class WellKnownText {
     public static final String RPAREN = ")";
     public static final String COMMA = ",";
     public static final String NAN = "NaN";
+    public static final int MAX_NESTED_DEPTH = 1000;
 
     private static final String NUMBER = "<NUMBER>";
     private static final String EOF = "END-OF-STREAM";
@@ -425,7 +426,7 @@ public class WellKnownText {
             tokenizer.whitespaceChars('\r', '\r');
             tokenizer.whitespaceChars('\n', '\n');
             tokenizer.commentChar('#');
-            Geometry geometry = parseGeometry(tokenizer, coerce);
+            Geometry geometry = parseGeometry(tokenizer, coerce, 0);
             validator.validate(geometry);
             return geometry;
         } finally {
@@ -436,40 +437,35 @@ public class WellKnownText {
     /**
      * parse geometry from the stream tokenizer
      */
-    private static Geometry parseGeometry(StreamTokenizer stream, boolean coerce) throws IOException, ParseException {
+    private static Geometry parseGeometry(StreamTokenizer stream, boolean coerce, int depth) throws IOException, ParseException {
         final String type = nextWord(stream).toLowerCase(Locale.ROOT);
-        switch (type) {
-            case "point":
-                return parsePoint(stream);
-            case "multipoint":
-                return parseMultiPoint(stream);
-            case "linestring":
-                return parseLine(stream);
-            case "multilinestring":
-                return parseMultiLine(stream);
-            case "polygon":
-                return parsePolygon(stream, coerce);
-            case "multipolygon":
-                return parseMultiPolygon(stream, coerce);
-            case "bbox":
-                return parseBBox(stream);
-            case "geometrycollection":
-                return parseGeometryCollection(stream, coerce);
-            case "circle": // Not part of the standard, but we need it for internal serialization
-                return parseCircle(stream);
-        }
-        throw new IllegalArgumentException("Unknown geometry type: " + type);
+        return switch (type) {
+            case "point" -> parsePoint(stream);
+            case "multipoint" -> parseMultiPoint(stream);
+            case "linestring" -> parseLine(stream);
+            case "multilinestring" -> parseMultiLine(stream);
+            case "polygon" -> parsePolygon(stream, coerce);
+            case "multipolygon" -> parseMultiPolygon(stream, coerce);
+            case "bbox" -> parseBBox(stream);
+            case "geometrycollection" -> parseGeometryCollection(stream, coerce, depth + 1);
+            case "circle" -> // Not part of the standard, but we need it for internal serialization
+                parseCircle(stream);
+            default -> throw new IllegalArgumentException("Unknown geometry type: " + type);
+        };
     }
 
-    private static GeometryCollection<Geometry> parseGeometryCollection(StreamTokenizer stream, boolean coerce) throws IOException,
-        ParseException {
+    private static GeometryCollection<Geometry> parseGeometryCollection(StreamTokenizer stream, boolean coerce, int depth)
+        throws IOException, ParseException {
         if (nextEmptyOrOpen(stream).equals(EMPTY)) {
             return GeometryCollection.EMPTY;
         }
+        if (depth > MAX_NESTED_DEPTH) {
+            throw new ParseException("maximum nested depth of " + MAX_NESTED_DEPTH + " exceeded", stream.lineno());
+        }
         List<Geometry> shapes = new ArrayList<>();
-        shapes.add(parseGeometry(stream, coerce));
+        shapes.add(parseGeometry(stream, coerce, depth));
         while (nextCloserOrComma(stream).equals(COMMA)) {
-            shapes.add(parseGeometry(stream, coerce));
+            shapes.add(parseGeometry(stream, coerce, depth));
         }
         return new GeometryCollection<>(shapes);
     }


### PR DESCRIPTION
This prevents StackOverflowErrors, replacing them with ParseException errors, which is more easily managed by running servers.
