### PR TITLE
ESQL: Remove date_nanos from generated docs

### DIFF
--- a/docs/reference/esql/functions/kibana/definition/mv_count.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_count.json
@@ -44,18 +44,6 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "date_nanos",
-          "optional" : false,
-          "description" : "Multivalue expression."
-        }
-      ],
-      "variadic" : false,
-      "returnType" : "integer"
-    },
-    {
-      "params" : [
-        {
-          "name" : "field",
           "type" : "datetime",
           "optional" : false,
           "description" : "Multivalue expression."

--- a/docs/reference/esql/functions/kibana/definition/mv_first.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_first.json
@@ -44,18 +44,6 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "date_nanos",
-          "optional" : false,
-          "description" : "Multivalue expression."
-        }
-      ],
-      "variadic" : false,
-      "returnType" : "date_nanos"
-    },
-    {
-      "params" : [
-        {
-          "name" : "field",
           "type" : "datetime",
           "optional" : false,
           "description" : "Multivalue expression."

--- a/docs/reference/esql/functions/kibana/definition/mv_last.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_last.json
@@ -44,18 +44,6 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "date_nanos",
-          "optional" : false,
-          "description" : "Multivalue expression."
-        }
-      ],
-      "variadic" : false,
-      "returnType" : "date_nanos"
-    },
-    {
-      "params" : [
-        {
-          "name" : "field",
           "type" : "datetime",
           "optional" : false,
           "description" : "Multivalue expression."

--- a/docs/reference/esql/functions/kibana/definition/mv_max.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_max.json
@@ -20,18 +20,6 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "date_nanos",
-          "optional" : false,
-          "description" : "Multivalue expression."
-        }
-      ],
-      "variadic" : false,
-      "returnType" : "date_nanos"
-    },
-    {
-      "params" : [
-        {
-          "name" : "field",
           "type" : "datetime",
           "optional" : false,
           "description" : "Multivalue expression."

--- a/docs/reference/esql/functions/kibana/definition/mv_min.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_min.json
@@ -20,18 +20,6 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "date_nanos",
-          "optional" : false,
-          "description" : "Multivalue expression."
-        }
-      ],
-      "variadic" : false,
-      "returnType" : "date_nanos"
-    },
-    {
-      "params" : [
-        {
-          "name" : "field",
           "type" : "datetime",
           "optional" : false,
           "description" : "Multivalue expression."

--- a/docs/reference/esql/functions/types/mv_count.asciidoc
+++ b/docs/reference/esql/functions/types/mv_count.asciidoc
@@ -8,7 +8,6 @@ field | result
 boolean | integer
 cartesian_point | integer
 cartesian_shape | integer
-date_nanos | integer
 datetime | integer
 double | integer
 geo_point | integer

--- a/docs/reference/esql/functions/types/mv_first.asciidoc
+++ b/docs/reference/esql/functions/types/mv_first.asciidoc
@@ -8,7 +8,6 @@ field | result
 boolean | boolean
 cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape
-date_nanos | date_nanos
 datetime | datetime
 double | double
 geo_point | geo_point

--- a/docs/reference/esql/functions/types/mv_last.asciidoc
+++ b/docs/reference/esql/functions/types/mv_last.asciidoc
@@ -8,7 +8,6 @@ field | result
 boolean | boolean
 cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape
-date_nanos | date_nanos
 datetime | datetime
 double | double
 geo_point | geo_point

--- a/docs/reference/esql/functions/types/mv_max.asciidoc
+++ b/docs/reference/esql/functions/types/mv_max.asciidoc
@@ -6,7 +6,6 @@
 |===
 field | result
 boolean | boolean
-date_nanos | date_nanos
 datetime | datetime
 double | double
 integer | integer

--- a/docs/reference/esql/functions/types/mv_min.asciidoc
+++ b/docs/reference/esql/functions/types/mv_min.asciidoc
@@ -6,7 +6,6 @@
 |===
 field | result
 boolean | boolean
-date_nanos | date_nanos
 datetime | datetime
 double | double
 integer | integer

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -859,6 +859,9 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
 
         List<String> table = new ArrayList<>();
         for (Map.Entry<List<DataType>, DataType> sig : signatures().entrySet()) { // TODO flip to using sortedSignatures
+            if (shouldHideSignature(sig.getKey(), sig.getValue())) {
+                continue;
+            }
             if (sig.getKey().size() > argNames.size()) { // skip variadic [test] cases (but not those with optional parameters)
                 continue;
             }
@@ -1090,6 +1093,9 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
                 if (sig.getKey().size() < minArgCount) {
                     throw new IllegalArgumentException("signature " + sig.getKey() + " is missing non-optional arg for " + args);
                 }
+                if (shouldHideSignature(sig.getKey(), sig.getValue())) {
+                    continue;
+                }
                 builder.startObject();
                 builder.startArray("params");
                 for (int i = 0; i < sig.getKey().size(); i++) {
@@ -1274,5 +1280,16 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      */
     private static boolean isAggregation() {
         return AbstractAggregationTestCase.class.isAssignableFrom(getTestClass());
+    }
+
+    /**
+     * Should this particular signature be hidden from the docs even though we test it?
+     */
+    private static boolean shouldHideSignature(List<DataType> argTypes, DataType returnType) {
+        // DATE_NANOS are under construction and behind a feature flag.
+        if (returnType == DataType.DATE_NANOS) {
+            return true;
+        }
+        return argTypes.contains(DataType.DATE_NANOS);
     }
 }


### PR DESCRIPTION
This removes date_nanos from the docs generated for all of our functions because it's still under construction. I've done so as a sort of one-off hack. My plan is to replace this in a follow up change with a centralized registry of "under construction" data types. So we can make new data types under a feature flag more easilly in the future. We're going to be doing that a fair bit.
