### PR TITLE
Fix query roles test by setting license synchronously

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -65,9 +65,6 @@ tests:
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: org.elasticsearch.xpack.security.LicenseDLSFLSRoleIT
-  method: testQueryDLSFLSRolesShowAsDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/110729
 - class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
   method: testPopulationOfCacheWhenLoadingPrivilegesForAllApplications
   issue: https://github.com/elastic/elasticsearch/issues/110789

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/LicenseDLSFLSRoleIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/LicenseDLSFLSRoleIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.test.cluster.local.model.User;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 
@@ -68,6 +69,14 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
         assertTrue((boolean) responseAsMap(response).get("trial_was_started"));
     }
 
+    @After
+    public void removeLicense() throws IOException {
+        // start with trial license
+        Request request = new Request("DELETE", "/_license");
+        Response response = adminClient().performRequest(request);
+        assertOK(response);
+    }
+
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
@@ -85,7 +94,6 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    @SuppressWarnings("unchecked")
     public void testQueryDLSFLSRolesShowAsDisabled() throws Exception {
         // neither DLS nor FLS role
         {

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/LicenseDLSFLSRoleIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/LicenseDLSFLSRoleIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.SecureString;
@@ -21,6 +20,7 @@ import org.elasticsearch.test.cluster.local.model.User;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -50,8 +50,6 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .nodes(1)
         .distribution(DistributionType.DEFAULT)
-        // start as "trial"
-        .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
         .setting("xpack.security.http.ssl.enabled", "false")
         .setting("xpack.security.transport.ssl.enabled", "false")
@@ -60,6 +58,15 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
         .user(REST_USER, REST_PASSWORD.toString(), "security_test_role", false)
         .user(READ_SECURITY_USER, READ_SECURITY_PASSWORD.toString(), "read_security_user_role", false)
         .build();
+
+    @Before
+    public void setupLicense() throws IOException {
+        // start with trial license
+        Request request = new Request("POST", "/_license/start_trial?acknowledge=true");
+        Response response = adminClient().performRequest(request);
+        assertOK(response);
+        assertTrue((boolean) responseAsMap(response).get("trial_was_started"));
+    }
 
     @Override
     protected String getTestRestCluster() {
@@ -80,8 +87,6 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testQueryDLSFLSRolesShowAsDisabled() throws Exception {
-        // auto-generated "trial"
-        waitForLicense(adminClient(), "trial");
         // neither DLS nor FLS role
         {
             RoleDescriptor.IndicesPrivileges[] indicesPrivileges = new RoleDescriptor.IndicesPrivileges[] {
@@ -138,7 +143,6 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
         Map<String, Object> responseMap = responseAsMap(response);
         assertTrue(((Boolean) responseMap.get("basic_was_started")));
         assertTrue(((Boolean) responseMap.get("acknowledged")));
-        waitForLicense(adminClient(), "basic");
         // now the same roles show up as disabled ("enabled" is "false")
         assertQuery(client(), "", 4, roles -> {
             roles.sort(Comparator.comparing(o -> ((String) o.get("name"))));
@@ -174,23 +178,5 @@ public final class LicenseDLSFLSRoleIT extends ESRestTestCase {
         assertTrue(roleMap.containsKey("transient_metadata"));
         assertThat(roleMap.get("transient_metadata"), instanceOf(Map.class));
         assertThat(((Map<String, Object>) roleMap.get("transient_metadata")).get("enabled"), equalTo(enabled));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void waitForLicense(RestClient adminClient, String type) throws Exception {
-        final Request request = new Request("GET", "_license");
-        assertBusy(() -> {
-            Response response;
-            try {
-                response = adminClient.performRequest(request);
-            } catch (ResponseException e) {
-                throw new AssertionError("license not yet installed", e);
-            }
-            assertOK(response);
-            Map<String, Object> responseMap = responseAsMap(response);
-            assertTrue(responseMap.containsKey("license"));
-            assertThat(((Map<String, Object>) responseMap.get("license")).get("status"), equalTo("active"));
-            assertThat(((Map<String, Object>) responseMap.get("license")).get("type"), equalTo(type));
-        });
     }
 }


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/110729

The `testQueryDLSFLSRolesShowAsDisabled` failed intermittently and my theory is that it's because applying the license of the cluster to cluster state has `NORMAL` priority and therefore sometimes (very rarely) takes more than 10 seconds. There are some related discussions to this, see: https://github.com/elastic/elasticsearch/pull/67182, https://github.com/elastic/elasticsearch/issues/64578

Since we're not testing the actual license lifecycle in this test, but instead how an applied license impacts the query roles API, I changed the approach to use the synchronous `/_license/start_trial` API in a `@before` so we can be sure the license was applied before we start testing. An alternative to this fix could be to increase the timeout. 