### PR TITLE
[8.15] (Doc+) Removing "current_node" from Allocation Explain API under Fix Watermark Errors (#111946)

### DIFF
--- a/docs/reference/troubleshooting/common-issues/disk-usage-exceeded.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/disk-usage-exceeded.asciidoc
@@ -36,13 +36,11 @@ GET _cluster/allocation/explain
 {
   "index": "my-index",
   "shard": 0,
-  "primary": false,
-  "current_node": "my-node"
+  "primary": false
 }
 ----
 // TEST[s/^/PUT my-index\n/]
 // TEST[s/"primary": false,/"primary": false/]
-// TEST[s/"current_node": "my-node"//]
 
 To immediately restore write operations, you can temporarily increase the disk
 watermarks and remove the write block.


### PR DESCRIPTION
Backports the following commits to 8.15:
 - (Doc+) Removing "current_node" from Allocation Explain API under Fix Watermark Errors (#111946)