### PR TITLE
Skip ModelRegistryIT's testGetModel if feature flag is disabled

### DIFF
--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsFeatureFlag;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.elasticsearch.xpack.inference.services.elser.ElserInternalModel;
@@ -101,6 +102,7 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
     }
 
     public void testGetModel() throws Exception {
+        assumeTrue("Only if 'inference_adaptive_allocations' feature flag is enabled", AdaptiveAllocationsFeatureFlag.isEnabled());
         String inferenceEntityId = "test-get-model";
         Model model = buildElserModelConfig(inferenceEntityId, TaskType.SPARSE_EMBEDDING);
         AtomicReference<Boolean> putModelHolder = new AtomicReference<>();


### PR DESCRIPTION
# Skip ModelRegistryIT's testGetModel if feature flag is disabled

## Description

This pull request addresses the issue where testGetModel in ModelRegistryIT fails because part of the functionality in ElserInternalService is hidden behind `inference_adaptive_allocations` feature flag. However, the tests do not account for the feature flag.

## Fix

Make the tests adaptive, so skip the test if the feature flag is disabled. Using `AdaptiveAllocationsFeatureFlag` class in conjunction with `assumeTrue` will skip the test if the feature flag is disabled.

## Related Issues:

#111570 

## Checklist 

- [x] Signed the Contributor License Agreement (CLA)
- [x] Followed the contributor guidelines
- [x] Built and tested your changes locally using `gradle check`.
- [x] Your pull request is against the main branch
- [x] Verified that your submission targets an OS and architecture we support
