### PR TITLE
[8.15] Avoid losing error message in failure collector (#111983)

### DIFF
--- a/docs/changelog/111983.yaml
+++ b/docs/changelog/111983.yaml
@@ -1,0 +1,6 @@
+pr: 111983
+summary: Avoid losing error message in failure collector
+area: ES|QL
+type: bug
+issues:
+ - 111894


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Avoid losing error message in failure collector (#111983)