### PR TITLE
[8.15] [DOCS] Fixes the description of 'affected_resources' in health API documentation (#111833)

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -204,9 +204,8 @@ for health status set `verbose` to `false` to disable the more expensive analysi
     `help_url` field.
 
 `affected_resources`::
-    (Optional, array of strings) If the root cause pertains to multiple resources in the
-    cluster (like indices, shards, nodes, etc...) this will hold all resources that this
-    diagnosis is applicable for.
+    (Optional, object) An object where the keys represent resource types (for example, indices, shards), 
+    and the values are lists of the specific resources affected by the issue.
 
 `help_url`::
     (string) A link to the troubleshooting guide that'll fix the health problem.


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [DOCS] Fixes the description of 'affected_resources' in health API documentation (#111833)