### PR TITLE
Fix known issue docs for #111866

### DIFF
--- a/docs/reference/release-notes/8.15.0.asciidoc
+++ b/docs/reference/release-notes/8.15.0.asciidoc
@@ -16,6 +16,12 @@ after it is killed up to four times in 24 hours. (issue: {es-issue}110530[#11053
 * Pipeline aggregations under `time_series` and `categorize_text` aggregations are never
 returned (issue: {es-issue}111679[#111679])
 
+* Elasticsearch will not start on Windows machines if
+[`bootstrap.memory_lock` is set to `true`](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#bootstrap-memory_lock).
+Either downgrade to an earlier version, upgrade to 8.15.1, or else follow the
+recommendation in the manual to entirely disable swap instead of using the
+memory lock feature.
+
 [[breaking-8.15.0]]
 [float]
 === Breaking changes
@@ -32,10 +38,6 @@ Rollup::
 Search::
 * Change `skip_unavailable` remote cluster setting default value to true {es-pull}105792[#105792]
 
-[[known-issues-8.15.0]]
-[float]
-=== Known issues
-* Elasticsearch will not start on Windows machines when the recommended [bootstrap.memory_lock: true](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#bootstrap-memory_lock) setting is configured due to [native access refactoring](https://github.com/elastic/elasticsearch/pull/111866). The workaround for 8.15.0 is to downgrade to the previous version.  This issue will be fixed in 8.15.1.
 
 [[bug-8.15.0]]
 [float]

--- a/docs/reference/release-notes/8.15.0.asciidoc
+++ b/docs/reference/release-notes/8.15.0.asciidoc
@@ -38,7 +38,6 @@ Rollup::
 Search::
 * Change `skip_unavailable` remote cluster setting default value to true {es-pull}105792[#105792]
 
-
 [[bug-8.15.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.15.0.asciidoc
+++ b/docs/reference/release-notes/8.15.0.asciidoc
@@ -20,7 +20,7 @@ returned (issue: {es-issue}111679[#111679])
 [`bootstrap.memory_lock` is set to `true`](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#bootstrap-memory_lock).
 Either downgrade to an earlier version, upgrade to 8.15.1, or else follow the
 recommendation in the manual to entirely disable swap instead of using the
-memory lock feature.
+memory lock feature (issue: {es-issue}111847[#111847])
 
 [[breaking-8.15.0]]
 [float]


### PR DESCRIPTION
The `known-issue-8.15.0` anchor appears twice which breaks the docs
build. Also the existing message suggests incorrectly that
`bootstrap.memory_lock: true` is recommended.