### PR TITLE
Updates-warning-about-mounting-snapshots

### DIFF
--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -24,7 +24,9 @@ For more information, see <<security-privileges>>.
 ==== {api-description-title}
 
 This API mounts a snapshot as a searchable snapshot index. 
-Note that manually mounting {ilm-init}-managed snapshots can <<manually-mounting-snapshots,interfere>> with <<index-lifecycle-management,{ilm-init} processes>>.
+Don't use this API for snapshots managed by {ilm-init}. Manually mounting
+{ilm-init}-managed snapshots can <<manually-mounting-snapshots,interfere>> with
+<<index-lifecycle-management,{ilm-init} processes>>.
 
 [[searchable-snapshots-api-mount-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -24,6 +24,7 @@ For more information, see <<security-privileges>>.
 ==== {api-description-title}
 
 This API mounts a snapshot as a searchable snapshot index. 
+
 Don't use this API for snapshots managed by {ilm-init}. Manually mounting
 {ilm-init}-managed snapshots can <<manually-mounting-snapshots,interfere>> with
 <<index-lifecycle-management,{ilm-init} processes>>.

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -176,9 +176,12 @@ nodes that have a shared cache.
 ====
 Manually mounting snapshots captured by an Index Lifecycle Management ({ilm-init}) policy can
 interfere with {ilm-init}'s automatic management. This may lead to issues such as data loss
-or complications with snapshot handling. For optimal results, allow {ilm-init} to manage
-snapshots automatically. If manual mounting is necessary, be aware of its potential
-impact on {ilm-init} processes. For more information, learn about <<index-lifecycle-management,{ilm-init} snapshot management>>.
+or complications with snapshot handling. 
+
+For optimal results, allow {ilm-init} to manage
+snapshots automatically. 
+
+<<ilm-searchable-snapshot,Learn more about {ilm-init} snapshot management>>.
 ====
 
 [[searchable-snapshots-shared-cache]]


### PR DESCRIPTION
## Overview

This PR introduces a warning to the documentation for the Mount Snapshot API. 
These updates are based on the feedback provided for the [Adds a warning about manually mounting snapshots managed by ILM](https://github.com/elastic/elasticsearch/pull/111883) PR.

**Related issue:** [#105816 ](https://github.com/elastic/elasticsearch/issues/105816)

### Preview

.