### PR TITLE
Update 8.15.0.asciidoc

### DIFF
--- a/docs/reference/release-notes/8.15.0.asciidoc
+++ b/docs/reference/release-notes/8.15.0.asciidoc
@@ -16,6 +16,8 @@ after it is killed up to four times in 24 hours. (issue: {es-issue}110530[#11053
 * Pipeline aggregations under `time_series` and `categorize_text` aggregations are never
 returned (issue: {es-issue}111679[#111679])
 
+* Elasticsearch will not start on Windows machines when the recommended {ref}/setup-configuration-memory.html#bootstrap-memory_lock[bootstrap.memory_lock: true] setting is configured due to https://github.com/elastic/elasticsearch/pull/111866[native access refactoring]. The workaround for 8.15.0 is to downgrade to the previous version.  This issue will be fixed in 8.15.1.
+
 [[breaking-8.15.0]]
 [float]
 === Breaking changes
@@ -31,11 +33,6 @@ Rollup::
 
 Search::
 * Change `skip_unavailable` remote cluster setting default value to true {es-pull}105792[#105792]
-
-[[known-issues-8.15.0]]
-[float]
-=== Known issues
-* Elasticsearch will not start on Windows machines when the recommended [bootstrap.memory_lock: true](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#bootstrap-memory_lock) setting is configured due to [native access refactoring](https://github.com/elastic/elasticsearch/pull/111866). The workaround for 8.15.0 is to downgrade to the previous version.  This issue will be fixed in 8.15.1.
 
 [[bug-8.15.0]]
 [float]


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/111949 broke the doc build by adding a duplicate link header to the docs. This PR fixes the doc build.