### PR TITLE
Update searchable snapshot doc about the timing to notice data loss

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -336,6 +336,8 @@ cluster has write access then you must make sure that the other cluster does not
 delete these snapshots. The snapshot contains the sole full copy of your data.
 If you delete it then the data cannot be recovered from elsewhere.
 
+* If snapshot data are cached onto local storage, your cluster may remain the functionality while the cache is alive. However, for partially mounted indices, the cache is cleared when a node is restarted. Therefore, if you delete the searchable snapshot, it's possible that you may notice the data loss later, for example, during a node restart. 
+
 * If the repository fails or corrupts the contents of the snapshot and you
 cannot restore it to its previous healthy state then the data is permanently
 lost.

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -336,7 +336,10 @@ cluster has write access then you must make sure that the other cluster does not
 delete these snapshots. The snapshot contains the sole full copy of your data.
 If you delete it then the data cannot be recovered from elsewhere.
 
-* If snapshot data are cached onto local storage, your cluster may remain the functionality while the cache is alive. However, for partially mounted indices, the cache is cleared when a node is restarted. Therefore, if you delete the searchable snapshot, it's possible that you may notice the data loss later, for example, during a node restart. 
+* The data in a searchable snapshot index are cached in local storage, so if you
+delete the underlying searchable snapshot {es} will continue to operate normally
+until the first cache miss. This may be much later, for instance when a shard
+relocates to a different node, or when the node holding the shard restarts.
 
 * If the repository fails or corrupts the contents of the snapshot and you
 cannot restore it to its previous healthy state then the data is permanently


### PR DESCRIPTION

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? => yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?  => yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`?  => not code
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.  => not code
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?  => not code
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.  => not code

## Description

Update searchable snapshot doc about the timing to notice data loss: Sometimes searchable snapshot data is cached onto disk so user may notice their data loss later during node restart (or on Elastic cloud - host maintenance) after they delete their snapshots.
