### PR TITLE
[plugin/apm-data] Set fallback to legacy ILM policies

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
@@ -23,3 +23,6 @@ template:
     index:
       default_pipeline: logs-apm.app@default-pipeline
       final_pipeline: apm@pipeline
+      lifecycle:
+        name: logs-apm.app_logs-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -30,3 +30,6 @@ template:
     index:
       default_pipeline: logs-apm.error@default-pipeline
       final_pipeline: apm@pipeline
+      lifecycle:
+        name: logs-apm.error_logs-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
@@ -24,3 +24,6 @@ template:
     index:
       default_pipeline: metrics-apm.app@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.app_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
@@ -25,6 +25,9 @@ template:
     index:
       default_pipeline: metrics-apm.internal@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.internal_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       data_stream.dataset:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_destination_10m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
@@ -26,6 +26,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_destination_1m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_destination_60m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_summary_10m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
@@ -26,6 +26,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_summary_1m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_summary_60m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_transaction_10m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
@@ -26,6 +26,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_transaction_1m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.service_transaction_60m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.transaction_10m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
@@ -26,6 +26,9 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.transaction_1m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
@@ -27,6 +27,9 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+      lifecycle:
+        name: metrics-apm.transaction_60m_metrics-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
@@ -25,6 +25,9 @@ template:
     index:
       default_pipeline: traces-apm.rum@default-pipeline
       final_pipeline: traces-apm@pipeline
+      lifecycle:
+        name: traces-apm.rum_traces-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
@@ -20,6 +20,11 @@ ignore_missing_component_templates:
 template:
   lifecycle:
     data_retention: 1h
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.sampled_traces-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
@@ -24,6 +24,9 @@ template:
     index:
       default_pipeline: traces-apm@default-pipeline
       final_pipeline: traces-apm@pipeline
+      lifecycle:
+        name: traces-apm.traces-default_policy
+        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 6
+version: 7
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
Fixes fallback to legacy ILM policies when a datastream is updated. Without this PR, post update the indexes would be unmanaged without any lifecycle. After this PR:

1. Any datastream created with apm-data plugin active (> `v8.15.0`) would be managed by datastream lifecycle
2. Any datastream created before apm-data plugin was active(< `v8.15.0`) and migrated to version on or after `v8.15.0` would be managed by ILM policies until they are [explicitly migrated to use DLM](https://www.elastic.co/guide/en/elasticsearch/reference/current/tutorial-manage-existing-data-stream.html).

The PR doesn't add the lifecycle policies as when/if they are required then they should be available via the previous apm-integration.

## Testing locally

1. Create a stack (ES, Kibana, APM-Server) with data-persistence enabled for ES using `8.14.3` version. We use the `8.14.3` as that is the latest available version which uses APM integration package and thus configures ILM policies.
    <details>
      <summary>Example docker-compose.yaml</summary>

	```yaml
	version: '3.9'
	x-logging: &default-logging
	  driver: "json-file"
	  options:
	    max-size: "1g"
	services:
	  elasticsearch:
	    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
	    ports:
	      - 9200:9200
	    healthcheck:
	      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=500ms"]
	      retries: 300
	      interval: 1s
	    environment:
	      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
	      - "network.host=0.0.0.0"
	      - "transport.host=127.0.0.1"
	      - "http.host=0.0.0.0"
	      - "cluster.routing.allocation.disk.threshold_enabled=false"
	      - "discovery.type=single-node"
	      - "xpack.security.authc.anonymous.roles=remote_monitoring_collector"
	      - "xpack.security.authc.realms.file.file1.order=0"
	      - "xpack.security.authc.realms.native.native1.order=1"
	      - "xpack.security.enabled=true"
	      - "xpack.license.self_generated.type=trial"
	      - "xpack.security.authc.token.enabled=true"
	      - "xpack.security.authc.api_key.enabled=true"
	      - "logger.org.elasticsearch=${ES_LOG_LEVEL:-error}"
	      - "action.destructive_requires_name=false"
	    volumes:
	      - "./testing/docker/elasticsearch/roles.yml:/usr/share/elasticsearch/config/roles.yml"
	      - "./testing/docker/elasticsearch/users:/usr/share/elasticsearch/config/users"
	      - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
	      - "./testing/docker/elasticsearch/ingest-geoip:/usr/share/elasticsearch/config/ingest-geoip"
	      - "/Users/lahsivjar/Projects/elastic/tmp/esdata2:/usr/share/elasticsearch/data"
	    logging: *default-logging
	
	  kibana:
	    image: docker.elastic.co/kibana/kibana:8.14.3
	    ports:
	      - 5601:5601
	    healthcheck:
	      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'All services are available'"]
	      retries: 300
	      interval: 1s
	    environment:
	      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
	      ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-kibana_system_user}"
	      ELASTICSEARCH_PASSWORD: "${KIBANA_ES_PASS:-changeme}"
	      XPACK_FLEET_AGENTS_ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
	    depends_on:
	      elasticsearch: { condition: service_healthy }
	    volumes:
	      - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
	    logging: *default-logging
	
	  apm-server:
	    image: docker.elastic.co/apm/apm-server:8.14.3
	    ports:
	      - 8200:8200
	    healthcheck:
	      test: ["CMD-SHELL", "bash -c 'echo -n > /dev/tcp/127.0.0.1/8200'"]
	      retries: 300
	      interval: 1s
	    depends_on:
	      elasticsearch: { condition: service_healthy }
	    volumes:
	      - "./testing/docker/apm-server/apm-server.yml:/usr/share/apm-server/apm-server.yml"
	    logging: *default-logging
	```
    </details>
    NOTE: The config files used in the example docker-compose are [available here](https://github.com/elastic/apm-server/tree/main/testing/docker). `apm.server.yml` file used in the docker-compose could be a simple config file:
    
    ```yaml
    apm-server:
      host: "0.0.0.0:8200"
    output.elasticsearch:
      hosts: ["elasticsearch:9200"]
      username: "admin"
      password: "changeme"
    logging.level: info
    logging.to_stderr: true
    ```
2. Install the APM integration in the cluster.
3. Send some data, for example: by using [apmsoak](https://github.com/elastic/apm-perf/tree/main/cmd/apmsoak). Example command: `go run ./cmd/apmsoak/ run --file cmd/apmsoak/scenarios.yml --scenario apm-server --server-url http://localhost:8200`
4. Assert that the APM indices created are managed by ILM, for example: by running `GET /_data_stream/traces-apm-default` to check for trace indices
5. Build an Elasticsearch docker image using the branch in this PR: `./gradlew buildAarch64DockerImage`
6. Update the versions used in the stack created in step 1 to `8.16.0-SNAPSHOT`, for ES use the docker image built in step 5
7. Send some more data as we did in step 3
8. Assert that all the APM indices are still managed by ILM
9. Rollover the datastream
10. Assert that all the APM indices, including the one created using rollover in step 9, are still managed by ILM

Also, test if the setup works by itself i.e. if a cluster is created using the latest version (with the changes in the PR) then it works as expected and the created APM indices in this case are managed by DSL (datastream lifecycle).

**NOTE:** Any indices created when APM is on version `8.15.0` and datastream created before `8.15.0` i.e. with ILM, will remain `Unmanaged` even after this fix. To fix them, we would need to explicitly update them OR use the PUT API on datastream to set DSL.

Fixes: https://github.com/elastic/apm-server/issues/13898