### PR TITLE
Add Enterprise Search Connector Service Account

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -82,7 +82,7 @@ final class ElasticServiceAccounts {
         new RoleDescriptor(
             NAMESPACE + "/enterprise-search-connector",
             new String[] { "read_security", "manage_own_api_key" },
-            null,
+            new RoleDescriptor.IndicesPrivileges[] { RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("read").build() },
             null,
             null,
             null,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -77,6 +77,20 @@ final class ElasticServiceAccounts {
         )
     );
 
+    private static final ServiceAccount ENTERPRISE_SEARCH_CONNECTOR_ACCOUNT = new ElasticServiceAccount(
+        "enterprise-search-connector",
+        new RoleDescriptor(
+            NAMESPACE + "/enterprise-search-connector",
+            new String[] { "read_security", "manage_own_api_key" },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+    );
+
     private static final ServiceAccount FLEET_ACCOUNT = new ElasticServiceAccount(
         "fleet-server",
         new RoleDescriptor(
@@ -194,6 +208,7 @@ final class ElasticServiceAccounts {
     static final Map<String, ServiceAccount> ACCOUNTS = Stream.of(
         AUTO_OPS_ACCOUNT,
         ENTERPRISE_SEARCH_ACCOUNT,
+        ENTERPRISE_SEARCH_CONNECTOR_ACCOUNT,
         FLEET_ACCOUNT,
         FLEET_REMOTE_ACCOUNT,
         KIBANA_SYSTEM_ACCOUNT

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -52,6 +52,7 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
             containsInAnyOrder(
                 "elastic/auto-ops",
                 "elastic/enterprise-search-server",
+                "elastic/enterprise-search-connector",
                 "elastic/fleet-server",
                 "elastic/fleet-server-remote",
                 "elastic/kibana"

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountActionTests.java
@@ -46,7 +46,7 @@ public class TransportGetServiceAccountActionTests extends ESTestCase {
         final PlainActionFuture<GetServiceAccountResponse> future1 = new PlainActionFuture<>();
         transportGetServiceAccountAction.doExecute(mock(Task.class), request1, future1);
         final GetServiceAccountResponse getServiceAccountResponse1 = future1.actionGet();
-        assertThat(getServiceAccountResponse1.getServiceAccountInfos().length, equalTo(5));
+        assertThat(getServiceAccountResponse1.getServiceAccountInfos().length, equalTo(6));
         assertThat(
             Arrays.stream(getServiceAccountResponse1.getServiceAccountInfos()).map(ServiceAccountInfo::getPrincipal).toList(),
             containsInAnyOrder(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -97,6 +97,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             containsInAnyOrder(
                 "elastic/auto-ops",
                 "elastic/enterprise-search-server",
+                "elastic/enterprise-search-connector",
                 "elastic/fleet-server",
                 "elastic/fleet-server-remote",
                 "elastic/kibana"


### PR DESCRIPTION
This adds a new service account intended to be used by customer backends generating API keys for use with indices populated by connectors. 

See drawing below: 
![connector_service_account drawio](https://github.com/user-attachments/assets/998a9181-37cc-4b50-957b-7ebce8eb91ee)

- `read_security` allows the customer backend to query roles. 
- `manage_own_api_key` allows the backend to create api keys and manage the created api keys. 

The API keys created will have a role descriptor with read index permissions on the connector populated data index and a DLS query that's fetched from the user role using the query roles API.