### PR TITLE
POC: add index execution time tracking

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
@@ -136,6 +136,10 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
             .append(", ");
     }
 
+    public boolean trackOngoingTasks() {
+        return trackOngoingTasks;
+    }
+
     /**
      * Returns the set of currently running tasks and their start timestamp.
      * <p>

--- a/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
@@ -135,7 +135,8 @@ class NodeServiceProvider {
             responseCollectorService,
             circuitBreakerService,
             executorSelector,
-            tracer
+            tracer,
+            null
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchIndexMetricsTracker.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchIndexMetricsTracker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.index.Index;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Tracks search metrics per index.
+ */
+public class SearchIndexMetricsTracker implements ClusterStateListener {
+
+    private final ConcurrentHashMap<String, LongAdder> indexExecutionTimes = new ConcurrentHashMap<>();
+
+    void addExecutionTime(String indexName, long executionTime) {
+        indexExecutionTimes.putIfAbsent(indexName, new LongAdder());
+        LongAdder indexExecutionTime = indexExecutionTimes.get(indexName);
+        if (indexExecutionTime != null) {
+            indexExecutionTime.add(executionTime);
+        }
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        for (Index index : event.indicesDeleted()) {
+            indexExecutionTimes.remove(index.getName());
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -2311,7 +2311,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     responseCollectorService,
                     new NoneCircuitBreakerService(),
                     EmptySystemIndices.INSTANCE.getExecutorSelector(),
-                    Tracer.NOOP
+                    Tracer.NOOP,
+                    null
                 );
 
                 final SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(repositoriesService);

--- a/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
@@ -100,7 +100,8 @@ public class MockSearchService extends SearchService {
             responseCollectorService,
             circuitBreakerService,
             executorSelector,
-            tracer
+            tracer,
+            null
         );
     }
 


### PR DESCRIPTION
This proof of concept adds index execution time tracking to the search service.

I expect this to get the conversation started about whether this is the best way to track the times and help us decide how to plumb things together to get the time info where it needs to go.