### PR TITLE
ESQL: Document the `profile` option (#110727)

### DIFF
--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -75,6 +75,11 @@ For syntax, refer to <<esql-locale-param>>.
 (Optional, array) Values for parameters in the `query`. For syntax, refer to
 <<esql-rest-params>>.
 
+`profile`::
+(Optional, boolean) If provided and `true` the response will include an extra `profile` object
+with information about how the query was executed. It provides insight into the performance
+of each part of the query. This is for human debugging as the object's format might change at any time.
+
 `query`::
 (Required, string) {esql} query to run. For syntax, refer to <<esql-syntax>>.
 
@@ -100,3 +105,8 @@ returned if `drop_null_columns` is sent with the request.
 `values`::
 (array of arrays)
 Values for the search results.
+
+`profile`::
+(object)
+Profile describing the execution of the query. Only returned if `profile` was sent in the body.
+The object itself is for human debugging and can change at any time.


### PR DESCRIPTION
This adds some basic documentation for the `profile` option in ESQL but doesn't really explain the results beyond "this is for human debugging." We're not ready for any kind of specification for this thing, but it is useful to look at.
