### PR TITLE
Re-enable xpack yaml tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -182,8 +182,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/111923
 - class: org.elasticsearch.xpack.sql.qa.security.JdbcCsvSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/111923
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/111944
 - class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
   method: testScaledFloat
   issue: https://github.com/elastic/elasticsearch/issues/112003


### PR DESCRIPTION
This was auto-silenced as part of #111944, although a single test was failing.

Related to #111944.