### PR TITLE
Stop setting java.library.path

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -77,7 +77,7 @@ tasks.named("run").configure {
   executable = "${BuildParams.runtimeJavaHome}/bin/java"
   args << "-Dplugins.dir=${buildDir}/plugins" << "-Dtests.index=${buildDir}/index"
   dependsOn "copyExpression", "copyPainless"
-  systemProperty 'java.library.path', file("../libs/native/libraries/build/platform/${platformName()}-${os.arch}")
+  systemProperty 'es.nativelibs.path', file("../libs/native/libraries/build/platform/${platformName()}-${os.arch}")
 }
 
 String platformName() {

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -168,8 +168,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
               '-ea',
               '-Djava.security.manager=allow',
               '-Djava.locale.providers=SPI,COMPAT',
-              '-Djava.library.path=' + testLibraryPath,
-              '-Djna.library.path=' + testLibraryPath,
+              '-Des.nativelibs.path=' + testLibraryPath,
               // TODO: only open these for mockito when it is modularized
               '--add-opens=java.base/java.security.cert=ALL-UNNAMED',
               '--add-opens=java.base/java.nio.channels=ALL-UNNAMED',

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -189,9 +189,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
             var libraryPath = (Supplier<String>) () -> TestUtil.getTestLibraryPath(nativeConfigFiles.getAsPath());
 
             test.dependsOn(nativeConfigFiles);
-            // we may use JNA or the JDK's foreign function api to load libraries, so we set both sysprops
-            systemProperties.systemProperty("java.library.path", libraryPath);
-            systemProperties.systemProperty("jna.library.path", libraryPath);
+            systemProperties.systemProperty("es.nativelibs.path", libraryPath);
         });
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestUtil.java
@@ -11,7 +11,6 @@ package org.elasticsearch.gradle.internal.test;
 import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.ElasticsearchDistribution;
 
-import java.io.File;
 import java.util.Locale;
 
 public class TestUtil {
@@ -19,8 +18,7 @@ public class TestUtil {
     public static String getTestLibraryPath(String nativeLibsDir) {
         String arch = Architecture.current().toString().toLowerCase(Locale.ROOT);
         String platform = String.format(Locale.ROOT, "%s-%s", ElasticsearchDistribution.CURRENT_PLATFORM, arch);
-        String existingLibraryPath = System.getProperty("java.library.path");
 
-        return String.format(Locale.ROOT, "%s/%s%c%s", nativeLibsDir, platform, File.pathSeparatorChar, existingLibraryPath);
+        return String.format(Locale.ROOT, "%s/%s", nativeLibsDir, platform);
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/LoaderHelper.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/LoaderHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.lib;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A utility for loading libraries from Elasticsearch's platform specific lib dir.
+ */
+public class LoaderHelper {
+    private static final Path platformLibDir = findPlatformLibDir();
+
+    private static Path findPlatformLibDir() {
+        // tests don't have an ES install, so the platform dir must be passed in explicitly
+        String path = System.getProperty("es.nativelibs.path");
+        if (path != null) {
+            return Paths.get(path);
+        }
+
+        Path platformDir = Paths.get("lib", "platform");
+
+        String osname = System.getProperty("os.name");
+        String os;
+        if (osname.startsWith("Windows")) {
+            os = "windows";
+        } else if (osname.startsWith("Linux")) {
+            os = "linux";
+        } else if (osname.startsWith("Mac OS")) {
+            os = "darwin";
+        } else {
+            os = "unsupported_os[" + osname + "]";
+        }
+        String archname = System.getProperty("os.arch");
+        String arch;
+        if (archname.equals("amd64") || archname.equals("x86_64")) {
+            arch = "x64";
+        } else if (archname.equals("aarch64")) {
+            arch = archname;
+        } else {
+            arch = "unsupported_arch[" + archname + "]";
+        }
+        return platformDir.resolve(os + "-" + arch);
+    }
+
+    public static void loadLibrary(String libname) {
+        Path libpath = platformLibDir.resolve(System.mapLibraryName(libname));
+        if (Files.exists(libpath) == false) {
+            throw new UnsatisfiedLinkError("Native library [" + libpath + "] does not exist");
+        }
+        System.load(libpath.toAbsolutePath().toString());
+    }
+
+    private LoaderHelper() {} // no construction
+}

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess.jdk;
 
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions;
+import org.elasticsearch.nativeaccess.lib.LoaderHelper;
 import org.elasticsearch.nativeaccess.lib.VectorLibrary;
 
 import java.lang.foreign.FunctionDescriptor;
@@ -29,7 +30,7 @@ public final class JdkVectorLibrary implements VectorLibrary {
     static final VectorSimilarityFunctions INSTANCE;
 
     static {
-        System.loadLibrary("vec");
+        LoaderHelper.loadLibrary("vec");
         final MethodHandle vecCaps$mh = downcallHandle("vec_caps", FunctionDescriptor.of(JAVA_INT));
 
         try {

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess.jdk;
 
 import org.elasticsearch.nativeaccess.CloseableByteBuffer;
+import org.elasticsearch.nativeaccess.lib.LoaderHelper;
 import org.elasticsearch.nativeaccess.lib.ZstdLibrary;
 
 import java.lang.foreign.FunctionDescriptor;
@@ -24,7 +25,7 @@ import static org.elasticsearch.nativeaccess.jdk.LinkerHelper.downcallHandle;
 class JdkZstdLibrary implements ZstdLibrary {
 
     static {
-        System.loadLibrary("zstd");
+        LoaderHelper.loadLibrary("zstd");
     }
 
     private static final MethodHandle compressBound$mh = downcallHandle("ZSTD_compressBound", FunctionDescriptor.of(JAVA_LONG, JAVA_INT));

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/VectorSystemPropertyTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/VectorSystemPropertyTests.java
@@ -49,7 +49,7 @@ public class VectorSystemPropertyTests extends ESTestCase {
             "-Xms4m",
             "-cp",
             jarPath + File.pathSeparator + System.getProperty("java.class.path"),
-            "-Djava.library.path=" + System.getProperty("java.library.path"),
+            "-Des.nativelibs.path=" + System.getProperty("es.nativelibs.path"),
             "p.Test"
         ).start();
         String output = new String(process.getInputStream().readAllBytes(), UTF_8);


### PR DESCRIPTION
Native libraries in Java are loaded by calling System.loadLibrary. This method inspects paths in the java.library.path to find the requested library. Elasticsearch previously used this to find libsystemd, but now the only remaining use is to set the additional platform directory in which Elasticsearch keeps its own native libraries.

One issue with setting java.library.path is that its not set for the cli process, which makes loading the native library infrastructure from clis difficult. This commit reworks how Elasticsearch native libraries are found in order to avoid needing to set java.library.path. There are two cases. The simplest is production, where the working directory is the Elasticsearch installation directory, so the platform specific directory can be constructed. The second case is for tests where we don't have an installtion. We already pass in java.library.path there, so this change renames the system property to be a test specific property that the new loading infrastructure looks for.