### PR TITLE
Add more cross-links about sniff/proxy modes

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
@@ -6,7 +6,10 @@ mode are described separately.
 
 `cluster.remote.<cluster_alias>.mode`::
   The mode used for a remote cluster connection. The only supported modes are
-  `sniff` and `proxy`.
+  `sniff` and `proxy`. The default is `sniff`. See <<sniff-proxy-modes>> for
+  further information about these modes, and <<remote-cluster-sniff-settings>>
+  and <<remote-cluster-proxy-settings>> for further information about their
+  settings.
 
 `cluster.remote.initial_connect_timeout`::
 
@@ -97,6 +100,11 @@ you configure the remotes.
 [[remote-cluster-sniff-settings]]
 ==== Sniff mode remote cluster settings
 
+To use <<sniff-mode,sniff mode>> to connect to a remote cluster, set
+`cluster.remote.<cluster_alias>.mode: sniff` and then configure the following
+settings. You may also leave `cluster.remote.<cluster_alias>.mode` unset since
+`sniff` is the default mode.
+
 `cluster.remote.<cluster_alias>.seeds`::
 
   The list of seed nodes used to sniff the remote cluster state.
@@ -116,6 +124,10 @@ you configure the remotes.
 
 [[remote-cluster-proxy-settings]]
 ==== Proxy mode remote cluster settings
+
+To use <<proxy-mode,proxy mode>> to connect to a remote cluster, set
+`cluster.remote.<cluster_alias>.mode: proxy` and then configure the following
+settings.
 
 `cluster.remote.<cluster_alias>.proxy_address`::
 

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -72,7 +72,8 @@ the local {es} cluster then opens several TCP connections to the publish
 addresses of the gateway nodes. This mode therefore requires that the gateway
 nodes' publish addresses are accessible to nodes in the local cluster.
 +
-Sniff mode is the default connection mode.
+Sniff mode is the default connection mode. See <<remote-cluster-sniff-settings>>
+for more information about configuring sniff mode.
 +
 [[gateway-nodes-selection]]
 The _gateway nodes_ selection depends on the following criteria:
@@ -98,7 +99,9 @@ cluster nodes which means that the publish addresses of the remote cluster
 nodes need not be accessible to the local cluster.
 +
 Proxy mode is not the default connection mode, so you must set
-`cluster.remote.<cluster_alias>.mode: proxy` to use it.
+`cluster.remote.<cluster_alias>.mode: proxy` to use it. See
+<<remote-cluster-proxy-settings>> for more information about configuring proxy
+mode.
 +
 Proxy mode has the same <<gateway-nodes-selection, version compatibility
 requirements>> as sniff mode.

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -1,7 +1,7 @@
 [[remote-clusters]]
 == Remote clusters
 You can connect a local cluster to other {es} clusters, known as _remote
-clusters_. Remote clusters can be located in different datacenters or 
+clusters_. Remote clusters can be located in different datacenters or
 geographic regions, and contain indices or data streams that can be replicated
 with {ccr} or searched by a local cluster using {ccs}.
 
@@ -30,9 +30,9 @@ capabilities, the local and remote cluster must be on the same
 [discrete]
 === Add remote clusters
 
-NOTE: The instructions that follow describe how to create a remote connection from a 
-self-managed cluster. You can also set up {ccs} and {ccr} from an 
-link:https://www.elastic.co/guide/en/cloud/current/ec-enable-ccs.html[{ess} deployment] 
+NOTE: The instructions that follow describe how to create a remote connection from a
+self-managed cluster. You can also set up {ccs} and {ccr} from an
+link:https://www.elastic.co/guide/en/cloud/current/ec-enable-ccs.html[{ess} deployment]
 or from an link:https://www.elastic.co/guide/en/cloud-enterprise/current/ece-enable-ccs.html[{ece} deployment].
 
 To add remote clusters, you can choose between
@@ -52,7 +52,7 @@ controls. <<remote-clusters-api-key>>.
 
 Certificate based security model::
 Uses mutual TLS authentication for cross-cluster operations. User authentication
-is performed on the local cluster and a user's role names are passed to the 
+is performed on the local cluster and a user's role names are passed to the
 remote cluster. In this model, a superuser on the local cluster gains total read
 access to the remote cluster, so it is only suitable for clusters that are in
 the same security domain. <<remote-clusters-cert>>.
@@ -63,13 +63,14 @@ the same security domain. <<remote-clusters-cert>>.
 
 [[sniff-mode]]
 Sniff mode::
-In sniff mode, a cluster is registered with a name of your choosing and a list
-of addresses of _seed_ nodes. When you register a remote cluster using sniff
-mode, {es} retrieves from one of the seed nodes the addresses of up to three
-_gateway nodes_. Each `remote_cluster_client` node in the local {es} cluster
-then opens several TCP connections to the publish addresses of the gateway
-nodes. This mode therefore requires that the gateway nodes' publish addresses
-are accessible to nodes in the local cluster.
+In sniff mode, a cluster alias is registered with a name of your choosing and a
+list of addresses of _seed_ nodes specified with the
+`cluster.remote.<cluster_alias>.seeds` setting. When you register a remote
+cluster using sniff mode, {es} retrieves from one of the seed nodes the
+addresses of up to three _gateway nodes_. Each `remote_cluster_client` node in
+the local {es} cluster then opens several TCP connections to the publish
+addresses of the gateway nodes. This mode therefore requires that the gateway
+nodes' publish addresses are accessible to nodes in the local cluster.
 +
 Sniff mode is the default connection mode.
 +
@@ -86,18 +87,21 @@ However, such nodes still have to satisfy the two above requirements.
 
 [[proxy-mode]]
 Proxy mode::
-In proxy mode, a cluster is registered with a name of your choosing and the
-address of a TCP (layer 4) reverse proxy which you must configure to route
-connections to the nodes of the remote cluster. When you register a remote
-cluster using proxy mode, {es} opens several TCP connections to the proxy
-address and uses these connections to communicate with the remote cluster. In
-proxy mode {es} disregards the publish addresses of the remote cluster nodes
-which means that the publish addresses of the remote cluster nodes need not be
-accessible to the local cluster.
+In proxy mode, a cluster alias is registered with a name of your choosing and
+the address of a TCP (layer 4) reverse proxy specified with the
+`cluster.remote.<cluster_alias>.proxy_address` setting. You must configure this
+proxy to route connections to one or more nodes of the remote cluster. When you
+register a remote cluster using proxy mode, {es} opens several TCP connections
+to the proxy address and uses these connections to communicate with the remote
+cluster. In proxy mode {es} disregards the publish addresses of the remote
+cluster nodes which means that the publish addresses of the remote cluster
+nodes need not be accessible to the local cluster.
 +
-Proxy mode is not the default connection mode, so you must configure it
-explicitly if desired. Proxy mode has the same <<gateway-nodes-selection,
-version compatibility requirements>> as sniff mode.
+Proxy mode is not the default connection mode, so you must set
+`cluster.remote.<cluster_alias>.mode: proxy` to use it.
++
+Proxy mode has the same <<gateway-nodes-selection, version compatibility
+requirements>> as sniff mode.
 
 include::cluster/remote-clusters-api-key.asciidoc[]
 


### PR DESCRIPTION
The info about remote cluster connection modes is a little disjointed.
This commit adds some cross-links between the sections to help users
find more relevant information.