### PR TITLE
[8.15] Merge multiple ignored source entires for the same field (#111994)

### DIFF
--- a/docs/changelog/111994.yaml
+++ b/docs/changelog/111994.yaml
@@ -1,0 +1,6 @@
+pr: 111994
+summary: Merge multiple ignored source entires for the same field
+area: Logs
+type: bug
+issues:
+ - 111694

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -83,7 +83,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
             XContentDataHelper.decodeAndWrite(builder, value());
         }
 
-        private String getFieldName() {
+        String getFieldName() {
             return parentOffset() == 0 ? name() : name().substring(parentOffset());
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -9,12 +9,12 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
@@ -74,7 +75,7 @@ public class ObjectMapper extends Mapper {
          * If no dynamic settings are explicitly configured, we default to {@link #TRUE}
          */
         static Dynamic getRootDynamic(MappingLookup mappingLookup) {
-            ObjectMapper.Dynamic rootDynamic = mappingLookup.getMapping().getRoot().dynamic;
+            Dynamic rootDynamic = mappingLookup.getMapping().getRoot().dynamic;
             return rootDynamic == null ? Defaults.DYNAMIC : rootDynamic;
         }
     }
@@ -142,13 +143,13 @@ public class ObjectMapper extends Mapper {
                 int firstDotIndex = name.indexOf('.');
                 String immediateChild = name.substring(0, firstDotIndex);
                 String immediateChildFullName = prefix == null ? immediateChild : prefix + "." + immediateChild;
-                ObjectMapper.Builder parentBuilder = findObjectBuilder(immediateChildFullName, context);
+                Builder parentBuilder = findObjectBuilder(immediateChildFullName, context);
                 parentBuilder.addDynamic(name.substring(firstDotIndex + 1), immediateChildFullName, mapper, context);
                 add(parentBuilder);
             }
         }
 
-        private static ObjectMapper.Builder findObjectBuilder(String fullName, DocumentParserContext context) {
+        private static Builder findObjectBuilder(String fullName, DocumentParserContext context) {
             // does the object mapper already exist? if so, use that
             ObjectMapper objectMapper = context.mappingLookup().objectMappers().get(fullName);
             if (objectMapper != null) {
@@ -215,7 +216,7 @@ public class ObjectMapper extends Mapper {
             throws MapperParsingException {
             parserContext.incrementMappingObjectDepth(); // throws MapperParsingException if depth limit is exceeded
             Explicit<Boolean> subobjects = parseSubobjects(node);
-            ObjectMapper.Builder builder = new Builder(name, subobjects);
+            Builder builder = new Builder(name, subobjects);
             parseObjectFields(node, parserContext, builder);
             parserContext.decrementMappingObjectDepth();
             return builder;
@@ -237,7 +238,7 @@ public class ObjectMapper extends Mapper {
             String fieldName,
             Object fieldNode,
             MappingParserContext parserContext,
-            ObjectMapper.Builder builder
+            Builder builder
         ) {
             if (fieldName.equals("dynamic")) {
                 String value = fieldNode.toString();
@@ -284,11 +285,7 @@ public class ObjectMapper extends Mapper {
             return Defaults.SUBOBJECTS;
         }
 
-        protected static void parseProperties(
-            ObjectMapper.Builder objBuilder,
-            Map<String, Object> propsNode,
-            MappingParserContext parserContext
-        ) {
+        protected static void parseProperties(Builder objBuilder, Map<String, Object> propsNode, MappingParserContext parserContext) {
             Iterator<Map.Entry<String, Object>> iterator = propsNode.entrySet().iterator();
             while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();
@@ -347,7 +344,7 @@ public class ObjectMapper extends Mapper {
                         for (int i = fieldNameParts.length - 2; i >= 0; --i) {
                             String intermediateObjectName = fieldNameParts[i];
                             validateFieldName(intermediateObjectName, parserContext.indexVersionCreated());
-                            ObjectMapper.Builder intermediate = new ObjectMapper.Builder(intermediateObjectName, Defaults.SUBOBJECTS);
+                            Builder intermediate = new Builder(intermediateObjectName, Defaults.SUBOBJECTS);
                             intermediate.add(fieldBuilder);
                             fieldBuilder = intermediate;
                         }
@@ -417,8 +414,8 @@ public class ObjectMapper extends Mapper {
     /**
      * @return a Builder that will produce an empty ObjectMapper with the same configuration as this one
      */
-    public ObjectMapper.Builder newBuilder(IndexVersion indexVersionCreated) {
-        ObjectMapper.Builder builder = new ObjectMapper.Builder(leafName(), subobjects);
+    public Builder newBuilder(IndexVersion indexVersionCreated) {
+        Builder builder = new Builder(leafName(), subobjects);
         builder.enabled = this.enabled;
         builder.dynamic = this.dynamic;
         return builder;
@@ -507,7 +504,7 @@ public class ObjectMapper extends Mapper {
         Explicit<Boolean> enabled,
         Explicit<Boolean> subObjects,
         Explicit<Boolean> trackArraySource,
-        ObjectMapper.Dynamic dynamic,
+        Dynamic dynamic,
         Map<String, Mapper> mappers
     ) {
         static MergeResult build(ObjectMapper existing, ObjectMapper mergeWithObject, MapperMergeContext parentMergeContext) {
@@ -789,9 +786,9 @@ public class ObjectMapper extends Mapper {
 
         @Override
         public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
-            List<SourceLoader.SyntheticFieldLoader.DocValuesLoader> loaders = new ArrayList<>();
+            List<DocValuesLoader> loaders = new ArrayList<>();
             for (SourceLoader.SyntheticFieldLoader field : fields) {
-                SourceLoader.SyntheticFieldLoader.DocValuesLoader loader = field.docValuesLoader(leafReader, docIdsInLeaf);
+                DocValuesLoader loader = field.docValuesLoader(leafReader, docIdsInLeaf);
                 if (loader != null) {
                     loaders.add(loader);
                 }
@@ -803,7 +800,7 @@ public class ObjectMapper extends Mapper {
         }
 
         private class ObjectDocValuesLoader implements DocValuesLoader {
-            private final List<SourceLoader.SyntheticFieldLoader.DocValuesLoader> loaders;
+            private final List<DocValuesLoader> loaders;
 
             private ObjectDocValuesLoader(List<DocValuesLoader> loaders) {
                 this.loaders = loaders;
@@ -812,7 +809,7 @@ public class ObjectMapper extends Mapper {
             @Override
             public boolean advanceToDoc(int docId) throws IOException {
                 boolean anyLeafHasDocValues = false;
-                for (SourceLoader.SyntheticFieldLoader.DocValuesLoader docValueLoader : loaders) {
+                for (DocValuesLoader docValueLoader : loaders) {
                     boolean leafHasValue = docValueLoader.advanceToDoc(docId);
                     anyLeafHasDocValues |= leafHasValue;
                 }
@@ -848,18 +845,24 @@ public class ObjectMapper extends Mapper {
 
             if (ignoredValues != null && ignoredValues.isEmpty() == false) {
                 // Use an ordered map between field names and writer functions, to order writing by field name.
-                Map<String, CheckedConsumer<XContentBuilder, IOException>> orderedFields = new TreeMap<>();
+                Map<String, FieldWriter> orderedFields = new TreeMap<>();
                 for (IgnoredSourceFieldMapper.NameValue value : ignoredValues) {
-                    orderedFields.put(value.name(), value::write);
+                    var existing = orderedFields.get(value.name());
+                    if (existing == null) {
+                        orderedFields.put(value.name(), new FieldWriter.IgnoredSource(value));
+                    } else if (existing instanceof FieldWriter.IgnoredSource isw) {
+                        isw.mergeWith(value);
+                    }
                 }
                 for (SourceLoader.SyntheticFieldLoader field : fields) {
                     if (field.hasValue()) {
                         // Skip if the field source is stored separately, to avoid double-printing.
-                        orderedFields.putIfAbsent(field.fieldName(), field::write);
+                        orderedFields.computeIfAbsent(field.fieldName(), k -> new FieldWriter.FieldLoader(field));
                     }
                 }
+
                 for (var writer : orderedFields.values()) {
-                    writer.accept(b);
+                    writer.writeTo(b);
                 }
                 ignoredValues = null;
             } else {
@@ -889,6 +892,42 @@ public class ObjectMapper extends Mapper {
         @Override
         public String fieldName() {
             return ObjectMapper.this.fullPath();
+        }
+
+        interface FieldWriter {
+            void writeTo(XContentBuilder builder) throws IOException;
+
+            record FieldLoader(SourceLoader.SyntheticFieldLoader loader) implements FieldWriter {
+                @Override
+                public void writeTo(XContentBuilder builder) throws IOException {
+                    loader.write(builder);
+                }
+            }
+
+            class IgnoredSource implements FieldWriter {
+                private final String fieldName;
+                private final String leafName;
+                private final List<BytesRef> values;
+
+                IgnoredSource(IgnoredSourceFieldMapper.NameValue initialValue) {
+                    this.fieldName = initialValue.name();
+                    this.leafName = initialValue.getFieldName();
+                    this.values = new ArrayList<>();
+                    this.values.add(initialValue.value());
+                }
+
+                @Override
+                public void writeTo(XContentBuilder builder) throws IOException {
+                    XContentDataHelper.writeMerged(builder, leafName, values);
+                }
+
+                public FieldWriter mergeWith(IgnoredSourceFieldMapper.NameValue nameValue) {
+                    assert Objects.equals(nameValue.name(), fieldName) : "IgnoredSource is merged with wrong field data";
+
+                    values.add(nameValue.value());
+                    return this;
+                }
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -8,8 +8,10 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.DirectoryReader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.test.FieldMaskingReader;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
@@ -19,6 +21,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
@@ -633,6 +636,132 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             {"path":[{"to":[{"name":"A"},{"name":"B"}]},{"to":[{"name":"C"},{"name":"D"}]}]}""", booleanValue), syntheticSource);
     }
 
+    public void testDisabledObjectWithinHigherLevelArray() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path");
+            {
+                b.field("type", "object");
+                b.startObject("properties");
+                {
+                    b.startObject("to").field("type", "object").field("enabled", false);
+                    {
+                        b.startObject("properties");
+                        {
+                            b.startObject("name").field("type", "keyword").endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+
+        boolean booleanValue = randomBoolean();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject();
+                {
+                    b.startObject("to").field("name", "A").endObject();
+                }
+                b.endObject();
+                b.startObject();
+                {
+                    b.startObject("to").field("name", "B").endObject();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        });
+        assertEquals(String.format(Locale.ROOT, """
+            {"path":{"to":[{"name":"A"},{"name":"B"}]}}""", booleanValue), syntheticSource);
+    }
+
+    public void testStoredArrayWithinHigherLevelArray() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path");
+            {
+                b.field("type", "object");
+                b.startObject("properties");
+                {
+                    b.startObject("to").field("type", "object").field("store_array_source", true);
+                    {
+                        b.startObject("properties");
+                        {
+                            b.startObject("name").field("type", "keyword").endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+
+        boolean booleanValue = randomBoolean();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject();
+                {
+                    b.startArray("to");
+                    {
+                        b.startObject().field("name", "A").endObject();
+                        b.startObject().field("name", "B").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+                b.startObject();
+                {
+                    b.startArray("to");
+                    {
+                        b.startObject().field("name", "C").endObject();
+                        b.startObject().field("name", "D").endObject();
+                    }
+                    b.endArray();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        });
+        assertEquals(String.format(Locale.ROOT, """
+            {"path":{"to":[{"name":"A"},{"name":"B"},{"name":"C"},{"name":"D"}]}}""", booleanValue), syntheticSource);
+    }
+
+    public void testFallbackFieldWithinHigherLevelArray() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path");
+            {
+                b.field("type", "object");
+                b.startObject("properties");
+                {
+                    b.startObject("name").field("type", "keyword").field("doc_values", false).endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+
+        boolean booleanValue = randomBoolean();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+
+                b.startObject().field("name", "A").endObject();
+                b.startObject().field("name", "B").endObject();
+                b.startObject().field("name", "C").endObject();
+                b.startObject().field("name", "D").endObject();
+            }
+            b.endArray();
+        });
+        assertEquals(String.format(Locale.ROOT, """
+            {"path":{"name":["A","B","C","D"]}}""", booleanValue), syntheticSource);
+    }
+
     public void testFieldOrdering() throws IOException {
         DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
             b.startObject("A").field("type", "integer").endObject();
@@ -1096,5 +1225,17 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         });
         assertEquals("""
             {"path":{"at":{"foo":"A"}}}""", syntheticSource);
+    }
+
+    protected void validateRoundTripReader(String syntheticSource, DirectoryReader reader, DirectoryReader roundTripReader)
+        throws IOException {
+        // We exclude ignored source field since in some cases it contains an exact copy of a part of document source.
+        // Sometime synthetic source is different in this case (structurally but not logically)
+        // and since the copy is exact, contents of ignored source are different.
+        assertReaderEquals(
+            "round trip " + syntheticSource,
+            new FieldMaskingReader(Set.of(SourceFieldMapper.RECOVERY_SOURCE_NAME, IgnoredSourceFieldMapper.NAME), reader),
+            new FieldMaskingReader(Set.of(SourceFieldMapper.RECOVERY_SOURCE_NAME, IgnoredSourceFieldMapper.NAME), roundTripReader)
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/XContentDataHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/XContentDataHelperTests.java
@@ -8,9 +8,11 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -21,8 +23,12 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -167,5 +173,95 @@ public class XContentDataHelperTests extends ESTestCase {
         assertEquals(data, dataInParser(tuple.v1().parser()));
         assertEquals(data, dataInParser(tuple.v2()));
         assertTrue(tuple.v1().getClonedSource());
+    }
+
+    public void testWriteMergedWithSingleValue() throws IOException {
+        testWriteMergedWithSingleValue(randomLong());
+        testWriteMergedWithSingleValue(randomDouble());
+        testWriteMergedWithSingleValue(randomBoolean());
+        testWriteMergedWithSingleValue(randomAlphaOfLength(5));
+        testWriteMergedWithSingleValue(null);
+        testWriteMergedWithSingleValue(Map.of("object_field", randomAlphaOfLength(5)));
+        testWriteMergedWithSingleValue(Map.of("object_field", Map.of("nested_object_field", randomAlphaOfLength(5))));
+    }
+
+    private void testWriteMergedWithSingleValue(Object value) throws IOException {
+        var map = executeWriteMergeOnRepeated(value);
+        assertEquals(Arrays.asList(value, value), map.get("foo"));
+    }
+
+    public void testWriteMergedWithMultipleValues() throws IOException {
+        testWriteMergedWithMultipleValues(List.of(randomLong(), randomLong()));
+        testWriteMergedWithMultipleValues(List.of(randomDouble(), randomDouble()));
+        testWriteMergedWithMultipleValues(List.of(randomBoolean(), randomBoolean()));
+        testWriteMergedWithMultipleValues(List.of(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        testWriteMergedWithMultipleValues(Arrays.asList(null, null));
+        testWriteMergedWithMultipleValues(
+            List.of(Map.of("object_field", randomAlphaOfLength(5)), Map.of("object_field", randomAlphaOfLength(5)))
+        );
+        testWriteMergedWithMultipleValues(
+            List.of(
+                Map.of("object_field", Map.of("nested_object_field", randomAlphaOfLength(5))),
+                Map.of("object_field", Map.of("nested_object_field", randomAlphaOfLength(5)))
+            )
+        );
+    }
+
+    private void testWriteMergedWithMultipleValues(List<Object> value) throws IOException {
+        var map = executeWriteMergeOnRepeated(value);
+        var expected = Stream.of(value, value).flatMap(Collection::stream).toList();
+        assertEquals(expected, map.get("foo"));
+    }
+
+    public void testWriteMergedWithMixedValues() throws IOException {
+        testWriteMergedWithMixedValues(randomLong(), List.of(randomLong(), randomLong()));
+        testWriteMergedWithMixedValues(randomDouble(), List.of(randomDouble(), randomDouble()));
+        testWriteMergedWithMixedValues(randomBoolean(), List.of(randomBoolean(), randomBoolean()));
+        testWriteMergedWithMixedValues(randomAlphaOfLength(5), List.of(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        testWriteMergedWithMixedValues(null, Arrays.asList(null, null));
+        testWriteMergedWithMixedValues(
+            Map.of("object_field", randomAlphaOfLength(5)),
+            List.of(Map.of("object_field", randomAlphaOfLength(5)), Map.of("object_field", randomAlphaOfLength(5)))
+        );
+        testWriteMergedWithMixedValues(
+            Map.of("object_field", Map.of("nested_object_field", randomAlphaOfLength(5))),
+            List.of(
+                Map.of("object_field", Map.of("nested_object_field", randomAlphaOfLength(5))),
+                Map.of("object_field", Map.of("nested_object_field", randomAlphaOfLength(5)))
+            )
+        );
+    }
+
+    private void testWriteMergedWithMixedValues(Object value, List<Object> multipleValues) throws IOException {
+        var map = executeWriteMergeOnTwoEncodedValues(value, multipleValues);
+        var expected = Stream.concat(Stream.of(value), multipleValues.stream()).toList();
+        assertEquals(expected, map.get("foo"));
+    }
+
+    private Map<String, Object> executeWriteMergeOnRepeated(Object value) throws IOException {
+        return executeWriteMergeOnTwoEncodedValues(value, value);
+    }
+
+    private Map<String, Object> executeWriteMergeOnTwoEncodedValues(Object first, Object second) throws IOException {
+        var xContentType = randomFrom(XContentType.values());
+
+        var firstEncoded = encodeSingleValue(first, xContentType);
+        var secondEncoded = encodeSingleValue(second, xContentType);
+
+        var destination = XContentFactory.contentBuilder(xContentType);
+        destination.startObject();
+        XContentDataHelper.writeMerged(destination, "foo", List.of(firstEncoded, secondEncoded));
+        destination.endObject();
+
+        return XContentHelper.convertToMap(BytesReference.bytes(destination), false, xContentType).v2();
+    }
+
+    private BytesRef encodeSingleValue(Object value, XContentType xContentType) throws IOException {
+        var builder = XContentFactory.contentBuilder(xContentType);
+        builder.value(value);
+
+        XContentParser parser = createParser(builder);
+        parser.nextToken();
+        return XContentDataHelper.encodeToken(parser);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/FieldMaskingReader.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/FieldMaskingReader.java
@@ -14,16 +14,20 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.tests.index.FieldFilterLeafReader;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Set;
 
 public class FieldMaskingReader extends FilterDirectoryReader {
-    private final String field;
+    private final Set<String> fields;
 
     public FieldMaskingReader(String field, DirectoryReader in) throws IOException {
+        this(Set.of(field), in);
+    }
+
+    public FieldMaskingReader(Set<String> fields, DirectoryReader in) throws IOException {
         super(in, new FilterDirectoryReader.SubReaderWrapper() {
             @Override
             public LeafReader wrap(LeafReader reader) {
-                return new FilterLeafReader(new FieldFilterLeafReader(reader, Collections.singleton(field), true)) {
+                return new FilterLeafReader(new FieldFilterLeafReader(reader, fields, true)) {
 
                     // FieldFilterLeafReader does not forward cache helpers
                     // since it considers it is illegal because of the fact
@@ -43,13 +47,13 @@ public class FieldMaskingReader extends FilterDirectoryReader {
                 };
             }
         });
-        this.field = field;
+        this.fields = fields;
 
     }
 
     @Override
     protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
-        return new FieldMaskingReader(field, in);
+        return new FieldMaskingReader(fields, in);
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Merge multiple ignored source entires for the same field (#111994)](https://github.com/elastic/elasticsearch/pull/111994)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)