### PR TITLE
Avoid losing error message in failure collector

### DIFF
--- a/docs/changelog/111983.yaml
+++ b/docs/changelog/111983.yaml
@@ -1,0 +1,5 @@
+pr: 111983
+summary: Avoid losing error message in failure collector
+area: ES|QL
+type: bug
+issues: []

--- a/docs/changelog/111983.yaml
+++ b/docs/changelog/111983.yaml
@@ -2,4 +2,5 @@ pr: 111983
 summary: Avoid losing error message in failure collector
 area: ES|QL
 type: bug
-issues: []
+issues:
+ - 111894

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FailureCollectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FailureCollectorTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -31,9 +29,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FailureCollectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FailureCollectorTests.java
@@ -7,12 +7,17 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.RemoteTransportException;
+import org.elasticsearch.transport.TransportException;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -25,6 +30,11 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 
 public class FailureCollectorTests extends ESTestCase {
@@ -86,5 +96,18 @@ public class FailureCollectorTests extends ESTestCase {
         FailureCollector collector = new FailureCollector(5);
         assertFalse(collector.hasFailure());
         assertNull(collector.getFailure());
+    }
+
+    public void testTransportExceptions() {
+        FailureCollector collector = new FailureCollector(5);
+        collector.unwrapAndCollect(new NodeDisconnectedException(DiscoveryNodeUtils.builder("node-1").build(), "/field_caps"));
+        collector.unwrapAndCollect(new TransportException(new CircuitBreakingException("too large", CircuitBreaker.Durability.TRANSIENT)));
+        Exception failure = collector.getFailure();
+        assertNotNull(failure);
+        assertThat(failure, instanceOf(NodeDisconnectedException.class));
+        assertThat(failure.getMessage(), equalTo("[][0.0.0.0:1][/field_caps] disconnected"));
+        Throwable[] suppressed = failure.getSuppressed();
+        assertThat(suppressed, arrayWithSize(1));
+        assertThat(suppressed[0], instanceOf(CircuitBreakingException.class));
     }
 }


### PR DESCRIPTION
The [node-disconnected](https://github.com/elastic/elasticsearch/blob/e92f2229b44595fe73884cbec0f6e00af07d4a05/server/src/main/java/org/elasticsearch/transport/TransportService.java#L1382) exception might not include the root cause. In this case, the failure collector incorrectly unwraps the exception and wraps it in a new Elasticsearch exception, losing the message. We should instead use the original exception to preserve the reason.

Closes #111894