### PR TITLE
Warning about manually mounting a snapshot

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -204,9 +204,8 @@ for health status set `verbose` to `false` to disable the more expensive analysi
     `help_url` field.
 
 `affected_resources`::
-    (Optional, array of strings) If the root cause pertains to multiple resources in the
-    cluster (like indices, shards, nodes, etc...) this will hold all resources that this
-    diagnosis is applicable for.
+    (Optional, object) This field contains an object where the keys represent resource types (e.g., indices, shards), 
+    and the values are lists of the specific resources affected by the issue.
 
 `help_url`::
     (string) A link to the troubleshooting guide that'll fix the health problem.

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -7,6 +7,20 @@
 
 Mount a snapshot as a searchable snapshot index.
 
+WARNING: Manual Snapshot Mounting
+====
+When manually mounting a snapshot that was captured by an Index Lifecycle Management (ILM) policy, be aware of the following:
+
+* **ILM Managed Snapshots:** Snapshots taken by ILM policies are handled automatically by ILM. If you manually mount these snapshots, it can interfere with ILM's automated processes, such as managing or deleting snapshots.
+
+* **Potential Issues:** Manually mounting a snapshot can disrupt ILM actions, like deletions or phase transitions. This can lead to data loss or complications in managing your snapshots.
+
+* **Best Practice:** It's best to let ILM manage your snapshots. If you must manually mount a snapshot, make sure you understand how this affects ILM and manage the snapshot lifecycle separately.
+
+Always review the documentation and consider the impact on your data management before manually handling snapshots managed by ILM.
+====
+
+
 [[searchable-snapshots-api-mount-request]]
 ==== {api-request-title}
 


### PR DESCRIPTION
### Overview

This PR adds a warning about manually mounting snapshots that were captured by Index Lifecycle Management (ILM) policies in the documentation for the Mount Snapshot API.

**Related issue**: [#105816 ](https://github.com/elastic/elasticsearch/issues/105816)

### Preview

The updated documentation now includes a section with a warning about manual snapshot mounting:

Mount snapshot API