### PR TITLE
ESQL: Document `date` instead of `datetime` (#111985)

### DIFF
--- a/docs/reference/esql/functions/kibana/definition/bucket.json
+++ b/docs/reference/esql/functions/kibana/definition/bucket.json
@@ -8,7 +8,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Numeric or date expression from which to derive buckets."
         },
@@ -20,13 +20,13 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Numeric or date expression from which to derive buckets."
         },
@@ -38,25 +38,25 @@
         },
         {
           "name" : "from",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : true,
           "description" : "Start of the range. Can be a number or a date expressed as a string."
         },
         {
           "name" : "to",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : true,
           "description" : "End of the range. Can be a number or a date expressed as a string."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Numeric or date expression from which to derive buckets."
         },
@@ -68,7 +68,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/case.json
+++ b/docs/reference/esql/functions/kibana/definition/case.json
@@ -50,13 +50,13 @@
         },
         {
           "name" : "trueValue",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "The value that's returned when the corresponding condition is the first to evaluate to `true`. The default value is returned when no condition matches."
         }
       ],
       "variadic" : true,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/coalesce.json
+++ b/docs/reference/esql/functions/kibana/definition/coalesce.json
@@ -74,19 +74,19 @@
       "params" : [
         {
           "name" : "first",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Expression to evaluate."
         },
         {
           "name" : "rest",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : true,
           "description" : "Other expression to evaluate."
         }
       ],
       "variadic" : true,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/date_diff.json
+++ b/docs/reference/esql/functions/kibana/definition/date_diff.json
@@ -14,13 +14,13 @@
         },
         {
           "name" : "startTimestamp",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "A string representing a start timestamp"
         },
         {
           "name" : "endTimestamp",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "A string representing an end timestamp"
         }
@@ -38,13 +38,13 @@
         },
         {
           "name" : "startTimestamp",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "A string representing a start timestamp"
         },
         {
           "name" : "endTimestamp",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "A string representing an end timestamp"
         }

--- a/docs/reference/esql/functions/kibana/definition/date_extract.json
+++ b/docs/reference/esql/functions/kibana/definition/date_extract.json
@@ -14,7 +14,7 @@
         },
         {
           "name" : "date",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Date expression. If `null`, the function returns `null`."
         }
@@ -32,7 +32,7 @@
         },
         {
           "name" : "date",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Date expression. If `null`, the function returns `null`."
         }

--- a/docs/reference/esql/functions/kibana/definition/date_format.json
+++ b/docs/reference/esql/functions/kibana/definition/date_format.json
@@ -14,7 +14,7 @@
         },
         {
           "name" : "date",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Date expression. If `null`, the function returns `null`."
         }
@@ -32,7 +32,7 @@
         },
         {
           "name" : "date",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Date expression. If `null`, the function returns `null`."
         }

--- a/docs/reference/esql/functions/kibana/definition/date_parse.json
+++ b/docs/reference/esql/functions/kibana/definition/date_parse.json
@@ -20,7 +20,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -38,7 +38,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -56,7 +56,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -74,7 +74,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     }
   ],
   "examples" : [

--- a/docs/reference/esql/functions/kibana/definition/date_trunc.json
+++ b/docs/reference/esql/functions/kibana/definition/date_trunc.json
@@ -14,13 +14,13 @@
         },
         {
           "name" : "date",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Date expression"
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -32,13 +32,13 @@
         },
         {
           "name" : "date",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Date expression"
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     }
   ],
   "examples" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_append.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_append.json
@@ -62,19 +62,19 @@
       "params" : [
         {
           "name" : "field1",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : ""
         },
         {
           "name" : "field2",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : ""
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_count.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_count.json
@@ -44,7 +44,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression."
         }

--- a/docs/reference/esql/functions/kibana/definition/mv_dedupe.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_dedupe.json
@@ -45,13 +45,13 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_first.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_first.json
@@ -44,13 +44,13 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_last.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_last.json
@@ -44,13 +44,13 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_max.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_max.json
@@ -20,13 +20,13 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_min.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_min.json
@@ -20,13 +20,13 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_slice.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_slice.json
@@ -80,7 +80,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression. If `null`, the function returns `null`."
         },
@@ -98,7 +98,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/mv_sort.json
+++ b/docs/reference/esql/functions/kibana/definition/mv_sort.json
@@ -26,7 +26,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Multivalue expression. If `null`, the function returns `null`."
         },
@@ -38,7 +38,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/kibana/definition/now.json
+++ b/docs/reference/esql/functions/kibana/definition/now.json
@@ -6,7 +6,7 @@
   "signatures" : [
     {
       "params" : [ ],
-      "returnType" : "datetime"
+      "returnType" : "date"
     }
   ],
   "examples" : [

--- a/docs/reference/esql/functions/kibana/definition/to_datetime.json
+++ b/docs/reference/esql/functions/kibana/definition/to_datetime.json
@@ -8,13 +8,13 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -26,7 +26,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -38,7 +38,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -50,7 +50,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -62,7 +62,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -74,7 +74,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [
@@ -86,7 +86,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     }
   ],
   "examples" : [

--- a/docs/reference/esql/functions/kibana/definition/to_double.json
+++ b/docs/reference/esql/functions/kibana/definition/to_double.json
@@ -56,7 +56,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."
         }

--- a/docs/reference/esql/functions/kibana/definition/to_integer.json
+++ b/docs/reference/esql/functions/kibana/definition/to_integer.json
@@ -32,7 +32,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."
         }

--- a/docs/reference/esql/functions/kibana/definition/to_long.json
+++ b/docs/reference/esql/functions/kibana/definition/to_long.json
@@ -44,7 +44,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."
         }

--- a/docs/reference/esql/functions/kibana/definition/to_string.json
+++ b/docs/reference/esql/functions/kibana/definition/to_string.json
@@ -44,7 +44,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."
         }

--- a/docs/reference/esql/functions/kibana/definition/to_unsigned_long.json
+++ b/docs/reference/esql/functions/kibana/definition/to_unsigned_long.json
@@ -20,7 +20,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "Input value. The input can be a single- or multi-valued column or an expression."
         }

--- a/docs/reference/esql/functions/kibana/definition/top.json
+++ b/docs/reference/esql/functions/kibana/definition/top.json
@@ -8,7 +8,7 @@
       "params" : [
         {
           "name" : "field",
-          "type" : "datetime",
+          "type" : "date",
           "optional" : false,
           "description" : "The field to collect the top values for."
         },
@@ -26,7 +26,7 @@
         }
       ],
       "variadic" : false,
-      "returnType" : "datetime"
+      "returnType" : "date"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/types/add.asciidoc
+++ b/docs/reference/esql/functions/types/add.asciidoc
@@ -5,10 +5,10 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 lhs | rhs | result
+date | date_period | date
+date | time_duration | date
+date_period | date | date
 date_period | date_period | date_period
-date_period | datetime | datetime
-datetime | date_period | datetime
-datetime | time_duration | datetime
 double | double | double
 double | integer | double
 double | long | double
@@ -18,7 +18,7 @@ integer | long | long
 long | double | double
 long | integer | long
 long | long | long
-time_duration | datetime | datetime
+time_duration | date | date
 time_duration | time_duration | time_duration
 unsigned_long | unsigned_long | unsigned_long
 |===

--- a/docs/reference/esql/functions/types/bucket.asciidoc
+++ b/docs/reference/esql/functions/types/bucket.asciidoc
@@ -5,9 +5,9 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 field | buckets | from | to | result
-datetime | date_period | | | datetime
-datetime | integer | datetime | datetime | datetime
-datetime | time_duration | | | datetime
+date | date_period | | | date
+date | integer | date | date | date
+date | time_duration | | | date
 double | double | | | double
 double | integer | double | double | double
 double | integer | double | integer | double

--- a/docs/reference/esql/functions/types/case.asciidoc
+++ b/docs/reference/esql/functions/types/case.asciidoc
@@ -7,7 +7,7 @@
 condition | trueValue | result
 boolean | boolean | boolean
 boolean | cartesian_point | cartesian_point
-boolean | datetime | datetime
+boolean | date | date
 boolean | double | double
 boolean | geo_point | geo_point
 boolean | integer | integer

--- a/docs/reference/esql/functions/types/coalesce.asciidoc
+++ b/docs/reference/esql/functions/types/coalesce.asciidoc
@@ -9,7 +9,7 @@ boolean | boolean | boolean
 boolean | | boolean
 cartesian_point | cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape | cartesian_shape
-datetime | datetime | datetime
+date | date | date
 geo_point | geo_point | geo_point
 geo_shape | geo_shape | geo_shape
 integer | integer | integer

--- a/docs/reference/esql/functions/types/date_diff.asciidoc
+++ b/docs/reference/esql/functions/types/date_diff.asciidoc
@@ -5,6 +5,6 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 unit | startTimestamp | endTimestamp | result
-keyword | datetime | datetime | integer
-text | datetime | datetime | integer
+keyword | date | date | integer
+text | date | date | integer
 |===

--- a/docs/reference/esql/functions/types/date_extract.asciidoc
+++ b/docs/reference/esql/functions/types/date_extract.asciidoc
@@ -5,6 +5,6 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 datePart | date | result
-keyword | datetime | long
-text | datetime | long
+keyword | date | long
+text | date | long
 |===

--- a/docs/reference/esql/functions/types/date_format.asciidoc
+++ b/docs/reference/esql/functions/types/date_format.asciidoc
@@ -5,6 +5,6 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 dateFormat | date | result
-keyword | datetime | keyword
-text | datetime | keyword
+keyword | date | keyword
+text | date | keyword
 |===

--- a/docs/reference/esql/functions/types/date_parse.asciidoc
+++ b/docs/reference/esql/functions/types/date_parse.asciidoc
@@ -5,8 +5,8 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 datePattern | dateString | result
-keyword | keyword | datetime
-keyword | text | datetime
-text | keyword | datetime
-text | text | datetime
+keyword | keyword | date
+keyword | text | date
+text | keyword | date
+text | text | date
 |===

--- a/docs/reference/esql/functions/types/date_trunc.asciidoc
+++ b/docs/reference/esql/functions/types/date_trunc.asciidoc
@@ -5,6 +5,6 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 interval | date | result
-date_period | datetime | datetime
-time_duration | datetime | datetime
+date_period | date | date
+time_duration | date | date
 |===

--- a/docs/reference/esql/functions/types/equals.asciidoc
+++ b/docs/reference/esql/functions/types/equals.asciidoc
@@ -8,7 +8,7 @@ lhs | rhs | result
 boolean | boolean | boolean
 cartesian_point | cartesian_point | boolean
 cartesian_shape | cartesian_shape | boolean
-datetime | datetime | boolean
+date | date | boolean
 double | double | boolean
 double | integer | boolean
 double | long | boolean

--- a/docs/reference/esql/functions/types/greater_than.asciidoc
+++ b/docs/reference/esql/functions/types/greater_than.asciidoc
@@ -5,7 +5,7 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 lhs | rhs | result
-datetime | datetime | boolean
+date | date | boolean
 double | double | boolean
 double | integer | boolean
 double | long | boolean

--- a/docs/reference/esql/functions/types/greater_than_or_equal.asciidoc
+++ b/docs/reference/esql/functions/types/greater_than_or_equal.asciidoc
@@ -5,7 +5,7 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 lhs | rhs | result
-datetime | datetime | boolean
+date | date | boolean
 double | double | boolean
 double | integer | boolean
 double | long | boolean

--- a/docs/reference/esql/functions/types/less_than.asciidoc
+++ b/docs/reference/esql/functions/types/less_than.asciidoc
@@ -5,7 +5,7 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 lhs | rhs | result
-datetime | datetime | boolean
+date | date | boolean
 double | double | boolean
 double | integer | boolean
 double | long | boolean

--- a/docs/reference/esql/functions/types/less_than_or_equal.asciidoc
+++ b/docs/reference/esql/functions/types/less_than_or_equal.asciidoc
@@ -5,7 +5,7 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 lhs | rhs | result
-datetime | datetime | boolean
+date | date | boolean
 double | double | boolean
 double | integer | boolean
 double | long | boolean

--- a/docs/reference/esql/functions/types/mv_append.asciidoc
+++ b/docs/reference/esql/functions/types/mv_append.asciidoc
@@ -8,7 +8,7 @@ field1 | field2 | result
 boolean | boolean | boolean
 cartesian_point | cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape | cartesian_shape
-datetime | datetime | datetime
+date | date | date
 double | double | double
 geo_point | geo_point | geo_point
 geo_shape | geo_shape | geo_shape

--- a/docs/reference/esql/functions/types/mv_count.asciidoc
+++ b/docs/reference/esql/functions/types/mv_count.asciidoc
@@ -8,7 +8,7 @@ field | result
 boolean | integer
 cartesian_point | integer
 cartesian_shape | integer
-datetime | integer
+date | integer
 double | integer
 geo_point | integer
 geo_shape | integer

--- a/docs/reference/esql/functions/types/mv_dedupe.asciidoc
+++ b/docs/reference/esql/functions/types/mv_dedupe.asciidoc
@@ -8,7 +8,7 @@ field | result
 boolean | boolean
 cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape
-datetime | datetime
+date | date
 double | double
 geo_point | geo_point
 geo_shape | geo_shape

--- a/docs/reference/esql/functions/types/mv_first.asciidoc
+++ b/docs/reference/esql/functions/types/mv_first.asciidoc
@@ -8,7 +8,7 @@ field | result
 boolean | boolean
 cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape
-datetime | datetime
+date | date
 double | double
 geo_point | geo_point
 geo_shape | geo_shape

--- a/docs/reference/esql/functions/types/mv_last.asciidoc
+++ b/docs/reference/esql/functions/types/mv_last.asciidoc
@@ -8,7 +8,7 @@ field | result
 boolean | boolean
 cartesian_point | cartesian_point
 cartesian_shape | cartesian_shape
-datetime | datetime
+date | date
 double | double
 geo_point | geo_point
 geo_shape | geo_shape

--- a/docs/reference/esql/functions/types/mv_max.asciidoc
+++ b/docs/reference/esql/functions/types/mv_max.asciidoc
@@ -6,7 +6,7 @@
 |===
 field | result
 boolean | boolean
-datetime | datetime
+date | date
 double | double
 integer | integer
 ip | ip

--- a/docs/reference/esql/functions/types/mv_min.asciidoc
+++ b/docs/reference/esql/functions/types/mv_min.asciidoc
@@ -6,7 +6,7 @@
 |===
 field | result
 boolean | boolean
-datetime | datetime
+date | date
 double | double
 integer | integer
 ip | ip

--- a/docs/reference/esql/functions/types/mv_slice.asciidoc
+++ b/docs/reference/esql/functions/types/mv_slice.asciidoc
@@ -8,7 +8,7 @@ field | start | end | result
 boolean | integer | integer | boolean
 cartesian_point | integer | integer | cartesian_point
 cartesian_shape | integer | integer | cartesian_shape
-datetime | integer | integer | datetime
+date | integer | integer | date
 double | integer | integer | double
 geo_point | integer | integer | geo_point
 geo_shape | integer | integer | geo_shape

--- a/docs/reference/esql/functions/types/mv_sort.asciidoc
+++ b/docs/reference/esql/functions/types/mv_sort.asciidoc
@@ -6,7 +6,7 @@
 |===
 field | order | result
 boolean | keyword | boolean
-datetime | keyword | datetime
+date | keyword | date
 double | keyword | double
 integer | keyword | integer
 ip | keyword | ip

--- a/docs/reference/esql/functions/types/not_equals.asciidoc
+++ b/docs/reference/esql/functions/types/not_equals.asciidoc
@@ -8,7 +8,7 @@ lhs | rhs | result
 boolean | boolean | boolean
 cartesian_point | cartesian_point | boolean
 cartesian_shape | cartesian_shape | boolean
-datetime | datetime | boolean
+date | date | boolean
 double | double | boolean
 double | integer | boolean
 double | long | boolean

--- a/docs/reference/esql/functions/types/now.asciidoc
+++ b/docs/reference/esql/functions/types/now.asciidoc
@@ -5,5 +5,5 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 result
-datetime
+date
 |===

--- a/docs/reference/esql/functions/types/sub.asciidoc
+++ b/docs/reference/esql/functions/types/sub.asciidoc
@@ -5,9 +5,9 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 lhs | rhs | result
+date | date_period | date
+date | time_duration | date
 date_period | date_period | date_period
-datetime | date_period | datetime
-datetime | time_duration | datetime
 double | double | double
 double | integer | double
 double | long | double

--- a/docs/reference/esql/functions/types/to_datetime.asciidoc
+++ b/docs/reference/esql/functions/types/to_datetime.asciidoc
@@ -5,11 +5,11 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 field | result
-datetime | datetime
-double | datetime
-integer | datetime
-keyword | datetime
-long | datetime
-text | datetime
-unsigned_long | datetime
+date | date
+double | date
+integer | date
+keyword | date
+long | date
+text | date
+unsigned_long | date
 |===

--- a/docs/reference/esql/functions/types/to_double.asciidoc
+++ b/docs/reference/esql/functions/types/to_double.asciidoc
@@ -9,7 +9,7 @@ boolean | double
 counter_double | double
 counter_integer | double
 counter_long | double
-datetime | double
+date | double
 double | double
 integer | double
 keyword | double

--- a/docs/reference/esql/functions/types/to_integer.asciidoc
+++ b/docs/reference/esql/functions/types/to_integer.asciidoc
@@ -7,7 +7,7 @@
 field | result
 boolean | integer
 counter_integer | integer
-datetime | integer
+date | integer
 double | integer
 integer | integer
 keyword | integer

--- a/docs/reference/esql/functions/types/to_long.asciidoc
+++ b/docs/reference/esql/functions/types/to_long.asciidoc
@@ -8,7 +8,7 @@ field | result
 boolean | long
 counter_integer | long
 counter_long | long
-datetime | long
+date | long
 double | long
 integer | long
 keyword | long

--- a/docs/reference/esql/functions/types/to_string.asciidoc
+++ b/docs/reference/esql/functions/types/to_string.asciidoc
@@ -8,7 +8,7 @@ field | result
 boolean | keyword
 cartesian_point | keyword
 cartesian_shape | keyword
-datetime | keyword
+date | keyword
 double | keyword
 geo_point | keyword
 geo_shape | keyword

--- a/docs/reference/esql/functions/types/to_unsigned_long.asciidoc
+++ b/docs/reference/esql/functions/types/to_unsigned_long.asciidoc
@@ -6,7 +6,7 @@
 |===
 field | result
 boolean | unsigned_long
-datetime | unsigned_long
+date | unsigned_long
 double | unsigned_long
 integer | unsigned_long
 keyword | unsigned_long

--- a/docs/reference/esql/functions/types/top.asciidoc
+++ b/docs/reference/esql/functions/types/top.asciidoc
@@ -5,7 +5,7 @@
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 field | limit | order | result
-datetime | integer | keyword | datetime
+date | integer | keyword | date
 double | integer | keyword | double
 integer | integer | keyword | integer
 long | integer | keyword | long

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -255,6 +255,14 @@ public enum DataType {
     }
 
     /**
+     * Return the Elasticsearch field name of this type if there is one,
+     * otherwise return the ESQL specific name.
+     */
+    public String esNameIfPossible() {
+        return esType != null ? esType : typeName;
+    }
+
+    /**
      * The name we give to types on the response.
      */
     public String outputType() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -72,7 +72,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
@@ -325,13 +324,12 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
         for (int i = 0; i < args.size(); i++) {
             typesFromSignature.add(new HashSet<>());
         }
-        Function<DataType, String> typeName = dt -> dt.esType() != null ? dt.esType() : dt.typeName();
         for (Map.Entry<List<DataType>, DataType> entry : signatures().entrySet()) {
             List<DataType> types = entry.getKey();
             for (int i = 0; i < args.size() && i < types.size(); i++) {
-                typesFromSignature.get(i).add(typeName.apply(types.get(i)));
+                typesFromSignature.get(i).add(types.get(i).esNameIfPossible());
             }
-            returnFromSignature.add(typeName.apply(entry.getValue()));
+            returnFromSignature.add(entry.getValue().esNameIfPossible());
         }
 
         for (int i = 0; i < args.size(); i++) {
@@ -491,15 +489,15 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
             }
             StringBuilder b = new StringBuilder();
             for (DataType arg : sig.getKey()) {
-                b.append(arg.typeName()).append(" | ");
+                b.append(arg.esNameIfPossible()).append(" | ");
             }
             b.append("| ".repeat(argNames.size() - sig.getKey().size()));
-            b.append(sig.getValue().typeName());
+            b.append(sig.getValue().esNameIfPossible());
             table.add(b.toString());
         }
         Collections.sort(table);
         if (table.isEmpty()) {
-            table.add(signatures.values().iterator().next().typeName());
+            table.add(signatures.values().iterator().next().esNameIfPossible());
         }
 
         String rendered = DOCS_WARNING + """
@@ -653,7 +651,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
             builder.startArray("params");
             builder.endArray();
             // There should only be one return type so just use that as the example
-            builder.field("returnType", signatures().values().iterator().next().typeName());
+            builder.field("returnType", signatures().values().iterator().next().esNameIfPossible());
             builder.endObject();
         } else {
             int minArgCount = (int) args.stream().filter(a -> false == a.optional()).count();
@@ -671,14 +669,14 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
                     EsqlFunctionRegistry.ArgSignature arg = args.get(i);
                     builder.startObject();
                     builder.field("name", arg.name());
-                    builder.field("type", sig.getKey().get(i).typeName());
+                    builder.field("type", sig.getKey().get(i).esNameIfPossible());
                     builder.field("optional", arg.optional());
                     builder.field("description", arg.description());
                     builder.endObject();
                 }
                 builder.endArray();
                 builder.field("variadic", variadic);
-                builder.field("returnType", sig.getValue().typeName());
+                builder.field("returnType", sig.getValue().esNameIfPossible());
                 builder.endObject();
             }
         }
@@ -714,12 +712,12 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
                     if (rhs.getKey().size() <= i) {
                         return 1;
                     }
-                    int c = lhs.getKey().get(i).typeName().compareTo(rhs.getKey().get(i).typeName());
+                    int c = lhs.getKey().get(i).esNameIfPossible().compareTo(rhs.getKey().get(i).esNameIfPossible());
                     if (c != 0) {
                         return c;
                     }
                 }
-                return lhs.getValue().typeName().compareTo(rhs.getValue().typeName());
+                return lhs.getValue().esNameIfPossible().compareTo(rhs.getValue().esNameIfPossible());
             }
         });
         return sortedSignatures;


### PR DESCRIPTION
This changes the generated types tables in the docs to say `date` instead of `datetime`. That's the name of the field in Elasticsearch so it's a lot less confusing to call it that.

Closes #111650
