### PR TITLE
Fix testSuggestProfilesWithHint

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileIntegTests.java
@@ -451,7 +451,7 @@ public class ProfileIntegTests extends AbstractProfileIntegTestCase {
         final List<String> spaces = List.of("space1", "space2", "space3", "space4", "*");
         final List<Profile> profiles = spaces.stream().map(space -> {
             final PlainActionFuture<Profile> future1 = new PlainActionFuture<>();
-            final String lastName = randomAlphaOfLengthBetween(3, 8);
+            final String lastName = randomAlphaOfLengthBetween(3, 8) + space;
             final Authentication.RealmRef realmRef = randomBoolean()
                 ? AuthenticationTestHelper.randomRealmRef(false)
                 : new Authentication.RealmRef(


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/106761

The profile suggestion API uses a multi match query under the hood to match name if provided, the last assert of `testSuggestProfilesWithHint` makes sure that if the name is not matched, other fields that match do not result in a match for the multi-match query (and hence an invalid profile suggestion). The issue happened because sometimes there were several random names that ended up being the same. To make them unique, I added the corresponding kibana space to the name, this guarantees name uniqueness since the test requires that. 