### PR TITLE
Normalize float vector in native scorer test when using Cosine

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/VectorScorerFactoryTests.java
@@ -236,6 +236,8 @@ public class VectorScorerFactoryTests extends AbstractVectorTestCase {
 
         try (Directory dir = new MMapDirectory(createTempDir("testRandom"), maxChunkSize)) {
             for (var sim : List.of(COSINE, DOT_PRODUCT, EUCLIDEAN, MAXIMUM_INNER_PRODUCT)) {
+                // Use the random supplier for COSINE, which returns values in the normalized range
+                floatArraySupplier = sim == COSINE ? FLOAT_ARRAY_RANDOM_FUNC : floatArraySupplier;
                 final int dims = randomIntBetween(1, 4096);
                 final int size = randomIntBetween(2, 100);
                 final float[][] vectors = new float[size][];


### PR DESCRIPTION
This commit effectively normalizes float vector values in native scorer test, when using Cosine.

closes #111885