### PR TITLE
[7.17] Add maximum nested depth check to WKT parser (#111843)

### DIFF
--- a/docs/changelog/111843.yaml
+++ b/docs/changelog/111843.yaml
@@ -1,0 +1,5 @@
+pr: 111843
+summary: Add maximum nested depth check to WKT parser
+area: Geo
+type: bug
+issues: []

--- a/docs/changelog/111876.yaml
+++ b/docs/changelog/111876.yaml
@@ -1,5 +1,0 @@
-pr: 111876
-summary: "[7.17] Add maximum nested depth check to WKT parser"
-area: Geo
-type: bug
-issues: []

--- a/docs/changelog/111876.yaml
+++ b/docs/changelog/111876.yaml
@@ -1,0 +1,5 @@
+pr: 111876
+summary: "[7.17] Add maximum nested depth check to WKT parser"
+area: Geo
+type: bug
+issues: []


### PR DESCRIPTION
Manually backported #111843 to 7.17.

Since the original PR used Java language features not supported in Java8, and 7.17 requires Java8 language level support, some small changes needed to be made.