### PR TITLE
#101472 Updates default index.translog.flush_threshold_size value

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -74,6 +74,6 @@ update, or bulk request. This setting accepts the following parameters:
   and had to be recovered.
   This setting controls the maximum total size of these operations to prevent
   recoveries from taking too long. Once the maximum size has been reached, a flush
-  will happen, generating a new Lucene commit point. *Defaults to* `10 GB`.
+  will happen, generating a new Lucene commit point. Defaults to `10 GB`.
   The translog size will never exceed `1%` and will never be smaller than `10 MB`,
   regardless of the specified size.

--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -71,7 +71,9 @@ update, or bulk request. This setting accepts the following parameters:
   The translog stores all operations that are not yet safely persisted in Lucene
   (i.e., are not part of a Lucene commit point). Although these operations are
   available for reads, they will need to be replayed if the shard was stopped
-  and had to be recovered. This setting controls the maximum total size of these
-  operations, to prevent recoveries from taking too long. Once the maximum size
-  has been reached a flush will happen, generating a new Lucene commit point.
-  Defaults to `512mb`.
+  and had to be recovered.
+  This setting controls the maximum total size of these operations to prevent
+  recoveries from taking too long. Once the maximum size has been reached, a flush
+  will happen, generating a new Lucene commit point. *Defaults to* `10 GB`.
+  The translog size will never exceed `1%` and will never be smaller than `10 MB`,
+  regardless of the specified size.

--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -19,7 +19,8 @@ An {es} <<indices-flush,flush>> is the process of performing a Lucene commit and
 starting a new translog generation. Flushes are performed automatically in the
 background in order to make sure the translog does not grow too large, which
 would make replaying its operations take a considerable amount of time during
-recovery. The ability to perform a flush manually is also exposed through an
+recovery.  The translog size will never exceed `1%` of the disk size.
+The ability to perform a flush manually is also exposed through an
 API, although this is rarely needed.
 
 [discrete]
@@ -75,5 +76,4 @@ update, or bulk request. This setting accepts the following parameters:
   This setting controls the maximum total size of these operations to prevent
   recoveries from taking too long. Once the maximum size has been reached, a flush
   will happen, generating a new Lucene commit point. Defaults to `10 GB`.
-  The translog size will never exceed `1%` and will never be smaller than `10 MB`,
-  regardless of the specified size.
+ 


### PR DESCRIPTION
### Description

- Updated the documentation to reflect the change in the default value of `index.translog.flush_threshold_size` from 512 MB to 10 GB.
- Added details about the new behavior: the translog size will never exceed 1% of the total disk space and will never be smaller than 10 MB, regardless of the specified size.

### Related ticket 

[#101472](https://github.com/elastic/elasticsearch/issues/101472)

### Preview

[Translog](https://elasticsearch_bk_112052.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/index-modules-translog.html)
