### PR TITLE
Speedup string interning in `ClusterName`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterName.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterName.java
@@ -39,7 +39,8 @@ public class ClusterName implements Writeable {
     }
 
     public ClusterName(String value) {
-        this.value = value.intern();
+        // cluster name string is most likely part of a setting so we can speed things up over outright interning here
+        this.value = Settings.internKeyOrValue(value);
     }
 
     public String value() {

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1567,7 +1567,7 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
      * @param s string to intern
      * @return interned string
      */
-    static String internKeyOrValue(String s) {
+    public static String internKeyOrValue(String s) {
         return settingLiteralDeduplicator.deduplicate(s);
     }
 


### PR DESCRIPTION
If we want to intern here, we should use the deduplicator to speed things up. This is showing up needlessly hot in profiling of tests at least.
