### PR TITLE
Expand docs on remote cluster proxying

### DIFF
--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -5,7 +5,9 @@ Each {es} node has two different network interfaces. Clients send requests to
 {es}'s REST APIs using its <<http-settings,HTTP interface>>, but nodes
 communicate with other nodes using the <<transport-settings,transport
 interface>>. The transport interface is also used for communication with
-<<remote-clusters,remote clusters>>.
+<<remote-clusters,remote clusters>>. The transport interface uses a custom
+binary protocol sent over <<long-lived-connections,long-lived>> TCP channels.
+Both interfaces can be configured to use <<secure-cluster,TLS for security>>.
 
 You can configure both of these interfaces at the same time using the
 `network.*` settings. If you have a more complicated network, you might need to

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -63,11 +63,13 @@ the same security domain. <<remote-clusters-cert>>.
 
 [[sniff-mode]]
 Sniff mode::
-In sniff mode, a cluster is created using a name and a list of seed nodes. When
-a remote cluster is registered, its cluster state is retrieved from one of the
-seed nodes and up to three _gateway nodes_ are selected as part of remote
-cluster requests. This mode requires that the gateway node's publish addresses
-are accessible by the local cluster.
+In sniff mode, a cluster is registered with a name of your choosing and a list
+of addresses of _seed_ nodes. When you register a remote cluster using sniff
+mode, {es} retrieves from one of the seed nodes the addresses of up to three
+_gateway nodes_. Each `remote_cluster_client` node in the local {es} cluster
+then opens several TCP connections to the publish addresses of the gateway
+nodes. This mode therefore requires that the gateway nodes' publish addresses
+are accessible to nodes in the local cluster.
 +
 Sniff mode is the default connection mode.
 +
@@ -84,15 +86,18 @@ However, such nodes still have to satisfy the two above requirements.
 
 [[proxy-mode]]
 Proxy mode::
-In proxy mode, a cluster is created using a name and a single proxy address.
-When you register a remote cluster, a configurable number of socket connections
-are opened to the proxy address. The proxy is required to route those
-connections to the remote cluster. Proxy mode does not require remote cluster
-nodes to have accessible publish addresses.
+In proxy mode, a cluster is registered with a name of your choosing and the
+address of a TCP (layer 4) reverse proxy which you must configure to route
+connections to the nodes of the remote cluster. When you register a remote
+cluster using proxy mode, {es} opens several TCP connections to the proxy
+address and uses these connections to communicate with the remote cluster. In
+proxy mode {es} disregards the publish addresses of the remote cluster nodes
+which means that the publish addresses of the remote cluster nodes need not be
+accessible to the local cluster.
 +
-The proxy mode is not the default connection mode and must be configured.
-Proxy mode has the same <<gateway-nodes-selection, version compatibility
-requirements>> as sniff mode.
+Proxy mode is not the default connection mode, so you must configure it
+explicitly if desired. Proxy mode has the same <<gateway-nodes-selection,
+version compatibility requirements>> as sniff mode.
 
 include::cluster/remote-clusters-api-key.asciidoc[]
 


### PR DESCRIPTION
It's not obvious from the docs that transport connections (including
connections to remote clusters) use a custom binary protocol and require
a _layer 4_ proxy. This commit clarifies this point.