### PR TITLE
Make `error.grouping_name` script compatible with synthetic _source

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error@mappings.yaml
@@ -28,9 +28,14 @@ template:
             return;
           }
           def exception = params['_source'].error?.exception;
-          def exceptionMessage = exception != null && exception.length > 0 ? exception[0]?.message : null;
-          if (exceptionMessage != null && exceptionMessage != "") {
-            emit(exception[0].message);
+          if (exception != null && exception.isEmpty() == false) {
+            def exceptionMessage = exception instanceof Map ? exception?.message : exception[0]?.message;
+            if (exceptionMessage instanceof List) {
+              exceptionMessage = exceptionMessage[0]
+            }
+            if (exceptionMessage != null && exceptionMessage != "") {
+              emit(exceptionMessage);
+            }
           }
 
       # http.*

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_error_grouping.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_error_grouping.yml
@@ -39,6 +39,10 @@ setup:
           - create: {}
           - '{"@timestamp": "2017-06-22", "error": {"log": {"message": ""}, "exception": [{"message": "exception_used"}]}}'
 
+          # Non-empty error.exception.message used from array
+          - create: {}
+          - '{"@timestamp": "2017-06-22", "error": {"log": {"message": ""}, "exception": [{"message": "first_exception_used"}, {"message": "2_ignored"}]}}'
+
   - is_false: errors
 
   - do:
@@ -46,7 +50,7 @@ setup:
         index: logs-apm.error-testing
         body:
           fields: ["error.grouping_name"]
-  - length: { hits.hits: 7 }
+  - length: { hits.hits: 8 }
   - match: { hits.hits.0.fields: null }
   - match: { hits.hits.1.fields: null }
   - match: { hits.hits.2.fields: null }
@@ -54,3 +58,4 @@ setup:
   - match: { hits.hits.4.fields: null }
   - match: { hits.hits.5.fields: {"error.grouping_name": ["log_used"]} }
   - match: { hits.hits.6.fields: {"error.grouping_name": ["exception_used"]} }
+  - match: { hits.hits.7.fields: {"error.grouping_name": ["first_exception_used"]} }


### PR DESCRIPTION
Makes the indexed runtime field script for `error.grouping_name` compatible with synthetic _source.