### PR TITLE
[Profiling] add container.id field to event index template

### DIFF
--- a/docs/changelog/111969.yaml
+++ b/docs/changelog/111969.yaml
@@ -1,0 +1,5 @@
+pr: 111969
+summary: "[Profiling] add `container.id` field to event index template"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -77,6 +77,9 @@
         },
         "service.name": {
           "type": "keyword"
+        },
+        "container.id": {
+          "type": "keyword"
         }
       }
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -53,10 +53,11 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 10: changed mapping profiling-events @timestamp to 'date_nanos' from 'date'
     // version 11: Added 'profiling.agent.protocol' keyword mapping to profiling-hosts
     // version 12: Added 'profiling.agent.env_https_proxy' keyword mapping to profiling-hosts
-    public static final int INDEX_TEMPLATE_VERSION = 12;
+    // version 13: Added 'container.id' keyword mapping to profiling-events
+    public static final int INDEX_TEMPLATE_VERSION = 13;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
-    public static final int PROFILING_EVENTS_VERSION = 4;
+    public static final int PROFILING_EVENTS_VERSION = 5;
     public static final int PROFILING_EXECUTABLES_VERSION = 1;
     public static final int PROFILING_METRICS_VERSION = 2;
     public static final int PROFILING_HOSTS_VERSION = 2;


### PR DESCRIPTION
This PR adds a new container.id field to the index template of the profiling-events data-stream. The field name was chosen in [accordance with ECS](https://www.elastic.co/guide/en/ecs/current/ecs-container.html#field-container-id) and also matches what the field is called in the APM indices.
