### PR TITLE
Fix DocValuesCodecDuelTests testDuel

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -176,9 +176,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
   method: testForceSleepsProfile {ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/112049
-- class: org.elasticsearch.index.codec.tsdb.DocValuesCodecDuelTests
-  method: testDuel
-  issue: https://github.com/elastic/elasticsearch/issues/112082
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/80_random_rerank_retriever/Random rerank retriever predictably shuffles results}
   issue: https://github.com/elastic/elasticsearch/issues/111999

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesCodecDuelTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesCodecDuelTests.java
@@ -141,6 +141,9 @@ public class DocValuesCodecDuelTests extends ESTestCase {
             for (int i = 0; i < docIdsToAdvanceTo.length; i++) {
                 int docId = docIdsToAdvanceTo[i];
                 int baselineTarget = assertAdvance(docId, baselineReader, contenderReader, baseline, contender);
+                if (baselineTarget == NO_MORE_DOCS) {
+                    break;
+                }
                 assertEquals(baseline.ordValue(), contender.ordValue());
                 assertEquals(baseline.lookupOrd(baseline.ordValue()), contender.lookupOrd(contender.ordValue()));
                 i = shouldSkipDocIds(i, docId, baselineTarget, docIdsToAdvanceTo);


### PR DESCRIPTION
We need to check the returned doc id from advance() before accessing the values of the current document.

Closes #112082