### PR TITLE
[DOCS] Documents output_field behavior after multiple inference runs

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -40,6 +40,11 @@ include::common-options.asciidoc[]
 Select the `content` field for inference and write the result to 
 `content_embedding`.
 
+IMPORTANT: If the specified `output_field` already exists, it won't be overwritten.
+The {infer} results will be added alongside the existing fields within `output_field`, which could lead to duplicate fields and potential errors.
+To avoid this, remove the `output_field` before running {infer} again.
+
+
 [source,js]
 --------------------------------------------------
 {

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -40,9 +40,9 @@ include::common-options.asciidoc[]
 Select the `content` field for inference and write the result to 
 `content_embedding`.
 
-IMPORTANT: If the specified `output_field` already exists, it won't be overwritten.
-The {infer} results will be added alongside the existing fields within `output_field`, which could lead to duplicate fields and potential errors.
-To avoid this, remove the `output_field` before running {infer} again.
+IMPORTANT: If the specified `output_field` already exists in the ingest document, it won't be overwritten.
+The {infer} results will be appended to the existing fields within `output_field`, which could lead to duplicate fields and potential errors.
+To avoid this, use an unique `output_field` field name that does not clash with any existing fields.
 
 
 [source,js]


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch/issues/107230.
This PR documents the `output_field` behavior after multiple inference process runs. The content won't be removed and overwritten. The new results will be added alongside the already existing fields. It may cause errors.

### Preview

[Inference processor docs](https://elasticsearch_bk_111875.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-processor.html#inference-input-output-example)