### PR TITLE
Reduce `CompletableFuture` usage in tests

### DIFF
--- a/libs/grok/src/test/java/org/elasticsearch/grok/MatcherWatchdogTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/MatcherWatchdogTests.java
@@ -7,12 +7,12 @@
  */
 package org.elasticsearch.grok;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.test.ESTestCase;
 import org.joni.Matcher;
 import org.mockito.Mockito;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -77,16 +77,17 @@ public class MatcherWatchdogTests extends ESTestCase {
         );
         // Periodic action is not scheduled because no thread is registered
         verifyNoMoreInteractions(threadPool);
-        CompletableFuture<Runnable> commandFuture = new CompletableFuture<>();
+
+        PlainActionFuture<Runnable> commandFuture = new PlainActionFuture<>();
         // Periodic action is scheduled because a thread is registered
         doAnswer(invocationOnMock -> {
-            commandFuture.complete((Runnable) invocationOnMock.getArguments()[0]);
+            commandFuture.onResponse(invocationOnMock.getArgument(0));
             return null;
         }).when(threadPool).schedule(any(Runnable.class), eq(interval), eq(TimeUnit.MILLISECONDS));
         Matcher matcher = mock(Matcher.class);
         watchdog.register(matcher);
         // Registering the first thread should have caused the command to get scheduled again
-        Runnable command = commandFuture.get(1L, TimeUnit.MILLISECONDS);
+        Runnable command = safeGet(commandFuture);
         Mockito.reset(threadPool);
         watchdog.unregister(matcher);
         command.run();

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterName;
@@ -60,9 +61,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -201,9 +200,6 @@ public class BulkOperationTests extends ESTestCase {
     public void testClusterBlockedFailsBulk() {
         NodeClient client = getNodeClient(assertNoClientInteraction());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
         // Not retryable
         ClusterState state = ClusterState.builder(DEFAULT_STATE)
             .blocks(ClusterBlocks.builder().addGlobalBlock(Metadata.CLUSTER_READ_ONLY_BLOCK).build())
@@ -215,9 +211,10 @@ public class BulkOperationTests extends ESTestCase {
         when(observer.isTimedOut()).thenReturn(false);
         doThrow(new AssertionError("Should not wait")).when(observer).waitForNextChange(any());
 
-        newBulkOperation(client, new BulkRequest(), state, observer, listener).run();
-
-        expectThrows(ExecutionException.class, ClusterBlockException.class, future::get);
+        assertThat(
+            safeAwaitFailure(BulkResponse.class, l -> newBulkOperation(client, new BulkRequest(), state, observer, l).run()),
+            instanceOf(ClusterBlockException.class)
+        );
     }
 
     /**
@@ -225,9 +222,6 @@ public class BulkOperationTests extends ESTestCase {
      */
     public void testTimeoutOnRetryableClusterBlockedFailsBulk() {
         NodeClient client = getNodeClient(assertNoClientInteraction());
-
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
 
         // Retryable
         final ClusterState state = ClusterState.builder(DEFAULT_STATE)
@@ -248,9 +242,11 @@ public class BulkOperationTests extends ESTestCase {
             return null;
         }).doThrow(new AssertionError("Should not wait")).when(observer).waitForNextChange(any());
 
-        newBulkOperation(client, new BulkRequest(), state, observer, listener).run();
+        assertThat(
+            safeAwaitFailure(BulkResponse.class, l -> newBulkOperation(client, new BulkRequest(), state, observer, l).run()),
+            instanceOf(ClusterBlockException.class)
+        );
 
-        expectThrows(ExecutionException.class, ClusterBlockException.class, future::get);
         verify(observer, times(2)).isTimedOut();
         verify(observer, times(1)).waitForNextChange(any());
     }
@@ -260,9 +256,6 @@ public class BulkOperationTests extends ESTestCase {
      */
     public void testNodeClosedOnRetryableClusterBlockedFailsBulk() {
         NodeClient client = getNodeClient(assertNoClientInteraction());
-
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
 
         // Retryable
         final ClusterState state = ClusterState.builder(DEFAULT_STATE)
@@ -278,9 +271,10 @@ public class BulkOperationTests extends ESTestCase {
             return null;
         }).doThrow(new AssertionError("Should not wait")).when(observer).waitForNextChange(any());
 
-        newBulkOperation(client, new BulkRequest(), state, observer, listener).run();
-
-        expectThrows(ExecutionException.class, NodeClosedException.class, future::get);
+        assertThat(
+            safeAwaitFailure(BulkResponse.class, l -> newBulkOperation(client, new BulkRequest(), state, observer, l).run()),
+            instanceOf(NodeClosedException.class)
+        );
         verify(observer, times(1)).isTimedOut();
         verify(observer, times(1)).waitForNextChange(any());
     }
@@ -296,12 +290,7 @@ public class BulkOperationTests extends ESTestCase {
 
         NodeClient client = getNodeClient(acceptAllShardWrites());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(false));
     }
 
@@ -318,12 +307,7 @@ public class BulkOperationTests extends ESTestCase {
             shardSpecificResponse(Map.of(new ShardId(indexMetadata.getIndex(), 0), failWithException(() -> new MapperException("test"))))
         );
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(true));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
@@ -344,12 +328,7 @@ public class BulkOperationTests extends ESTestCase {
 
         NodeClient client = getNodeClient(acceptAllShardWrites());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(false));
     }
 
@@ -366,12 +345,7 @@ public class BulkOperationTests extends ESTestCase {
             shardSpecificResponse(Map.of(new ShardId(ds1BackingIndex2.getIndex(), 0), failWithException(() -> new MapperException("test"))))
         );
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(true));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
@@ -396,12 +370,7 @@ public class BulkOperationTests extends ESTestCase {
             shardSpecificResponse(Map.of(new ShardId(ds2BackingIndex1.getIndex(), 0), failWithException(() -> new MapperException("test"))))
         );
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(false));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(item -> item.getIndex().equals(ds2FailureStore1.getIndex().getName()))
@@ -426,12 +395,7 @@ public class BulkOperationTests extends ESTestCase {
             thatFailsDocuments(Map.of(new IndexAndId(ds2BackingIndex1.getIndex().getName(), "3"), () -> new MapperException("test")))
         );
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(false));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(item -> item.getIndex().equals(ds2FailureStore1.getIndex().getName()))
@@ -465,12 +429,7 @@ public class BulkOperationTests extends ESTestCase {
             )
         );
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(true));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
@@ -500,16 +459,12 @@ public class BulkOperationTests extends ESTestCase {
             thatFailsDocuments(Map.of(new IndexAndId(ds2BackingIndex1.getIndex().getName(), "3"), () -> new MapperException("root cause")))
         );
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
         // Mock a failure store document converter that always fails
         FailureStoreDocumentConverter mockConverter = mock(FailureStoreDocumentConverter.class);
         when(mockConverter.transformFailedRequest(any(), any(), any(), any())).thenThrow(new IOException("Could not serialize json"));
 
-        newBulkOperation(client, bulkRequest, mockConverter, listener).run();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, mockConverter, l).run());
 
-        BulkResponse bulkItemResponses = future.get();
         assertThat(bulkItemResponses.hasFailures(), is(true));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
@@ -579,12 +534,9 @@ public class BulkOperationTests extends ESTestCase {
             return null;
         }).when(observer).waitForNextChange(any());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.notifyOnce(
-            ActionListener.wrap(future::complete, future::completeExceptionally)
+        final SubscribableListener<BulkResponse> responseListener = SubscribableListener.newForked(
+            l -> newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, l).run()
         );
-
-        newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, listener).run();
 
         // The operation will attempt to write the documents in the request, receive a failure, wait for a stable cluster state, and then
         // redirect the failed documents to the failure store. Wait for that failure store write to start:
@@ -595,7 +547,7 @@ public class BulkOperationTests extends ESTestCase {
         }
 
         // Check to make sure there is no response yet
-        if (future.isDone()) {
+        if (responseListener.isDone()) {
             // we're going to fail the test, but be a good citizen and unblock the other thread first
             beginFailureStoreWrite.countDown();
             fail("bulk operation completed prematurely");
@@ -605,7 +557,7 @@ public class BulkOperationTests extends ESTestCase {
         beginFailureStoreWrite.countDown();
 
         // Await final result and verify
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(responseListener);
         assertThat(bulkItemResponses.hasFailures(), is(false));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(item -> item.getIndex().equals(ds2FailureStore1.getIndex().getName()))
@@ -650,12 +602,7 @@ public class BulkOperationTests extends ESTestCase {
         when(observer.isTimedOut()).thenReturn(false);
         doThrow(new AssertionError("Should not wait on non retryable block")).when(observer).waitForNextChange(any());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(true));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
@@ -715,12 +662,7 @@ public class BulkOperationTests extends ESTestCase {
             return null;
         }).doThrow(new AssertionError("Should not wait any longer")).when(observer).waitForNextChange(any());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, l).run());
         assertThat(bulkItemResponses.hasFailures(), is(true));
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
@@ -775,12 +717,10 @@ public class BulkOperationTests extends ESTestCase {
             return null;
         }).doThrow(new AssertionError("Should not wait any longer")).when(observer).waitForNextChange(any());
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, listener).run();
-
-        expectThrows(ExecutionException.class, NodeClosedException.class, future::get);
+        assertThat(
+            safeAwaitFailure(BulkResponse.class, l -> newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, l).run()),
+            instanceOf(NodeClosedException.class)
+        );
 
         verify(observer, times(1)).isTimedOut();
         verify(observer, times(1)).waitForNextChange(any());
@@ -832,12 +772,7 @@ public class BulkOperationTests extends ESTestCase {
         ClusterState rolledOverState = ClusterState.builder(DEFAULT_STATE).metadata(metadata).build();
         ClusterStateObserver observer = mockObserver(DEFAULT_STATE, DEFAULT_STATE, rolledOverState);
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, l).run());
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(item -> item.getIndex().equals(ds3FailureStore2.getIndex().getName()))
             .findFirst()
@@ -880,12 +815,7 @@ public class BulkOperationTests extends ESTestCase {
         ClusterState rolledOverState = ClusterState.builder(DEFAULT_STATE).metadata(metadata).build();
         ClusterStateObserver observer = mockObserver(DEFAULT_STATE, DEFAULT_STATE, rolledOverState);
 
-        CompletableFuture<BulkResponse> future = new CompletableFuture<>();
-        ActionListener<BulkResponse> listener = ActionListener.wrap(future::complete, future::completeExceptionally);
-
-        newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, listener).run();
-
-        BulkResponse bulkItemResponses = future.get();
+        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, DEFAULT_STATE, observer, l).run());
         BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
             .filter(BulkItemResponse::isFailed)
             .findFirst()


### PR DESCRIPTION
Fixes some spots in tests where we use `CompletableFuture` instead of
one of the preferred alternatives.