### PR TITLE
Adds a warning about manually mounting snapshots managed by ILM

### DIFF
--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -7,19 +7,6 @@
 
 Mount a snapshot as a searchable snapshot index.
 
-WARNING: Manual Snapshot Mounting
-====
-When manually mounting a snapshot that was captured by an Index Lifecycle Management (ILM) policy, be aware of the following:
-
-* **ILM Managed Snapshots:** Snapshots taken by ILM policies are handled automatically by ILM. If you manually mount these snapshots, it can interfere with ILM's automated processes, such as managing or deleting snapshots.
-
-* **Potential Issues:** Manually mounting a snapshot can disrupt ILM actions, like deletions or phase transitions. This can lead to data loss or complications in managing your snapshots.
-
-* **Best Practice:** It's best to let ILM manage your snapshots. If you must manually mount a snapshot, make sure you understand how this affects ILM and manage the snapshot lifecycle separately.
-
-Always review the documentation and consider the impact on your data management before manually handling snapshots managed by ILM.
-====
-
 [[searchable-snapshots-api-mount-request]]
 ==== {api-request-title}
 
@@ -36,6 +23,8 @@ For more information, see <<security-privileges>>.
 [[searchable-snapshots-api-mount-desc]]
 ==== {api-description-title}
 
+This API mounts a snapshot as a searchable snapshot index. 
+Note that manually mounting {ilm-init}-managed snapshots can <<manually-mounting-snapshots,interfere>> with <<index-lifecycle-management,{ilm-init} processes>>.
 
 [[searchable-snapshots-api-mount-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -7,6 +7,19 @@
 
 Mount a snapshot as a searchable snapshot index.
 
+WARNING: Manual Snapshot Mounting
+====
+When manually mounting a snapshot that was captured by an Index Lifecycle Management (ILM) policy, be aware of the following:
+
+* **ILM Managed Snapshots:** Snapshots taken by ILM policies are handled automatically by ILM. If you manually mount these snapshots, it can interfere with ILM's automated processes, such as managing or deleting snapshots.
+
+* **Potential Issues:** Manually mounting a snapshot can disrupt ILM actions, like deletions or phase transitions. This can lead to data loss or complications in managing your snapshots.
+
+* **Best Practice:** It's best to let ILM manage your snapshots. If you must manually mount a snapshot, make sure you understand how this affects ILM and manage the snapshot lifecycle separately.
+
+Always review the documentation and consider the impact on your data management before manually handling snapshots managed by ILM.
+====
+
 [[searchable-snapshots-api-mount-request]]
 ==== {api-request-title}
 

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -170,6 +170,17 @@ do not have a dedicated frozen tier, you must configure the
 cache on one or more nodes. Partially mounted indices are only allocated to
 nodes that have a shared cache.
 
+[[manually-mounting-snapshots]]
+[WARNING]
+.Manual snapshot mounting
+====
+Manually mounting snapshots captured by an Index Lifecycle Management ({ilm-init}) policy can
+interfere with {ilm-init}'s automatic management. This may lead to issues such as data loss
+or complications with snapshot handling. For optimal results, allow {ilm-init} to manage
+snapshots automatically. If manual mounting is necessary, be aware of its potential
+impact on {ilm-init} processes. For more information, learn about <<index-lifecycle-management,{ilm-init} snapshot management>>.
+====
+
 [[searchable-snapshots-shared-cache]]
 `xpack.searchable.snapshot.shared_cache.size`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
## Overview

This PR introduces a warning to the documentation for the Mount Snapshot API. 

**Related issue:** [#105816 ](https://github.com/elastic/elasticsearch/issues/105816)

### Preview

[Searchable snapshots](https://elasticsearch_bk_111883.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/searchable-snapshots.html)
[Mount snapshot API](https://elasticsearch_bk_111883.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html)