### PR TITLE
[DOCS] The logs index.mode has been renamed logsdb

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -113,7 +113,7 @@ Index mode supports the following values:
 
 `time_series`::: Index mode optimized for storage of metrics documented in <<tsds-index-settings,TSDS Settings>>.
 
-`logs`::: Index mode optimized for storage of logs. It applies default sort settings on the `hostname` and `timestamp` fields and uses <<synthetic-source,synthetic `_source`>>. <<index-modules-index-sorting,Index sorting>> on different fields is still allowed.
+`logsdb`::: Index mode optimized for storage of logs. It applies default sort settings on the `hostname` and `timestamp` fields and uses <<synthetic-source,synthetic `_source`>>. <<index-modules-index-sorting,Index sorting>> on different fields is still allowed.
 preview:[]
 
 [[routing-partition-size]] `index.routing_partition_size`::


### PR DESCRIPTION
Docfix for `logsdb`.
This should be backported to 8.15

I've not yet checked if there are other locations where `index.mode` is mentioned.