### PR TITLE
Fix windows memory locking

### DIFF
--- a/docs/changelog/111866.yaml
+++ b/docs/changelog/111866.yaml
@@ -2,4 +2,5 @@ pr: 111866
 summary: Fix windows memory locking
 area: Infra/Core
 type: bug
-issues: []
+issues:
+ - 111847

--- a/docs/changelog/111866.yaml
+++ b/docs/changelog/111866.yaml
@@ -1,0 +1,5 @@
+pr: 111866
+summary: Fix windows memory locking
+area: Infra/Core
+type: bug
+issues: []

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkKernel32Library.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkKernel32Library.java
@@ -115,7 +115,7 @@ class JdkKernel32Library implements Kernel32Library {
 
         @Override
         public Address add(long offset) {
-            return new JdkAddress(MemorySegment.ofAddress(address.address()));
+            return new JdkAddress(MemorySegment.ofAddress(address.address() + offset));
         }
     }
 

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkKernel32Library.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkKernel32Library.java
@@ -56,7 +56,7 @@ class JdkKernel32Library implements Kernel32Library {
     );
     private static final MethodHandle SetProcessWorkingSetSize$mh = downcallHandleWithError(
         "SetProcessWorkingSetSize",
-        FunctionDescriptor.of(ADDRESS, JAVA_LONG, JAVA_LONG)
+        FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_LONG, JAVA_LONG)
     );
     private static final MethodHandle GetCompressedFileSizeW$mh = downcallHandleWithError(
         "GetCompressedFileSizeW",

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/MemoryLockingTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/MemoryLockingTests.java
@@ -23,17 +23,20 @@ public class MemoryLockingTests extends PackagingTestCase {
     }
 
     public void test20MemoryLockingEnabled() throws Exception {
-        configureAndRun(Map.of(
-            "bootstrap.memory_lock",
-            "true",
-            "xpack.security.enabled",
-            "false",
-            "xpack.security.http.ssl.enabled",
-            "false",
-            "xpack.security.enrollment.enabled",
-            "false",
-            "discovery.type",
-            "single-node"));
+        configureAndRun(
+            Map.of(
+                "bootstrap.memory_lock",
+                "true",
+                "xpack.security.enabled",
+                "false",
+                "xpack.security.http.ssl.enabled",
+                "false",
+                "xpack.security.enrollment.enabled",
+                "false",
+                "discovery.type",
+                "single-node"
+            )
+        );
         // TODO: very locking worked. logs? check memory of process? at least we know the process started successfully
         stopElasticsearch();
     }

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/MemoryLockingTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/MemoryLockingTests.java
@@ -23,7 +23,17 @@ public class MemoryLockingTests extends PackagingTestCase {
     }
 
     public void test20MemoryLockingEnabled() throws Exception {
-        configureAndRun(Map.of("bootstrap.memory_lock", "true"));
+        configureAndRun(Map.of(
+            "bootstrap.memory_lock",
+            "true",
+            "xpack.security.enabled",
+            "false",
+            "xpack.security.http.ssl.enabled",
+            "false",
+            "xpack.security.enrollment.enabled",
+            "false",
+            "discovery.type",
+            "single-node"));
         // TODO: very locking worked. logs? check memory of process? at least we know the process started successfully
         stopElasticsearch();
     }

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/MemoryLockingTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/MemoryLockingTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.packaging.test;
+
+import org.elasticsearch.packaging.util.ServerUtils;
+import org.elasticsearch.packaging.util.docker.DockerRun;
+
+import java.util.Map;
+
+import static org.elasticsearch.packaging.util.docker.Docker.runContainer;
+import static org.elasticsearch.packaging.util.docker.DockerRun.builder;
+
+public class MemoryLockingTests extends PackagingTestCase {
+
+    public void test10Install() throws Exception {
+        install();
+    }
+
+    public void test20MemoryLockingEnabled() throws Exception {
+        configureAndRun(Map.of("bootstrap.memory_lock", "true"));
+        // TODO: very locking worked. logs? check memory of process? at least we know the process started successfully
+        stopElasticsearch();
+    }
+
+    public void configureAndRun(Map<String, String> settings) throws Exception {
+        if (distribution().isDocker()) {
+            DockerRun builder = builder();
+            settings.forEach(builder::envVar);
+            runContainer(distribution(), builder);
+        } else {
+
+            for (var setting : settings.entrySet()) {
+                ServerUtils.addSettingToExistingConfiguration(installation.config, setting.getKey(), setting.getValue());
+            }
+            ServerUtils.removeSettingFromExistingConfiguration(installation.config, "cluster.initial_master_nodes");
+        }
+
+        startElasticsearch();
+    }
+}


### PR DESCRIPTION
Memory locking on Windows with the bundled jdk was broken by native access refactoring. This commit fixes the linking issue, as well as adds a packaging test to ensure memory locking is invoked on all supported platforms.

closes #111847