### PR TITLE
[ES|QL] Add required_capability for casting string to version

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -134,9 +134,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
   method: testSnapshotRestore {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111799
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {comparison.RangeVersion SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/111814
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: "test {p0=esql/26_aggs_bucket/friendlier BUCKET interval hourly: #110916}"
   issue: https://github.com/elastic/elasticsearch/issues/111901

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/comparison.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/comparison.csv-spec
@@ -181,6 +181,7 @@ emp_no:integer |first_name:keyword
 ;
 
 rangeVersion
+required_capability: string_literal_auto_casting_extended
 from apps
 | where version > "2" and version < "4"
 | keep id, version


### PR DESCRIPTION
Resolves: #111814 

Implicit casting from string literals to Version happens to 8.14.1 and after. Add required_capability to the failed test to prevent it from running on older versions.