### PR TITLE
SLM interval schedule followup - add back getFieldName style getters

### DIFF
--- a/docs/changelog/112123.yaml
+++ b/docs/changelog/112123.yaml
@@ -1,0 +1,5 @@
+pr: 112123
+summary: SLM interval schedule followup - add back `getFieldName` style getters
+area: ILM+SLM
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/scheduler/SchedulerEngine.java
+++ b/server/src/main/java/org/elasticsearch/common/scheduler/SchedulerEngine.java
@@ -58,12 +58,46 @@ public class SchedulerEngine {
         public Job(String id, Schedule schedule) {
             this(id, schedule, null);
         }
+
+        /**
+         * The following getters are redundant with the getters built in by the record.
+         * Unfortunately, getFieldName form getters are expected by serverless.
+         * These getters are being added back until serverless can be updated for the new getters.
+         */
+        public String getId() {
+            return id;
+        }
+
+        public Schedule getSchedule() {
+            return schedule;
+        }
+
+        public Long getFixedStartTime() {
+            return fixedStartTime;
+        }
     }
 
     public record Event(String jobName, long triggeredTime, long scheduledTime) {
         @Override
         public String toString() {
             return "Event[jobName=" + jobName + "," + "triggeredTime=" + triggeredTime + "," + "scheduledTime=" + scheduledTime + "]";
+        }
+
+        /**
+         * The following getters are redundant with the getters built in by the record.
+         * Unfortunately, getFieldName form getters are expected by serverless.
+         * These getters are being added back until serverless can be updated for the new getters.
+         */
+        public String getJobName() {
+            return jobName;
+        }
+
+        public long getTriggeredTime() {
+            return triggeredTime;
+        }
+
+        public long getScheduledTime() {
+            return scheduledTime;
         }
     }
 


### PR DESCRIPTION
Recent SLM interval change https://github.com/elastic/elasticsearch/pull/110847 included changing two classes to records. This changed the getter methods from the form getFieldName() to fieldName(). Unfortunately, serverless expected the fieldName() form.

Until serverless can be updated, we'll add back the `getFieldName()` style getters, in addition to the `fieldName()` getters, so as not to break the build.