### PR TITLE
SLM interval schedule followup - change records back to classes

### DIFF
--- a/docs/changelog/112122.yaml
+++ b/docs/changelog/112122.yaml
@@ -1,0 +1,5 @@
+pr: 112122
+summary: SLM interval schedule followup - change records back to classes
+area: ILM+SLM
+type: bug
+issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
@@ -296,13 +296,13 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
 
     @Override
     public void triggered(SchedulerEngine.Event event) {
-        if (event.jobName().equals(LIFECYCLE_JOB_NAME)) {
+        if (event.getJobName().equals(LIFECYCLE_JOB_NAME)) {
             if (this.isMaster) {
                 logger.trace(
                     "Data stream lifecycle job triggered: {}, {}, {}",
-                    event.jobName(),
-                    event.scheduledTime(),
-                    event.triggeredTime()
+                    event.getJobName(),
+                    event.getScheduledTime(),
+                    event.getTriggeredTime()
                 );
                 run(clusterService.state());
                 dslHealthInfoPublisher.publishDslErrorEntries(new ActionListener<>() {

--- a/server/src/main/java/org/elasticsearch/common/scheduler/SchedulerEngine.java
+++ b/server/src/main/java/org/elasticsearch/common/scheduler/SchedulerEngine.java
@@ -49,18 +49,63 @@ public class SchedulerEngine {
      * This could change if a master change or restart causes a new SchedulerEngine to be constructed.
      * But using a `fixedStartTime` populated  from a time stored in cluster state allows the basis time
      * to remain unchanged across master changes and restarts.
-     *
-     * @param id the id of the job
-     * @param schedule the schedule which is used to calculate when the job runs
-     * @param fixedStartTime a fixed time in the past which the schedule uses to calculate run times,
      */
-    public record Job(String id, Schedule schedule, @Nullable Long fixedStartTime) {
+    public static class Job {
+        // id of the job
+        private final String id;
+
+        // schedule which is used to calculate when the job runs
+        private final Schedule schedule;
+
+        // fixedStartTime a fixed time in the past which the schedule uses to calculate run times,
+        private final @Nullable Long fixedStartTime;
+
         public Job(String id, Schedule schedule) {
             this(id, schedule, null);
         }
+
+        public Job(String id, Schedule schedule, Long fixedStartTime) {
+            this.id = id;
+            this.schedule = schedule;
+            this.fixedStartTime = fixedStartTime;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Schedule getSchedule() {
+            return schedule;
+        }
+
+        public Long getFixedStartTime() {
+            return fixedStartTime;
+        }
     }
 
-    public record Event(String jobName, long triggeredTime, long scheduledTime) {
+    public static class Event {
+        private final String jobName;
+        private final long triggeredTime;
+        private final long scheduledTime;
+
+        public Event(String jobName, long triggeredTime, long scheduledTime) {
+            this.jobName = jobName;
+            this.triggeredTime = triggeredTime;
+            this.scheduledTime = scheduledTime;
+        }
+
+        public String getJobName() {
+            return jobName;
+        }
+
+        public long getTriggeredTime() {
+            return triggeredTime;
+        }
+
+        public long getScheduledTime() {
+            return scheduledTime;
+        }
+
         @Override
         public String toString() {
             return "Event[jobName=" + jobName + "," + "triggeredTime=" + triggeredTime + "," + "scheduledTime=" + scheduledTime + "]";
@@ -140,13 +185,13 @@ public class SchedulerEngine {
     }
 
     public void add(Job job) {
-        final long startTime = job.fixedStartTime() == null ? clock.millis() : job.fixedStartTime();
-        ActiveSchedule schedule = new ActiveSchedule(job.id(), job.schedule(), startTime);
+        final long startTime = job.getFixedStartTime() == null ? clock.millis() : job.getFixedStartTime();
+        ActiveSchedule schedule = new ActiveSchedule(job.getId(), job.getSchedule(), startTime);
         schedules.compute(schedule.name, (name, previousSchedule) -> {
             if (previousSchedule != null) {
                 previousSchedule.cancel();
             }
-            logger.debug(() -> "added job [" + job.id() + "]");
+            logger.debug(() -> "added job [" + job.getId() + "]");
             return schedule;
         });
     }

--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -299,7 +299,7 @@ public class HealthPeriodicLogger extends AbstractLifecycleComponent implements 
 
     @Override
     public void triggered(SchedulerEngine.Event event) {
-        if (event.jobName().equals(HEALTH_PERIODIC_LOGGER_JOB_NAME) && this.enabled) {
+        if (event.getJobName().equals(HEALTH_PERIODIC_LOGGER_JOB_NAME) && this.enabled) {
             this.tryToLogHealth();
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/scheduler/SchedulerEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/common/scheduler/SchedulerEngineTests.java
@@ -166,7 +166,7 @@ public class SchedulerEngineTests extends ESTestCase {
         final String jobId = randomAlphaOfLength(4);
         try {
             engine.register(event -> {
-                assertThat(event.jobName(), is(jobId));
+                assertThat(event.getJobName(), is(jobId));
                 calledCount.incrementAndGet();
                 jobRunningLatch.countDown();
                 try {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/ClusterStateLicenseService.java
@@ -289,11 +289,11 @@ public class ClusterStateLicenseService extends AbstractLifecycleComponent
         final LicensesMetadata licensesMetadata = getLicensesMetadata();
         if (licensesMetadata != null) {
             final License license = licensesMetadata.getLicense();
-            if (event.jobName().equals(LICENSE_JOB)) {
+            if (event.getJobName().equals(LICENSE_JOB)) {
                 updateXPackLicenseState(license);
-            } else if (event.jobName().startsWith(ExpirationCallback.EXPIRATION_JOB_PREFIX)) {
+            } else if (event.getJobName().startsWith(ExpirationCallback.EXPIRATION_JOB_PREFIX)) {
                 expirationCallbacks.stream()
-                    .filter(expirationCallback -> expirationCallback.getId().equals(event.jobName()))
+                    .filter(expirationCallback -> expirationCallback.getId().equals(event.getJobName()))
                     .forEach(expirationCallback -> expirationCallback.on(license));
             }
         }

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -496,7 +496,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
             assertThat(indexLifecycleService.getScheduler().jobCount(), equalTo(1));
         });
         {
-            TimeValueSchedule schedule = (TimeValueSchedule) indexLifecycleService.getScheduledJob().schedule();
+            TimeValueSchedule schedule = (TimeValueSchedule) indexLifecycleService.getScheduledJob().getSchedule();
             assertThat(schedule.getInterval(), equalTo(pollInterval));
         }
 
@@ -504,7 +504,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         TimeValue newPollInterval = TimeValue.timeValueHours(randomLongBetween(6, 1000));
         updateClusterSettings(Settings.builder().put(LifecycleSettings.LIFECYCLE_POLL_INTERVAL, newPollInterval.getStringRep()));
         {
-            TimeValueSchedule schedule = (TimeValueSchedule) indexLifecycleService.getScheduledJob().schedule();
+            TimeValueSchedule schedule = (TimeValueSchedule) indexLifecycleService.getScheduledJob().getSchedule();
             assertThat(schedule.getInterval(), equalTo(newPollInterval));
         }
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -353,8 +353,8 @@ public class IndexLifecycleService
 
     @Override
     public void triggered(SchedulerEngine.Event event) {
-        if (event.jobName().equals(XPackField.INDEX_LIFECYCLE)) {
-            logger.trace("job triggered: " + event.jobName() + ", " + event.scheduledTime() + ", " + event.triggeredTime());
+        if (event.getJobName().equals(XPackField.INDEX_LIFECYCLE)) {
+            logger.trace("job triggered: " + event.getJobName() + ", " + event.getScheduledTime() + ", " + event.getTriggeredTime());
             triggerPolicies(clusterService.state(), false);
         }
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
@@ -463,8 +463,8 @@ public class RollupJobTask extends AllocatedPersistentTask implements SchedulerE
     public synchronized void triggered(SchedulerEngine.Event event) {
         // Verify this is actually the event that we care about, then trigger the indexer.
         // Note that the status of the indexer is checked in the indexer itself
-        if (event.jobName().equals(SCHEDULE_NAME + "_" + job.getConfig().getId())) {
-            logger.debug("Rollup indexer [" + event.jobName() + "] schedule has triggered, state: [" + indexer.getState() + "]");
+        if (event.getJobName().equals(SCHEDULE_NAME + "_" + job.getConfig().getId())) {
+            logger.debug("Rollup indexer [" + event.getJobName() + "] schedule has triggered, state: [" + indexer.getState() + "]");
             indexer.maybeTriggerAsyncJob(System.currentTimeMillis());
         }
     }

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -68,21 +68,21 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
 
     @Override
     public void triggered(SchedulerEngine.Event event) {
-        logger.debug("snapshot lifecycle policy task triggered from job [{}]", event.jobName());
+        logger.debug("snapshot lifecycle policy task triggered from job [{}]", event.getJobName());
 
-        final Optional<String> snapshotName = maybeTakeSnapshot(event.jobName(), client, clusterService, historyStore);
+        final Optional<String> snapshotName = maybeTakeSnapshot(event.getJobName(), client, clusterService, historyStore);
 
         // Would be cleaner if we could use Optional#ifPresentOrElse
         snapshotName.ifPresent(
             name -> logger.info(
                 "snapshot lifecycle policy job [{}] issued new snapshot creation for [{}] successfully",
-                event.jobName(),
+                event.getJobName(),
                 name
             )
         );
 
         if (snapshotName.isPresent() == false) {
-            logger.warn("snapshot lifecycle policy for job [{}] no longer exists, snapshot not created", event.jobName());
+            logger.warn("snapshot lifecycle policy for job [{}] no longer exists, snapshot not created", event.getJobName());
         }
     }
 

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -88,21 +88,21 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
 
     @Override
     public void triggered(SchedulerEngine.Event event) {
-        assert event.jobName().equals(SnapshotRetentionService.SLM_RETENTION_JOB_ID)
-            || event.jobName().equals(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID)
+        assert event.getJobName().equals(SnapshotRetentionService.SLM_RETENTION_JOB_ID)
+            || event.getJobName().equals(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID)
             : "expected id to be "
                 + SnapshotRetentionService.SLM_RETENTION_JOB_ID
                 + " or "
                 + SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID
                 + " but it was "
-                + event.jobName();
+                + event.getJobName();
 
         final ClusterState state = clusterService.state();
 
         // Skip running retention if SLM is disabled, however, even if it's
         // disabled we allow manual running.
         if (SnapshotLifecycleService.slmStoppedOrStopping(state)
-            && event.jobName().equals(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID) == false) {
+            && event.getJobName().equals(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID) == false) {
             logger.debug("skipping SLM retention as SLM is currently stopped or stopping");
             return;
         }

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
@@ -256,7 +256,7 @@ public class SnapshotLifecycleServiceTests extends ESTestCase {
 
             CopyOnWriteArrayList<String> triggeredJobs = new CopyOnWriteArrayList<>();
             trigger.set(e -> {
-                triggeredJobs.add(e.jobName());
+                triggeredJobs.add(e.getJobName());
                 triggerCount.incrementAndGet();
             });
             clock.fastForwardSeconds(1);

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionServiceTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionServiceTests.java
@@ -82,7 +82,7 @@ public class SnapshotRetentionServiceTests extends ESTestCase {
         try (
             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, clusterSettings);
             SnapshotRetentionService service = new SnapshotRetentionService(Settings.EMPTY, () -> new FakeRetentionTask(event -> {
-                assertThat(event.jobName(), equalTo(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID));
+                assertThat(event.getJobName(), equalTo(SnapshotRetentionService.SLM_RETENTION_MANUAL_JOB_ID));
                 invoked.incrementAndGet();
             }), clock)
         ) {


### PR DESCRIPTION
Recent SLM interval change https://github.com/elastic/elasticsearch/pull/110847  included changing two classes to records. This changed the getter methods from the form `getFieldName()` to `fieldName()`. Unfortunately, serverless expected the `fieldName()` form. Since the change from classes to records was just an aesthetic change, for the mean time it seems best to change them back to classes. 