### PR TITLE
[8.15] fixing data setup for knn yaml tests (#111794)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -28,17 +28,6 @@ setup:
                   type: hnsw
                   m: 16
                   ef_construction: 200
-
-  - do:
-      indices.create:
-        index: test_empty
-        body:
-          mappings:
-            properties:
-              vector:
-                type: dense_vector
-
-
   - do:
       index:
         index: test
@@ -501,6 +490,16 @@ setup:
   - requires:
       cluster_features: "gte_v8.15.1"
       reason: 'Error fixed in 8.15.1'
+
+  - do:
+      indices.create:
+        index: test_empty
+        body:
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+
   - do:
       search:
         index: test_empty


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [fixing data setup for knn yaml tests (#111794)](https://github.com/elastic/elasticsearch/pull/111794)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

closes: https://github.com/elastic/elasticsearch/issues/111861
closes: https://github.com/elastic/elasticsearch/issues/111860