### PR TITLE
[8.15] [DOCS] Update `rank_constant` value in retriever example (#112056)

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -250,7 +250,7 @@ GET /restaurants/_search
           }
         }
       ],
-      "rank_constant": 0.3, <5>
+      "rank_constant": 1, <5>
       "rank_window_size": 50  <6>
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [DOCS] Update `rank_constant` value in retriever example (#112056)