### PR TITLE
[8.15] (Doc+) Link API doc to parent object - part1 (#111951)

### DIFF
--- a/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
+++ b/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
@@ -4,7 +4,7 @@
 
 NOTE: {cloud-only}
 
-You can use the following APIs to perform autoscaling operations.
+You can use the following APIs to perform {cloud}/ec-autoscaling.html[autoscaling operations].
 
 [discrete]
 [[autoscaling-api-top-level]]

--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -7,7 +7,7 @@
 
 NOTE: {cloud-only}
 
-Delete autoscaling policy.
+Delete {cloud}/ec-autoscaling.html[autoscaling] policy.
 
 [[autoscaling-delete-autoscaling-policy-request]]
 ==== {api-request-title}

--- a/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
@@ -7,7 +7,7 @@
 
 NOTE: {cloud-only}
 
-Get autoscaling capacity.
+Get {cloud}/ec-autoscaling.html[autoscaling] capacity.
 
 [[autoscaling-get-autoscaling-capacity-request]]
 ==== {api-request-title}

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -7,7 +7,7 @@
 
 NOTE: {cloud-only}
 
-Get autoscaling policy.
+Get {cloud}/ec-autoscaling.html[autoscaling] policy.
 
 [[autoscaling-get-autoscaling-policy-request]]
 ==== {api-request-title}

--- a/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
@@ -7,7 +7,7 @@
 
 NOTE: {cloud-only}
 
-Creates or updates an autoscaling policy.
+Creates or updates an {cloud}/ec-autoscaling.html[autoscaling] policy.
 
 [[autoscaling-put-autoscaling-policy-request]]
 ==== {api-request-title}

--- a/docs/reference/autoscaling/deciders/fixed-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/fixed-decider.asciidoc
@@ -6,7 +6,7 @@ experimental[]
 [WARNING]
 The fixed decider is intended for testing only. Do not use this decider in production.
 
-The `fixed` decider responds with a fixed required capacity. It is not enabled
+The {cloud}/ec-autoscaling.html[autoscaling] `fixed` decider responds with a fixed required capacity. It is not enabled
 by default but can be enabled for any policy by explicitly configuring it.
 
 ==== Configuration settings

--- a/docs/reference/autoscaling/deciders/frozen-existence-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/frozen-existence-decider.asciidoc
@@ -2,7 +2,7 @@
 [[autoscaling-frozen-existence-decider]]
 === Frozen existence decider
 
-The frozen existence decider (`frozen_existence`) ensures that once the first
+The {cloud}/ec-autoscaling.html[autoscaling] frozen existence decider (`frozen_existence`) ensures that once the first
 index enters the frozen ILM phase, the frozen tier is scaled into existence.
 
 The frozen existence decider is enabled for all policies governing frozen data

--- a/docs/reference/autoscaling/deciders/frozen-shards-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/frozen-shards-decider.asciidoc
@@ -2,7 +2,7 @@
 [[autoscaling-frozen-shards-decider]]
 === Frozen shards decider
 
-The frozen shards decider (`frozen_shards`) calculates the memory required to search
+The {cloud}/ec-autoscaling.html[autoscaling] frozen shards decider (`frozen_shards`) calculates the memory required to search
 the current set of partially mounted indices in the frozen tier. Based on a
 required memory amount per shard, it calculates the necessary memory in the frozen tier.
 

--- a/docs/reference/autoscaling/deciders/frozen-storage-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/frozen-storage-decider.asciidoc
@@ -2,7 +2,7 @@
 [[autoscaling-frozen-storage-decider]]
 === Frozen storage decider
 
-The frozen storage decider (`frozen_storage`) calculates the local storage
+The {cloud}/ec-autoscaling.html[autoscaling] frozen storage decider (`frozen_storage`) calculates the local storage
 required to search the current set of partially mounted indices based on a
 percentage of the total data set size of such indices. It signals that
 additional storage capacity is necessary when existing capacity is less than the

--- a/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
@@ -2,7 +2,7 @@
 [[autoscaling-machine-learning-decider]]
 === Machine learning decider
 
-The {ml} decider (`ml`) calculates the memory and CPU requirements to run {ml} 
+The {cloud}/ec-autoscaling.html[autoscaling] {ml} decider (`ml`) calculates the memory and CPU requirements to run {ml} 
 jobs and trained models.
 
 The {ml} decider is enabled for policies governing `ml` nodes.

--- a/docs/reference/autoscaling/deciders/proactive-storage-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/proactive-storage-decider.asciidoc
@@ -2,7 +2,7 @@
 [[autoscaling-proactive-storage-decider]]
 === Proactive storage decider
 
-The proactive storage decider (`proactive_storage`) calculates the storage required to contain
+The {cloud}/ec-autoscaling.html[autoscaling] proactive storage decider (`proactive_storage`) calculates the storage required to contain
 the current data set plus an estimated amount of expected additional data.
 
 The proactive storage decider is enabled for all policies governing nodes with the `data_hot` role.

--- a/docs/reference/autoscaling/deciders/reactive-storage-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/reactive-storage-decider.asciidoc
@@ -2,7 +2,7 @@
 [[autoscaling-reactive-storage-decider]]
 === Reactive storage decider
 
-The reactive storage decider (`reactive_storage`) calculates the storage required to contain
+The {cloud}/ec-autoscaling.html[autoscaling] reactive storage decider (`reactive_storage`) calculates the storage required to contain
 the current data set. It signals that additional storage capacity is necessary
 when existing capacity has been exceeded (reactively).
 

--- a/docs/reference/autoscaling/index.asciidoc
+++ b/docs/reference/autoscaling/index.asciidoc
@@ -4,7 +4,7 @@
 
 NOTE: {cloud-only}
 
-The autoscaling feature enables an operator to configure tiers of nodes that
+The {cloud}/ec-autoscaling.html[autoscaling] feature enables an operator to configure tiers of nodes that
 self-monitor whether or not they need to scale based on an operator-defined
 policy. Then, via the autoscaling API, an Elasticsearch cluster can report
 whether or not it needs additional resources to meet the policy. For example, an

--- a/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
@@ -17,7 +17,7 @@ PUT _application/analytics/my_analytics_collection
 
 ////
 
-Removes an Analytics Collection and its associated data stream.
+Removes a <<behavioral-analytics-overview,Behavioral Analytics>> Collection and its associated data stream.
 
 [[delete-analytics-collection-request]]
 ==== {api-request-title}

--- a/docs/reference/behavioral-analytics/apis/index.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/index.asciidoc
@@ -9,7 +9,7 @@ beta::[]
 
 ---
 
-Use the following APIs to manage tasks and resources related to Behavioral Analytics:
+Use the following APIs to manage tasks and resources related to <<behavioral-analytics-overview,Behavioral Analytics>>:
 
 * <<put-analytics-collection>>
 * <<delete-analytics-collection>>

--- a/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
@@ -24,7 +24,7 @@ DELETE _application/analytics/my_analytics_collection2
 // TEARDOWN
 ////
 
-Returns information about Analytics Collections.
+Returns information about <<behavioral-analytics-overview,Behavioral Analytics>> Collections.
 
 [[list-analytics-collection-request]]
 ==== {api-request-title}

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -22,7 +22,7 @@ DELETE _application/analytics/my_analytics_collection
 // TEARDOWN
 ////
 
-Post an event to an Analytics Collection.
+Post an event to a <<behavioral-analytics-overview,Behavioral Analytics>> Collection.
 
 [[post-analytics-collection-event-request]]
 ==== {api-request-title}

--- a/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
@@ -16,7 +16,7 @@ DELETE _application/analytics/my_analytics_collection
 // TEARDOWN
 ////
 
-Creates an Analytics Collection.
+Creates a <<behavioral-analytics-overview,Behavioral Analytics>> Collection.
 
 [[put-analytics-collection-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/delete-auto-follow-pattern.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Delete auto-follow pattern</titleabbrev>
 ++++
 
-Delete auto-follow patterns.
+Delete {ccr} <<ccr-auto-follow,auto-follow patterns>>.
 
 [[ccr-delete-auto-follow-pattern-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/get-auto-follow-pattern.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Get auto-follow pattern</titleabbrev>
 ++++
 
-Get auto-follow patterns.
+Get {ccr} <<ccr-auto-follow,auto-follow patterns>>.
 
 [[ccr-get-auto-follow-pattern-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/auto-follow/pause-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/pause-auto-follow-pattern.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Pause auto-follow pattern</titleabbrev>
 ++++
 
-Pauses an auto-follow pattern.
+Pauses a {ccr} <<ccr-auto-follow,auto-follow pattern>>.
 
 [[ccr-pause-auto-follow-pattern-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Create auto-follow pattern</titleabbrev>
 ++++
 
-Creates an auto-follow pattern.
+Creates a {ccr} <<ccr-auto-follow,auto-follow pattern>>.
 
 [[ccr-put-auto-follow-pattern-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/auto-follow/resume-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/resume-auto-follow-pattern.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Resume auto-follow pattern</titleabbrev>
 ++++
 
-Resumes an auto-follow pattern.
+Resumes a {ccr} <<ccr-auto-follow,auto-follow pattern>>.
 
 [[ccr-resume-auto-follow-pattern-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/ccr-apis.asciidoc
+++ b/docs/reference/ccr/apis/ccr-apis.asciidoc
@@ -2,7 +2,7 @@
 [[ccr-apis]]
 == {ccr-cap} APIs
 
-You can use the following APIs to perform {ccr} operations.
+You can use the following APIs to perform <<xpack-ccr,{ccr}>> operations.
 
 [discrete]
 [[ccr-api-top-level]]

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Get follower info</titleabbrev>
 ++++
 
-Retrieves information about all follower indices.
+Retrieves information about all <<xpack-ccr,{ccr}>> follower indices.
 
 [[ccr-get-follow-info-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Get follower stats</titleabbrev>
 ++++
 
-Get follower stats.
+Get <<xpack-ccr,{ccr}>> follower stats.
 
 [[ccr-get-follow-stats-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-forget-follower.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Forget follower</titleabbrev>
 ++++
 
-Removes the follower retention leases from the leader.
+Removes the <<xpack-ccr,{ccr}>> follower retention leases from the leader.
 
 [[ccr-post-forget-follower-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-pause-follow.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Pause follower</titleabbrev>
 ++++
 
-Pauses a follower index.
+Pauses a <<xpack-ccr,{ccr}>> follower index.
 
 [[ccr-post-pause-follow-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-resume-follow.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Resume follower</titleabbrev>
 ++++
 
-Resumes a follower index.
+Resumes a <<xpack-ccr,{ccr}>> follower index.
 
 [[ccr-post-resume-follow-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
+++ b/docs/reference/ccr/apis/follow/post-unfollow.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Unfollow</titleabbrev>
 ++++
 
-Converts a follower index to a regular index.
+Converts a <<xpack-ccr,{ccr}>> follower index to a regular index.
 
 [[ccr-post-unfollow-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/follow/put-follow.asciidoc
+++ b/docs/reference/ccr/apis/follow/put-follow.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Create follower</titleabbrev>
 ++++
 
-Creates a follower index.
+Creates a <<xpack-ccr,{ccr}>> follower index.
 
 [[ccr-put-follow-request]]
 ==== {api-request-title}

--- a/docs/reference/ccr/apis/get-ccr-stats.asciidoc
+++ b/docs/reference/ccr/apis/get-ccr-stats.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Get {ccr-init} stats</titleabbrev>
 ++++
 
-Get {ccr} stats.
+Get <<xpack-ccr,{ccr}>> stats.
 
 [[ccr-get-stats-request]]
 ==== {api-request-title}

--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Cluster allocation explain</titleabbrev>
 ++++
 
-Provides an explanation for a shard's current allocation.
+Provides an explanation for a shard's current <<index-modules-allocation,allocation>>.
 
 [source,console]
 ----

--- a/docs/reference/cluster/delete-desired-balance.asciidoc
+++ b/docs/reference/cluster/delete-desired-balance.asciidoc
@@ -6,7 +6,7 @@
 
 NOTE: {cloud-only}
 
-Discards the current desired balance and computes a new desired balance starting from the current allocation of shards.
+Discards the current <<shards-rebalancing-heuristics,desired balance>> and computes a new desired balance starting from the current allocation of shards.
 This can sometimes help {es} find a desired balance which needs fewer shard movements to achieve, especially if the
 cluster has experienced changes so substantial that the current desired balance is no longer optimal without {es} having
 detected that the current desired balance will take more shard movements to achieve than needed. However, this API

--- a/docs/reference/cluster/get-desired-balance.asciidoc
+++ b/docs/reference/cluster/get-desired-balance.asciidoc
@@ -8,7 +8,7 @@ NOTE: {cloud-only}
 
 Exposes:
 
-* the desired balance computation and reconciliation stats
+* the <<shards-rebalancing-heuristics,desired balance>> computation and reconciliation stats
 * balancing stats such as distribution of shards, disk and ingest forecasts
   across nodes and data tiers (based on the current cluster state)
 * routing table with each shard current and desired location

--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -5,7 +5,7 @@
 [[data-streams-change-mappings-and-settings]]
 === Change mappings and settings for a data stream
 
-Each data stream has a <<create-index-template,matching index
+Each <<data-streams,data stream>> has a <<create-index-template,matching index
 template>>. Mappings and index settings from this template are applied to new
 backing indices created for the stream. This includes the stream's first
 backing index, which is auto-generated when the stream is created.

--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -14,7 +14,7 @@ DELETE _ingest/pipeline/my-timestamp-pipeline
 // TEARDOWN
 ////
 
-The recommended way to downsample a time series data stream (TSDS) is
+The recommended way to <<downsampling,downsample>> a <<tsds,time-series data stream (TSDS)>> is
 <<downsampling-ilm,through index lifecycle management (ILM)>>. However, if
 you're not using ILM, you can downsample a TSDS manually. This guide shows you
 how, using typical Kubernetes cluster monitoring data.
@@ -32,7 +32,7 @@ To test out manual downsampling, follow these steps:
 ==== Prerequisites
 
 * Refer to the <<tsds-prereqs,TSDS prerequisites>>.
-* It is not possible to downsample a data stream directly, nor
+* It is not possible to downsample a <<data-streams,data stream>> directly, nor
 multiple indices at once. It's only possible to downsample one time series index
 (TSDS backing index).
 * In order to downsample an index, it needs to be read-only. For a TSDS write

--- a/docs/reference/data-streams/lifecycle/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/delete-lifecycle.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete Data Stream Lifecycle</titleabbrev>
 ++++
 
-Deletes the lifecycle from a set of data streams.
+Deletes the <<data-stream-lifecycle,lifecycle>> from a set of data streams.
 
 [[delete-lifecycle-api-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/data-streams/lifecycle/apis/explain-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/explain-lifecycle.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Explain Data Stream Lifecycle</titleabbrev>
 ++++
 
-Retrieves the current data stream lifecycle status for one or more data stream backing indices.
+Retrieves the current <<data-stream-lifecycle,data stream lifecycle>> status for one or more data stream backing indices.
 
 [[explain-lifecycle-api-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/data-streams/lifecycle/apis/get-lifecycle-stats.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/get-lifecycle-stats.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get Data Stream Lifecycle</titleabbrev>
 ++++
 
-Gets stats about the execution of data stream lifecycle.
+Gets stats about the execution of <<data-stream-lifecycle,data stream lifecycle>>.
 
 [[get-lifecycle-stats-api-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/data-streams/lifecycle/apis/get-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/get-lifecycle.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get Data Stream Lifecycle</titleabbrev>
 ++++
 
-Gets the lifecycle of a set of data streams.
+Gets the <<data-stream-lifecycle,lifecycle>> of a set of <<data-streams,data streams>>.
 
 [[get-lifecycle-api-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/data-streams/lifecycle/apis/put-lifecycle.asciidoc
+++ b/docs/reference/data-streams/lifecycle/apis/put-lifecycle.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Put Data Stream Lifecycle</titleabbrev>
 ++++
 
-Configures the data stream lifecycle for the targeted data streams.
+Configures the data stream <<data-stream-lifecycle,lifecycle>> for the targeted <<data-streams,data streams>>.
 
 [[put-lifecycle-api-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/data-streams/lifecycle/tutorial-migrate-data-stream-from-ilm-to-dsl.asciidoc
+++ b/docs/reference/data-streams/lifecycle/tutorial-migrate-data-stream-from-ilm-to-dsl.asciidoc
@@ -2,8 +2,8 @@
 [[tutorial-migrate-data-stream-from-ilm-to-dsl]]
 === Tutorial: Migrate ILM managed data stream to data stream lifecycle 
 
-In this tutorial we'll look at migrating an existing data stream from Index Lifecycle Management ({ilm-init}) to
-data stream lifecycle. The existing {ilm-init} managed backing indices will continue 
+In this tutorial we'll look at migrating an existing data stream from <<index-lifecycle-management,Index Lifecycle Management ({ilm-init})>> to
+<<data-stream-lifecycle,data stream lifecycle>>. The existing {ilm-init} managed backing indices will continue 
 to be managed by {ilm-init} until they age out and get deleted by {ilm-init}; however,
 the new backing indices will be managed by data stream lifecycle. 
 This way, a data stream is gradually migrated away from being managed by {ilm-init} to 

--- a/docs/reference/data-streams/modify-data-streams-api.asciidoc
+++ b/docs/reference/data-streams/modify-data-streams-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Modify data streams</titleabbrev>
 ++++
 
-Performs one or more data stream modification actions in a single atomic
+Performs one or more <<data-streams,data stream>> modification actions in a single atomic
 operation.
 
 [source,console]

--- a/docs/reference/data-streams/promote-data-stream-api.asciidoc
+++ b/docs/reference/data-streams/promote-data-stream-api.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Promote data stream</titleabbrev>
 ++++
 
-The purpose of the promote data stream api is to turn
+The purpose of the promote <<data-streams,data stream>> API is to turn
 a data stream that is replicated by CCR into a regular
 data stream.
 

--- a/docs/reference/data-streams/tsds-reindex.asciidoc
+++ b/docs/reference/data-streams/tsds-reindex.asciidoc
@@ -9,7 +9,7 @@
 [[tsds-reindex-intro]]
 ==== Introduction
 
-With reindexing, you can copy documents from an old time-series data stream (TSDS) to a new one. Data streams support
+With reindexing, you can copy documents from an old <<tsds,time-series data stream (TSDS)>> to a new one. Data streams support
 reindexing in general, with a few <<reindex-with-a-data-stream, restrictions>>. Still, time-series data streams
 introduce additional challenges due to tight control on the accepted timestamp range for each backing index they
 contain. Direct use of the reindex API would likely error out due to attempting to insert documents with timestamps that are

--- a/docs/reference/eql/eql-apis.asciidoc
+++ b/docs/reference/eql/eql-apis.asciidoc
@@ -1,7 +1,7 @@
 [[eql-apis]]
 == EQL APIs
 
-Event Query Language (EQL) is a query language for event-based time series data,
+<<eql,Event Query Language (EQL)>> is a query language for event-based time series data,
 such as logs, metrics, and traces. For an overview of EQL and related tutorials,
 see <<eql>>.
 

--- a/docs/reference/esql/esql-apis.asciidoc
+++ b/docs/reference/esql/esql-apis.asciidoc
@@ -1,7 +1,7 @@
 [[esql-apis]]
 == {esql} APIs
 
-The {es} Query Language ({esql}) provides a powerful way to filter, transform,
+The <<esql,{es} Query Language ({esql})>> provides a powerful way to filter, transform,
 and analyze data stored in {es}, and in the future in other runtimes. For an
 overview of {esql} and related tutorials, see <<esql>>.
 

--- a/docs/reference/esql/esql-async-query-delete-api.asciidoc
+++ b/docs/reference/esql/esql-async-query-delete-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>{esql} async query delete API</titleabbrev>
 ++++
 
-The {esql} async query delete API is used to manually delete an async query
+The <<esql,{esql}>> async query delete API is used to manually delete an async query
 by ID. If the query is still running, the query will be cancelled. Otherwise,
 the stored results are deleted.
 

--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Delete policy</titleabbrev>
 ++++
 
-Deletes an index lifecycle policy.
+Deletes an index <<index-lifecycle-management,lifecycle>> policy.
 
 [[ilm-delete-lifecycle-request]]
 ==== {api-request-title}

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Explain lifecycle</titleabbrev>
 ++++
 
-Retrieves the current lifecycle status for one or more indices. For data
+Retrieves the current <<index-lifecycle-management,lifecycle>> status for one or more indices. For data
 streams, the API retrieves the current lifecycle status for the stream's backing
 indices.
 

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Get policy</titleabbrev>
 ++++
 
-Retrieves a lifecycle policy.
+Retrieves a <<index-lifecycle-management,lifecycle>> policy.
 
 [[ilm-get-lifecycle-request]]
 ==== {api-request-title}

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Get {ilm} status</titleabbrev>
 ++++
 
-Retrieves the current {ilm} ({ilm-init}) status.
+Retrieves the current <<index-lifecycle-management,{ilm}>> ({ilm-init}) status.
 
 You can start or stop {ilm-init} with the <<ilm-start,start {ilm-init}>> and
 <<ilm-stop,stop {ilm-init}>> APIs.

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Move to step</titleabbrev>
 ++++
 
-Triggers execution of a specific step in the lifecycle policy.
+Triggers execution of a specific step in the <<index-lifecycle-management,lifecycle>> policy.
 
 [[ilm-move-to-step-request]]
 ==== {api-request-title}

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Create or update lifecycle policy</titleabbrev>
 ++++
 
-Creates or updates lifecycle policy. See <<ilm-index-lifecycle>> for
+Creates or updates <<index-lifecycle-management,lifecycle>> policy. See <<ilm-index-lifecycle>> for
 definitions of policy components.
 
 [[ilm-put-lifecycle-request]]

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Remove policy</titleabbrev>
 ++++
 
-Removes assigned lifecycle policies from an index or a data stream's backing
+Removes assigned <<index-lifecycle-management,lifecycle>> policies from an index or a data stream's backing
 indices.
 
 [[ilm-remove-policy-request]]

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Retry policy</titleabbrev>
 ++++
 
-Retry executing the policy for an index that is in the ERROR step.
+Retry executing the <<index-lifecycle-management,lifecycle>> policy for an index that is in the ERROR step.
 
 [[ilm-retry-policy-request]]
 ==== {api-request-title}

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Start {ilm}</titleabbrev>
 ++++
 
-Start the {ilm} ({ilm-init}) plugin.
+Start the <<index-lifecycle-management,{ilm}>> ({ilm-init}) plugin.
 
 [[ilm-start-request]]
 ==== {api-request-title}

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Stop {ilm}</titleabbrev>
 ++++
 
-Stop the {ilm} ({ilm-init}) plugin.
+Stop the <<index-lifecycle-management,{ilm}>> ({ilm-init}) plugin.
 
 [[ilm-stop-request]]
 ==== {api-request-title}

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -2,7 +2,7 @@
 [[index-lifecycle-error-handling]]
 == Troubleshooting {ilm} errors
 
-When {ilm-init} executes a lifecycle policy, it's possible for errors to occur
+When <<index-lifecycle-management,{ilm-init}>> executes a lifecycle policy, it's possible for errors to occur
 while performing the necessary index operations for a step. 
 When this happens, {ilm-init} moves the index to an `ERROR` step. 
 If {ilm-init} cannot resolve the error automatically, execution is halted  

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Index lifecycle</titleabbrev>
 ++++
 
-{ilm-init} defines five index lifecycle _phases_:
+<<index-lifecycle-management,{ilm-init}>> defines five index lifecycle _phases_:
 
 * **Hot**: The index is actively being updated and queried.
 * **Warm**: The index is no longer being updated but is still being queried.


### PR DESCRIPTION
Backports the following commits to 8.15:
 - (Doc+) Link API doc to parent object - part1 (#111951)