### PR TITLE
ESQL: Fix mutateInstance in EsIndexSerializationTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/index/EsIndexSerializationTests.java
@@ -58,8 +58,8 @@ public class EsIndexSerializationTests extends AbstractWireSerializingTestCase<E
     @Override
     protected EsIndex mutateInstance(EsIndex instance) throws IOException {
         String name = instance.name();
-        Map<String, EsField> mapping = randomMapping();
-        Set<String> concreteIndices = randomConcreteIndices();
+        Map<String, EsField> mapping = instance.mapping();
+        Set<String> concreteIndices = instance.concreteIndices();
         switch (between(0, 2)) {
             case 0 -> name = randomValueOtherThan(name, () -> randomAlphaOfLength(5));
             case 1 -> mapping = randomValueOtherThan(mapping, EsIndexSerializationTests::randomMapping);


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/111868

On main, I can find seeds with failures easily with
```
$ while ./gradlew ":x-pack:plugin:esql:test" --tests "org.elasticsearch.xpack.esql.index.EsIndexSerializationTests.testEqualsAndHashcode" -Dtests.iters=1000; do echo ok; done
```
I did that for a couple of minutes with the fixed code, and the tests continue to pass.