### PR TITLE
Explain Function Score Query 8.15 Backport

### DIFF
--- a/docs/changelog/111807.yaml
+++ b/docs/changelog/111807.yaml
@@ -1,0 +1,5 @@
+pr: 111807
+summary: Explain Function Score Query
+area: Search
+type: bug
+issues: []

--- a/docs/changelog/111864.yaml
+++ b/docs/changelog/111864.yaml
@@ -1,0 +1,5 @@
+pr: 111864
+summary: Explain function score query 815
+area: Search
+type: bug
+issues: []

--- a/docs/changelog/111864.yaml
+++ b/docs/changelog/111864.yaml
@@ -1,5 +1,0 @@
-pr: 111864
-summary: Explain function score query 815
-area: Search
-type: bug
-issues: []

--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -35,10 +35,7 @@ import java.util.Set;
 public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
 
     @Override
-    public ScriptEngine getScriptEngine(
-        Settings settings,
-        Collection<ScriptContext<?>> contexts
-    ) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new MyExpertScriptEngine();
     }
 
@@ -143,6 +140,9 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
                         public double execute(
                             ExplanationHolder explanation
                         ) {
+                            if(explanation != null) {
+                                explanation.set("An example optional custom description to explain details for this script's execution; we'll provide a default one if you leave this out.");
+                            }
                             return 0.0d;
                         }
                     };
@@ -166,6 +166,9 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
                     }
                     @Override
                     public double execute(ExplanationHolder explanation) {
+                        if(explanation != null) {
+                            explanation.set("An example optional custom description to explain details for this script's execution; we'll provide a default one if you leave this out.");
+                        }
                         if (postings.docID() != currentDocid) {
                             /*
                              * advance moved past the current doc, so this

--- a/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/20_score.yml
+++ b/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/20_score.yml
@@ -4,26 +4,27 @@
 setup:
   - do:
       indices.create:
-          index:  test
+        index: test
 
   - do:
       index:
-        index:  test
-        id:     "1"
-        body:   { "important_field": "foo" }
+        index: test
+        id: "1"
+        body: { "important_field": "foo" }
   - do:
-        index:
-          index:  test
-          id:     "2"
-          body:   { "important_field": "foo foo foo" }
+      index:
+        index: test
+        id: "2"
+        body: { "important_field": "foo foo foo" }
   - do:
-        index:
-          index:  test
-          id:     "3"
-          body:   { "important_field": "foo foo" }
+      index:
+        index: test
+        id: "3"
+        body: { "important_field": "foo foo" }
 
   - do:
-      indices.refresh: {}
+      indices.refresh: { }
+
 ---
 "document scoring":
   - do:
@@ -46,6 +47,39 @@ setup:
                         term: "foo"
 
   - length: { hits.hits: 3 }
-  - match: {hits.hits.0._id: "2" }
-  - match: {hits.hits.1._id: "3" }
-  - match: {hits.hits.2._id: "1" }
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "3" }
+  - match: { hits.hits.2._id: "1" }
+
+---
+"document scoring with custom explanation":
+
+  - requires:
+      cluster_features: [ "gte_v8.16.0" ]
+      reason: "bug fixed where explanations were throwing npe prior to 8.16"
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          explain: true
+          query:
+            function_score:
+              query:
+                match:
+                  important_field: "foo"
+              functions:
+                - script_score:
+                    script:
+                      source: "pure_df"
+                      lang: "expert_scripts"
+                      params:
+                        field: "important_field"
+                        term: "foo"
+
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "3" }
+  - match: { hits.hits.2._id: "1" }
+  - match: { hits.hits.0._explanation.details.1.details.0.description: "An example optional custom description to explain details for this script's execution; we'll provide a default one if you leave this out." }

--- a/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/20_score.yml
+++ b/plugins/examples/script-expert-scoring/src/yamlRestTest/resources/rest-api-spec/test/script_expert_scoring/20_score.yml
@@ -55,7 +55,7 @@ setup:
 "document scoring with custom explanation":
 
   - requires:
-      cluster_features: [ "gte_v8.16.0" ]
+      cluster_features: [ "gte_v8.15.1" ]
       reason: "bug fixed where explanations were throwing npe prior to 8.16"
 
   - do:


### PR DESCRIPTION
Addressing an NPE found when building a custom plugin leveraging a script.
https://github.com/elastic/elasticsearch/issues/109177

This occurs when calling execute on a ScoreScript like this: 
```
public double execute(ExplanationHolder explanation) {
    explanation.set("An example optional custom description to explain details for this script's execution; we'll provide a default one if you leave this out.");
   ...
}
```

<details>
<summary>Example Returned Hit with the Explanation Customized</summary>
<pre>
{
  "_shard" : "[test][0]",
  "_node" : "6aOP4_Q5SOGIyr4oIxj0TQ",
  "_index" : "test",
  "_id" : "2",
  "_score" : 0.5685853,
  "_source" : {
    "important_field" : "foo foo foo"
  },
  "_explanation" : {
    "value" : 0.5685853,
    "description" : "function score, product of:",
    "details" : [
      ...
      {
        "value" : 3.0,
        "description" : "min of:",
        "details" : [
          {
            "value" : 3.0,
            "description" : "An example optional custom description to explain details for this script's execution; we'll provide a default one if you leave this out.",
            "details" : [
              {
                "value" : 0.18952844,
                "description" : "_score: ",
                "details" : [
                  {
                    "value" : 0.18952844,
                    "description" : "weight(important_field:foo in 1) [PerFieldSimilarity], result of:",
                    "details" : [
                      {
                        "value" : 0.18952844,
                        "description" : "score(freq=3.0), computed as boost * idf * tf from:",
                        "details" : [
                          {
                            "value" : 2.2,
                            "description" : "boost",
                            "details" : [ ]
                          },
                          {
                            "value" : 0.13353139,
                            "description" : "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                            "details" : [
                              {
                                "value" : 3,
                                "description" : "n, number of documents containing term",
                                "details" : [ ]
                              },
                              {
                                "value" : 3,
                                "description" : "N, total number of documents with field",
                                "details" : [ ]
                              }
                            ]
                          },
                          {
                            "value" : 0.6451613,
                            "description" : "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                            "details" : [
                              {
                                "value" : 3.0,
                                "description" : "freq, occurrences of term within document",
                                "details" : [ ]
                              },
                              {
                                "value" : 1.2,
                                "description" : "k1, term saturation parameter",
                                "details" : [ ]
                              },
                              {
                                "value" : 0.75,
                                "description" : "b, length normalization parameter",
                                "details" : [ ]
                              },
                              {
                                "value" : 3.0,
                                "description" : "dl, length of field",
                                "details" : [ ]
                              },
                              {
                                "value" : 2.0,
                                "description" : "avgdl, average length of field",
                                "details" : [ ]
                              }
                            ]
                          }
                        ]
                      }
                    ]
                  }
                ]
              }
            ]
          },
          {
            "value" : 3.4028235E38,
            "description" : "maxBoost",
            "details" : [ ]
          }
        ]
      }
    ]
  }
}
</pre>
</details> 

<details>
<summary>What the Hit Would Normally Look Like Without the Custom Explanation</summary>
<pre>
{
  "_shard" : "[test][0]",
  "_node" : "Fg3ne_PXSi2ljhqljA6QOQ",
  "_index" : "test",
  "_id" : "2",
  "_score" : 0.5685853,
  "_source" : {
    "important_field" : "foo foo foo"
  },
  "_explanation" : {
    "value" : 0.5685853,
    "description" : "function score, product of:",
    "details" : [
      ...
      {
        "value" : 3.0,
        "description" : "min of:",
        "details" : [
          {
            "value" : 3.0,
            "description" : "script score function, computed with script:\"Script{type=inline, lang='expert_scripts', idOrCode='pure_df', options={}, params={field=important_field, term=foo}}\"",
            "details" : [
              {
                "value" : 0.18952844,
                "description" : "_score: ",
                "details" : [
                  {
                    "value" : 0.18952844,
                    "description" : "weight(important_field:foo in 1) [PerFieldSimilarity], result of:",
                    "details" : [
                      {
                        "value" : 0.18952844,
                        "description" : "score(freq=3.0), computed as boost * idf * tf from:",
                        "details" : [
                          {
                            "value" : 2.2,
                            "description" : "boost",
                            "details" : [ ]
                          },
                          {
                            "value" : 0.13353139,
                            "description" : "idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
                            "details" : [
                              {
                                "value" : 3,
                                "description" : "n, number of documents containing term",
                                "details" : [ ]
                              },
                              {
                                "value" : 3,
                                "description" : "N, total number of documents with field",
                                "details" : [ ]
                              }
                            ]
                          },
                          {
                            "value" : 0.6451613,
                            "description" : "tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
                            "details" : [
                              {
                                "value" : 3.0,
                                "description" : "freq, occurrences of term within document",
                                "details" : [ ]
                              },
                              {
                                "value" : 1.2,
                                "description" : "k1, term saturation parameter",
                                "details" : [ ]
                              },
                              {
                                "value" : 0.75,
                                "description" : "b, length normalization parameter",
                                "details" : [ ]
                              },
                              {
                                "value" : 3.0,
                                "description" : "dl, length of field",
                                "details" : [ ]
                              },
                              {
                                "value" : 2.0,
                                "description" : "avgdl, average length of field",
                                "details" : [ ]
                              }
                            ]
                          }
                        ]
                      }
                    ]
                  }
                ]
              }
            ]
          },
          {
            "value" : 3.4028235E38,
            "description" : "maxBoost",
            "details" : [ ]
          }
        ]
      }
    ]
  }
}
</pre>
</details> 

