### PR TITLE
Collecting CCS usage telemetry stats

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.ccs;
+
+import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.query.SlowRunningQueryBuilder;
+import org.elasticsearch.search.query.ThrowingQueryBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.usage.UsageService;
+import org.junit.Assert;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.WILDCARD_FEATURE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
+    private static final String REMOTE1 = "cluster-a";
+    private static final String REMOTE2 = "cluster-b";
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    @Override
+    protected Collection<String> remoteClusterAlias() {
+        return List.of(REMOTE1, REMOTE2);
+    }
+
+    @Override
+    protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
+        return Map.of(REMOTE1, true, REMOTE2, true);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        return CollectionUtils.appendToCopy(super.nodePlugins(clusterAlias), CrossClusterSearchIT.TestQueryBuilderPlugin.class);
+    }
+
+    private SearchRequest makeSearchRequest(String... indices) {
+        SearchRequest searchRequest = new SearchRequest(indices);
+        searchRequest.allowPartialSearchResults(false);
+        searchRequest.setBatchedReduceSize(randomIntBetween(3, 20));
+        searchRequest.setCcsMinimizeRoundtrips(randomBoolean());
+        if (randomBoolean()) {
+            searchRequest.setPreFilterShardSize(1);
+        }
+        searchRequest.source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).size(10));
+        return searchRequest;
+    }
+
+    /**
+    * Run search request and get telemetry from it
+    */
+    private CCSTelemetrySnapshot getTelemetryFromSearch(SearchRequest searchRequest) throws ExecutionException, InterruptedException {
+        // We want to send search to a specific node (we don't care which one) so that we could
+        // collect the CCS telemetry from it later
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        // We don't care here too much about the response, we just want to trigger the telemetry collection.
+        // So we check it's not null and leave the rest to other tests.
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        return getTelemetrySnapshot(nodeName);
+    }
+
+    /**
+     * Create search request for indices and get telemetry from it
+     */
+    private CCSTelemetrySnapshot getTelemetryFromSearch(String... indices) throws ExecutionException, InterruptedException {
+        return getTelemetryFromSearch(makeSearchRequest(indices));
+    }
+
+    /**
+     * Search on all remotes
+     */
+    public void testAllRemotesSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        boolean minimizeRoundtrips = TransportSearchAction.shouldMinimizeRoundtrips(searchRequest);
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(
+            cluster(LOCAL_CLUSTER).client(nodeName)
+                .filterWithHeader(Map.of(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, "kibana"))
+                .search(searchRequest),
+            Assert::assertNotNull
+        );
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(minimizeRoundtrips ? 1L : 0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 1L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getClientCounts().size(), equalTo(1));
+        assertThat(telemetry.getClientCounts().get("kibana"), equalTo(1L));
+        if (minimizeRoundtrips) {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(1L));
+        } else {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(null));
+        }
+        assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(null));
+
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String clusterAlias : remoteClusterAlias()) {
+            var clusterTelemetry = perCluster.get(clusterAlias);
+            assertThat(clusterTelemetry.getCount(), equalTo(1L));
+            assertThat(clusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(clusterTelemetry.getTook().count(), equalTo(1L));
+        }
+
+        // another search
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(2L));
+        assertThat(telemetry.getSuccessCount(), equalTo(2L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(2L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(minimizeRoundtrips ? 2L : 0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 2L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getClientCounts().size(), equalTo(1));
+        assertThat(telemetry.getClientCounts().get("kibana"), equalTo(1L));
+        perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String clusterAlias : remoteClusterAlias()) {
+            var clusterTelemetry = perCluster.get(clusterAlias);
+            assertThat(clusterTelemetry.getCount(), equalTo(2L));
+            assertThat(clusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(clusterTelemetry.getTook().count(), equalTo(2L));
+        }
+    }
+
+    /**
+     * Search on a specific remote
+     */
+    public void testOneRemoteSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        // Make request to cluster a
+        SearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex);
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(2));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2), equalTo(null));
+        assertThat(telemetry.getClientCounts().size(), equalTo(0));
+
+        // Make request to cluster b
+        searchRequest = makeSearchRequest(localIndex, REMOTE2 + ":" + remoteIndex);
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(2L));
+        assertThat(telemetry.getSuccessCount(), equalTo(2L));
+        perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getTook().count(), equalTo(1L));
+    }
+
+    /**
+     * Local search should not produce any telemetry at all
+     */
+    public void testLocalOnlySearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(localIndex);
+        assertThat(telemetry.getTotalCount(), equalTo(0L));
+    }
+
+    /**
+    * Search on remotes only, without local index
+    */
+    public void testRemoteOnlySearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch("*:" + remoteIndex);
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        assertThat(perCluster.size(), equalTo(2));
+        assertThat(telemetry.getClientCounts().size(), equalTo(0));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getSkippedCount(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getSkippedCount(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE2).getTook().count(), equalTo(1L));
+    }
+
+    /**
+     * Count wildcard searches. Only wildcards in index names (not in cluster names) are counted.
+     */
+    public void testWildcardSearch() throws ExecutionException, InterruptedException {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(null));
+
+        searchRequest = makeSearchRequest("*", REMOTE1 + ":" + remoteIndex);
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(2L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(1L));
+
+        searchRequest = makeSearchRequest(localIndex, REMOTE2 + ":*");
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(3L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(2L));
+
+        // Wildcards in cluster name do not count
+        searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(4L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(2L));
+
+        // Wildcard in the middle of the index name counts
+        searchRequest = makeSearchRequest(localIndex, REMOTE2 + ":rem*");
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(5L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(3L));
+
+        // Wildcard only counted once per search
+        searchRequest = makeSearchRequest("*", REMOTE1 + ":rem*", REMOTE2 + ":remote*");
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(6L));
+        assertThat(telemetry.getFeatureCounts().get(WILDCARD_FEATURE), equalTo(4L));
+    }
+
+    /**
+     * Test complete search failure
+     */
+    public void testFailedSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        // shardId -1 means to throw the Exception on all shards, so should result in complete search failure
+        ThrowingQueryBuilder queryBuilder = new ThrowingQueryBuilder(randomLong(), new IllegalStateException("index corrupted"), -1);
+        searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10));
+        searchRequest.allowPartialSearchResults(true);
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        PlainActionFuture<SearchResponse> queryFuture = new PlainActionFuture<>();
+
+        // Borrowed from CrossClusterSearchIT#testSearchWithFailure
+        cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest, queryFuture);
+        assertBusy(() -> assertTrue(queryFuture.isDone()));
+
+        // We expect failure, but we don't care too much which failure it is in this test
+        ExecutionException ee = expectThrows(ExecutionException.class, queryFuture::get);
+        assertNotNull(ee.getCause());
+
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(0L));
+        assertThat(telemetry.getTook().count(), equalTo(0L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(0L));
+        // TODO: check search failure reasons once that function is properly implemented
+    }
+
+    /**
+     * Search when all the remotes failed and skipped
+     */
+    public void testSkippedAllRemotesSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        // throw Exception on all shards of remoteIndex, but not against localIndex
+        ThrowingQueryBuilder queryBuilder = new ThrowingQueryBuilder(
+            randomLong(),
+            new IllegalStateException("index corrupted"),
+            remoteIndex
+        );
+        searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10));
+        searchRequest.allowPartialSearchResults(true);
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        // Note that this counts how many searches had skipped remotes, not how many remotes are skipped
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
+        // Still count the remote that failed
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        // Each remote will have its skipped count bumped
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String remote : remoteClusterAlias()) {
+            assertThat(perCluster.get(remote).getCount(), equalTo(0L));
+            assertThat(perCluster.get(remote).getSkippedCount(), equalTo(1L));
+            assertThat(perCluster.get(remote).getTook().count(), equalTo(0L));
+        }
+    }
+
+    public void testSkippedOneRemoteSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        // Remote1 will fail, Remote2 will just do nothing but it counts as success
+        SearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex, REMOTE2 + ":" + "nosuchindex*");
+        // throw Exception on all shards of remoteIndex, but not against localIndex
+        ThrowingQueryBuilder queryBuilder = new ThrowingQueryBuilder(
+            randomLong(),
+            new IllegalStateException("index corrupted"),
+            remoteIndex
+        );
+        searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10));
+        searchRequest.allowPartialSearchResults(true);
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        // Note that this counts how many searches had skipped remotes, not how many remotes are skipped
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
+        // Still count the remote that failed
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        // Each remote will have its skipped count bumped
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        // This one is skipped
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE1).getSkippedCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(0L));
+        // This one is OK
+        assertThat(perCluster.get(REMOTE2).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2).getSkippedCount(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE2).getTook().count(), equalTo(1L));
+    }
+
+    /**
+     * Test what happens if remote times out - it should be skipped
+     */
+    public void testRemoteTimesOut() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex);
+        // This works only with minimize_roundtrips enabled, since otherwise timed out shards will be counted as
+        // partial failure, and we disable partial results..
+        searchRequest.setCcsMinimizeRoundtrips(true);
+
+        TimeValue searchTimeout = new TimeValue(200, TimeUnit.MILLISECONDS);
+        // query builder that will sleep for the specified amount of time in the query phase
+        SlowRunningQueryBuilder slowRunningQueryBuilder = new SlowRunningQueryBuilder(searchTimeout.millis() * 5, remoteIndex);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(slowRunningQueryBuilder).timeout(searchTimeout);
+        searchRequest.source(sourceBuilder);
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(searchRequest);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(1L));
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(2));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE1).getSkippedCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE2), equalTo(null));
+    }
+
+    /**
+     * Test that we're still counting remote search even if remote cluster has no such index
+     */
+    public void testRemoteHasNoIndex() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(localIndex, REMOTE1 + ":" + "no_such_index*");
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(2));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE2), equalTo(null));
+    }
+
+    private CCSTelemetrySnapshot getTelemetrySnapshot(String nodeName) {
+        var usage = cluster(LOCAL_CLUSTER).getInstance(UsageService.class, nodeName);
+        return usage.getCcsUsageHolder().getCCSTelemetrySnapshot();
+    }
+
+    private Map<String, Object> setupClusters() {
+        String localIndex = "demo";
+        int numShardsLocal = randomIntBetween(2, 10);
+        Settings localSettings = indexSettings(numShardsLocal, randomIntBetween(0, 1)).build();
+        assertAcked(
+            client(LOCAL_CLUSTER).admin()
+                .indices()
+                .prepareCreate(localIndex)
+                .setSettings(localSettings)
+                .setMapping("@timestamp", "type=date", "f", "type=text")
+        );
+        indexDocs(client(LOCAL_CLUSTER), localIndex);
+
+        String remoteIndex = "prod";
+        int numShardsRemote = randomIntBetween(2, 10);
+        for (String clusterAlias : remoteClusterAlias()) {
+            final InternalTestCluster remoteCluster = cluster(clusterAlias);
+            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+            assertAcked(
+                client(clusterAlias).admin()
+                    .indices()
+                    .prepareCreate(remoteIndex)
+                    .setSettings(indexSettings(numShardsRemote, randomIntBetween(0, 1)))
+                    .setMapping("@timestamp", "type=date", "f", "type=text")
+            );
+            assertFalse(
+                client(clusterAlias).admin()
+                    .cluster()
+                    .prepareHealth(remoteIndex)
+                    .setWaitForYellowStatus()
+                    .setTimeout(TimeValue.timeValueSeconds(10))
+                    .get()
+                    .isTimedOut()
+            );
+            indexDocs(client(clusterAlias), remoteIndex);
+        }
+
+        Map<String, Object> clusterInfo = new HashMap<>();
+        clusterInfo.put("local.num_shards", numShardsLocal);
+        clusterInfo.put("local.index", localIndex);
+        clusterInfo.put("remote.num_shards", numShardsRemote);
+        clusterInfo.put("remote.index", remoteIndex);
+        clusterInfo.put("remote.skip_unavailable", true);
+        return clusterInfo;
+    }
+
+    private int indexDocs(Client client, String index) {
+        int numDocs = between(5, 20);
+        for (int i = 0; i < numDocs; i++) {
+            client.prepareIndex(index).setSource("f", "v", "@timestamp", randomNonNegativeLong()).get();
+        }
+        client.admin().indices().prepareRefresh(index).get();
+        return numDocs;
+    }
+
+    // TODO: implement the following tests:
+    // - scenarios with remotes not allowed to be skipped
+    // - various search failure reasons
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -8,7 +8,10 @@
 
 package org.elasticsearch.search.ccs;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
@@ -27,13 +30,24 @@ import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.usage.UsageService;
 import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
@@ -43,6 +57,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResp
 import static org.hamcrest.Matchers.equalTo;
 
 public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
+    private static final Logger LOGGER = LogManager.getLogger(CCSUsageTelemetryIT.class);
     private static final String REMOTE1 = "cluster-a";
     private static final String REMOTE2 = "cluster-b";
 
@@ -56,9 +71,14 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         return List.of(REMOTE1, REMOTE2);
     }
 
+    @Rule
+    public SkipUnavailableRule skipOverride = new SkipUnavailableRule(REMOTE1, REMOTE2);
+
     @Override
     protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
-        return Map.of(REMOTE1, true, REMOTE2, true);
+        var map = skipOverride.getMap();
+        LOGGER.info("Using skip_unavailable map: [{}]", map);
+        return map;
     }
 
     @Override
@@ -88,6 +108,21 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         // We don't care here too much about the response, we just want to trigger the telemetry collection.
         // So we check it's not null and leave the rest to other tests.
         assertResponse(cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest), Assert::assertNotNull);
+        return getTelemetrySnapshot(nodeName);
+    }
+
+    private CCSTelemetrySnapshot getTelemetryFromFailedSearch(SearchRequest searchRequest) throws Exception {
+        // We want to send search to a specific node (we don't care which one) so that we could
+        // collect the CCS telemetry from it later
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        PlainActionFuture<SearchResponse> queryFuture = new PlainActionFuture<>();
+        cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest, queryFuture);
+        assertBusy(() -> assertTrue(queryFuture.isDone()));
+
+        // We expect failure, but we don't care too much which failure it is in this test
+        ExecutionException ee = expectThrows(ExecutionException.class, queryFuture::get);
+        assertNotNull(ee.getCause());
+
         return getTelemetrySnapshot(nodeName);
     }
 
@@ -219,7 +254,6 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
     */
     public void testRemoteOnlySearch() throws ExecutionException, InterruptedException {
         Map<String, Object> testClusterInfo = setupClusters();
-        String localIndex = (String) testClusterInfo.get("local.index");
         String remoteIndex = (String) testClusterInfo.get("remote.index");
 
         CCSTelemetrySnapshot telemetry = getTelemetryFromSearch("*:" + remoteIndex);
@@ -301,24 +335,14 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10));
         searchRequest.allowPartialSearchResults(true);
 
-        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
-        PlainActionFuture<SearchResponse> queryFuture = new PlainActionFuture<>();
-
-        // Borrowed from CrossClusterSearchIT#testSearchWithFailure
-        cluster(LOCAL_CLUSTER).client(nodeName).search(searchRequest, queryFuture);
-        assertBusy(() -> assertTrue(queryFuture.isDone()));
-
-        // We expect failure, but we don't care too much which failure it is in this test
-        ExecutionException ee = expectThrows(ExecutionException.class, queryFuture::get);
-        assertNotNull(ee.getCause());
-
-        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        CCSTelemetrySnapshot telemetry = getTelemetryFromFailedSearch(searchRequest);
         assertThat(telemetry.getTotalCount(), equalTo(1L));
         assertThat(telemetry.getSuccessCount(), equalTo(0L));
         assertThat(telemetry.getTook().count(), equalTo(0L));
         assertThat(telemetry.getTookMrtTrue().count(), equalTo(0L));
         assertThat(telemetry.getTookMrtFalse().count(), equalTo(0L));
-        // TODO: check search failure reasons once that function is properly implemented
+        Map<String, Long> expectedFailures = Map.of(Result.UNKNOWN.getName(), 1L);
+        assertThat(telemetry.getFailureReasons(), equalTo(expectedFailures));
     }
 
     /**
@@ -433,6 +457,96 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
     }
 
     /**
+    * Test what happens if remote times out and there's no local - it should be skipped
+    */
+    public void testRemoteOnlyTimesOut() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(REMOTE1 + ":" + remoteIndex);
+        // This works only with minimize_roundtrips enabled, since otherwise timed out shards will be counted as
+        // partial failure, and we disable partial results...
+        searchRequest.setCcsMinimizeRoundtrips(true);
+
+        TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
+        // query builder that will sleep for the specified amount of time in the query phase
+        SlowRunningQueryBuilder slowRunningQueryBuilder = new SlowRunningQueryBuilder(searchTimeout.millis() * 5, remoteIndex);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(slowRunningQueryBuilder).timeout(searchTimeout);
+        searchRequest.source(sourceBuilder);
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(searchRequest);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(1L));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(1L));
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(1));
+        assertThat(perCluster.get(REMOTE1).getCount(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE1).getSkippedCount(), equalTo(1L));
+        assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(0L));
+        assertThat(perCluster.get(REMOTE2), equalTo(null));
+    }
+
+    @SkipOverride(aliases = { REMOTE1 })
+    public void testRemoteTimesOutFailure() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(REMOTE1 + ":" + remoteIndex);
+
+        TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
+        // query builder that will sleep for the specified amount of time in the query phase
+        SlowRunningQueryBuilder slowRunningQueryBuilder = new SlowRunningQueryBuilder(searchTimeout.millis() * 5, remoteIndex);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(slowRunningQueryBuilder).timeout(searchTimeout);
+        searchRequest.source(sourceBuilder);
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromFailedSearch(searchRequest);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(0L));
+        // Failure is not skipping
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        // Still count the remote that failed
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(1L));
+        assertThat(telemetry.getTook().count(), equalTo(0L));
+        Map<String, Long> expectedFailure = Map.of(Result.TIMEOUT.getName(), 1L);
+        assertThat(telemetry.getFailureReasons(), equalTo(expectedFailure));
+        // No per-cluster data on total failure
+        assertThat(telemetry.getByRemoteCluster().size(), equalTo(0));
+    }
+
+    /**
+    * Search when all the remotes failed and not skipped
+    */
+    @SkipOverride(aliases = { REMOTE1, REMOTE2 })
+    public void testFailedAllRemotesSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        // throw Exception on all shards of remoteIndex, but not against localIndex
+        ThrowingQueryBuilder queryBuilder = new ThrowingQueryBuilder(
+            randomLong(),
+            new IllegalStateException("index corrupted"),
+            remoteIndex
+        );
+        searchRequest.source(new SearchSourceBuilder().query(queryBuilder).size(10));
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromFailedSearch(searchRequest);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(0L));
+        // Failure is not skipping
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        // Still count the remote that failed
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getTook().count(), equalTo(0L));
+        Map<String, Long> expectedFailure = Map.of(Result.REMOTES_UNAVAILABLE.getName(), 1L);
+        assertThat(telemetry.getFailureReasons(), equalTo(expectedFailure));
+        // No per-cluster data on total failure
+        assertThat(telemetry.getByRemoteCluster().size(), equalTo(0));
+    }
+
+    /**
      * Test that we're still counting remote search even if remote cluster has no such index
      */
     public void testRemoteHasNoIndex() throws Exception {
@@ -447,6 +561,21 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         assertThat(perCluster.get(REMOTE1).getCount(), equalTo(1L));
         assertThat(perCluster.get(REMOTE1).getTook().count(), equalTo(1L));
         assertThat(perCluster.get(REMOTE2), equalTo(null));
+    }
+
+    /**
+     * Test that we're still counting remote search even if remote cluster has no such index
+     */
+    @SkipOverride(aliases = { REMOTE1 })
+    public void testRemoteHasNoIndexFailure() throws Exception {
+        SearchRequest searchRequest = makeSearchRequest(REMOTE1 + ":no_such_index");
+        CCSTelemetrySnapshot telemetry = getTelemetryFromFailedSearch(searchRequest);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(0L));
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(0));
+        Map<String, Long> expectedFailure = Map.of(Result.NOT_FOUND.getName(), 1L);
+        assertThat(telemetry.getFailureReasons(), equalTo(expectedFailure));
     }
 
     private CCSTelemetrySnapshot getTelemetrySnapshot(String nodeName) {
@@ -492,11 +621,8 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         }
 
         Map<String, Object> clusterInfo = new HashMap<>();
-        clusterInfo.put("local.num_shards", numShardsLocal);
         clusterInfo.put("local.index", localIndex);
-        clusterInfo.put("remote.num_shards", numShardsRemote);
         clusterInfo.put("remote.index", remoteIndex);
-        clusterInfo.put("remote.skip_unavailable", true);
         return clusterInfo;
     }
 
@@ -509,7 +635,40 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         return numDocs;
     }
 
-    // TODO: implement the following tests:
-    // - scenarios with remotes not allowed to be skipped
-    // - various search failure reasons
+    /**
+     * Annotation to mark specific cluster in a test as not to be skipped when unavailable
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface SkipOverride {
+        String[] aliases();
+    }
+
+    /**
+     * Test rule to process skip annotations
+     */
+    static class SkipUnavailableRule implements TestRule {
+        private final Map<String, Boolean> skipMap;
+
+        SkipUnavailableRule(String... clusterAliases) {
+            this.skipMap = Arrays.stream(clusterAliases).collect(Collectors.toMap(Function.identity(), alias -> true));
+        }
+
+        public Map<String, Boolean> getMap() {
+            return skipMap;
+        }
+
+        @Override
+        public Statement apply(Statement base, Description description) {
+            // Check for annotation named "SkipOverride" and set the overrides accordingly
+            var aliases = description.getAnnotation(SkipOverride.class);
+            if (aliases != null) {
+                for (String alias : aliases.aliases()) {
+                    skipMap.put(alias, false);
+                }
+            }
+            return base;
+        }
+
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -171,7 +171,7 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
         return remotesPerSearchAvg;
     }
 
-    public long getSkippedRemotes() {
+    public long getSearchCountWithSkippedRemotes() {
         return skippedRemotes;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.action.admin.cluster.stats.LongMetric.LongMetricValue;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Holds a snapshot of the CCS telemetry statistics from {@link CCSUsageTelemetry}.
+ * Used to hold the stats for a single node that's part of a {@link ClusterStatsNodeResponse}, as well as to
+ * accumulate stats for the entire cluster and return them as part of the {@link ClusterStatsResponse}.
+ * <br>
+ * Theory of operation:
+ * - The snapshot is created on each particular node with the stats for the node, and is sent to the coordinating node
+ * - Coordinating node creates an empty snapshot and merges all the node snapshots into it using add()
+ * <br>
+ * The snapshot contains {@link LongMetricValue}s for latencies, which currently contain full histograms (since you can't
+ * produce p90 from a set of node p90s, you need the full histogram for that). To avoid excessive copying (histogram weights several KB),
+ * the snapshot is designed to be mutable, so that you can add multiple snapshots to it without copying the histograms all the time.
+ * It is not the intent to mutate the snapshot objects otherwise.
+ * <br>
+ */
+public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment {
+    private long totalCount;
+    private long successCount;
+    private final Map<String, Long> failureReasons;
+
+    /**
+     * Latency metrics, overall.
+     */
+    private final LongMetricValue took;
+    /**
+     * Latency metrics with minimize_roundtrips=true
+     */
+    private final LongMetricValue tookMrtTrue;
+    /**
+     * Latency metrics with minimize_roundtrips=false
+     */
+    private final LongMetricValue tookMrtFalse;
+    private long remotesPerSearchMax;
+    private double remotesPerSearchAvg;
+    private long skippedRemotes;
+
+    private final Map<String, Long> featureCounts;
+
+    private final Map<String, Long> clientCounts;
+    private final Map<String, PerClusterCCSTelemetry> byRemoteCluster;
+
+    /**
+    * Creates a new stats instance with the provided info.
+    */
+    public CCSTelemetrySnapshot(
+        long totalCount,
+        long successCount,
+        Map<String, Long> failureReasons,
+        LongMetricValue took,
+        LongMetricValue tookMrtTrue,
+        LongMetricValue tookMrtFalse,
+        long remotesPerSearchMax,
+        double remotesPerSearchAvg,
+        long skippedRemotes,
+        Map<String, Long> featureCounts,
+        Map<String, Long> clientCounts,
+        Map<String, PerClusterCCSTelemetry> byRemoteCluster
+    ) {
+        this.totalCount = totalCount;
+        this.successCount = successCount;
+        this.failureReasons = failureReasons;
+        this.took = took;
+        this.tookMrtTrue = tookMrtTrue;
+        this.tookMrtFalse = tookMrtFalse;
+        this.remotesPerSearchMax = remotesPerSearchMax;
+        this.remotesPerSearchAvg = remotesPerSearchAvg;
+        this.skippedRemotes = skippedRemotes;
+        this.featureCounts = featureCounts;
+        this.clientCounts = clientCounts;
+        this.byRemoteCluster = byRemoteCluster;
+    }
+
+    /**
+     * Creates a new empty stats instance, that will get additional stats added through {@link #add(CCSTelemetrySnapshot)}
+     */
+    public CCSTelemetrySnapshot() {
+        // Note this produces modifyable maps, so other snapshots can be added to it
+        failureReasons = new HashMap<>();
+        featureCounts = new HashMap<>();
+        clientCounts = new HashMap<>();
+        byRemoteCluster = new HashMap<>();
+        took = new LongMetricValue();
+        tookMrtTrue = new LongMetricValue();
+        tookMrtFalse = new LongMetricValue();
+    }
+
+    public CCSTelemetrySnapshot(StreamInput in) throws IOException {
+        this.totalCount = in.readVLong();
+        this.successCount = in.readVLong();
+        this.failureReasons = in.readMap(StreamInput::readLong);
+        this.took = LongMetricValue.fromStream(in);
+        this.tookMrtTrue = LongMetricValue.fromStream(in);
+        this.tookMrtFalse = LongMetricValue.fromStream(in);
+        this.remotesPerSearchMax = in.readVLong();
+        this.remotesPerSearchAvg = in.readDouble();
+        this.skippedRemotes = in.readVLong();
+        this.featureCounts = in.readMap(StreamInput::readLong);
+        this.clientCounts = in.readMap(StreamInput::readLong);
+        this.byRemoteCluster = in.readMap(PerClusterCCSTelemetry::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(totalCount);
+        out.writeVLong(successCount);
+        out.writeMap(failureReasons, StreamOutput::writeLong);
+        took.writeTo(out);
+        tookMrtTrue.writeTo(out);
+        tookMrtFalse.writeTo(out);
+        out.writeVLong(remotesPerSearchMax);
+        out.writeDouble(remotesPerSearchAvg);
+        out.writeVLong(skippedRemotes);
+        out.writeMap(featureCounts, StreamOutput::writeLong);
+        out.writeMap(clientCounts, StreamOutput::writeLong);
+        out.writeMap(byRemoteCluster, StreamOutput::writeWriteable);
+    }
+
+    public long getTotalCount() {
+        return totalCount;
+    }
+
+    public long getSuccessCount() {
+        return successCount;
+    }
+
+    public Map<String, Long> getFailureReasons() {
+        return Collections.unmodifiableMap(failureReasons);
+    }
+
+    public LongMetricValue getTook() {
+        return took;
+    }
+
+    public LongMetricValue getTookMrtTrue() {
+        return tookMrtTrue;
+    }
+
+    public LongMetricValue getTookMrtFalse() {
+        return tookMrtFalse;
+    }
+
+    public long getRemotesPerSearchMax() {
+        return remotesPerSearchMax;
+    }
+
+    public double getRemotesPerSearchAvg() {
+        return remotesPerSearchAvg;
+    }
+
+    public long getSkippedRemotes() {
+        return skippedRemotes;
+    }
+
+    public Map<String, Long> getFeatureCounts() {
+        return Collections.unmodifiableMap(featureCounts);
+    }
+
+    public Map<String, Long> getClientCounts() {
+        return Collections.unmodifiableMap(clientCounts);
+    }
+
+    public Map<String, PerClusterCCSTelemetry> getByRemoteCluster() {
+        return Collections.unmodifiableMap(byRemoteCluster);
+    }
+
+    public static class PerClusterCCSTelemetry implements Writeable, ToXContentFragment {
+        private long count;
+        private long skippedCount;
+        private final LongMetricValue took;
+
+        public PerClusterCCSTelemetry() {
+            took = new LongMetricValue();
+        }
+
+        public PerClusterCCSTelemetry(long count, long skippedCount, LongMetricValue took) {
+            this.took = took;
+            this.skippedCount = skippedCount;
+            this.count = count;
+        }
+
+        public PerClusterCCSTelemetry(PerClusterCCSTelemetry other) {
+            this.count = other.count;
+            this.skippedCount = other.skippedCount;
+            this.took = new LongMetricValue(other.took);
+        }
+
+        public PerClusterCCSTelemetry(StreamInput in) throws IOException {
+            this.count = in.readVLong();
+            this.skippedCount = in.readVLong();
+            this.took = LongMetricValue.fromStream(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeVLong(count);
+            out.writeVLong(skippedCount);
+            took.writeTo(out);
+        }
+
+        public PerClusterCCSTelemetry add(PerClusterCCSTelemetry v) {
+            count += v.count;
+            skippedCount += v.skippedCount;
+            took.add(v.took);
+            return this;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("total", count);
+            builder.field("skipped", skippedCount);
+            publishLatency(builder, "took", took);
+            builder.endObject();
+            return builder;
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        public long getSkippedCount() {
+            return skippedCount;
+        }
+
+        public LongMetricValue getTook() {
+            return took;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PerClusterCCSTelemetry that = (PerClusterCCSTelemetry) o;
+            return count == that.count && skippedCount == that.skippedCount && Objects.equals(took, that.took);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(count, skippedCount, took);
+        }
+    }
+
+    /**
+     * Add the provided stats to the ones held by the current instance, effectively merging the two.
+     * @param stats the other stats object to add to this one
+     */
+    public void add(CCSTelemetrySnapshot stats) {
+        // This should be called in ClusterStatsResponse ctor only, so we don't need to worry about concurrency
+        if (stats.totalCount == 0) {
+            // Just ignore the empty stats.
+            // This could happen if the node is brand new or if the stats are not available, e.g. because it runs an old version.
+            return;
+        }
+        long oldCount = totalCount;
+        totalCount += stats.totalCount;
+        successCount += stats.successCount;
+        skippedRemotes += stats.skippedRemotes;
+        stats.failureReasons.forEach((k, v) -> failureReasons.merge(k, v, Long::sum));
+        stats.featureCounts.forEach((k, v) -> featureCounts.merge(k, v, Long::sum));
+        stats.clientCounts.forEach((k, v) -> clientCounts.merge(k, v, Long::sum));
+        took.add(stats.took);
+        tookMrtTrue.add(stats.tookMrtTrue);
+        tookMrtFalse.add(stats.tookMrtFalse);
+        remotesPerSearchMax = Math.max(remotesPerSearchMax, stats.remotesPerSearchMax);
+        if (totalCount > 0 && oldCount > 0) {
+            // Weighted average
+            remotesPerSearchAvg = (remotesPerSearchAvg * oldCount + stats.remotesPerSearchAvg * stats.totalCount) / totalCount;
+        } else {
+            // If we didn't have any old value, we just take the new one
+            remotesPerSearchAvg = stats.remotesPerSearchAvg;
+        }
+        // we copy the object here since we'll be modifying it later on subsequent adds
+        // TODO: this may be sub-optimal, as we'll be copying histograms when adding first snapshot to an empty container,
+        // which we could have avoided probably.
+        stats.byRemoteCluster.forEach((r, v) -> byRemoteCluster.merge(r, new PerClusterCCSTelemetry(v), PerClusterCCSTelemetry::add));
+    }
+
+    /**
+     * Publishes the latency statistics to the provided {@link XContentBuilder}.
+     * Example:
+     * "took": {
+     *      "max": 345032,
+     *      "avg": 1620,
+     *      "p90": 2570
+     * }
+     */
+    public static void publishLatency(XContentBuilder builder, String name, LongMetricValue took) throws IOException {
+        builder.startObject(name);
+        {
+            builder.field("max", took.max());
+            builder.field("avg", took.avg());
+            builder.field("p90", took.p90());
+        }
+        builder.endObject();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("ccs_telemetry");
+        {
+            builder.field("total", totalCount);
+            builder.field("success", successCount);
+            builder.field("skipped", skippedRemotes);
+            publishLatency(builder, "took", took);
+            publishLatency(builder, "took_mrt_true", tookMrtTrue);
+            publishLatency(builder, "took_mrt_false", tookMrtFalse);
+            builder.field("remotes_per_search_max", remotesPerSearchMax);
+            builder.field("remotes_per_search_avg", remotesPerSearchAvg);
+            builder.field("failure_reasons", failureReasons);
+            builder.field("features", featureCounts);
+            builder.field("clients", clientCounts);
+            builder.startObject("remote_clusters");
+            {
+                builder.field("count", byRemoteCluster.size());
+                for (var entry : byRemoteCluster.entrySet()) {
+                    builder.field(entry.getKey(), entry.getValue());
+                }
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CCSTelemetrySnapshot that = (CCSTelemetrySnapshot) o;
+        return totalCount == that.totalCount
+            && successCount == that.successCount
+            && skippedRemotes == that.skippedRemotes
+            && Objects.equals(failureReasons, that.failureReasons)
+            && Objects.equals(took, that.took)
+            && Objects.equals(tookMrtTrue, that.tookMrtTrue)
+            && Objects.equals(tookMrtFalse, that.tookMrtFalse)
+            && Objects.equals(remotesPerSearchMax, that.remotesPerSearchMax)
+            && Objects.equals(remotesPerSearchAvg, that.remotesPerSearchAvg)
+            && Objects.equals(featureCounts, that.featureCounts)
+            && Objects.equals(clientCounts, that.clientCounts)
+            && Objects.equals(byRemoteCluster, that.byRemoteCluster);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            totalCount,
+            successCount,
+            failureReasons,
+            took,
+            tookMrtTrue,
+            tookMrtFalse,
+            remotesPerSearchMax,
+            remotesPerSearchAvg,
+            skippedRemotes,
+            featureCounts,
+            clientCounts,
+            byRemoteCluster
+        );
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -9,10 +9,12 @@
 package org.elasticsearch.action.admin.cluster.stats;
 
 import org.elasticsearch.action.admin.cluster.stats.LongMetric.LongMetricValue;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -337,11 +339,15 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
             builder.field("failure_reasons", failureReasons);
             builder.field("features", featureCounts);
             builder.field("clients", clientCounts);
-            builder.startObject("remote_clusters");
+            builder.startObject("clusters");
             {
                 builder.field("count", byRemoteCluster.size());
                 for (var entry : byRemoteCluster.entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue());
+                    String remoteName = entry.getKey();
+                    if (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(remoteName)) {
+                        remoteName = SearchResponse.LOCAL_CLUSTER_NAME_REPRESENTATION;
+                    }
+                    builder.field(remoteName, entry.getValue());
                 }
             }
             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -40,6 +40,7 @@ import java.util.Objects;
  * <br>
  */
 public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment {
+    public static final String CCS_TELEMETRY_FIELD_NAME = "_search";
     private long totalCount;
     private long successCount;
     private final Map<String, Long> failureReasons;
@@ -326,7 +327,7 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject("ccs_telemetry");
+        builder.startObject(CCS_TELEMETRY_FIELD_NAME);
         {
             builder.field("total", totalCount);
             builder.field("success", successCount);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * - Coordinating node creates an empty snapshot and merges all the node snapshots into it using add()
  * <br>
  * The snapshot contains {@link LongMetricValue}s for latencies, which currently contain full histograms (since you can't
- * produce p90 from a set of node p90s, you need the full histogram for that). To avoid excessive copying (histogram weights several KB),
+ * produce p90 from a set of node p90s, you need the full histogram for that). To avoid excessive copying (histogram weighs several KB),
  * the snapshot is designed to be mutable, so that you can add multiple snapshots to it without copying the histograms all the time.
  * It is not the intent to mutate the snapshot objects otherwise.
  * <br>
@@ -98,7 +98,7 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
      * Creates a new empty stats instance, that will get additional stats added through {@link #add(CCSTelemetrySnapshot)}
      */
     public CCSTelemetrySnapshot() {
-        // Note this produces modifyable maps, so other snapshots can be added to it
+        // Note this produces modifiable maps, so other snapshots can be merged into it
         failureReasons = new HashMap<>();
         featureCounts = new HashMap<>();
         clientCounts = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshot.java
@@ -341,7 +341,6 @@ public final class CCSTelemetrySnapshot implements Writeable, ToXContentFragment
             builder.field("clients", clientCounts);
             builder.startObject("clusters");
             {
-                builder.field("count", byRemoteCluster.size());
                 for (var entry : byRemoteCluster.entrySet()) {
                     String remoteName = entry.getKey();
                     if (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(remoteName)) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.core.TimeValue;
+
+import java.util.Map;
+
+/**
+ * This is a snapshot of telemetry from an individual cross-cluster search for _search or _async_search (or
+ * other search endpoints that use the TransportSearchAction such as _msearch).
+ */
+public class CCSUsage {
+    private final long took;
+    private final String failureType;  // TODO: enum?
+    private final boolean minimizeRoundTrips;
+    private final boolean async;
+    private final int skippedRemotes;
+    private final Map<String, PerClusterUsage> perClusterUsage;
+
+    public static class Builder {
+        private long took;
+        private String failureType;  // TODO: enum?
+        private boolean minimizeRoundTrips;
+        private boolean async;
+        private int skippedRemotes;
+        private Map<String, PerClusterUsage> perClusterUsage;
+
+        public Builder took(long took) {
+            this.took = took;
+            return this;
+        }
+
+        public Builder failureType(String failureType) {
+            this.failureType = failureType;
+            return this;
+        }
+
+        public Builder minimizeRoundTrips(boolean minimizeRoundTrips) {
+            this.minimizeRoundTrips = minimizeRoundTrips;
+            return this;
+        }
+
+        public Builder async(boolean async) {
+            this.async = async;
+            return this;
+        }
+
+        public Builder numSkippedRemotes(int skippedRemotes) {
+            this.skippedRemotes = skippedRemotes;
+            return this;
+        }
+
+        // TODO: this should probably be a per cluster "add", not a setter that takes map - change later
+        public Builder perClusterUsage(Map<String, PerClusterUsage> perClusterUsage) {
+            this.perClusterUsage = perClusterUsage;
+            return this;
+        }
+
+        public CCSUsage build() {
+            return new CCSUsage(minimizeRoundTrips, async, took, skippedRemotes, failureType, perClusterUsage);
+        }
+    }
+
+    private CCSUsage(
+        boolean minimizeRoundTrips,
+        boolean async,
+        long took,
+        int skippedRemotes,
+        String failureType,
+        Map<String, PerClusterUsage> perClusterUsage
+    ) {
+        this.minimizeRoundTrips = minimizeRoundTrips;
+        this.async = async;
+        this.took = took;
+        this.skippedRemotes = skippedRemotes;
+        this.failureType = failureType;
+        this.perClusterUsage = perClusterUsage;
+    }
+
+    public Map<String, PerClusterUsage> getPerClusterUsage() {
+        return perClusterUsage;
+    }
+
+    public int getSkippedRemotes() {
+        return skippedRemotes;
+    }
+
+    public long getTook() {
+        return took;
+    }
+
+    public String getFailureType() {
+        return failureType;
+    }
+
+    public boolean isMinimizeRoundTrips() {
+        return minimizeRoundTrips;
+    }
+
+    public boolean isAsync() {
+        return async;
+    }
+
+    public static class PerClusterUsage {
+
+        // if MRT=true, the took time on the remote cluster (if MRT=true), otherwise the overall took time
+        private long took;
+
+        public PerClusterUsage(TimeValue took) {
+            if (took != null) {
+                this.took = took.millis();
+            }
+        }
+
+        public long getTook() {
+            return took;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import static org.elasticsearch.transport.RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
 
 /**
- * This is a snapshot of telemetry from an individual cross-cluster search for _search or _async_search (or
+ * This is a container for telemetry data from an individual cross-cluster search for _search or _async_search (or
  * other search endpoints that use the {@link TransportSearchAction} such as _msearch).
  */
 public class CCSUsage {
@@ -152,7 +152,7 @@ public class CCSUsage {
          * Is this failure exception because remote was unavailable?
          * See also: TransportResolveClusterAction#notConnectedError
          */
-        public static boolean isRemoteUnavailable(Exception e) {
+        static boolean isRemoteUnavailable(Exception e) {
             if (ExceptionsHelper.unwrap(
                 e,
                 ConnectTransportException.class,
@@ -172,7 +172,7 @@ public class CCSUsage {
         /**
          * Is this failure coming from a remote cluster?
          */
-        public static boolean isRemoteFailure(ShardOperationFailedException failure) {
+        static boolean isRemoteFailure(ShardOperationFailedException failure) {
             if (failure instanceof ShardSearchFailure shardFailure) {
                 SearchShardTarget shard = shardFailure.shard();
                 return shard != null && shard.getClusterAlias() != null && LOCAL_CLUSTER_GROUP_KEY.equals(shard.getClusterAlias()) == false;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
@@ -8,14 +8,29 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.query.SearchTimeoutException;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.NoSeedNodeLeftException;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static org.elasticsearch.transport.RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
 
 /**
  * This is a snapshot of telemetry from an individual cross-cluster search for _search or _async_search (or
@@ -57,6 +72,10 @@ public class CCSUsage {
             return this;
         }
 
+        public Builder setFailure(Exception e) {
+            return setFailure(getFailureType(e));
+        }
+
         public Builder setFeature(String feature) {
             this.features.add(feature);
             return this;
@@ -88,6 +107,77 @@ public class CCSUsage {
 
         public int getRemotesCount() {
             return remotesCount;
+        }
+
+        /**
+         * Get failure type as {@link Result} from the search failure exception.
+         */
+        public static Result getFailureType(Exception e) {
+            var unwrapped = ExceptionsHelper.unwrapCause(e);
+            if (unwrapped instanceof Exception) {
+                e = (Exception) unwrapped;
+            }
+            if (isRemoteUnavailable(e)) {
+                return Result.REMOTES_UNAVAILABLE;
+            }
+            if (ExceptionsHelper.unwrap(e, ResourceNotFoundException.class) != null) {
+                return Result.NOT_FOUND;
+            }
+            if (e instanceof TaskCancelledException || (ExceptionsHelper.unwrap(e, TaskCancelledException.class) != null)) {
+                return Result.CANCELED;
+            }
+            if (ExceptionsHelper.unwrap(e, SearchTimeoutException.class) != null) {
+                return Result.TIMEOUT;
+            }
+            if (ExceptionsHelper.unwrap(e, ElasticsearchSecurityException.class) != null) {
+                return Result.SECURITY;
+            }
+            if (ExceptionsHelper.unwrapCorruption(e) != null) {
+                return Result.CORRUPTION;
+            }
+            // This is kind of last resort check - if we still don't know the reason but all shard failures are remote,
+            // we assume it's remote's fault somehow.
+            if (e instanceof SearchPhaseExecutionException spe) {
+                // If this is a failure that happened because of remote failures only
+                var groupedFails = ExceptionsHelper.groupBy(spe.shardFailures());
+                if (Arrays.stream(groupedFails).allMatch(Builder::isRemoteFailure)) {
+                    return Result.REMOTES_UNAVAILABLE;
+                }
+            }
+            // OK we don't know what happened
+            return Result.UNKNOWN;
+        }
+
+        /**
+         * Is this failure exception because remote was unavailable?
+         * See also: TransportResolveClusterAction#notConnectedError
+         */
+        public static boolean isRemoteUnavailable(Exception e) {
+            if (ExceptionsHelper.unwrap(
+                e,
+                ConnectTransportException.class,
+                NoSuchRemoteClusterException.class,
+                NoSeedNodeLeftException.class
+            ) != null) {
+                return true;
+            }
+            Throwable ill = ExceptionsHelper.unwrap(e, IllegalStateException.class, IllegalArgumentException.class);
+            if (ill != null && (ill.getMessage().contains("Unable to open any connections") || ill.getMessage().contains("unknown host"))) {
+                return true;
+            }
+            // Ok doesn't look like any of the known remote exceptions
+            return false;
+        }
+
+        /**
+         * Is this failure coming from a remote cluster?
+         */
+        public static boolean isRemoteFailure(ShardOperationFailedException failure) {
+            if (failure instanceof ShardSearchFailure shardFailure) {
+                SearchShardTarget shard = shardFailure.shard();
+                return shard != null && shard.getClusterAlias() != null && LOCAL_CLUSTER_GROUP_KEY.equals(shard.getClusterAlias()) == false;
+            }
+            return false;
         }
     }
 
@@ -152,4 +242,5 @@ public class CCSUsage {
             return took;
         }
     }
+
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsage.java
@@ -8,79 +8,104 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result;
+import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.core.TimeValue;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This is a snapshot of telemetry from an individual cross-cluster search for _search or _async_search (or
- * other search endpoints that use the TransportSearchAction such as _msearch).
+ * other search endpoints that use the {@link TransportSearchAction} such as _msearch).
  */
 public class CCSUsage {
     private final long took;
-    private final String failureType;  // TODO: enum?
-    private final boolean minimizeRoundTrips;
-    private final boolean async;
-    private final int skippedRemotes;
+    private final Result status;
+    private final Set<String> features;
+    private final int remotesCount;
+
+    private final String client;
+
+    private final Set<String> skippedRemotes;
     private final Map<String, PerClusterUsage> perClusterUsage;
 
     public static class Builder {
         private long took;
-        private String failureType;  // TODO: enum?
-        private boolean minimizeRoundTrips;
-        private boolean async;
-        private int skippedRemotes;
-        private Map<String, PerClusterUsage> perClusterUsage;
+        private final Set<String> features;
+        private Result status = Result.SUCCESS;
+        private int remotesCount;
+        private String client;
+        private final Set<String> skippedRemotes;
+        private final Map<String, PerClusterUsage> perClusterUsage;
+
+        public Builder() {
+            features = new HashSet<>();
+            skippedRemotes = new HashSet<>();
+            perClusterUsage = new HashMap<>();
+        }
 
         public Builder took(long took) {
             this.took = took;
             return this;
         }
 
-        public Builder failureType(String failureType) {
-            this.failureType = failureType;
+        public Builder setFailure(Result failureType) {
+            this.status = failureType;
             return this;
         }
 
-        public Builder minimizeRoundTrips(boolean minimizeRoundTrips) {
-            this.minimizeRoundTrips = minimizeRoundTrips;
+        public Builder setFeature(String feature) {
+            this.features.add(feature);
             return this;
         }
 
-        public Builder async(boolean async) {
-            this.async = async;
+        public Builder setClient(String client) {
+            this.client = client;
             return this;
         }
 
-        public Builder numSkippedRemotes(int skippedRemotes) {
-            this.skippedRemotes = skippedRemotes;
+        public Builder skippedRemote(String remote) {
+            this.skippedRemotes.add(remote);
             return this;
         }
 
-        // TODO: this should probably be a per cluster "add", not a setter that takes map - change later
-        public Builder perClusterUsage(Map<String, PerClusterUsage> perClusterUsage) {
-            this.perClusterUsage = perClusterUsage;
+        public Builder perClusterUsage(String remote, TimeValue took) {
+            this.perClusterUsage.put(remote, new PerClusterUsage(took));
             return this;
         }
 
         public CCSUsage build() {
-            return new CCSUsage(minimizeRoundTrips, async, took, skippedRemotes, failureType, perClusterUsage);
+            return new CCSUsage(took, status, remotesCount, skippedRemotes, features, client, perClusterUsage);
+        }
+
+        public Builder setRemotesCount(int remotesCount) {
+            this.remotesCount = remotesCount;
+            return this;
+        }
+
+        public int getRemotesCount() {
+            return remotesCount;
         }
     }
 
     private CCSUsage(
-        boolean minimizeRoundTrips,
-        boolean async,
         long took,
-        int skippedRemotes,
-        String failureType,
+        Result status,
+        int remotesCount,
+        Set<String> skippedRemotes,
+        Set<String> features,
+        String client,
         Map<String, PerClusterUsage> perClusterUsage
     ) {
-        this.minimizeRoundTrips = minimizeRoundTrips;
-        this.async = async;
+        this.status = status;
+        this.remotesCount = remotesCount;
+        this.features = features;
+        this.client = client;
         this.took = took;
         this.skippedRemotes = skippedRemotes;
-        this.failureType = failureType;
         this.perClusterUsage = perClusterUsage;
     }
 
@@ -88,24 +113,28 @@ public class CCSUsage {
         return perClusterUsage;
     }
 
-    public int getSkippedRemotes() {
-        return skippedRemotes;
+    public Result getStatus() {
+        return status;
+    }
+
+    public Set<String> getFeatures() {
+        return features;
+    }
+
+    public long getRemotesCount() {
+        return remotesCount;
+    }
+
+    public String getClient() {
+        return client;
     }
 
     public long getTook() {
         return took;
     }
 
-    public String getFailureType() {
-        return failureType;
-    }
-
-    public boolean isMinimizeRoundTrips() {
-        return minimizeRoundTrips;
-    }
-
-    public boolean isAsync() {
-        return async;
+    public Set<String> getSkippedRemotes() {
+        return skippedRemotes;
     }
 
     public static class PerClusterUsage {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.HdrHistogram.DoubleHistogram;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Service holding accumulated CCS search usage statistics. Individual cross-cluster searches will pass
+ * CCSUsage data here to have it collated and aggregated. Snapshots of the current CCS Telemetry Usage
+ * can be obtained by getting CCSTelemetrySnapshot objects (TODO: create that class (and determine the best name)).
+ */
+public class CCSUsageTelemetry {
+
+    private final LongAdder totalCCSCount;  // TODO: need this? or just sum the successfulSearchTelem and failedSearchTelem ?
+    private final SuccessfulCCSTelemetry successfulSearchTelem;
+    private final FailedCCSTelemetry failedSearchTelem;
+    private final Map<String, PerClusterCCSTelemetry> byRemoteCluster;
+
+    public CCSUsageTelemetry() {
+        this.totalCCSCount = new LongAdder();
+        this.successfulSearchTelem = new SuccessfulCCSTelemetry();
+        this.failedSearchTelem = new FailedCCSTelemetry();
+        this.byRemoteCluster = new ConcurrentHashMap<>();
+    }
+
+    public void updateUsage(CCSUsage ccsUsage) {
+        // TODO: fork this to a background thread? if yes, could just pass in the SearchResponse to parse it off the response thread
+        doUpdate(ccsUsage);
+    }
+
+    // TODO: what is the best thread-safety model here? Start with locking model in order to get the functionality working.
+    private synchronized void doUpdate(CCSUsage ccsUsage) {
+        totalCCSCount.increment();
+        if (ccsUsage.getFailureType() == null) {
+            // handle successful (or partially successful query)
+            successfulSearchTelem.update(ccsUsage);
+            for (Map.Entry<String, CCSUsage.PerClusterUsage> entry : ccsUsage.getPerClusterUsage().entrySet()) {
+                PerClusterCCSTelemetry perClusterCCSTelemetry = byRemoteCluster.get(entry.getKey());
+                if (perClusterCCSTelemetry == null) {
+                    perClusterCCSTelemetry = new PerClusterCCSTelemetry(entry.getKey());
+                    byRemoteCluster.put(entry.getKey(), perClusterCCSTelemetry);
+                }
+                // TODO: add more fields/data to the perClusterCCSTelemetry
+                perClusterCCSTelemetry.update(entry.getValue());
+            }
+
+        } else {
+            // handle failed query
+            failedSearchTelem.update(ccsUsage);
+        }
+    }
+
+    public long getTotalCCSCount() {
+        return totalCCSCount.sum();
+    }
+
+    // TODO: the getters below need to create an immutable snapshot of CCS Telemetry and return that - see SearchUsageStats as example
+    public SuccessfulCCSTelemetry getSuccessfulSearchTelemetry() {
+        return successfulSearchTelem;
+    }
+
+    public FailedCCSTelemetry getFailedSearchTelemetry() {
+        return failedSearchTelem;
+    }
+
+    public Map<String, PerClusterCCSTelemetry> getTelemetryByCluster() {
+        return byRemoteCluster;
+    }
+
+    /**
+     * Telemetry metrics for successful searches (includes searches with partial failures)
+     */
+    static class SuccessfulCCSTelemetry {
+        private long count; // total number of searches
+        private long countMinimizeRoundtrips;
+        private long countSearchesWithSkippedRemotes;
+        private long countAsync;
+        private DoubleHistogram latency;
+
+        SuccessfulCCSTelemetry() {
+            this.count = 0;
+            this.countMinimizeRoundtrips = 0;
+            this.countSearchesWithSkippedRemotes = 0;
+            this.countAsync = 0;
+            this.latency = new DoubleHistogram(2);
+        }
+
+        void update(CCSUsage ccsUsage) {
+            count++;
+            countMinimizeRoundtrips += ccsUsage.isMinimizeRoundTrips() ? 1 : 0;
+            countSearchesWithSkippedRemotes += ccsUsage.getSkippedRemotes() > 0 ? 1 : 0;
+            countAsync += ccsUsage.isAsync() ? 1 : 0;
+            latency.recordValue(ccsUsage.getTook());
+        }
+
+        // TODO: remove these getters and replace with a toSuccessfulCCSUsageSnapshot method?
+        public long getCount() {
+            return count;
+        }
+
+        public long getCountMinimizeRoundtrips() {
+            return countMinimizeRoundtrips;
+        }
+
+        public long getCountSearchesWithSkippedRemotes() {
+            return countSearchesWithSkippedRemotes;
+        }
+
+        public long getCountAsync() {
+            return countAsync;
+        }
+
+        public double getMeanLatency() {
+            return latency.getMean();
+        }
+    }
+
+    /**
+     * Telemetry metrics for failed searches (no data returned)
+     */
+    static class FailedCCSTelemetry {
+        private long count;
+        private Map<String, Integer> causes;
+
+        FailedCCSTelemetry() {
+            causes = new HashMap<>();
+        }
+
+        void update(CCSUsage ccsUsage) {
+            count++;
+            causes.compute(ccsUsage.getFailureType(), (k, v) -> (v == null) ? 1 : v + 1);
+        }
+
+        public long getCount() {
+            return count;
+        }
+    }
+
+    /**
+     * Telemetry of each remote involved in cross cluster searches
+     */
+    static class PerClusterCCSTelemetry {
+        private String clusterAlias;
+        private long count;
+        private DoubleHistogram latency;
+
+        PerClusterCCSTelemetry(String clusterAlias) {
+            this.clusterAlias = clusterAlias;
+            this.count = 0;
+            // TODO: what should we use for num significant value digits?
+            latency = new DoubleHistogram(2);
+        }
+
+        void update(CCSUsage.PerClusterUsage remoteUsage) {
+            count++;
+            latency.recordValue(remoteUsage.getTook()); // TODO: do we need to add count as well using recordValueWithCount?
+        }
+
+        public long getCount() {
+            return count;
+        }
+
+        // TODO: add additional getters around latency (max, p90)
+        public double getMeanLatency() {
+            return latency.getMean();
+        }
+
+        @Override
+        public String toString() {
+            return "PerClusterCCSTelemetry{"
+                + "clusterAlias='"
+                + clusterAlias
+                + '\''
+                + ", count="
+                + count
+                + ", latency(mean)="
+                + latency.getMean()
+                + '}';
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.Maps;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -59,6 +60,22 @@ public class CCSUsageTelemetry {
     public static final String MRT_FEATURE = "mrt_on";
     public static final String ASYNC_FEATURE = "async";
     public static final String WILDCARD_FEATURE = "wildcards";
+
+    // The list of known Elastic clients. May be incomplete.
+    public static final Set<String> KNOWN_CLIENTS = Set.of(
+        "kibana",
+        "cloud",
+        "logstash",
+        "beats",
+        "fleet",
+        "ml",
+        "security",
+        "observability",
+        "enterprise-search",
+        "elasticsearch",
+        "connectors",
+        "connectors-cli"
+    );
 
     // TODO: do we need LongAdder here or long is enough? Since updateUsage is synchronized, worst that can happen is
     // we may miss a count on read.
@@ -129,7 +146,9 @@ public class CCSUsageTelemetry {
             ccsUsage.getSkippedRemotes().forEach(remote -> byRemoteCluster.computeIfAbsent(remote, PerClusterCCSTelemetry::new).skipped());
         }
         ccsUsage.getFeatures().forEach(f -> featureCounts.computeIfAbsent(f, k -> new LongAdder()).increment());
-        if (ccsUsage.getClient() != null) {
+        String client = ccsUsage.getClient();
+        if (client != null && KNOWN_CLIENTS.contains(client)) {
+            // We count only known clients for now
             clientCounts.computeIfAbsent(ccsUsage.getClient(), k -> new LongAdder()).increment();
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -8,9 +8,9 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.HdrHistogram.DoubleHistogram;
+import org.elasticsearch.common.util.Maps;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
@@ -18,60 +18,128 @@ import java.util.concurrent.atomic.LongAdder;
 /**
  * Service holding accumulated CCS search usage statistics. Individual cross-cluster searches will pass
  * CCSUsage data here to have it collated and aggregated. Snapshots of the current CCS Telemetry Usage
- * can be obtained by getting CCSTelemetrySnapshot objects (TODO: create that class (and determine the best name)).
+ * can be obtained by getting {@link CCSTelemetrySnapshot} objects.
+ * <br>
+ * Theory of operation:
+ * Each search creates a {@link CCSUsage.Builder}, which can be updated during the progress of the search request,
+ * and then it instantiates a {@link CCSUsage} object when the request is finished.
+ * That object is passed to {@link #updateUsage(CCSUsage)} on the request processing end (whether successful or not).
+ * The {@link #updateUsage(CCSUsage)} method will then update the internal counters and metrics.
+ * <br>
+ * When we need to return the current state of the telemetry, we can call {@link #getCCSTelemetrySnapshot()} which produces
+ * a snapshot of the current state of the telemetry as {@link CCSTelemetrySnapshot}. These snapshots are additive so
+ * when collecting the snapshots from multiple nodes, an empty snapshot is created and then all the node's snapshots are added
+ * to it to obtain the summary telemetry.
  */
 public class CCSUsageTelemetry {
 
-    private final LongAdder totalCCSCount;  // TODO: need this? or just sum the successfulSearchTelem and failedSearchTelem ?
-    private final SuccessfulCCSTelemetry successfulSearchTelem;
-    private final FailedCCSTelemetry failedSearchTelem;
+    /**
+     * Result of the request execution.
+     * Either "success" or a failure reason.
+     */
+    public enum Result {
+        SUCCESS("success"),
+        REMOTES_UNAVAILABLE("remotes_unavailable"),
+        CANCELED("canceled"),
+        // May be helpful if there's a lot of other reasons, and it may be hard to calculate the unknowns for some clients.
+        UNKNOWN("unknown");
+
+        private final String name;
+
+        Result(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    // Not enum because we won't mind other places adding their own features
+    public static final String MRT_FEATURE = "mrt_on";
+    public static final String ASYNC_FEATURE = "async";
+    public static final String WILDCARD_FEATURE = "wildcards";
+
+    // TODO: do we need LongAdder here or long is enough? Since updateUsage is synchronized, worst that can happen is
+    // we may miss a count on read.
+    private final LongAdder totalCount;
+    private final LongAdder successCount;
+    private final Map<Result, LongAdder> failureReasons;
+
+    /**
+     * Latency metrics overall
+     */
+    private final LongMetric took;
+    /**
+     * Latency metrics with minimize_roundtrips=true
+     */
+    private final LongMetric tookMrtTrue;
+    /**
+     * Latency metrics with minimize_roundtrips=false
+     */
+    private final LongMetric tookMrtFalse;
+    private final LongMetric remotesPerSearch;
+    private final LongAdder skippedRemotes;
+
+    private final Map<String, LongAdder> featureCounts;
+
+    private final Map<String, LongAdder> clientCounts;
     private final Map<String, PerClusterCCSTelemetry> byRemoteCluster;
 
     public CCSUsageTelemetry() {
-        this.totalCCSCount = new LongAdder();
-        this.successfulSearchTelem = new SuccessfulCCSTelemetry();
-        this.failedSearchTelem = new FailedCCSTelemetry();
         this.byRemoteCluster = new ConcurrentHashMap<>();
+        totalCount = new LongAdder();
+        successCount = new LongAdder();
+        failureReasons = new ConcurrentHashMap<>();
+        took = new LongMetric();
+        tookMrtTrue = new LongMetric();
+        tookMrtFalse = new LongMetric();
+        remotesPerSearch = new LongMetric();
+        skippedRemotes = new LongAdder();
+        featureCounts = new ConcurrentHashMap<>();
+        clientCounts = new ConcurrentHashMap<>();
     }
 
     public void updateUsage(CCSUsage ccsUsage) {
+        assert ccsUsage.getRemotesCount() > 0 : "Expected at least one remote cluster in CCSUsage";
         // TODO: fork this to a background thread? if yes, could just pass in the SearchResponse to parse it off the response thread
         doUpdate(ccsUsage);
     }
 
     // TODO: what is the best thread-safety model here? Start with locking model in order to get the functionality working.
     private synchronized void doUpdate(CCSUsage ccsUsage) {
-        totalCCSCount.increment();
-        if (ccsUsage.getFailureType() == null) {
-            // handle successful (or partially successful query)
-            successfulSearchTelem.update(ccsUsage);
-            for (Map.Entry<String, CCSUsage.PerClusterUsage> entry : ccsUsage.getPerClusterUsage().entrySet()) {
-                PerClusterCCSTelemetry perClusterCCSTelemetry = byRemoteCluster.get(entry.getKey());
-                if (perClusterCCSTelemetry == null) {
-                    perClusterCCSTelemetry = new PerClusterCCSTelemetry(entry.getKey());
-                    byRemoteCluster.put(entry.getKey(), perClusterCCSTelemetry);
-                }
-                // TODO: add more fields/data to the perClusterCCSTelemetry
-                perClusterCCSTelemetry.update(entry.getValue());
+        totalCount.increment();
+        long searchTook = ccsUsage.getTook();
+        if (isSuccess(ccsUsage)) {
+            successCount.increment();
+            took.record(searchTook);
+            if (isMRT(ccsUsage)) {
+                tookMrtTrue.record(searchTook);
+            } else {
+                tookMrtFalse.record(searchTook);
             }
-
+            ccsUsage.getPerClusterUsage().forEach((r, u) -> byRemoteCluster.computeIfAbsent(r, PerClusterCCSTelemetry::new).update(u));
         } else {
-            // handle failed query
-            failedSearchTelem.update(ccsUsage);
+            failureReasons.computeIfAbsent(ccsUsage.getStatus(), k -> new LongAdder()).increment();
+        }
+
+        remotesPerSearch.record(ccsUsage.getRemotesCount());
+        if (ccsUsage.getSkippedRemotes().isEmpty() == false) {
+            skippedRemotes.increment();
+            ccsUsage.getSkippedRemotes().forEach(remote -> byRemoteCluster.computeIfAbsent(remote, PerClusterCCSTelemetry::new).skipped());
+        }
+        ccsUsage.getFeatures().forEach(f -> featureCounts.computeIfAbsent(f, k -> new LongAdder()).increment());
+        if (ccsUsage.getClient() != null) {
+            clientCounts.computeIfAbsent(ccsUsage.getClient(), k -> new LongAdder()).increment();
         }
     }
 
-    public long getTotalCCSCount() {
-        return totalCCSCount.sum();
+    private boolean isMRT(CCSUsage ccsUsage) {
+        return ccsUsage.getFeatures().contains(MRT_FEATURE);
     }
 
-    // TODO: the getters below need to create an immutable snapshot of CCS Telemetry and return that - see SearchUsageStats as example
-    public SuccessfulCCSTelemetry getSuccessfulSearchTelemetry() {
-        return successfulSearchTelem;
-    }
-
-    public FailedCCSTelemetry getFailedSearchTelemetry() {
-        return failedSearchTelem;
+    private boolean isSuccess(CCSUsage ccsUsage) {
+        return ccsUsage.getStatus() == Result.SUCCESS;
     }
 
     public Map<String, PerClusterCCSTelemetry> getTelemetryByCluster() {
@@ -79,101 +147,35 @@ public class CCSUsageTelemetry {
     }
 
     /**
-     * Telemetry metrics for successful searches (includes searches with partial failures)
-     */
-    static class SuccessfulCCSTelemetry {
-        private long count; // total number of searches
-        private long countMinimizeRoundtrips;
-        private long countSearchesWithSkippedRemotes;
-        private long countAsync;
-        private DoubleHistogram latency;
-
-        SuccessfulCCSTelemetry() {
-            this.count = 0;
-            this.countMinimizeRoundtrips = 0;
-            this.countSearchesWithSkippedRemotes = 0;
-            this.countAsync = 0;
-            this.latency = new DoubleHistogram(2);
-        }
-
-        void update(CCSUsage ccsUsage) {
-            count++;
-            countMinimizeRoundtrips += ccsUsage.isMinimizeRoundTrips() ? 1 : 0;
-            countSearchesWithSkippedRemotes += ccsUsage.getSkippedRemotes() > 0 ? 1 : 0;
-            countAsync += ccsUsage.isAsync() ? 1 : 0;
-            latency.recordValue(ccsUsage.getTook());
-        }
-
-        // TODO: remove these getters and replace with a toSuccessfulCCSUsageSnapshot method?
-        public long getCount() {
-            return count;
-        }
-
-        public long getCountMinimizeRoundtrips() {
-            return countMinimizeRoundtrips;
-        }
-
-        public long getCountSearchesWithSkippedRemotes() {
-            return countSearchesWithSkippedRemotes;
-        }
-
-        public long getCountAsync() {
-            return countAsync;
-        }
-
-        public double getMeanLatency() {
-            return latency.getMean();
-        }
-    }
-
-    /**
-     * Telemetry metrics for failed searches (no data returned)
-     */
-    static class FailedCCSTelemetry {
-        private long count;
-        private Map<String, Integer> causes;
-
-        FailedCCSTelemetry() {
-            causes = new HashMap<>();
-        }
-
-        void update(CCSUsage ccsUsage) {
-            count++;
-            causes.compute(ccsUsage.getFailureType(), (k, v) -> (v == null) ? 1 : v + 1);
-        }
-
-        public long getCount() {
-            return count;
-        }
-    }
-
-    /**
      * Telemetry of each remote involved in cross cluster searches
      */
-    static class PerClusterCCSTelemetry {
-        private String clusterAlias;
+    public static class PerClusterCCSTelemetry {
+        private final String clusterAlias;
+        // Right now, this is the number of successful (not skipped) requests to this cluster.
+        // We need to make it clear in the docs that it does not count skipped requests.
+        // TODO: are we OK to use long and not LongAdder here?
         private long count;
-        private DoubleHistogram latency;
+        private long skippedCount;
+        private final LongMetric took;
 
         PerClusterCCSTelemetry(String clusterAlias) {
             this.clusterAlias = clusterAlias;
             this.count = 0;
-            // TODO: what should we use for num significant value digits?
-            latency = new DoubleHistogram(2);
+            took = new LongMetric();
+            this.skippedCount = 0;
         }
 
         void update(CCSUsage.PerClusterUsage remoteUsage) {
             count++;
-            latency.recordValue(remoteUsage.getTook()); // TODO: do we need to add count as well using recordValueWithCount?
+            took.record(remoteUsage.getTook());
+        }
+
+        void skipped() {
+            skippedCount++;
         }
 
         public long getCount() {
             return count;
-        }
-
-        // TODO: add additional getters around latency (max, p90)
-        public double getMeanLatency() {
-            return latency.getMean();
         }
 
         @Override
@@ -184,9 +186,43 @@ public class CCSUsageTelemetry {
                 + '\''
                 + ", count="
                 + count
-                + ", latency(mean)="
-                + latency.getMean()
+                + ", latency="
+                + took.toString()
                 + '}';
         }
+
+        public long getSkippedCount() {
+            return skippedCount;
+        }
+
+        public CCSTelemetrySnapshot.PerClusterCCSTelemetry getSnapshot() {
+            return new CCSTelemetrySnapshot.PerClusterCCSTelemetry(count, skippedCount, took.getValue());
+        }
+
+    }
+
+    // TODO: I wonder if it wouldn't be more correct if this lived on the Snapshot side,
+    // but SearchUsage does it this way so following the pattern here.
+    public CCSTelemetrySnapshot getCCSTelemetrySnapshot() {
+        Map<String, Long> reasonsMap = Maps.newMapWithExpectedSize(failureReasons.size());
+        failureReasons.forEach((k, v) -> reasonsMap.put(k.getName(), v.longValue()));
+
+        LongMetric.LongMetricValue remotes = remotesPerSearch.getValue();
+
+        // Maps returned here are unmodifyable, but the empty ctor produces modifyable maps
+        return new CCSTelemetrySnapshot(
+            totalCount.longValue(),
+            successCount.longValue(),
+            Collections.unmodifiableMap(reasonsMap),
+            took.getValue(),
+            tookMrtTrue.getValue(),
+            tookMrtFalse.getValue(),
+            remotes.max(),
+            remotes.avg(),
+            skippedRemotes.longValue(),
+            Collections.unmodifiableMap(Maps.transformValues(featureCounts, LongAdder::longValue)),
+            Collections.unmodifiableMap(Maps.transformValues(clientCounts, LongAdder::longValue)),
+            Collections.unmodifiableMap(Maps.transformValues(byRemoteCluster, PerClusterCCSTelemetry::getSnapshot))
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetry.java
@@ -42,8 +42,12 @@ public class CCSUsageTelemetry {
         SUCCESS("success"),
         REMOTES_UNAVAILABLE("remotes_unavailable"),
         CANCELED("canceled"),
+        NOT_FOUND("not_found"),
+        TIMEOUT("timeout"),
+        CORRUPTION("corruption"),
+        SECURITY("security"),
         // May be helpful if there's a lot of other reasons, and it may be hard to calculate the unknowns for some clients.
-        UNKNOWN("unknown");
+        UNKNOWN("other");
 
         private final String name;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.zip.DataFormatException;
 
 /**
- * Metric class that accepts longs and provides count, average, max and maybe percentiles.
+ * Metric class that accepts longs and provides count, average, max and percentiles.
  * Abstracts out the details of how exactly the values are stored and calculated.
  * {@link LongMetricValue} is a snapshot of the current state of the metric.
  */

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.HdrHistogram.DoubleHistogram;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.zip.DataFormatException;
+
+/**
+ * Metric class that accepts longs and provides count, average, max and maybe percentiles.
+ * Abstracts out the details of how exactly the values are stored and calculated.
+ * {@link LongMetricValue} is a snapshot of the current state of the metric.
+ */
+public class LongMetric {
+    private final DoubleHistogram values;
+    private static final int SIGNIFICANT_DIGITS = 2;
+
+    LongMetric() {
+        values = new DoubleHistogram(SIGNIFICANT_DIGITS);
+    }
+
+    void record(long v) {
+        values.recordValue(v);
+    }
+
+    LongMetricValue getValue() {
+        return new LongMetricValue(values);
+    }
+
+    /**
+     * Snapshot of {@link LongMetric} value that provides the current state of the metric.
+     * Can be added with another {@link LongMetricValue} object.
+     */
+    public static final class LongMetricValue implements Writeable {
+        // We have to carry the full histogram around since we might need to calculate aggregate percentiles
+        // after collecting individual stats from the nodes, and we can't do that without having the full histogram.
+        // This costs about 2K per metric, which was deemed acceptable.
+        private final DoubleHistogram values;
+
+        public LongMetricValue(DoubleHistogram values) {
+            // Copy here since we don't want the snapshot value to change if somebody updates the original one
+            this.values = values.copy();
+        }
+
+        public LongMetricValue(LongMetricValue v) {
+            this.values = v.values.copy();
+        }
+
+        LongMetricValue() {
+            this.values = new DoubleHistogram(SIGNIFICANT_DIGITS);
+        }
+
+        public void add(LongMetricValue v) {
+            this.values.add(v.values);
+        }
+
+        public static LongMetricValue fromStream(StreamInput in) throws IOException {
+            byte[] b = in.readByteArray();
+            ByteBuffer bb = ByteBuffer.wrap(b);
+            try {
+                // TODO: not sure what is the good value for minBarForHighestToLowestValueRatio here?
+                DoubleHistogram dh = DoubleHistogram.decodeFromCompressedByteBuffer(bb, 1);
+                return new LongMetricValue(dh);
+            } catch (DataFormatException e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            ByteBuffer b = ByteBuffer.allocate(values.getNeededByteBufferCapacity());
+            values.encodeIntoCompressedByteBuffer(b);
+            int size = b.position();
+            out.writeVInt(size);
+            out.writeBytes(b.array(), 0, size);
+        }
+
+        public long count() {
+            return values.getTotalCount();
+        }
+
+        public long max() {
+            return (long) Math.ceil(values.getMaxValue());
+        }
+
+        public long avg() {
+            return (long) Math.ceil(values.getMean());
+        }
+
+        public long p90() {
+            return (long) Math.ceil(values.getValueAtPercentile(90));
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (LongMetricValue) obj;
+            return this.values.equals(that.values);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(values);
+        }
+
+        @Override
+        public String toString() {
+            return "LongMetricValue[count=" + count() + ", " + "max=" + max() + ", " + "avg=" + avg() + "]";
+        }
+
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -702,6 +703,13 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         }
 
         /**
+         * @return collection of cluster aliases in the search response (including "(local)" if was searched).
+         */
+        public Set<String> getClusterAliases() {
+            return clusterInfo.keySet();
+        }
+
+        /**
          * Utility to swap a Cluster object. Guidelines for the remapping function:
          * <ul>
          * <li> The remapping function should return a new Cluster object to swap it for
@@ -803,6 +811,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         public boolean hasRemoteClusters() {
             return total > 1 || clusterInfo.keySet().stream().anyMatch(alias -> alias != RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
         }
+
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse
 import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
 import org.elasticsearch.action.admin.cluster.stats.CCSUsage;
 import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry;
-import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -80,7 +79,6 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.profile.SearchProfileShardResult;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
@@ -1929,17 +1927,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         public void onFailure(Exception e) {
             searchResponseMetrics.incrementResponseCount(SearchResponseMetrics.ResponseCountTotalStatus.FAILURE);
             if (collectTelemetry()) {
-                // TODO: better failure recognition
-                Result status;
-                if (e instanceof RemoteTransportException) {
-                    status = Result.REMOTES_UNAVAILABLE;
-                } else if (task.isCancelled() || (e instanceof TaskCancelledException)) {
-                    status = Result.CANCELED;
-                } else {
-                    status = Result.UNKNOWN;
-                }
-                usageBuilder.setFailure(status);
-                // TODO: can we still get some time measurements here? Do we want to?
+                usageBuilder.setFailure(e);
                 recordTelemetry();
             }
             listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1943,7 +1943,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
          */
         private void extractCCSTelemetry(SearchResponse searchResponse) {
             usageBuilder.took(searchResponse.getTookInMillis());
-            // TODO: what happens with the local cluster there? Are we tracking it too just like the others?
             for (String clusterAlias : searchResponse.getClusters().getClusterAliases()) {
                 SearchResponse.Cluster cluster = searchResponse.getClusters().getCluster(clusterAlias);
                 if (cluster.getStatus() == SearchResponse.Cluster.Status.SKIPPED) {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -384,7 +384,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     if (resolvedIndices.getRemoteClusterIndices()
                         .values()
                         .stream()
-                        .anyMatch(originalIndices -> Arrays.stream(originalIndices.indices()).anyMatch(Regex::isSimpleMatchPattern))) {
+                        .anyMatch(indices -> Arrays.stream(indices.indices()).anyMatch(Regex::isSimpleMatchPattern))) {
                         tl.setFeature(CCSUsageTelemetry.WILDCARD_FEATURE);
                     }
                 }
@@ -1521,7 +1521,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
      * @return true if this is an async search task; false if a synchronous search task
      */
     private boolean isAsyncSearchTask(SearchTask searchTask) {
-        assert assertAsyncSearchTaskListener(searchTask) : "AsyncSearchTask SearchProgressListener name has ";
+        assert assertAsyncSearchTaskListener(searchTask) : "AsyncSearchTask SearchProgressListener is not one of the expected types";
         // AsyncSearchTask will not return SearchProgressListener.NOOP, since it uses its own progress listener
         // which delegates to CCSSingleCoordinatorSearchProgressListener when minimizing roundtrips.
         // Only synchronous SearchTask uses SearchProgressListener.NOOP or CCSSingleCoordinatorSearchProgressListener directly

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1914,12 +1914,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     extractCCSTelemetry(searchResponse);
                     recordTelemetry();
                 }
-                // This is last because we want to collect telemetry before returning the response.
-                // We rely on the fact that onResponse would never throw so the increment won't happen more than once.
-                listener.onResponse(searchResponse);
             } catch (Exception e) {
                 onFailure(e);
+                return;
             }
+            // This is last because we want to collect telemetry before returning the response.
+            listener.onResponse(searchResponse);
         }
 
         @Override
@@ -1934,6 +1934,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
         private void recordTelemetry() {
             usageService.getCcsUsageHolder().updateUsage(usageBuilder.build());
+            usageBuilder.setRemotesCount(0); // prevent double recording
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1908,15 +1908,14 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         }
                     }
                 }
-                // increment after the delegated onResponse to ensure we don't
-                // record both a success and a failure if there is an exception
                 searchResponseMetrics.incrementResponseCount(responseCountTotalStatus);
 
                 if (collectTelemetry()) {
                     extractCCSTelemetry(searchResponse);
                     recordTelemetry();
                 }
-                // TODO: should this be last?
+                // This is last because we want to collect telemetry before returning the response.
+                // We rely on the fact that onResponse would never throw so the increment won't happen more than once.
                 listener.onResponse(searchResponse);
             } catch (Exception e) {
                 onFailure(e);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsage;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -84,6 +85,7 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentFactory;
 
@@ -156,6 +158,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     private final boolean ccsCheckCompatibility;
     private final SearchResponseMetrics searchResponseMetrics;
     private final Client client;
+    private final UsageService usageService;
 
     @Inject
     public TransportSearchAction(
@@ -172,7 +175,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         ExecutorSelector executorSelector,
         SearchTransportAPMMetrics searchTransportMetrics,
         SearchResponseMetrics searchResponseMetrics,
-        Client client
+        Client client,
+        UsageService usageService
     ) {
         super(TYPE.name(), transportService, actionFilters, SearchRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.threadPool = threadPool;
@@ -191,6 +195,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         this.ccsCheckCompatibility = SearchService.CCS_VERSION_CHECK_SETTING.get(clusterService.getSettings());
         this.searchResponseMetrics = searchResponseMetrics;
         this.client = client;
+        this.usageService = usageService;
     }
 
     private Map<String, OriginalIndices> buildPerIndexOriginalIndices(
@@ -327,10 +332,15 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             }
                         }
                     }
-                    listener.onResponse(searchResponse);
                     // increment after the delegated onResponse to ensure we don't
                     // record both a success and a failure if there is an exception
                     searchResponseMetrics.incrementResponseCount(responseCountTotalStatus);
+
+                    if (CCS_TELEMETRY_FEATURE_FLAG.isEnabled() && searchResponse.getClusters().hasRemoteClusters()) {
+                        extractCCSTelemetry(searchResponse, (SearchTask) task);
+                    }
+                    // TODO: should this be last?
+                    listener.onResponse(searchResponse);
                 } catch (Exception e) {
                     onFailure(e);
                 }
@@ -1518,6 +1528,51 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 }
             }
         }
+    }
+
+    private void extractCCSTelemetry(SearchResponse searchResponse, SearchTask searchTask) {
+        Map<String, CCSUsage.PerClusterUsage> clusterUsageMap = new HashMap<>();
+        for (String clusterAlias : searchResponse.getClusters().getClusterAliases()) {
+            SearchResponse.Cluster cluster = searchResponse.getClusters().getCluster(clusterAlias);
+            CCSUsage.PerClusterUsage clusterUsageInfo = new CCSUsage.PerClusterUsage(cluster.getTook());
+            clusterUsageMap.put(clusterAlias, clusterUsageInfo);
+        }
+
+        CCSUsage ccsUsage = new CCSUsage.Builder().took(searchResponse.getTookInMillis())
+            .async(isAsyncSearchTask(searchTask))
+            .minimizeRoundTrips(searchResponse.getClusters().isCcsMinimizeRoundtrips())
+            .numSkippedRemotes(searchResponse.getClusters().getClusterStateCount(SearchResponse.Cluster.Status.SKIPPED))
+            .perClusterUsage(clusterUsageMap)
+            .build();
+        usageService.getCcsUsageHolder().updateUsage(ccsUsage);
+    }
+
+    /**
+     * TransportSearchAction cannot access async-search code, so can't check whether this the Task
+     * is an instance of AsyncSearchTask, so this roundabout method is used
+     * @param searchTask SearchTask to analyze
+     * @return true if this is an async search task; false if a synchronous search task
+     */
+    private boolean isAsyncSearchTask(SearchTask searchTask) {
+        assert assertAsyncSearchTaskListener(searchTask) : "AsyncSearchTask SearchProgressListener name has ";
+        // AsyncSearchTask will not return SearchProgressListener.NOOP, since it uses its own progress listener
+        // which delegates to CCSSingleCoordinatorSearchProgressListener when minimizing roundtrips.
+        // Only synchronous SearchTask uses SearchProgressListener.NOOP or CCSSingleCoordinatorSearchProgressListener directly
+        return searchTask.getProgressListener() != SearchProgressListener.NOOP
+            && searchTask.getProgressListener() instanceof CCSSingleCoordinatorSearchProgressListener == false;
+    }
+
+    /**
+     * @param searchTask SearchTask to analyze
+     * @return true if AsyncSearchTask still uses its own special listener, not one of the two that synchronous SearchTask uses
+     */
+    private boolean assertAsyncSearchTaskListener(SearchTask searchTask) {
+        if (searchTask.getClass().getSimpleName().contains("AsyncSearchTask")) {
+            SearchProgressListener progressListener = searchTask.getProgressListener();
+            return progressListener != SearchProgressListener.NOOP
+                && progressListener instanceof CCSSingleCoordinatorSearchProgressListener == false;
+        }
+        return true;
     }
 
     private static void validateAndResolveWaitForCheckpoint(

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1934,7 +1934,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
         private void recordTelemetry() {
             usageService.getCcsUsageHolder().updateUsage(usageBuilder.build());
-            usageBuilder.setRemotesCount(0); // prevent double recording
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/usage/UsageService.java
+++ b/server/src/main/java/org/elasticsearch/usage/UsageService.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.usage;
 
 import org.elasticsearch.action.admin.cluster.node.usage.NodeUsage;
+import org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry;
 import org.elasticsearch.rest.BaseRestHandler;
 
 import java.util.HashMap;
@@ -23,10 +24,12 @@ public class UsageService {
 
     private final Map<String, BaseRestHandler> handlers;
     private final SearchUsageHolder searchUsageHolder;
+    private final CCSUsageTelemetry ccsUsageHolder;
 
     public UsageService() {
         this.handlers = new HashMap<>();
         this.searchUsageHolder = new SearchUsageHolder();
+        this.ccsUsageHolder = new CCSUsageTelemetry();
     }
 
     /**
@@ -80,5 +83,9 @@ public class UsageService {
      */
     public SearchUsageHolder getSearchUsageHolder() {
         return searchUsageHolder;
+    }
+
+    public CCSUsageTelemetry getCcsUsageHolder() {
+        return ccsUsageHolder;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ApproximateMatcher.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ApproximateMatcher.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matches a value that is within given range (currently 1%) of an expected value.
+ *
+ * We need this because histograms do not store exact values, but only value ranges.
+ * Since we have 2 significant digits, the value should be within 1% of the expected value.
+ */
+public class ApproximateMatcher extends TypeSafeMatcher<Long> {
+    public static double ACCURACY = 0.01;
+    private final long expectedValue;
+
+    public ApproximateMatcher(long expectedValue) {
+        this.expectedValue = expectedValue;
+    }
+
+    @Override
+    protected boolean matchesSafely(Long actualValue) {
+        double lowerBound = Math.floor(expectedValue * (1.00 - ACCURACY));
+        double upperBound = Math.ceil(expectedValue * (1.00 + ACCURACY));
+        return actualValue >= lowerBound && actualValue <= upperBound;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a long value within 1% of ").appendValue(expectedValue);
+    }
+
+    /**
+     * Matches a value that is within given range (currently 1%) of an expected value.
+     */
+    public static ApproximateMatcher closeTo(long expectedValue) {
+        return new ApproximateMatcher(expectedValue);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -78,7 +78,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         LongMetricValue took = instance.getTook();
         LongMetricValue tookMrtTrue = instance.getTookMrtTrue();
         LongMetricValue tookMrtFalse = instance.getTookMrtFalse();
-        long skippedRemotes = instance.getSkippedRemotes();
+        long skippedRemotes = instance.getSearchCountWithSkippedRemotes();
         long remotesPerSearchMax = instance.getRemotesPerSearchMax();
         double remotesPerSearchAvg = instance.getRemotesPerSearchAvg();
         var featureCounts = instance.getFeatureCounts();
@@ -184,7 +184,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         assertThat(empty.getTook().count(), equalTo(full.getTook().count() * 2));
         assertThat(empty.getTookMrtTrue().count(), equalTo(full.getTookMrtTrue().count() * 2));
         assertThat(empty.getTookMrtFalse().count(), equalTo(full.getTookMrtFalse().count() * 2));
-        assertThat(empty.getSkippedRemotes(), equalTo(full.getSkippedRemotes() * 2));
+        assertThat(empty.getSearchCountWithSkippedRemotes(), equalTo(full.getSearchCountWithSkippedRemotes() * 2));
         assertThat(empty.getRemotesPerSearchMax(), equalTo(full.getRemotesPerSearchMax()));
         assertThat(empty.getRemotesPerSearchAvg(), closeTo(full.getRemotesPerSearchAvg(), 0.01));
         empty.getFeatureCounts().forEach((k, v) -> assertThat(v, equalTo(full.getFeatureCounts().get(k) * 2)));
@@ -215,7 +215,10 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         assertThat(empty.getTook().count(), equalTo(full.getTook().count() + full2.getTook().count()));
         assertThat(empty.getTookMrtTrue().count(), equalTo(full.getTookMrtTrue().count() + full2.getTookMrtTrue().count()));
         assertThat(empty.getTookMrtFalse().count(), equalTo(full.getTookMrtFalse().count() + full2.getTookMrtFalse().count()));
-        assertThat(empty.getSkippedRemotes(), equalTo(full.getSkippedRemotes() + full2.getSkippedRemotes()));
+        assertThat(
+            empty.getSearchCountWithSkippedRemotes(),
+            equalTo(full.getSearchCountWithSkippedRemotes() + full2.getSearchCountWithSkippedRemotes())
+        );
         assertThat(empty.getRemotesPerSearchMax(), equalTo(Math.max(full.getRemotesPerSearchMax(), full2.getRemotesPerSearchMax())));
         double expectedAvg = (full.getRemotesPerSearchAvg() * full.getTotalCount() + full2.getRemotesPerSearchAvg() * full2.getTotalCount())
             / empty.getTotalCount();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot.PerClusterCCSTelemetry;
+import org.elasticsearch.action.admin.cluster.stats.LongMetric.LongMetricValue;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+
+public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<CCSTelemetrySnapshot> {
+
+    private LongMetricValue randomLongMetricValue() {
+        LongMetric v = new LongMetric();
+        for (int i = 0; i < randomIntBetween(1, 10); i++) {
+            v.record(randomIntBetween(0, 1_000_000));
+        }
+        return v.getValue();
+    }
+
+    private PerClusterCCSTelemetry randomPerClusterCCSTelemetry() {
+        return new PerClusterCCSTelemetry(randomLongBetween(0, 1_000_000), randomLongBetween(0, 1_000_000), randomLongMetricValue());
+    }
+
+    @Override
+    protected CCSTelemetrySnapshot createTestInstance() {
+        if (randomBoolean()) {
+            return new CCSTelemetrySnapshot();
+        } else {
+            return randomCCSTelemetrySnapshot();
+        }
+    }
+
+    private CCSTelemetrySnapshot randomCCSTelemetrySnapshot() {
+        return new CCSTelemetrySnapshot(
+            randomLongBetween(0, 1_000_000),
+            randomLongBetween(0, 1_000_000),
+            Map.of(),
+            randomLongMetricValue(),
+            randomLongMetricValue(),
+            randomLongMetricValue(),
+            randomLongBetween(0, 1_000_000),
+            randomDoubleBetween(0.0, 100.0, false),
+            randomLongBetween(0, 1_000_000),
+            Map.of(),
+            Map.of(),
+            randomMap(1, 10, () -> new Tuple<>(randomAlphaOfLengthBetween(5, 10), randomPerClusterCCSTelemetry()))
+        );
+    }
+
+    @Override
+    protected Writeable.Reader<CCSTelemetrySnapshot> instanceReader() {
+        return CCSTelemetrySnapshot::new;
+    }
+
+    @Override
+    protected CCSTelemetrySnapshot mutateInstance(CCSTelemetrySnapshot instance) throws IOException {
+        // create a copy of CCSTelemetrySnapshot by extracting each field and mutating it
+        long totalCount = instance.getTotalCount();
+        long successCount = instance.getSuccessCount();
+        var failureReasons = instance.getFailureReasons();
+        LongMetricValue took = instance.getTook();
+        LongMetricValue tookMrtTrue = instance.getTookMrtTrue();
+        LongMetricValue tookMrtFalse = instance.getTookMrtFalse();
+        long skippedRemotes = instance.getSkippedRemotes();
+        long remotesPerSearchMax = instance.getRemotesPerSearchMax();
+        double remotesPerSearchAvg = instance.getRemotesPerSearchAvg();
+        var featureCounts = instance.getFeatureCounts();
+        var clientCounts = instance.getClientCounts();
+        var perClusterCCSTelemetries = instance.getByRemoteCluster();
+
+        // Mutate values
+        int i = randomInt(11);
+        switch (i) {
+            case 0:
+                totalCount += randomNonNegativeLong();
+                break;
+            case 1:
+                successCount += randomNonNegativeLong();
+                break;
+            case 2:
+                failureReasons = new HashMap<>(failureReasons);
+                if (failureReasons.isEmpty() || randomBoolean()) {
+                    failureReasons.put(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(failureReasons.keySet());
+                    failureReasons.put(key, randomNonNegativeLong());
+                }
+                break;
+            case 3:
+                took = randomLongMetricValue();
+                break;
+            case 4:
+                tookMrtTrue = randomLongMetricValue();
+                break;
+            case 5:
+                tookMrtFalse = randomLongMetricValue();
+                break;
+            case 6:
+                skippedRemotes += randomNonNegativeLong();
+                break;
+            case 7:
+                remotesPerSearchMax += randomNonNegativeLong();
+                break;
+            case 8:
+                remotesPerSearchAvg = randomDoubleBetween(0.0, 100.0, false);
+                break;
+            case 9:
+                featureCounts = new HashMap<>(featureCounts);
+                if (featureCounts.isEmpty() || randomBoolean()) {
+                    featureCounts.put(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(featureCounts.keySet());
+                    featureCounts.put(key, randomNonNegativeLong());
+                }
+                break;
+            case 10:
+                clientCounts = new HashMap<>(clientCounts);
+                if (clientCounts.isEmpty() || randomBoolean()) {
+                    clientCounts.put(randomAlphaOfLengthBetween(5, 10), randomNonNegativeLong());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(clientCounts.keySet());
+                    clientCounts.put(key, randomNonNegativeLong());
+                }
+                break;
+            case 11:
+                perClusterCCSTelemetries = new HashMap<>(perClusterCCSTelemetries);
+                if (perClusterCCSTelemetries.isEmpty() || randomBoolean()) {
+                    perClusterCCSTelemetries.put(randomAlphaOfLengthBetween(5, 10), randomPerClusterCCSTelemetry());
+                } else {
+                    // modify random element of the map
+                    String key = randomFrom(perClusterCCSTelemetries.keySet());
+                    perClusterCCSTelemetries.put(key, randomPerClusterCCSTelemetry());
+                }
+                break;
+        }
+        // Return new instance
+        return new CCSTelemetrySnapshot(
+            totalCount,
+            successCount,
+            failureReasons,
+            took,
+            tookMrtTrue,
+            tookMrtFalse,
+            remotesPerSearchMax,
+            remotesPerSearchAvg,
+            skippedRemotes,
+            featureCounts,
+            clientCounts,
+            perClusterCCSTelemetries
+        );
+    }
+
+    public void testAdd() {
+        CCSTelemetrySnapshot empty = new CCSTelemetrySnapshot();
+        CCSTelemetrySnapshot full = randomCCSTelemetrySnapshot();
+        empty.add(full);
+        assertThat(empty, equalTo(full));
+        // Add again
+        empty.add(full);
+        assertThat(empty.getTotalCount(), equalTo(full.getTotalCount() * 2));
+        assertThat(empty.getSuccessCount(), equalTo(full.getSuccessCount() * 2));
+        // check that each element of the map is doubled
+        empty.getFailureReasons().forEach((k, v) -> assertThat(v, equalTo(full.getFailureReasons().get(k) * 2)));
+        assertThat(empty.getTook().count(), equalTo(full.getTook().count() * 2));
+        assertThat(empty.getTookMrtTrue().count(), equalTo(full.getTookMrtTrue().count() * 2));
+        assertThat(empty.getTookMrtFalse().count(), equalTo(full.getTookMrtFalse().count() * 2));
+        assertThat(empty.getSkippedRemotes(), equalTo(full.getSkippedRemotes() * 2));
+        assertThat(empty.getRemotesPerSearchMax(), equalTo(full.getRemotesPerSearchMax()));
+        assertThat(empty.getRemotesPerSearchAvg(), closeTo(full.getRemotesPerSearchAvg(), 0.01));
+        empty.getFeatureCounts().forEach((k, v) -> assertThat(v, equalTo(full.getFeatureCounts().get(k) * 2)));
+        empty.getClientCounts().forEach((k, v) -> assertThat(v, equalTo(full.getClientCounts().get(k) * 2)));
+        empty.getByRemoteCluster().forEach((k, v) -> {
+            assertThat(v.getCount(), equalTo(full.getByRemoteCluster().get(k).getCount() * 2));
+            assertThat(v.getSkippedCount(), equalTo(full.getByRemoteCluster().get(k).getSkippedCount() * 2));
+            assertThat(v.getTook().count(), equalTo(full.getByRemoteCluster().get(k).getTook().count() * 2));
+        });
+    }
+
+    public void testAddTwo() {
+        CCSTelemetrySnapshot empty = new CCSTelemetrySnapshot();
+        CCSTelemetrySnapshot full = randomCCSTelemetrySnapshot();
+        CCSTelemetrySnapshot full2 = randomCCSTelemetrySnapshot();
+
+        empty.add(full);
+        empty.add(full2);
+        assertThat(empty.getTotalCount(), equalTo(full.getTotalCount() + full2.getTotalCount()));
+        assertThat(empty.getSuccessCount(), equalTo(full.getSuccessCount() + full2.getSuccessCount()));
+        empty.getFailureReasons()
+            .forEach(
+                (k, v) -> assertThat(
+                    v,
+                    equalTo(full.getFailureReasons().getOrDefault(k, 0L) + full2.getFailureReasons().getOrDefault(k, 0L))
+                )
+            );
+        assertThat(empty.getTook().count(), equalTo(full.getTook().count() + full2.getTook().count()));
+        assertThat(empty.getTookMrtTrue().count(), equalTo(full.getTookMrtTrue().count() + full2.getTookMrtTrue().count()));
+        assertThat(empty.getTookMrtFalse().count(), equalTo(full.getTookMrtFalse().count() + full2.getTookMrtFalse().count()));
+        assertThat(empty.getSkippedRemotes(), equalTo(full.getSkippedRemotes() + full2.getSkippedRemotes()));
+        assertThat(empty.getRemotesPerSearchMax(), equalTo(Math.max(full.getRemotesPerSearchMax(), full2.getRemotesPerSearchMax())));
+        double expectedAvg = (full.getRemotesPerSearchAvg() * full.getTotalCount() + full2.getRemotesPerSearchAvg() * full2.getTotalCount())
+            / empty.getTotalCount();
+        assertThat(empty.getRemotesPerSearchAvg(), closeTo(expectedAvg, 0.01));
+        empty.getFeatureCounts()
+            .forEach(
+                (k, v) -> assertThat(v, equalTo(full.getFeatureCounts().getOrDefault(k, 0L) + full2.getFeatureCounts().getOrDefault(k, 0L)))
+            );
+        empty.getClientCounts()
+            .forEach(
+                (k, v) -> assertThat(v, equalTo(full.getClientCounts().getOrDefault(k, 0L) + full2.getClientCounts().getOrDefault(k, 0L)))
+            );
+        PerClusterCCSTelemetry zeroDummy = new PerClusterCCSTelemetry();
+        empty.getByRemoteCluster().forEach((k, v) -> {
+            assertThat(
+                v.getCount(),
+                equalTo(
+                    full.getByRemoteCluster().getOrDefault(k, zeroDummy).getCount() + full2.getByRemoteCluster()
+                        .getOrDefault(k, zeroDummy)
+                        .getCount()
+                )
+            );
+            assertThat(
+                v.getSkippedCount(),
+                equalTo(
+                    full.getByRemoteCluster().getOrDefault(k, zeroDummy).getSkippedCount() + full2.getByRemoteCluster()
+                        .getOrDefault(k, zeroDummy)
+                        .getSkippedCount()
+                )
+            );
+            assertThat(
+                v.getTook().count(),
+                equalTo(
+                    full.getByRemoteCluster().getOrDefault(k, zeroDummy).getTook().count() + full2.getByRemoteCluster()
+                        .getOrDefault(k, zeroDummy)
+                        .getTook()
+                        .count()
+                )
+            );
+        });
+    }
+
+    private LongMetricValue manyValuesHistogram(long startingWith) {
+        LongMetric metric = new LongMetric();
+        // Produce 100 values from startingWith to 2 * startingWith with equal intervals
+        // We need to space values relative to initial value, otherwise the histogram would put them all in one bucket
+        for (long i = startingWith; i < 2 * startingWith; i += startingWith / 100) {
+            metric.record(i);
+        }
+        return metric.getValue();
+    }
+
+    public void testToXContent() throws IOException {
+        long totalCount = 10;
+        long successCount = 20;
+        // Using TreeMap's here to ensure consistent ordering in the JSON output
+        var failureReasons = new TreeMap<>(Map.of("reason1", 1L, "reason2", 2L, "unknown", 3L));
+        LongMetricValue took = manyValuesHistogram(1000);
+        LongMetricValue tookMrtTrue = manyValuesHistogram(5000);
+        LongMetricValue tookMrtFalse = manyValuesHistogram(10000);
+        long skippedRemotes = 5;
+        long remotesPerSearchMax = 6;
+        double remotesPerSearchAvg = 7.89;
+        var featureCounts = new TreeMap<>(Map.of("async", 10L, "mrt", 20L, "wildcard", 30L));
+        var clientCounts = new TreeMap<>(Map.of("kibana", 40L, "other", 500L));
+        var perClusterCCSTelemetries = new TreeMap<>(
+            Map.of(
+                "remote1",
+                new PerClusterCCSTelemetry(100, 22, manyValuesHistogram(2000)),
+                "remote2",
+                new PerClusterCCSTelemetry(300, 42, manyValuesHistogram(500000))
+            )
+        );
+
+        var snapshot = new CCSTelemetrySnapshot(
+            totalCount,
+            successCount,
+            failureReasons,
+            took,
+            tookMrtTrue,
+            tookMrtFalse,
+            remotesPerSearchMax,
+            remotesPerSearchAvg,
+            skippedRemotes,
+            featureCounts,
+            clientCounts,
+            perClusterCCSTelemetries
+        );
+        String expected = readJSONFromResource("telemetry_test.json");
+        assertEquals(expected, snapshot.toString());
+    }
+
+    private String readJSONFromResource(String fileName) throws IOException {
+        try (InputStream inputStream = getClass().getResourceAsStream("/org/elasticsearch/action/admin/cluster/stats/" + fileName)) {
+            if (inputStream == null) {
+                throw new IOException("Resource not found: " + fileName);
+            }
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -286,6 +286,8 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
         var clientCounts = new TreeMap<>(Map.of("kibana", 40L, "other", 500L));
         var perClusterCCSTelemetries = new TreeMap<>(
             Map.of(
+                "",
+                new PerClusterCCSTelemetry(12, 0, manyValuesHistogram(2000)),
                 "remote1",
                 new PerClusterCCSTelemetry(100, 22, manyValuesHistogram(2000)),
                 "remote2",

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.stats;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class CCSUsageTelemetryTests extends ESTestCase {
+
+    public void testSuccessfulSearchResults() {
+        CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
+
+        long expectedAsyncCount = 0L;
+        long expectedMinRTCount = 0L;
+        long expectedSearchesWithSkippedRemotes = 0L;
+        long took1 = 0L;
+        long took1Remote1 = 0L;
+
+        // first search
+        {
+            boolean minimizeRoundTrips = randomBoolean();
+            boolean async = randomBoolean();
+            took1 = randomLongBetween(5, 10000);
+            int numSkippedRemotes = randomIntBetween(0, 3);
+            expectedSearchesWithSkippedRemotes = numSkippedRemotes > 0 ? 1 : 0;
+            expectedAsyncCount = async ? 1 : 0;
+            expectedMinRTCount = minimizeRoundTrips ? 1 : 0;
+
+            // per cluster telemetry
+            long tookLocal = randomLongBetween(2, 8000);
+            took1Remote1 = randomLongBetween(2, 8000);
+            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
+                "(local)",
+                new CCSUsage.PerClusterUsage(new TimeValue(tookLocal)),
+                "remote1",
+                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
+            );
+
+            CCSUsage ccsUsage = new CCSUsage.Builder().took(took1)
+                .async(async)
+                .minimizeRoundTrips(minimizeRoundTrips)
+                .numSkippedRemotes(numSkippedRemotes)
+                .perClusterUsage(perClusterUsage)
+                .build();
+
+            ccsUsageHolder.updateUsage(ccsUsage);
+
+            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(1L));
+            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
+            assertThat(successfulCCSTelemetry.getCount(), equalTo(1L));
+            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
+            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
+            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1));
+
+            // per cluster telemetry asserts
+            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+            assertThat(telemetryByCluster.size(), equalTo(2));
+            var localClusterTelemetry = telemetryByCluster.get("(local)");
+            assertNotNull(localClusterTelemetry);
+            assertThat(localClusterTelemetry.getCount(), equalTo(1L));
+            assertThat(localClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(localClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) tookLocal));
+
+            var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
+            assertNotNull(remote1ClusterTelemetry);
+            assertThat(remote1ClusterTelemetry.getCount(), equalTo(1L));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1Remote1));
+        }
+
+        // second search
+        {
+            boolean minimizeRoundTrips = randomBoolean();
+            boolean async = randomBoolean();
+            expectedAsyncCount += async ? 1 : 0;
+            expectedMinRTCount += minimizeRoundTrips ? 1 : 0;
+            long took2 = randomLongBetween(5, 10000);
+            int numSkippedRemotes = randomIntBetween(0, 3);
+            expectedSearchesWithSkippedRemotes += numSkippedRemotes > 0 ? 1 : 0;
+
+            long took2Remote1 = randomLongBetween(2, 8000);
+            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
+                "remote1",
+                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
+            );
+
+            CCSUsage ccsUsage = new CCSUsage.Builder().took(took2)
+                .async(async)
+                .minimizeRoundTrips(minimizeRoundTrips)
+                .numSkippedRemotes(numSkippedRemotes)
+                .perClusterUsage(perClusterUsage)
+                .build();
+
+            ccsUsageHolder.updateUsage(ccsUsage);
+
+            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(2L));
+            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
+            assertThat(successfulCCSTelemetry.getCount(), equalTo(2L));
+            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
+            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
+            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1, took2)));
+
+            // per cluster telemetry asserts
+            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+            assertThat(telemetryByCluster.size(), equalTo(2));
+            var localClusterTelemetry = telemetryByCluster.get("(local)");
+            assertNotNull(localClusterTelemetry);
+            assertThat(localClusterTelemetry.getCount(), equalTo(1L));  // not part of second search
+
+            var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
+            assertNotNull(remote1ClusterTelemetry);
+            assertThat(remote1ClusterTelemetry.getCount(), equalTo(2L));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
+            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1Remote1, took2Remote1)));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -16,9 +16,9 @@ import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASY
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.KNOWN_CLIENTS;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
 import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result.CANCELED;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.WILDCARD_FEATURE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class CCSUsageTelemetryTests extends ESTestCase {
 
@@ -72,7 +72,7 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getTook().avg(), greaterThan(0L));
             // Expect it to be within 1% of the actual value
             assertThat(snapshot.getTook().avg(), closeTo(took1));
-            assertThat(snapshot.getTook().max(), lessThanOrEqualTo(took1));
+            assertThat(snapshot.getTook().max(), closeTo(took1));
             if (minimizeRoundTrips) {
                 assertThat(snapshot.getTookMrtTrue().count(), equalTo(1L));
                 assertThat(snapshot.getTookMrtTrue().avg(), greaterThan(0L));
@@ -273,5 +273,70 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             assertThat(snapshot.getFailureReasons().get(CANCELED.getName()), equalTo(2L));
             assertThat(snapshot.getClientCounts().get("kibana"), equalTo(1L));
         }
+    }
+
+    public void testConcurrentUpdates() throws InterruptedException {
+        CCSUsageTelemetry ccsUsageHolder = new CCSUsageTelemetry();
+        CCSUsageTelemetry expectedHolder = new CCSUsageTelemetry();
+        int numSearches = randomIntBetween(1000, 5000);
+        int numThreads = randomIntBetween(10, 20);
+        Thread[] threads = new Thread[numThreads];
+        CCSUsage[] ccsUsages = new CCSUsage[numSearches];
+
+        // Make random usage objects
+        for (int i = 0; i < numSearches; i++) {
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(randomLongBetween(5, 10000)).setRemotesCount(randomIntBetween(1, 10));
+            if (randomBoolean()) {
+                builder.setFeature(ASYNC_FEATURE);
+            }
+            if (randomBoolean()) {
+                builder.setFeature(WILDCARD_FEATURE);
+            }
+            if (randomBoolean()) {
+                builder.setFeature(MRT_FEATURE);
+            }
+            if (randomBoolean()) {
+                builder.setClient("kibana");
+            }
+            if (randomInt(20) == 7) {
+                // 5% of requests will fail
+                builder.setFailure(randomFrom(CCSUsageTelemetry.Result.values()));
+                ccsUsages[i] = builder.build();
+                continue;
+            }
+            builder.perClusterUsage("", new TimeValue(randomLongBetween(1, 10000)));
+            if (randomBoolean()) {
+                builder.skippedRemote("remote1");
+            } else {
+                builder.perClusterUsage("remote1", new TimeValue(randomLongBetween(1, 10000)));
+            }
+            builder.perClusterUsage(randomFrom("remote2", "remote3", "remote4"), new TimeValue(randomLongBetween(1, 10000)));
+            ccsUsages[i] = builder.build();
+        }
+
+        // Add each of the search objects to the telemetry holder in a different thread
+        for (int i = 0; i < numThreads; i++) {
+            final int threadNo = i;
+            threads[i] = new Thread(() -> {
+                for (int j = threadNo; j < numSearches; j += numThreads) {
+                    ccsUsageHolder.updateUsage(ccsUsages[j]);
+                }
+            });
+            threads[i].start();
+        }
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i].join();
+        }
+
+        // Add the same search objects to the expected holder in a single thread
+        for (int i = 0; i < numSearches; i++) {
+            expectedHolder.updateUsage(ccsUsages[i]);
+        }
+
+        CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+        CCSTelemetrySnapshot expectedSnapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+        assertThat(snapshot, equalTo(expectedSnapshot));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSUsageTelemetryTests.java
@@ -11,8 +11,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Map;
-
+import static org.elasticsearch.action.admin.cluster.stats.ApproximateMatcher.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -33,53 +32,81 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             boolean minimizeRoundTrips = randomBoolean();
             boolean async = randomBoolean();
             took1 = randomLongBetween(5, 10000);
-            int numSkippedRemotes = randomIntBetween(0, 3);
-            expectedSearchesWithSkippedRemotes = numSkippedRemotes > 0 ? 1 : 0;
+            boolean skippedRemote = randomBoolean();
+            expectedSearchesWithSkippedRemotes = skippedRemote ? 1 : 0;
             expectedAsyncCount = async ? 1 : 0;
             expectedMinRTCount = minimizeRoundTrips ? 1 : 0;
 
             // per cluster telemetry
             long tookLocal = randomLongBetween(2, 8000);
             took1Remote1 = randomLongBetween(2, 8000);
-            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
-                "(local)",
-                new CCSUsage.PerClusterUsage(new TimeValue(tookLocal)),
-                "remote1",
-                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
-            );
 
-            CCSUsage ccsUsage = new CCSUsage.Builder().took(took1)
-                .async(async)
-                .minimizeRoundTrips(minimizeRoundTrips)
-                .numSkippedRemotes(numSkippedRemotes)
-                .perClusterUsage(perClusterUsage)
-                .build();
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(took1).setRemotesCount(1);
+            if (async) {
+                builder.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+            }
+            if (minimizeRoundTrips) {
+                builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+            }
+            if (skippedRemote) {
+                builder.skippedRemote("remote1");
+            }
+            builder.perClusterUsage("(local)", new TimeValue(tookLocal));
+            builder.perClusterUsage("remote1", new TimeValue(took1Remote1));
 
+            CCSUsage ccsUsage = builder.build();
             ccsUsageHolder.updateUsage(ccsUsage);
 
-            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(1L));
-            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
-            assertThat(successfulCCSTelemetry.getCount(), equalTo(1L));
-            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
-            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
-            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1));
+            CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+
+            assertThat(snapshot.getTotalCount(), equalTo(1L));
+            assertThat(snapshot.getSuccessCount(), equalTo(1L));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
+            assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(snapshot.getTook().avg(), greaterThan(0L));
+            // Expect it to be within 1% of the actual value
+            assertThat(snapshot.getTook().avg(), closeTo(took1));
+            assertThat(snapshot.getTook().max(), lessThanOrEqualTo(took1));
+            if (minimizeRoundTrips) {
+                assertThat(snapshot.getTookMrtTrue().count(), equalTo(1L));
+                assertThat(snapshot.getTookMrtTrue().avg(), greaterThan(0L));
+                assertThat(snapshot.getTookMrtTrue().avg(), closeTo(took1));
+                assertThat(snapshot.getTookMrtFalse().count(), equalTo(0L));
+                assertThat(snapshot.getTookMrtFalse().max(), equalTo(0L));
+            } else {
+                assertThat(snapshot.getTookMrtFalse().count(), equalTo(1L));
+                assertThat(snapshot.getTookMrtFalse().avg(), greaterThan(0L));
+                assertThat(snapshot.getTookMrtFalse().avg(), closeTo(took1));
+                assertThat(snapshot.getTookMrtTrue().count(), equalTo(0L));
+                assertThat(snapshot.getTookMrtTrue().max(), equalTo(0L));
+            }
+            // We currently don't count unknown clients
+            assertThat(snapshot.getClientCounts().size(), equalTo(0));
 
             // per cluster telemetry asserts
-            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+
+            var telemetryByCluster = snapshot.getByRemoteCluster();
             assertThat(telemetryByCluster.size(), equalTo(2));
             var localClusterTelemetry = telemetryByCluster.get("(local)");
             assertNotNull(localClusterTelemetry);
             assertThat(localClusterTelemetry.getCount(), equalTo(1L));
-            assertThat(localClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(localClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) tookLocal));
+            assertThat(localClusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(localClusterTelemetry.getTook().count(), equalTo(1L));
+            assertThat(localClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(localClusterTelemetry.getTook().avg(), closeTo(tookLocal));
+            // assertThat(localClusterTelemetry.getTook().max(), greaterThanOrEqualTo(tookLocal));
 
             var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
             assertNotNull(remote1ClusterTelemetry);
             assertThat(remote1ClusterTelemetry.getCount(), equalTo(1L));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) took1Remote1));
+            assertThat(remote1ClusterTelemetry.getSkippedCount(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().count(), equalTo(1L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), closeTo(took1Remote1));
+            // assertThat(remote1ClusterTelemetry.getTook().max(), greaterThanOrEqualTo(took1Remote1));
         }
 
         // second search
@@ -89,45 +116,60 @@ public class CCSUsageTelemetryTests extends ESTestCase {
             expectedAsyncCount += async ? 1 : 0;
             expectedMinRTCount += minimizeRoundTrips ? 1 : 0;
             long took2 = randomLongBetween(5, 10000);
-            int numSkippedRemotes = randomIntBetween(0, 3);
-            expectedSearchesWithSkippedRemotes += numSkippedRemotes > 0 ? 1 : 0;
-
+            boolean skippedRemote = randomBoolean();
+            expectedSearchesWithSkippedRemotes += skippedRemote ? 1 : 0;
             long took2Remote1 = randomLongBetween(2, 8000);
-            Map<String, CCSUsage.PerClusterUsage> perClusterUsage = Map.of(
-                "remote1",
-                new CCSUsage.PerClusterUsage(new TimeValue(took1Remote1))
-            );
 
-            CCSUsage ccsUsage = new CCSUsage.Builder().took(took2)
-                .async(async)
-                .minimizeRoundTrips(minimizeRoundTrips)
-                .numSkippedRemotes(numSkippedRemotes)
-                .perClusterUsage(perClusterUsage)
-                .build();
+            CCSUsage.Builder builder = new CCSUsage.Builder();
+            builder.took(took2).setRemotesCount(1).setClient("kibana");
+            if (async) {
+                builder.setFeature(CCSUsageTelemetry.ASYNC_FEATURE);
+            }
+            if (minimizeRoundTrips) {
+                builder.setFeature(CCSUsageTelemetry.MRT_FEATURE);
+            }
+            if (skippedRemote) {
+                builder.skippedRemote("remote1");
+            }
+            builder.perClusterUsage("remote1", new TimeValue(took2Remote1));
 
+            CCSUsage ccsUsage = builder.build();
             ccsUsageHolder.updateUsage(ccsUsage);
 
-            assertThat(ccsUsageHolder.getTotalCCSCount(), equalTo(2L));
-            CCSUsageTelemetry.SuccessfulCCSTelemetry successfulCCSTelemetry = ccsUsageHolder.getSuccessfulSearchTelemetry();
-            assertThat(successfulCCSTelemetry.getCount(), equalTo(2L));
-            assertThat(successfulCCSTelemetry.getCountAsync(), equalTo(expectedAsyncCount));
-            assertThat(successfulCCSTelemetry.getCountMinimizeRoundtrips(), equalTo(expectedMinRTCount));
-            assertThat(successfulCCSTelemetry.getCountSearchesWithSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(successfulCCSTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1, took2)));
+            CCSTelemetrySnapshot snapshot = ccsUsageHolder.getCCSTelemetrySnapshot();
+
+            assertThat(snapshot.getTotalCount(), equalTo(2L));
+            assertThat(snapshot.getSuccessCount(), equalTo(2L));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.ASYNC_FEATURE, 0L), equalTo(expectedAsyncCount));
+            assertThat(snapshot.getFeatureCounts().getOrDefault(CCSUsageTelemetry.MRT_FEATURE, 0L), equalTo(expectedMinRTCount));
+            assertThat(snapshot.getSkippedRemotes(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(snapshot.getTook().avg(), greaterThan(0L));
+            assertThat(snapshot.getTook().avg(), closeTo((took1 + took2) / 2));
+            // assertThat(snapshot.getTook().max(), greaterThanOrEqualTo(Math.max(took1, took2)));
+
+            // Counting only known clients
+            assertThat(snapshot.getClientCounts().get("kibana"), equalTo(1L));
+            assertThat(snapshot.getClientCounts().size(), equalTo(1));
 
             // per cluster telemetry asserts
-            Map<String, CCSUsageTelemetry.PerClusterCCSTelemetry> telemetryByCluster = ccsUsageHolder.getTelemetryByCluster();
+
+            var telemetryByCluster = snapshot.getByRemoteCluster();
             assertThat(telemetryByCluster.size(), equalTo(2));
             var localClusterTelemetry = telemetryByCluster.get("(local)");
             assertNotNull(localClusterTelemetry);
-            assertThat(localClusterTelemetry.getCount(), equalTo(1L));  // not part of second search
+            assertThat(localClusterTelemetry.getCount(), equalTo(1L));
+            assertThat(localClusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(localClusterTelemetry.getTook().count(), equalTo(1L));
 
             var remote1ClusterTelemetry = telemetryByCluster.get("remote1");
             assertNotNull(remote1ClusterTelemetry);
             assertThat(remote1ClusterTelemetry.getCount(), equalTo(2L));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), greaterThan(0.0d));
-            assertThat(remote1ClusterTelemetry.getMeanLatency(), lessThanOrEqualTo((double) Math.max(took1Remote1, took2Remote1)));
+            assertThat(remote1ClusterTelemetry.getSkippedCount(), equalTo(expectedSearchesWithSkippedRemotes));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().count(), equalTo(2L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), greaterThan(0L));
+            assertThat(remote1ClusterTelemetry.getTook().avg(), closeTo((took1Remote1 + took2Remote1) / 2));
+            // assertThat(remote1ClusterTelemetry.getTook().max(), greaterThanOrEqualTo(Math.max(took1Remote1, took2Remote1)));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -99,6 +99,7 @@ import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1765,7 +1766,8 @@ public class TransportSearchActionTests extends ESTestCase {
                 null,
                 new SearchTransportAPMMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
                 new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
-                client
+                client,
+                new UsageService()
             );
 
             CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -196,6 +196,7 @@ import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.junit.After;
 import org.junit.Before;
@@ -2059,6 +2060,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
             private final BigArrays bigArrays;
 
+            private final UsageService usageService;
+
             private Coordinator coordinator;
 
             TestClusterNode(DiscoveryNode node, TransportInterceptorFactory transportInterceptorFactory) throws IOException {
@@ -2069,6 +2072,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 masterService = new FakeThreadPoolMasterService(node.getName(), threadPool, deterministicTaskQueue::scheduleNow);
                 final Settings settings = environment.settings();
                 client = new NodeClient(settings, threadPool);
+                this.usageService = new UsageService();
                 final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
                 clusterService = new ClusterService(
                     settings,
@@ -2486,7 +2490,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                         EmptySystemIndices.INSTANCE.getExecutorSelector(),
                         new SearchTransportAPMMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
                         new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
-                        client
+                        client,
+                        usageService
                     )
                 );
                 actions.put(

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -35,7 +35,6 @@
       "other" : 500
     },
     "clusters" : {
-      "count" : 3,
       "(local)" : {
         "total" : 12,
         "skipped" : 0,

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -4,19 +4,19 @@
     "success" : 20,
     "skipped" : 5,
     "took" : {
-      "max" : 1988,
+      "max" : 1991,
       "avg" : 1496,
-      "p90" : 1892
+      "p90" : 1895
     },
     "took_mrt_true" : {
-      "max" : 9952,
-      "avg" : 7466,
-      "p90" : 9440
+      "max" : 9983,
+      "avg" : 7476,
+      "p90" : 9471
     },
     "took_mrt_false" : {
-      "max" : 19904,
-      "avg" : 14932,
-      "p90" : 18880
+      "max" : 19967,
+      "avg" : 14952,
+      "p90" : 18943
     },
     "remotes_per_search_max" : 6,
     "remotes_per_search_avg" : 7.89,
@@ -40,18 +40,18 @@
         "total" : 100,
         "skipped" : 22,
         "took" : {
-          "max" : 3976,
+          "max" : 3983,
           "avg" : 2992,
-          "p90" : 3784
+          "p90" : 3791
         }
       },
       "remote2" : {
         "total" : 300,
         "skipped" : 42,
         "took" : {
-          "max" : 993280,
-          "avg" : 747480,
-          "p90" : 944128
+          "max" : 995327,
+          "avg" : 747531,
+          "p90" : 946175
         }
       }
     }

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -1,0 +1,59 @@
+{
+  "ccs_telemetry" : {
+    "total" : 10,
+    "success" : 20,
+    "skipped" : 5,
+    "took" : {
+      "max" : 1988,
+      "avg" : 1496,
+      "p90" : 1892
+    },
+    "took_mrt_true" : {
+      "max" : 9952,
+      "avg" : 7466,
+      "p90" : 9440
+    },
+    "took_mrt_false" : {
+      "max" : 19904,
+      "avg" : 14932,
+      "p90" : 18880
+    },
+    "remotes_per_search_max" : 6,
+    "remotes_per_search_avg" : 7.89,
+    "failure_reasons" : {
+      "reason1" : 1,
+      "reason2" : 2,
+      "unknown" : 3
+    },
+    "features" : {
+      "async" : 10,
+      "mrt" : 20,
+      "wildcard" : 30
+    },
+    "clients" : {
+      "kibana" : 40,
+      "other" : 500
+    },
+    "remote_clusters" : {
+      "count" : 2,
+      "remote1" : {
+        "total" : 100,
+        "skipped" : 22,
+        "took" : {
+          "max" : 3976,
+          "avg" : 2992,
+          "p90" : 3784
+        }
+      },
+      "remote2" : {
+        "total" : 300,
+        "skipped" : 42,
+        "took" : {
+          "max" : 993280,
+          "avg" : 747480,
+          "p90" : 944128
+        }
+      }
+    }
+  }
+}

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -1,5 +1,5 @@
 {
-  "ccs_telemetry" : {
+  "_search" : {
     "total" : 10,
     "success" : 20,
     "skipped" : 5,

--- a/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
+++ b/server/src/test/resources/org/elasticsearch/action/admin/cluster/stats/telemetry_test.json
@@ -34,8 +34,17 @@
       "kibana" : 40,
       "other" : 500
     },
-    "remote_clusters" : {
-      "count" : 2,
+    "clusters" : {
+      "count" : 3,
+      "(local)" : {
+        "total" : 12,
+        "skipped" : 0,
+        "took" : {
+          "max" : 3983,
+          "avg" : 2992,
+          "p90" : 3791
+        }
+      },
       "remote1" : {
         "total" : 100,
         "skipped" : 22,

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryAsyncSearchIT.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot;
+import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.usage.UsageService;
+import org.elasticsearch.xpack.async.AsyncResultsIndexPlugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.ASYNC_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.MRT_FEATURE;
+import static org.elasticsearch.action.admin.cluster.stats.CCSUsageTelemetry.Result.CANCELED;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class CCSUsageTelemetryAsyncSearchIT extends AbstractMultiClustersTestCase {
+    private static final String REMOTE1 = "cluster-a";
+    private static final String REMOTE2 = "cluster-b";
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    @Override
+    protected Collection<String> remoteClusterAlias() {
+        return List.of(REMOTE1, REMOTE2);
+    }
+
+    @Override
+    protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
+        return Map.of(REMOTE1, true, REMOTE2, true);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        List<Class<? extends Plugin>> plugs = Arrays.asList(
+            CrossClusterAsyncSearchIT.SearchListenerPlugin.class,
+            AsyncSearch.class,
+            AsyncResultsIndexPlugin.class,
+            LocalStateCompositeXPackPlugin.class,
+            CrossClusterAsyncSearchIT.TestQueryBuilderPlugin.class
+        );
+        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+    }
+
+    @Before
+    public void resetSearchListenerPlugin() {
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.reset();
+    }
+
+    private SubmitAsyncSearchRequest makeSearchRequest(String... indices) {
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.blockQueryPhase();
+
+        SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(indices);
+        request.setCcsMinimizeRoundtrips(randomBoolean());
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1));
+        request.setKeepOnCompletion(true);
+        request.getSearchRequest().allowPartialSearchResults(false);
+        request.getSearchRequest().source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).size(10));
+        if (randomBoolean()) {
+            request.setBatchedReduceSize(randomIntBetween(2, 256));
+        }
+
+        return request;
+    }
+
+    /**
+    * Run async search request and get telemetry from it
+    */
+    private CCSTelemetrySnapshot getTelemetryFromSearch(SubmitAsyncSearchRequest searchRequest) throws Exception {
+        // We want to send search to a specific node (we don't care which one) so that we could
+        // collect the CCS telemetry from it later
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        final AsyncSearchResponse response = cluster(LOCAL_CLUSTER).client(nodeName)
+            .execute(SubmitAsyncSearchAction.INSTANCE, searchRequest)
+            .get();
+        // We don't care here too much about the response, we just want to trigger the telemetry collection.
+        // So we check it's not null and leave the rest to other tests.
+        final String responseId;
+        try {
+            assertNotNull(response.getSearchResponse());
+            responseId = response.getId();
+        } finally {
+            response.decRef();
+        }
+        waitForSearchTasksToFinish();
+        final AsyncSearchResponse finishedResponse = cluster(LOCAL_CLUSTER).client(nodeName)
+            .execute(GetAsyncSearchAction.INSTANCE, new GetAsyncResultRequest(responseId))
+            .get();
+        try {
+            assertNotNull(finishedResponse.getSearchResponse());
+        } finally {
+            finishedResponse.decRef();
+        }
+        return getTelemetrySnapshot(nodeName);
+
+    }
+
+    private void waitForSearchTasksToFinish() throws Exception {
+        assertBusy(() -> {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(TransportSearchAction.TYPE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(0));
+
+            for (String clusterAlias : remoteClusterAlias()) {
+                ListTasksResponse remoteTasksResponse = client(clusterAlias).admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .setActions(TransportSearchAction.TYPE.name())
+                    .get();
+                List<TaskInfo> remoteTasks = remoteTasksResponse.getTasks();
+                assertThat(remoteTasks.size(), equalTo(0));
+            }
+        });
+
+        assertBusy(() -> {
+            for (String clusterAlias : remoteClusterAlias()) {
+                final Iterable<TransportService> transportServices = cluster(clusterAlias).getInstances(TransportService.class);
+                for (TransportService transportService : transportServices) {
+                    assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
+                }
+            }
+        });
+    }
+
+    /**
+     * Create search request for indices and get telemetry from it
+     */
+    private CCSTelemetrySnapshot getTelemetryFromSearch(String... indices) throws Exception {
+        return getTelemetryFromSearch(makeSearchRequest(indices));
+    }
+
+    /**
+     * Async search on all remotes
+     */
+    public void testAllRemotesSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SubmitAsyncSearchRequest searchRequest = makeSearchRequest(localIndex, "*:" + remoteIndex);
+        boolean minimizeRoundtrips = TransportSearchAction.shouldMinimizeRoundtrips(searchRequest.getSearchRequest());
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.negate();
+
+        CCSTelemetrySnapshot telemetry = getTelemetryFromSearch(searchRequest);
+
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(1L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(0));
+        assertThat(telemetry.getTook().count(), equalTo(1L));
+        assertThat(telemetry.getTookMrtTrue().count(), equalTo(minimizeRoundtrips ? 1L : 0L));
+        assertThat(telemetry.getTookMrtFalse().count(), equalTo(minimizeRoundtrips ? 0L : 1L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(2.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(2L));
+        assertThat(telemetry.getSearchCountWithSkippedRemotes(), equalTo(0L));
+        assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(1L));
+        if (minimizeRoundtrips) {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(1L));
+        } else {
+            assertThat(telemetry.getFeatureCounts().get(MRT_FEATURE), equalTo(null));
+        }
+        var perCluster = telemetry.getByRemoteCluster();
+        assertThat(perCluster.size(), equalTo(3));
+        for (String clusterAlias : remoteClusterAlias()) {
+            var clusterTelemetry = perCluster.get(clusterAlias);
+            assertThat(clusterTelemetry.getCount(), equalTo(1L));
+            assertThat(clusterTelemetry.getSkippedCount(), equalTo(0L));
+            assertThat(clusterTelemetry.getTook().count(), equalTo(1L));
+        }
+    }
+
+    /**
+     * Search that is cancelled
+     */
+    public void testCancelledSearch() throws Exception {
+        Map<String, Object> testClusterInfo = setupClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+
+        SubmitAsyncSearchRequest searchRequest = makeSearchRequest(localIndex, REMOTE1 + ":" + remoteIndex);
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.blockQueryPhase();
+
+        String nodeName = cluster(LOCAL_CLUSTER).getRandomNodeName();
+        final AsyncSearchResponse response = cluster(LOCAL_CLUSTER).client(nodeName)
+            .execute(SubmitAsyncSearchAction.INSTANCE, searchRequest)
+            .get();
+        try {
+            assertNotNull(response.getSearchResponse());
+        } finally {
+            response.decRef();
+            assertTrue(response.isRunning());
+        }
+        CrossClusterAsyncSearchIT.SearchListenerPlugin.waitSearchStarted();
+
+        ActionFuture<ListTasksResponse> cancelFuture;
+        try {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(TransportSearchAction.TYPE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(1));
+            final TaskInfo rootTask = tasks.get(0);
+
+            AtomicReference<List<TaskInfo>> remoteClusterSearchTasks = new AtomicReference<>();
+            assertBusy(() -> {
+                List<TaskInfo> remoteSearchTasks = client(REMOTE1).admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .get()
+                    .getTasks()
+                    .stream()
+                    .filter(t -> t.action().contains(TransportSearchAction.TYPE.name()))
+                    .collect(Collectors.toList());
+                assertThat(remoteSearchTasks.size(), greaterThan(0));
+                remoteClusterSearchTasks.set(remoteSearchTasks);
+            });
+
+            for (TaskInfo taskInfo : remoteClusterSearchTasks.get()) {
+                assertFalse("taskInfo on remote cluster should not be cancelled yet: " + taskInfo, taskInfo.cancelled());
+            }
+
+            final CancelTasksRequest cancelRequest = new CancelTasksRequest().setTargetTaskId(rootTask.taskId());
+            cancelRequest.setWaitForCompletion(randomBoolean());
+            cancelFuture = client().admin().cluster().cancelTasks(cancelRequest);
+            assertBusy(() -> {
+                final Iterable<TransportService> transportServices = cluster(REMOTE1).getInstances(TransportService.class);
+                for (TransportService transportService : transportServices) {
+                    Collection<CancellableTask> cancellableTasks = transportService.getTaskManager().getCancellableTasks().values();
+                    for (CancellableTask cancellableTask : cancellableTasks) {
+                        if (cancellableTask.getAction().contains(TransportSearchAction.TYPE.name())) {
+                            assertTrue(cancellableTask.getDescription(), cancellableTask.isCancelled());
+                        }
+                    }
+                }
+            });
+
+            List<TaskInfo> remoteSearchTasksAfterCancellation = client(REMOTE1).admin()
+                .cluster()
+                .prepareListTasks()
+                .get()
+                .getTasks()
+                .stream()
+                .filter(t -> t.action().contains(TransportSearchAction.TYPE.name()))
+                .toList();
+            for (TaskInfo taskInfo : remoteSearchTasksAfterCancellation) {
+                assertTrue(taskInfo.description(), taskInfo.cancelled());
+            }
+        } finally {
+            CrossClusterAsyncSearchIT.SearchListenerPlugin.allowQueryPhase();
+        }
+
+        assertBusy(() -> assertTrue(cancelFuture.isDone()));
+        waitForSearchTasksToFinish();
+
+        CCSTelemetrySnapshot telemetry = getTelemetrySnapshot(nodeName);
+        assertThat(telemetry.getTotalCount(), equalTo(1L));
+        assertThat(telemetry.getSuccessCount(), equalTo(0L));
+        assertThat(telemetry.getFailureReasons().size(), equalTo(1));
+        assertThat(telemetry.getFailureReasons().get(CANCELED.getName()), equalTo(1L));
+        assertThat(telemetry.getTook().count(), equalTo(0L));
+        assertThat(telemetry.getRemotesPerSearchAvg(), equalTo(1.0));
+        assertThat(telemetry.getRemotesPerSearchMax(), equalTo(1L));
+        // Still counts as async search
+        assertThat(telemetry.getFeatureCounts().get(ASYNC_FEATURE), equalTo(1L));
+    }
+
+    private CCSTelemetrySnapshot getTelemetrySnapshot(String nodeName) {
+        var usage = cluster(LOCAL_CLUSTER).getInstance(UsageService.class, nodeName);
+        return usage.getCcsUsageHolder().getCCSTelemetrySnapshot();
+    }
+
+    private Map<String, Object> setupClusters() {
+        String localIndex = "demo";
+        int numShardsLocal = randomIntBetween(2, 10);
+        Settings localSettings = indexSettings(numShardsLocal, randomIntBetween(0, 1)).build();
+        assertAcked(
+            client(LOCAL_CLUSTER).admin()
+                .indices()
+                .prepareCreate(localIndex)
+                .setSettings(localSettings)
+                .setMapping("@timestamp", "type=date", "f", "type=text")
+        );
+        indexDocs(client(LOCAL_CLUSTER), localIndex);
+
+        String remoteIndex = "prod";
+        int numShardsRemote = randomIntBetween(2, 10);
+        for (String clusterAlias : remoteClusterAlias()) {
+            final InternalTestCluster remoteCluster = cluster(clusterAlias);
+            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+            assertAcked(
+                client(clusterAlias).admin()
+                    .indices()
+                    .prepareCreate(remoteIndex)
+                    .setSettings(indexSettings(numShardsRemote, randomIntBetween(0, 1)))
+                    .setMapping("@timestamp", "type=date", "f", "type=text")
+            );
+            assertFalse(
+                client(clusterAlias).admin()
+                    .cluster()
+                    .prepareHealth(remoteIndex)
+                    .setWaitForYellowStatus()
+                    .setTimeout(TimeValue.timeValueSeconds(10))
+                    .get()
+                    .isTimedOut()
+            );
+            indexDocs(client(clusterAlias), remoteIndex);
+        }
+
+        Map<String, Object> clusterInfo = new HashMap<>();
+        clusterInfo.put("local.num_shards", numShardsLocal);
+        clusterInfo.put("local.index", localIndex);
+        clusterInfo.put("remote.num_shards", numShardsRemote);
+        clusterInfo.put("remote.index", remoteIndex);
+        clusterInfo.put("remote.skip_unavailable", true);
+        return clusterInfo;
+    }
+
+    private int indexDocs(Client client, String index) {
+        int numDocs = between(5, 20);
+        for (int i = 0; i < numDocs; i++) {
+            client.prepareIndex(index).setSource("f", "v", "@timestamp", randomNonNegativeLong()).get();
+        }
+        client.admin().indices().prepareRefresh(index).get();
+        return numDocs;
+    }
+}


### PR DESCRIPTION
This implements the stats collection mechanism for CCS usage telemetry. 

Note that the stats are not connected to the _cluster/stats API yet, see https://github.com/elastic/elasticsearch/pull/111598 for that. 