### PR TITLE
[ES|QL] allow mixed numeric types as inputs to coalesce

### DIFF
--- a/docs/changelog/111853.yaml
+++ b/docs/changelog/111853.yaml
@@ -1,0 +1,5 @@
+pr: 111853
+summary: "[ES|QL] allow mixed numeric types as inputs to coalesce"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/null.csv-spec
@@ -142,3 +142,35 @@ emp_no:integer | first_name:keyword | foo:boolean
          10002 | Bezalel            | true
          10003 | Parto              | true
 ;
+
+coalesceMixedNumeric
+required_capability: mixed_numeric_types_in_coalesce
+FROM employees
+| WHERE emp_no <= 10021 and emp_no >= 10018
+| EVAL x = coalesce(languages.long, 0.0), y = coalesce(languages.long, 0), z = coalesce(languages, 0.0), w = coalesce(height, 0)
+| SORT emp_no ASC
+| KEEP emp_no, languages.long, x, y, z, w
+;
+
+emp_no:integer | languages.long:long | x:double | y:long | z:double | w:double
+         10018 | 2                   | 2.0      | 2      | 2.0      | 1.97
+         10019 | 1                   | 1.0      | 1      | 1.0      | 2.06
+         10020 | null                | 0.0      | 0      | 0.0      | 1.41
+         10021 | null                | 0.0      | 0      | 0.0      | 1.47
+;
+
+coalesceMixedNumericWithNull
+required_capability: mixed_numeric_types_in_coalesce
+FROM employees
+| WHERE emp_no <= 10021 and emp_no >= 10018
+| EVAL x = coalesce(languages.long, null, 0.0), y = coalesce(languages.long, null, 0), z = coalesce(languages, 0.0), w = coalesce(height, 0)
+| SORT emp_no ASC
+| KEEP emp_no, languages.long, x, y, z, w
+;
+
+emp_no:integer | languages.long:long | x:double | y:long | z:double | w:double
+         10018 | 2                   | 2.0      | 2      | 2.0      | 1.97
+         10019 | 1                   | 1.0      | 1      | 1.0      | 2.06
+         10020 | null                | 0.0      | 0      | 0.0      | 1.41
+         10021 | null                | 0.0      | 0      | 0.0      | 1.47
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -224,7 +224,12 @@ public class EsqlCapabilities {
         /**
          * Support CIDRMatch in CombineDisjunctions rule.
          */
-        COMBINE_DISJUNCTIVE_CIDRMATCHES;
+        COMBINE_DISJUNCTIVE_CIDRMATCHES,
+
+        /**
+         * Allow mixed numeric types in coalesce
+         */
+        MIXED_NUMERIC_TYPES_IN_COALESCE;
 
         private final boolean snapshotOnly;
         private final FeatureFlag featureFlag;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/DateTimeArithmeticOperation.java
@@ -29,6 +29,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.isDateTime;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isDateTimeOrTemporal;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isNull;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isTemporalAmount;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.formatIncompatibleTypesMessage;
 
 public abstract class DateTimeArithmeticOperation extends EsqlArithmeticOperation {
     /** Arithmetic (quad) function. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/EsqlArithmeticOperation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/EsqlArithmeticOperation.java
@@ -26,11 +26,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.formatIncompatibleTypesMessage;
 
 public abstract class EsqlArithmeticOperation extends ArithmeticOperation implements EvaluatorMapper {
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
@@ -164,10 +164,6 @@ public abstract class EsqlArithmeticOperation extends ArithmeticOperation implem
 
         // at this point, left should be null, and right should be null or numeric.
         return TypeResolution.TYPE_RESOLVED;
-    }
-
-    public static String formatIncompatibleTypesMessage(String symbol, DataType leftType, DataType rightType) {
-        return format(null, "[{}] has arguments with incompatible types [{}] and [{}]", symbol, leftType.typeName(), rightType.typeName());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -54,6 +54,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.util.Map.entry;
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
@@ -489,5 +490,9 @@ public class EsqlDataTypeConverter {
 
     public static BiFunction<Source, Expression, AbstractConvertFunction> converterFunctionFactory(DataType toType) {
         return TYPE_TO_CONVERTER_FUNCTION.get(toType);
+    }
+
+    public static String formatIncompatibleTypesMessage(String symbol, DataType leftType, DataType rightType) {
+        return format(null, "[{}] has arguments with incompatible types [{}] and [{}]", symbol, leftType.typeName(), rightType.typeName());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2065,6 +2065,16 @@ public class AnalyzerTests extends ESTestCase {
         );
     }
 
+    public void testCoalesceWithMixedNumericTypes() {
+        LogicalPlan plan = analyze("""
+            from test
+            | eval x = coalesce(salary_change, null, 0), y = coalesce(languages, null, 0.0), z = coalesce(languages.long, null, 0.0)
+            | keep x, y
+            """, "mapping-default.json");
+        var limit = as(plan, Limit.class);
+        assertThat(limit.limit().fold(), equalTo(1000));
+    }
+
     private void verifyUnsupported(String query, String errorMessage) {
         verifyUnsupported(query, errorMessage, "mapping-multi-field-variation.json");
     }


### PR DESCRIPTION
Today, `COALESCE` enforces the same data type among all of the input parameters, e.g. if there are both `INTEGER` and `LONG` in the inputs, it returns an error, please refer to the example below. 

```
FROM employees
| WHERE emp_no <= 10021 and emp_no >= 10018
| EVAL x = coalesce(languages.long, null, 0.0), y = coalesce(languages.long, null, 0), z = coalesce(languages, 0.0), w = coalesce(height, 0);

org.elasticsearch.xpack.esql.VerificationException: Found 4 problems
line 3:12: third argument of [coalesce(languages.long, null, 0.0)] must be [long], found value [0.0] type [double]
line 3:53: third argument of [coalesce(languages.long, null, 0)] must be [long], found value [0] type [integer]
line 3:92: second argument of [coalesce(languages, 0.0)] must be [integer], found value [0.0] type [double]
line 3:122: second argument of [coalesce(height, 0)] must be [double], found value [0] type [integer]
```

This PR is to allow mixed numeric types in the inputs.