### PR TITLE
Add ability to rescore inner hits

### DIFF
--- a/docs/changelog/112062.yaml
+++ b/docs/changelog/112062.yaml
@@ -1,5 +1,6 @@
 pr: 112062
 summary: Add ability to rescore inner hits
-area: "Relevance, Search"
+area: Ranking
 type: enhancement
-issues: []
+issues:
+  - 108163

--- a/docs/changelog/112062.yaml
+++ b/docs/changelog/112062.yaml
@@ -1,0 +1,5 @@
+pr: 112062
+summary: Add ability to rescore inner hits
+area: "Relevance, Search"
+type: enhancement
+issues: []

--- a/docs/changelog/112062.yaml
+++ b/docs/changelog/112062.yaml
@@ -2,5 +2,4 @@ pr: 112062
 summary: Add ability to rescore inner hits
 area: Ranking
 type: enhancement
-issues:
-  - 108163
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -1043,8 +1043,8 @@ public class QueryRescorerIT extends ESIntegTestCase {
                 assertThat(innerHits.getTotalHits().value, equalTo(2L));
                 assertThat(innerHits.getHits().length, equalTo(2));
                 assertThat(innerHits.getMaxScore(), equalTo(innerHits.getAt(0).getScore()));
-                assertThat(innerHits.getAt(0).docId(), equalTo(1));
-                assertThat(innerHits.getAt(1).docId(), equalTo(0));
+                assertThat(innerHits.getAt(0).getNestedIdentity().getOffset(), equalTo(1));
+                assertThat(innerHits.getAt(1).getNestedIdentity().getOffset(), equalTo(0));
             }
         );
     }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -192,6 +192,7 @@ public class TransportVersions {
     public static final TransportVersion ZDT_NANOS_SUPPORT = def(8_722_00_0);
     public static final TransportVersion REMOVE_GLOBAL_RETENTION_FROM_TEMPLATES = def(8_723_00_0);
     public static final TransportVersion RANDOM_RERANKER_RETRIEVER = def(8_724_00_0);
+    public static final TransportVersion INNER_HITS_RESCORE = def(8_725_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -579,6 +579,13 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         if (innerCollapseBuilder != null) {
             builder.field(COLLAPSE_FIELD.getPreferredName(), innerCollapseBuilder);
         }
+        if (rescoreBuilders != null) {
+            builder.startArray(SearchSourceBuilder.RESCORE_FIELD.getPreferredName());
+            for (RescorerBuilder<?> rescoreBuilder : rescoreBuilders) {
+                rescoreBuilder.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -133,7 +133,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         PARSER.declareField((p, i, c) -> {
             // TODO: Use real usage tracker?
             if (p.currentToken() == XContentParser.Token.START_ARRAY) {
-                while(p.nextToken() != XContentParser.Token.END_ARRAY) {
+                while (p.nextToken() != XContentParser.Token.END_ARRAY) {
                     i.addRescoreBuilder(RescorerBuilder.parseFromXContent(p, s -> {}));
                 }
             } else {

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -131,12 +131,9 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
 
         }, COLLAPSE_FIELD, ObjectParser.ValueType.OBJECT);
         PARSER.declareField((p, i, c) -> {
-            @SuppressWarnings("rawtypes")
-            List<RescorerBuilder> rescoreBuilders = new ArrayList<>();
             for (XContentParser.Token token = p.nextToken(); token != END_OBJECT; token = p.nextToken()) {
-                rescoreBuilders.add(RescorerBuilder.parseFromXContent(p, s -> {}));  // TODO: Use real usage tracker?
+                i.addRescoreBuilder(RescorerBuilder.parseFromXContent(p, s -> {}));  // TODO: Use real usage tracker?
             }
-            i.setRescoreBuilders(rescoreBuilders);
         }, SearchSourceBuilder.RESCORE_FIELD, ObjectParser.ValueType.OBJECT_ARRAY);
     }
     private String name;
@@ -502,9 +499,11 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
         return innerCollapseBuilder;
     }
 
-    @SuppressWarnings("rawtypes")
-    public InnerHitBuilder setRescoreBuilders(List<RescorerBuilder> rescoreBuilders) {
-        this.rescoreBuilders = rescoreBuilders;
+    public InnerHitBuilder addRescoreBuilder(RescorerBuilder<?> rescoreBuilder) {
+        if (rescoreBuilders == null) {
+            rescoreBuilders = new ArrayList<>();
+        }
+        rescoreBuilders.add(rescoreBuilder);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -131,8 +131,13 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
 
         }, COLLAPSE_FIELD, ObjectParser.ValueType.OBJECT);
         PARSER.declareField((p, i, c) -> {
-            for (XContentParser.Token token = p.nextToken(); token != END_OBJECT; token = p.nextToken()) {
-                i.addRescoreBuilder(RescorerBuilder.parseFromXContent(p, s -> {}));  // TODO: Use real usage tracker?
+            // TODO: Use real usage tracker?
+            if (p.currentToken() == XContentParser.Token.START_ARRAY) {
+                while(p.nextToken() != XContentParser.Token.END_ARRAY) {
+                    i.addRescoreBuilder(RescorerBuilder.parseFromXContent(p, s -> {}));
+                }
+            } else {
+                i.addRescoreBuilder(RescorerBuilder.parseFromXContent(p, s -> {}));
             }
         }, SearchSourceBuilder.RESCORE_FIELD, ObjectParser.ValueType.OBJECT_ARRAY);
     }

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
@@ -115,6 +115,16 @@ public abstract class InnerHitContextBuilder {
         if (innerHitBuilder.getSorts() != null) {
             Optional<SortAndFormats> optionalSort = SortBuilder.buildSort(innerHitBuilder.getSorts(), searchExecutionContext);
             if (optionalSort.isPresent()) {
+                if (innerHitBuilder.getRescoreBuilders() != null) {
+                    throw new IllegalArgumentException(
+                        "Invalid inner hits: cannot use ["
+                            + SearchSourceBuilder.SORT_FIELD
+                            + "] option in conjunction with ["
+                            + SearchSourceBuilder.RESCORE_FIELD
+                            + "]"
+                    );
+                }
+
                 innerHitsContext.sort(optionalSort.get());
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
@@ -15,6 +15,7 @@ import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
 import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.fetch.subphase.InnerHitsContext;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.rescore.RescorerBuilder;
 import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.sort.SortBuilder;
 
@@ -127,6 +128,12 @@ public abstract class InnerHitContextBuilder {
             children
         );
         innerHitsContext.setChildInnerHits(baseChildren);
+
+        if (innerHitBuilder.getRescoreBuilders() != null) {
+            for (RescorerBuilder<?> rescoreBuilder : innerHitBuilder.getRescoreBuilders()) {
+                innerHitsContext.addRescore(rescoreBuilder.buildContext(searchExecutionContext));
+            }
+        }
     }
 
     private static Map<String, InnerHitsContext.InnerHitSubContext> buildChildInnerHits(

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -76,7 +76,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
         this(path, query, scoreMode, null);
     }
 
-    private NestedQueryBuilder(String path, QueryBuilder query, ScoreMode scoreMode, InnerHitBuilder innerHitBuilder) {
+    public NestedQueryBuilder(String path, QueryBuilder query, ScoreMode scoreMode, InnerHitBuilder innerHitBuilder) {
         this.path = requireValue(path, "[" + NAME + "] requires 'path' field");
         this.query = requireValue(query, "[" + NAME + "] requires 'query' field");
         this.scoreMode = requireValue(scoreMode, "[" + NAME + "] requires 'score_mode' field");

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -146,6 +146,7 @@ public final class InnerHitsContext {
             this.rootSource = rootSource;
         }
 
+        @Override
         public List<RescoreContext> rescore() {
             if (rescore == null) {
                 return List.of();
@@ -153,6 +154,7 @@ public final class InnerHitsContext {
             return rescore;
         }
 
+        @Override
         public void addRescore(RescoreContext rescore) {
             if (this.rescore == null) {
                 this.rescore = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsContext.java
@@ -26,10 +26,13 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SubSearchContext;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.profile.Profilers;
+import org.elasticsearch.search.rescore.RescoreContext;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -73,6 +76,7 @@ public final class InnerHitsContext {
         protected final SearchContext context;
         private InnerHitsContext childInnerHits;
         private Weight innerHitQueryWeight;
+        private List<RescoreContext> rescore;
 
         private String rootId;
         private Source rootSource;
@@ -140,6 +144,20 @@ public final class InnerHitsContext {
 
         public void setRootLookup(Source rootSource) {
             this.rootSource = rootSource;
+        }
+
+        public List<RescoreContext> rescore() {
+            if (rescore == null) {
+                return List.of();
+            }
+            return rescore;
+        }
+
+        public void addRescore(RescoreContext rescore) {
+            if (this.rescore == null) {
+                this.rescore = new ArrayList<>();
+            }
+            this.rescore.add(rescore);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
@@ -89,19 +89,19 @@ public final class InnerHitsPhase implements FetchSubPhase {
                 hit.setInnerHits(results = new HashMap<>());
             }
 
-            // TODO: What inner hits context sort formats need to be enforced here?
-            DocValueFormat[] sortValueFormats = innerHitsContext.sort() == null ? null : innerHitsContext.sort().formats;
+            final DocValueFormat[] sortValueFormats = innerHitsContext.sort() == null ? null : innerHitsContext.sort().formats;
             List<RescoreContext> rescore = innerHitsContext.rescore();
             if (rescore != null) {
+                assert sortValueFormats == null;
+
                 TopDocs justTopDocs = topDoc.topDocs;
                 for (RescoreContext ctx : rescore) {
                     justTopDocs = ctx.rescorer().rescore(justTopDocs, innerHitsContext.searcher(), ctx);
-                    // TODO: Check that top docs are sorted by score
+                    // TODO: Assert that top docs are sorted by score
                 }
 
                 // TODO: Can there ever be no docs to rescore?
                 topDoc = new TopDocsAndMaxScore(justTopDocs, justTopDocs.scoreDocs[0].score);
-                sortValueFormats = null;
             }
 
             innerHitsContext.queryResult().topDocs(topDoc, sortValueFormats);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsPhase.java
@@ -91,17 +91,18 @@ public final class InnerHitsPhase implements FetchSubPhase {
 
             final DocValueFormat[] sortValueFormats = innerHitsContext.sort() == null ? null : innerHitsContext.sort().formats;
             List<RescoreContext> rescore = innerHitsContext.rescore();
-            if (rescore != null) {
+            if (rescore.isEmpty() == false) {
                 assert sortValueFormats == null;
 
                 TopDocs justTopDocs = topDoc.topDocs;
-                for (RescoreContext ctx : rescore) {
-                    justTopDocs = ctx.rescorer().rescore(justTopDocs, innerHitsContext.searcher(), ctx);
-                    // TODO: Assert that top docs are sorted by score
-                }
+                if (justTopDocs.scoreDocs.length > 0) {
+                    for (RescoreContext ctx : rescore) {
+                        justTopDocs = ctx.rescorer().rescore(justTopDocs, innerHitsContext.searcher(), ctx);
+                        // TODO: Assert that top docs are sorted by score
+                    }
 
-                // TODO: Can there ever be no docs to rescore?
-                topDoc = new TopDocsAndMaxScore(justTopDocs, justTopDocs.scoreDocs[0].score);
+                    topDoc = new TopDocsAndMaxScore(justTopDocs, justTopDocs.scoreDocs[0].score);
+                }
             }
 
             innerHitsContext.queryResult().topDocs(topDoc, sortValueFormats);

--- a/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
@@ -169,7 +169,10 @@ public class QueryRescorerBuilder extends RescorerBuilder<QueryRescorerBuilder> 
     public QueryRescoreContext innerBuildContext(int windowSize, SearchExecutionContext context) throws IOException {
         QueryRescoreContext queryRescoreContext = new QueryRescoreContext(windowSize);
         // query is rewritten at this point already
-        queryRescoreContext.setQuery(context.toQuery(queryBuilder));
+        // Copy context so that calling toQuery does not reset the passed-in context.
+        // This causes problems when the passed-in context has a nested scope that is not at root level.
+        SearchExecutionContext contextCopy = new SearchExecutionContext(context);
+        queryRescoreContext.setQuery(contextCopy.toQuery(queryBuilder));
         queryRescoreContext.setQueryWeight(this.queryWeight);
         queryRescoreContext.setRescoreQueryWeight(this.rescoreQueryWeight);
         queryRescoreContext.setScoreMode(this.scoreMode);


### PR DESCRIPTION
Addresses #108163 

Adds the ability to rescore inner hits. For example:

```json
PUT test-index
{
  "mappings": {
    "properties": {
      "department": {
        "type": "text"
      },
      "employees": {
        "type": "nested",
        "properties": {
          "first_name": {
            "type": "text"
          },
          "last_name": {
            "type": "text"
          },
          "years_of_experience": {
            "type": "integer"
          }
        }
      }
    }
  }
}

PUT test-index/_doc/1
{
  "department": "Engineering",
  "employees": [
    {
      "first_name": "Alice",
      "last_name": "Anderson",
      "years_of_experience": 5
    },
    {
      "first_name": "Bob",
      "last_name": "Bukowski",
      "years_of_experience": 3
    },
    {
      "first_name": "Claire",
      "last_name": "Cavendish",
      "years_of_experience": 1
    }
  ]
}

GET test-index/_search
{
  "query": {
    "nested": {
      "path": "employees",
      "query": {
        "range": {
          "employees.years_of_experience": { "gt": 2 }
        }
      },
      "inner_hits": {
        "rescore": {
          "query": {
            "rescore_query": {
              "match": {
                "employees.first_name": "Bob"
              }
            }
          }
        }
      }
    }
  }
}
```

```json
{
    "took": 67,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 1,
        "hits": [
            {
                "_index": "test-index",
                "_id": "1",
                "_score": 1,
                "_source": {
                    "department": "Engineering",
                    "employees": [
                        {
                            "first_name": "Alice",
                            "last_name": "Anderson",
                            "years_of_experience": 5
                        },
                        {
                            "first_name": "Bob",
                            "last_name": "Bukowski",
                            "years_of_experience": 3
                        },
                        {
                            "first_name": "Claire",
                            "last_name": "Cavendish",
                            "years_of_experience": 1
                        }
                    ]
                },
                "inner_hits": {
                    "employees": {
                        "hits": {
                            "total": {
                                "value": 2,
                                "relation": "eq"
                            },
                            "max_score": 1.9808291,
                            "hits": [
                                {
                                    "_index": "test-index",
                                    "_id": "1",
                                    "_nested": {
                                        "field": "employees",
                                        "offset": 1
                                    },
                                    "_score": 1.9808291,
                                    "_source": {
                                        "first_name": "Bob",
                                        "last_name": "Bukowski",
                                        "years_of_experience": 3
                                    }
                                },
                                {
                                    "_index": "test-index",
                                    "_id": "1",
                                    "_nested": {
                                        "field": "employees",
                                        "offset": 0
                                    },
                                    "_score": 1,
                                    "_source": {
                                        "first_name": "Alice",
                                        "last_name": "Anderson",
                                        "years_of_experience": 5
                                    }
                                }
                            ]
                        }
                    }
                }
            }
        ]
    }
}
```

A couple things to note:

- The max score of the reranked inner hits can be different than the max score of the top-level hits
- The inner hits for each document are reranked separately, so the time complexity of the operation is M * N, where M is the number of inner hits and N is the number of documents returned. This could be expensive for large page sizes.

This is in draft right now to solicit early feedback on the approach and time complexity of the operation. I need to add a bunch of tests and documentation and address some TODOs before it's ready for formal review.