### PR TITLE
Pin default codec to index mode.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.DocumentDimensions;
@@ -297,6 +298,11 @@ public enum IndexMode {
         public boolean isSyntheticSourceEnabled() {
             return true;
         }
+
+        @Override
+        public String getDefaultCodec() {
+            return CodecService.BEST_COMPRESSION_CODEC;
+        }
     };
 
     private static void validateTimeSeriesSettings(Map<Setting<?>, Object> settings) {
@@ -465,6 +471,10 @@ public enum IndexMode {
      * @return whether synthetic source is the only allowed source mode.
      */
     public abstract boolean isSyntheticSourceEnabled();
+
+    public String getDefaultCodec() {
+        return CodecService.DEFAULT_CODEC;
+    }
 
     /**
      * Parse a string into an {@link IndexMode}.

--- a/server/src/main/java/org/elasticsearch/index/codec/zstd/Zstd814StoredFieldsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/zstd/Zstd814StoredFieldsFormat.java
@@ -78,6 +78,10 @@ public final class Zstd814StoredFieldsFormat extends Lucene90CompressingStoredFi
         return super.fieldsWriter(directory, si, context);
     }
 
+    public Mode getMode() {
+        return mode;
+    }
+
     private static class ZstdCompressionMode extends CompressionMode {
         private final int level;
 

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.MemorySizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.codec.CodecProvider;
 import org.elasticsearch.index.codec.CodecService;
@@ -96,7 +97,10 @@ public final class EngineConfig {
      * This setting is also settable on the node and the index level, it's commonly used in hot/cold node archs where index is likely
      * allocated on both `kind` of nodes.
      */
-    public static final Setting<String> INDEX_CODEC_SETTING = new Setting<>("index.codec", "default", s -> {
+    public static final Setting<String> INDEX_CODEC_SETTING = new Setting<>("index.codec", settings -> {
+        IndexMode indexMode = IndexSettings.MODE.get(settings);
+        return indexMode.getDefaultCodec();
+    }, s -> {
         switch (s) {
             case CodecService.DEFAULT_CODEC:
             case CodecService.LEGACY_DEFAULT_CODEC:
@@ -181,7 +185,7 @@ public final class EngineConfig {
         this.similarity = similarity;
         this.codecProvider = codecProvider;
         this.eventListener = eventListener;
-        codecName = indexSettings.getValue(INDEX_CODEC_SETTING);
+        this.codecName = indexSettings.getValue(INDEX_CODEC_SETTING);
         this.mapperService = mapperService;
         // We need to make the indexing buffer for this shard at least as large
         // as the amount of memory that is available for all engines on the


### PR DESCRIPTION
By default, the 'default' codec will be used as default, in case of logsdb index mode best_compression codec will be used as default.