### PR TITLE
Add audit_unenrolled_* attributes to fleet-agents template

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -319,6 +319,12 @@
         },
         "namespaces": {
           "type": "keyword"
+        },
+        "audit_unenrolled_time": {
+          "type": "date"
+        },
+        "audit_unenrolled_reason": {
+          "type": "keyword"
         }
       }
     }


### PR DESCRIPTION
# Description

Add `audit_unenrolled_time` and `audit_unenrolled_reason` attributes to fleet-agents template.

# Related issues

- Relates https://github.com/elastic/elastic-agent/issues/484