### PR TITLE
Fix testPEMKeyConfigReloading intermittent failures

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloaderTests.java
@@ -72,6 +72,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationReloaderTests.java
@@ -72,6 +72,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/101427

The purpose of `testPEMKeyConfigReloading` is to make sure `SSLConfigurationReloader` works as expected when the ssl public key and certificate files the ssl config points to are changed. The `SSLConfigurationReloader` uses a `ResourceWatcherService` to notify a provided consumer when the files have changed. 

In this test we first setup a web server using a valid certificate and key that the client trusts and then we validate that the SSL handshake is ok. We then modify the key and cert file to contain a certificate that's not trusted by the client and  validate that the SSL handshake fails ("PKIX path validation failed"). 

Overwriting the key and certificate is a two step non-atomic process (two file overwrites). The test was failing intermittently because sometimes the one second refresh interval happened between the two overwrites, so only the public key was overwritten, resulting in an unexpected (to the test) error: "Signature length not correct: got 512 but was expecting 256". This can be reproduced by commenting out the certificate overwrite. 

The proposed fix is to separate the two file overwrite operations into two separate reload events by sleeping for the reload interval + 1ms between each file overwrite. I also lowered the interval to make sure the test isn't slower than before. 