### PR TITLE
Fix RRF validation for rank_constant < 1

### DIFF
--- a/docs/changelog/112058.yaml
+++ b/docs/changelog/112058.yaml
@@ -1,0 +1,5 @@
+pr: 112058
+summary: Fix RRF validation for `rank_constant` < 1
+area: Ranking
+type: bug
+issues: []

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankBuilder.java
@@ -46,9 +46,6 @@ public class RRFRankBuilder extends RankBuilder {
     static final ConstructingObjectParser<RRFRankBuilder, Void> PARSER = new ConstructingObjectParser<>(RRFRankPlugin.NAME, args -> {
         int windowSize = args[0] == null ? DEFAULT_RANK_WINDOW_SIZE : (int) args[0];
         int rankConstant = args[1] == null ? DEFAULT_RANK_CONSTANT : (int) args[1];
-        if (rankConstant < 1) {
-            throw new IllegalArgumentException("[rank_constant] must be greater than [0] for [rrf]");
-        }
         return new RRFRankBuilder(windowSize, rankConstant);
     });
 
@@ -73,6 +70,11 @@ public class RRFRankBuilder extends RankBuilder {
 
     public RRFRankBuilder(int rankWindowSize, int rankConstant) {
         super(rankWindowSize);
+
+        if (rankConstant < 1) {
+            throw new IllegalArgumentException("[rank_constant] must be greater or equal to [1] for [rrf]");
+        }
+
         this.rankConstant = rankConstant;
     }
 

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/100_rank_rrf.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/100_rank_rrf.yml
@@ -33,7 +33,7 @@ setup:
         body:
           text: "term term"
           keyword: "other"
-          vector: [0.0]
+          vector: [ 0.0 ]
 
   - do:
       index:
@@ -42,7 +42,7 @@ setup:
         body:
           text: "other"
           keyword: "other"
-          vector: [1.0]
+          vector: [ 1.0 ]
 
   - do:
       index:
@@ -51,10 +51,10 @@ setup:
         body:
           text: "term"
           keyword: "keyword"
-          vector: [2.0]
+          vector: [ 2.0 ]
 
   - do:
-      indices.refresh: {}
+      indices.refresh: { }
 
 ---
 "Simple rank with bm25 search and kNN search":
@@ -67,7 +67,7 @@ setup:
           fields: [ "text", "keyword" ]
           knn:
             field: vector
-            query_vector: [0.0]
+            query_vector: [ 0.0 ]
             k: 3
             num_candidates: 3
           query:
@@ -125,7 +125,7 @@ setup:
               rank_constant: 1
           size: 10
 
-  - match: { hits.total.value : 2 }
+  - match: { hits.total.value: 2 }
 
   - match: { hits.hits.0._id: "3" }
   - match: { hits.hits.0._rank: 1 }
@@ -173,7 +173,7 @@ setup:
               rank_constant: 1
           size: 10
 
-  - match: { hits.total.value : 3 }
+  - match: { hits.total.value: 3 }
 
   - match: { hits.hits.0._id: "3" }
   - match: { hits.hits.0._rank: 1 }
@@ -226,4 +226,44 @@ setup:
             rrf:
               rank_window_size: 2
               rank_constant: 1
+          size: 10
+
+---
+"RRF rank should fail if rank_constant < 1":
+  - requires:
+      cluster_features: "gte_v8.16.0"
+      reason: 'validation fixed in 8.16.0'
+
+  - do:
+      catch: "/\\[rank_constant\\] must be greater or equal to \\[1\\] for \\[rrf\\]/"
+      search:
+        index: test
+        body:
+          track_total_hits: true
+          fields: [ "text", "keyword" ]
+          knn:
+            field: vector
+            query_vector: [ 0.0 ]
+            k: 3
+            num_candidates: 3
+          sub_searches: [
+            {
+              "query": {
+                "term": {
+                  "text": "term"
+                }
+              }
+            },
+            {
+              "query": {
+                "match": {
+                  "keyword": "keyword"
+                }
+              }
+            }
+          ]
+          rank:
+            rrf:
+              rank_window_size: 10
+              rank_constant: 0.3
           size: 10


### PR DESCRIPTION
RRF requires that `rank_constant` be >= 1, however the validation wasn't happening all the time. This PR fixes this. 