### PR TITLE
Minor cleanup of o.e.index.codec package

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -24,8 +24,6 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
-import java.util.Objects;
-
 /**
  * Class that encapsulates the logic of figuring out the most appropriate file format for a given field, across postings, doc values and
  * vectors.
@@ -33,7 +31,6 @@ import java.util.Objects;
 public class PerFieldFormatSupplier {
 
     private final MapperService mapperService;
-    private final BigArrays bigArrays;
     private final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
     private final KnnVectorsFormat knnVectorsFormat = new Lucene99HnswVectorsFormat();
     private final ES87BloomFilterPostingsFormat bloomFilterPostingsFormat;
@@ -43,7 +40,6 @@ public class PerFieldFormatSupplier {
 
     public PerFieldFormatSupplier(MapperService mapperService, BigArrays bigArrays) {
         this.mapperService = mapperService;
-        this.bigArrays = Objects.requireNonNull(bigArrays);
         this.bloomFilterPostingsFormat = new ES87BloomFilterPostingsFormat(bigArrays, this::internalGetPostingsFormatForField);
         this.tsdbDocValuesFormat = new ES87TSDBDocValuesFormat();
         this.es812PostingsFormat = new ES812PostingsFormat();

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ES812PostingsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ES812PostingsReader.java
@@ -874,10 +874,6 @@ final class ES812PostingsReader extends PostingsReaderBase {
         private void skipPositions() throws IOException {
             // Skip positions now:
             int toSkip = posPendingCount - freq;
-            // if (DEBUG) {
-            // System.out.println(" FPR.skipPositions: toSkip=" + toSkip);
-            // }
-
             final int leftInBlock = BLOCK_SIZE - posBufferUpto;
             if (toSkip < leftInBlock) {
                 int end = posBufferUpto + toSkip;
@@ -1010,7 +1006,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
 
         final boolean indexHasFreqs;
 
-        private int docFreq; // number of docs in this posting list
+        private final int docFreq; // number of docs in this posting list
         private int blockUpto; // number of documents in or before the current block
         private int doc; // doc we last read
         private long accum; // accumulator for doc deltas
@@ -1211,8 +1207,8 @@ final class ES812PostingsReader extends PostingsReaderBase {
         final boolean indexHasOffsets;
         final boolean indexHasPayloads;
 
-        private int docFreq; // number of docs in this posting list
-        private long totalTermFreq; // number of positions in this posting list
+        private final int docFreq; // number of docs in this posting list
+        private final long totalTermFreq; // number of positions in this posting list
         private int docUpto; // how many docs we've read
         private int doc; // doc we last read
         private long accum; // accumulator for doc deltas
@@ -1228,19 +1224,19 @@ final class ES812PostingsReader extends PostingsReaderBase {
         private long posPendingFP;
 
         // Where this term's postings start in the .doc file:
-        private long docTermStartFP;
+        private final long docTermStartFP;
 
         // Where this term's postings start in the .pos file:
-        private long posTermStartFP;
+        private final long posTermStartFP;
 
         // Where this term's payloads/offsets start in the .pay
         // file:
-        private long payTermStartFP;
+        private final long payTermStartFP;
 
         // File pointer where the last (vInt encoded) pos delta
         // block is. We need this to know whether to bulk
         // decode vs vInt decode the block:
-        private long lastPosBlockFP;
+        private final long lastPosBlockFP;
 
         private int nextSkipDoc = -1;
 
@@ -1507,8 +1503,8 @@ final class ES812PostingsReader extends PostingsReaderBase {
         final boolean indexHasOffsets;
         final boolean indexHasPayloads;
 
-        private int docFreq; // number of docs in this posting list
-        private long totalTermFreq; // number of positions in this posting list
+        private final int docFreq; // number of docs in this posting list
+        private final long totalTermFreq; // number of positions in this posting list
         private int docUpto; // how many docs we've read
         private int posDocUpTo; // for how many docs we've read positions, offsets, and payloads
         private int doc; // doc we last read
@@ -1528,19 +1524,19 @@ final class ES812PostingsReader extends PostingsReaderBase {
         private long payPendingFP;
 
         // Where this term's postings start in the .doc file:
-        private long docTermStartFP;
+        private final long docTermStartFP;
 
         // Where this term's postings start in the .pos file:
-        private long posTermStartFP;
+        private final long posTermStartFP;
 
         // Where this term's payloads/offsets start in the .pay
         // file:
-        private long payTermStartFP;
+        private final long payTermStartFP;
 
         // File pointer where the last (vInt encoded) pos delta
         // block is. We need this to know whether to bulk
         // decode vs vInt decode the block:
-        private long lastPosBlockFP;
+        private final long lastPosBlockFP;
 
         private int nextSkipDoc = -1;
 
@@ -1835,10 +1831,6 @@ final class ES812PostingsReader extends PostingsReaderBase {
         private void skipPositions() throws IOException {
             // Skip positions now:
             int toSkip = posPendingCount - (int) freqBuffer[docBufferUpto - 1];
-            // if (DEBUG) {
-            // System.out.println(" FPR.skipPositions: toSkip=" + toSkip);
-            // }
-
             final int leftInBlock = BLOCK_SIZE - posBufferUpto;
             if (toSkip < leftInBlock) {
                 int end = posBufferUpto + toSkip;

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ES812SkipReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ES812SkipReader.java
@@ -54,8 +54,8 @@ import java.util.Arrays;
  * <p>Therefore, we'll trim df before passing it to the interface. see trim(int)
  */
 class ES812SkipReader extends MultiLevelSkipListReader {
-    private long[] docPointer;
-    private long[] posPointer;
+    private final long[] docPointer;
+    private final long[] posPointer;
     private long[] payPointer;
     private int[] posBufferUpto;
     private int[] payloadByteUpto;

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ES812SkipWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ES812SkipWriter.java
@@ -51,8 +51,8 @@ import java.util.Collection;
  * uptos(position, payload). 4. start offset.
  */
 final class ES812SkipWriter extends MultiLevelSkipListWriter {
-    private int[] lastSkipDoc;
-    private long[] lastSkipDocPointer;
+    private final int[] lastSkipDoc;
+    private final long[] lastSkipDocPointer;
     private long[] lastSkipPosPointer;
     private long[] lastSkipPayPointer;
 
@@ -66,7 +66,7 @@ final class ES812SkipWriter extends MultiLevelSkipListWriter {
     private long curPayPointer;
     private int curPosBufferUpto;
     private int curPayloadByteUpto;
-    private CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
+    private final CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
     private boolean fieldHasPositions;
     private boolean fieldHasOffsets;
     private boolean fieldHasPayloads;
@@ -197,7 +197,7 @@ final class ES812SkipWriter extends MultiLevelSkipListWriter {
         }
 
         CompetitiveImpactAccumulator competitiveFreqNorms = curCompetitiveFreqNorms[level];
-        assert competitiveFreqNorms.getCompetitiveFreqNormPairs().size() > 0;
+        assert competitiveFreqNorms.getCompetitiveFreqNormPairs().isEmpty() == false;
         if (level + 1 < numberOfSkipLevels) {
             curCompetitiveFreqNorms[level + 1].addAll(competitiveFreqNorms);
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
@@ -342,14 +342,10 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         @Override
         public int lookupTerm(BytesRef key) throws IOException {
             TermsEnum.SeekStatus status = termsEnum.seekCeil(key);
-            switch (status) {
-                case FOUND:
-                    return Math.toIntExact(termsEnum.ord());
-                case NOT_FOUND:
-                case END:
-                default:
-                    return Math.toIntExact(-1L - termsEnum.ord());
-            }
+            return switch (status) {
+                case FOUND -> Math.toIntExact(termsEnum.ord());
+                default -> Math.toIntExact(-1L - termsEnum.ord());
+            };
         }
 
         @Override
@@ -384,14 +380,10 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         @Override
         public long lookupTerm(BytesRef key) throws IOException {
             TermsEnum.SeekStatus status = termsEnum.seekCeil(key);
-            switch (status) {
-                case FOUND:
-                    return termsEnum.ord();
-                case NOT_FOUND:
-                case END:
-                default:
-                    return -1L - termsEnum.ord();
-            }
+            return switch (status) {
+                case FOUND -> termsEnum.ord();
+                default -> -1L - termsEnum.ord();
+            };
         }
 
         @Override
@@ -400,7 +392,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         }
     }
 
-    private class TermsDict extends BaseTermsEnum {
+    private static class TermsDict extends BaseTermsEnum {
         static final int LZ4_DECOMPRESSOR_PADDING = 7;
 
         final TermsDictEntry entry;


### PR DESCRIPTION
Minor cleanup of code in the org.elasticsearch.index.codec package:
* Removing unnecessary field
* making inner class static
* use enhanced switch statement
* removed commented out code.
* made immutable fields final