### PR TITLE
ESQL: Make a field for types under construction

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function;
 import org.elasticsearch.Build;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.xpack.esql.core.ParsingException;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -479,10 +480,7 @@ public class EsqlFunctionRegistry {
         Constructor<?> constructor = constructors[0];
         FunctionInfo functionInfo = functionInfo(def);
         String functionDescription = functionInfo == null ? "" : functionInfo.description().replace('\n', ' ');
-        String[] returnType = functionInfo == null ? new String[] { "?" } : functionInfo.returnType();
-        if (EsqlCorePlugin.DATE_NANOS_FEATURE_FLAG.isEnabled() == false) {
-            returnType = Arrays.stream(returnType).filter(t -> "date_nanos".equals(t) == false).toArray(String[]::new);
-        }
+        String[] returnType = functionInfo == null ? new String[] { "?" } : removeUnderConstruction(functionInfo.returnType());
         var params = constructor.getParameters(); // no multiple c'tors supported
 
         List<EsqlFunctionRegistry.ArgSignature> args = new ArrayList<>(params.length);
@@ -493,10 +491,7 @@ public class EsqlFunctionRegistry {
                 Param paramInfo = params[i].getAnnotation(Param.class);
                 String name = paramInfo == null ? params[i].getName() : paramInfo.name();
                 variadic |= List.class.isAssignableFrom(params[i].getType());
-                String[] type = paramInfo == null ? new String[] { "?" } : paramInfo.type();
-                if (EsqlCorePlugin.DATE_NANOS_FEATURE_FLAG.isEnabled() == false) {
-                    type = Arrays.stream(type).filter(t -> "date_nanos".equals(t) == false).toArray(String[]::new);
-                }
+                String[] type = paramInfo == null ? new String[] { "?" } : removeUnderConstruction(paramInfo.type());
                 String desc = paramInfo == null ? "" : paramInfo.description().replace('\n', ' ');
                 boolean optional = paramInfo == null ? false : paramInfo.optional();
                 DataType targetDataType = getTargetType(type);
@@ -504,6 +499,15 @@ public class EsqlFunctionRegistry {
             }
         }
         return new FunctionDescription(def.name(), args, returnType, functionDescription, variadic, isAggregation);
+    }
+
+    private static String[] removeUnderConstruction(String[] types) {
+        for (Map.Entry<DataType, FeatureFlag> underConstruction : DataType.UNDER_CONSTRUCTION.entrySet()) {
+            if (underConstruction.getValue().isEnabled() == false) {
+                types = Arrays.stream(types).filter(t -> underConstruction.getKey().typeName().equals(t) == false).toArray(String[]::new);
+            }
+        }
+        return types;
     }
 
     public static FunctionInfo functionInfo(FunctionDefinition def) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.esql.core.ParsingException;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
-import org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
@@ -501,6 +500,9 @@ public class EsqlFunctionRegistry {
         return new FunctionDescription(def.name(), args, returnType, functionDescription, variadic, isAggregation);
     }
 
+    /**
+     * Remove types that are being actively built.
+     */
     private static String[] removeUnderConstruction(String[] types) {
         for (Map.Entry<DataType, FeatureFlag> underConstruction : DataType.UNDER_CONSTRUCTION.entrySet()) {
             if (underConstruction.getValue().isEnabled() == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -443,8 +443,12 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
                 // We don't test that functions don't take date_period or time_duration. We should.
                 return false;
             }
-            if (t == DataType.DATE_NANOS) {
-                // Date nanos is still under construction
+            if (DataType.UNDER_CONSTRUCTION.containsKey(t)) {
+                /*
+                 * Types under construction aren't checked because we're actively
+                 * adding support for them to functions. That's *why* they are
+                 * under construction.
+                 */
                 return false;
             }
             if (t.isCounter()) {
@@ -1286,10 +1290,12 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      * Should this particular signature be hidden from the docs even though we test it?
      */
     private static boolean shouldHideSignature(List<DataType> argTypes, DataType returnType) {
-        // DATE_NANOS are under construction and behind a feature flag.
-        if (returnType == DataType.DATE_NANOS) {
-            return true;
+        for (DataType dt : DataType.UNDER_CONSTRUCTION.keySet()) {
+            if (returnType == dt) {
+                return true;
+            }
+            return argTypes.contains(dt);
         }
-        return argTypes.contains(DataType.DATE_NANOS);
+        return false;
     }
 }


### PR DESCRIPTION
This makes a constant that holds all our "under construction" data types and links all of the "under construction" hacks to the constant.
