### PR TITLE
Revert "[plugin/apm-data] Set fallback to legacy ILM policies"

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
@@ -23,6 +23,3 @@ template:
     index:
       default_pipeline: logs-apm.app@default-pipeline
       final_pipeline: apm@pipeline
-      lifecycle:
-        name: logs-apm.app_logs-default_policy
-        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -30,6 +30,3 @@ template:
     index:
       default_pipeline: logs-apm.error@default-pipeline
       final_pipeline: apm@pipeline
-      lifecycle:
-        name: logs-apm.error_logs-default_policy
-        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
@@ -24,6 +24,3 @@ template:
     index:
       default_pipeline: metrics-apm.app@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.app_metrics-default_policy
-        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
@@ -25,9 +25,6 @@ template:
     index:
       default_pipeline: metrics-apm.internal@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.internal_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.dataset:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_destination_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
@@ -26,9 +26,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_destination_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_destination_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_summary_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
@@ -26,9 +26,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_summary_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_summary_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_transaction_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
@@ -26,9 +26,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_transaction_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_transaction_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.transaction_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
@@ -26,9 +26,6 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.transaction_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
@@ -27,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.transaction_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
@@ -25,9 +25,6 @@ template:
     index:
       default_pipeline: traces-apm.rum@default-pipeline
       final_pipeline: traces-apm@pipeline
-      lifecycle:
-        name: traces-apm.rum_traces-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
@@ -20,11 +20,6 @@ ignore_missing_component_templates:
 template:
   lifecycle:
     data_retention: 1h
-  settings:
-    index:
-      lifecycle:
-        name: traces-apm.sampled_traces-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
@@ -24,9 +24,6 @@ template:
     index:
       default_pipeline: traces-apm@default-pipeline
       final_pipeline: traces-apm@pipeline
-      lifecycle:
-        name: traces-apm.traces-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 6
+version: 7
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 7
+version: 6
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 7
+version: 8
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
Reverts elastic/elasticsearch#112028

Looks like `prefer_ilm` does not work with serverless deployment. Creating a revert PR until we can figure out a fix.