### PR TITLE
Remove zstd change from release highlights.

### DIFF
--- a/docs/reference/release-notes/8.15.0.asciidoc
+++ b/docs/reference/release-notes/8.15.0.asciidoc
@@ -413,7 +413,6 @@ Search::
 * Add support for hiragana_uppercase & katakana_uppercase token filters in kuromoji analysis plugin {es-pull}106553[#106553]
 * Adding support for explain in rrf {es-pull}108682[#108682]
 * Allow rescorer with field collapsing {es-pull}107779[#107779] (issue: {es-issue}27243[#27243])
-* Cut over stored fields to ZSTD for compression {es-pull}103374[#103374]
 * Limit the value in prefix query {es-pull}108537[#108537] (issue: {es-issue}108486[#108486])
 * Make dense vector field type updatable {es-pull}106591[#106591]
 * Multivalue Sparse Vector Support {es-pull}109007[#109007]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -32,19 +32,6 @@ endif::[]
 // tag::notable-highlights[]
 
 [discrete]
-[[stored_fields_are_compressed_with_zstandard_instead_of_lz4_deflate]]
-=== Stored fields are now compressed with ZStandard instead of LZ4/DEFLATE
-Stored fields are now compressed by splitting documents into blocks, which
-are then compressed independently with ZStandard. `index.codec: default`
-(default) uses blocks of at most 14kB or 128 documents compressed with level
-0, while `index.codec: best_compression` uses blocks of at most 240kB or
-2048 documents compressed at level 3. On most datasets that we tested
-against, this yielded storage improvements in the order of 10%, slightly
-faster indexing and similar retrieval latencies.
-
-{es-pull}103374[#103374]
-
-[discrete]
 [[stricter_failure_handling_in_multi_repo_get_snapshots_request_handling]]
 === Stricter failure handling in multi-repo get-snapshots request handling
 If a multi-repo get-snapshots request encounters a failure in one of the


### PR DESCRIPTION
The feature flag isn't removed yet and zstd isn't available in released versions of Elasticsearch.