### PR TITLE
Updating fix version for bulk api took time fix now that it has been backported (#111863) (#111899)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -232,8 +232,8 @@
 ---
 "Took is not orders of magnitude off":
   - requires:
-      cluster_features: ["gte_v8.16.0"]
-      reason: "Bug reporting wrong took time introduced in 8.15.0, fixed in 8.16.0"
+      cluster_features: ["gte_v8.15.1"]
+      reason: "Bug reporting wrong took time introduced in 8.15.0, fixed in 8.15.1"
   - do:
       bulk:
         body:


### PR DESCRIPTION
The bug fix from #111863 has been backported to 8.15.1. So this updates the fix version in the yaml rest test to 8.15.1.