### PR TITLE
ESQL: Unskip mv_percentile tests and add extra debugging data

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -176,12 +176,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
   method: testScaledFloat
   issue: https://github.com/elastic/elasticsearch/issues/112003
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {mv_percentile.FromIndex SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/112036
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {mv_percentile.FromIndex ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/112037
 - class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
   method: testForceSleepsProfile {SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/112039

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_percentile.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_percentile.csv-spec
@@ -95,15 +95,15 @@ FROM employees
     integer = MV_PERCENTILE(salary_change.int, 75),
     long = MV_PERCENTILE(salary_change.long, 75),
     double = MV_PERCENTILE(salary_change, 75)
-| KEEP integer, long, double
+| KEEP emp_no, integer, long, double
 | SORT double
 | LIMIT 3
 ;
 
-integer:integer | long:long | double:double
--8              | -8        | -8.46
--7              | -7        | -7.08
--6              | -6        | -6.9
+emp_no:integer | integer:integer | long:long | double:double
+10034          | -8              | -8        | -8.46
+10037          | -7              | -7        | -7.08
+10039          | -6              | -6        | -6.9
 ;
 
 fromIndexPercentile


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/112036
Closes https://github.com/elastic/elasticsearch/issues/112037

This isn't fixing anything, as I couldn't reproduce the issue.
But at least now, if it fails again, we know which data rendered that result exactly (Or so I wish...)