### PR TITLE
Add support for spatial relationships in point field mapper

### DIFF
--- a/docs/changelog/112126.yaml
+++ b/docs/changelog/112126.yaml
@@ -1,0 +1,5 @@
+pr: 112126
+summary: Add support for spatial relationships in point field mapper
+area: Geo
+type: enhancement
+issues: []

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverPointTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverPointTests.java
@@ -6,141 +6,23 @@
  */
 package org.elasticsearch.xpack.spatial.search;
 
-import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.geo.ShapeRelation;
-import org.elasticsearch.geometry.GeometryCollection;
-import org.elasticsearch.geometry.Line;
-import org.elasticsearch.geometry.LinearRing;
-import org.elasticsearch.geometry.MultiLine;
-import org.elasticsearch.geometry.MultiPoint;
-import org.elasticsearch.geometry.Point;
-import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xpack.spatial.index.query.ShapeQueryBuilder;
-import org.hamcrest.CoreMatchers;
-
-import java.util.List;
 
 public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
     @Override
     protected XContentBuilder createDefaultMapping() throws Exception {
-        XContentBuilder xcb = XContentFactory.jsonBuilder()
+        final boolean isIndexed = randomBoolean();
+        final boolean hasDocValues = isIndexed == false || randomBoolean();
+        return XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(defaultFieldName)
             .field("type", "point")
+            .field("index", isIndexed)
+            .field("doc_values", hasDocValues)
             .endObject()
             .endObject()
             .endObject();
-
-        return xcb;
     }
-
-    public void testProcessRelationSupport() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
-        ensureGreen();
-
-        Rectangle rectangle = new Rectangle(-35, -25, -25, -35);
-
-        for (ShapeRelation shapeRelation : ShapeRelation.values()) {
-            if (shapeRelation.equals(ShapeRelation.INTERSECTS) == false) {
-                SearchPhaseExecutionException e = expectThrows(
-                    SearchPhaseExecutionException.class,
-                    () -> client().prepareSearch("test")
-                        .setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle).relation(shapeRelation))
-                        .get()
-                );
-                assertThat(
-                    e.getCause().getMessage(),
-                    CoreMatchers.containsString(shapeRelation + " query relation not supported for Field [" + defaultFieldName + "]")
-                );
-            }
-        }
-    }
-
-    public void testQueryLine() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
-        ensureGreen();
-
-        Line line = new Line(new double[] { -25, -25 }, new double[] { -35, -35 });
-
-        try {
-            client().prepareSearch("test").setQuery(new ShapeQueryBuilder(defaultFieldName, line)).get();
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.getCause().getMessage(), CoreMatchers.containsString("does not support " + ShapeType.LINESTRING + " queries"));
-        }
-    }
-
-    public void testQueryLinearRing() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
-        ensureGreen();
-
-        LinearRing linearRing = new LinearRing(new double[] { -25, -35, -25 }, new double[] { -25, -35, -25 });
-
-        IllegalArgumentException ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> new ShapeQueryBuilder(defaultFieldName, linearRing)
-        );
-        assertThat(ex.getMessage(), CoreMatchers.containsString("[LINEARRING] geometries are not supported"));
-
-        ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> new ShapeQueryBuilder(defaultFieldName, new GeometryCollection<>(List.of(linearRing)))
-        );
-        assertThat(ex.getMessage(), CoreMatchers.containsString("[LINEARRING] geometries are not supported"));
-    }
-
-    public void testQueryMultiLine() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
-        ensureGreen();
-
-        Line lsb1 = new Line(new double[] { -35, -25 }, new double[] { -35, -25 });
-        Line lsb2 = new Line(new double[] { -15, -5 }, new double[] { -15, -5 });
-
-        MultiLine multiline = new MultiLine(List.of(lsb1, lsb2));
-        try {
-            client().prepareSearch("test").setQuery(new ShapeQueryBuilder(defaultFieldName, multiline)).get();
-        } catch (Exception e) {
-            assertThat(
-                e.getCause().getMessage(),
-                CoreMatchers.containsString("does not support " + ShapeType.MULTILINESTRING + " queries")
-            );
-        }
-    }
-
-    public void testQueryMultiPoint() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
-        ensureGreen();
-
-        MultiPoint multiPoint = new MultiPoint(List.of(new Point(-35, -25), new Point(-15, -5)));
-
-        try {
-            client().prepareSearch("test").setQuery(new ShapeQueryBuilder(defaultFieldName, multiPoint)).get();
-        } catch (Exception e) {
-            assertThat(e.getCause().getMessage(), CoreMatchers.containsString("does not support " + ShapeType.MULTIPOINT + " queries"));
-        }
-    }
-
-    public void testQueryPoint() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
-        ensureGreen();
-
-        Point point = new Point(-35, -2);
-
-        try {
-            client().prepareSearch("test").setQuery(new ShapeQueryBuilder(defaultFieldName, point)).get();
-        } catch (Exception e) {
-            assertThat(e.getCause().getMessage(), CoreMatchers.containsString("does not support " + ShapeType.POINT + " queries"));
-        }
-    }
-
 }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
@@ -78,7 +78,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
         prepareIndex(defaultIndexName).setId("4")
             .setSource(
                 jsonBuilder().startObject()
-                    .field("name", "Document 3")
+                    .field("name", "Document 4")
                     .field(defaultFieldName, new String[] { "POINT(-30 -30)", "POINT(50 50)" })
                     .endObject()
             )
@@ -87,7 +87,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
         prepareIndex(defaultIndexName).setId("5")
             .setSource(
                 jsonBuilder().startObject()
-                    .field("name", "Document 3")
+                    .field("name", "Document 5")
                     .field(defaultFieldName, new String[] { "POINT(60 60)", "POINT(50 50)" })
                     .endObject()
             )
@@ -100,12 +100,12 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
     static String defaultFieldName = "xy";
     static String defaultIndexName = "test-points";
 
-    public void testNullShape() throws Exception {
+    public void testNullShape() {
         GetResponse result = client().prepareGet(defaultIndexName, "aNullshape").get();
         assertThat(result.getField(defaultFieldName), nullValue());
     };
 
-    public void testIndexPointsFilterRectangle() throws Exception {
+    public void testIndexPointsFilterRectangle() {
         Rectangle rectangle = new Rectangle(-45, 45, 45, -45);
 
         assertNoFailuresAndResponse(
@@ -184,7 +184,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
         );
     }
 
-    public void testIndexPointsRectangle() throws Exception {
+    public void testIndexPointsRectangle() {
         Rectangle rectangle = new Rectangle(-50, -40, -45, -55);
 
         assertNoFailuresAndResponse(
@@ -250,7 +250,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     }
 
-    public void testDistanceQuery() throws Exception {
+    public void testDistanceQuery() {
         Circle circle = new Circle(-25, -25, 10);
 
         assertHitCount(

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
@@ -7,16 +7,18 @@
 package org.elasticsearch.xpack.spatial.search;
 
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.Circle;
+import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.Line;
 import org.elasticsearch.geometry.LinearRing;
+import org.elasticsearch.geometry.MultiLine;
+import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -26,6 +28,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryBuilder;
+import org.hamcrest.CoreMatchers;
 
 import java.util.Collection;
 import java.util.List;
@@ -35,6 +38,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -46,106 +50,103 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
         return pluginList(LocalStateSpatialPlugin.class, LocalStateCompositeXPackPlugin.class);
     }
 
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        String mapping = Strings.toString(createDefaultMapping());
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        ensureGreen();
+
+        prepareIndex(defaultIndexName).setId("aNullshape")
+            .setSource("{\"" + defaultFieldName + "\": null}", XContentType.JSON)
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+        prepareIndex(defaultIndexName).setId("1")
+            .setSource(jsonBuilder().startObject().field("name", "Document 1").field(defaultFieldName, "POINT(-30 -30)").endObject())
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        prepareIndex(defaultIndexName).setId("2")
+            .setSource(jsonBuilder().startObject().field("name", "Document 2").field(defaultFieldName, "POINT(-45 -50)").endObject())
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+        prepareIndex(defaultIndexName).setId("3")
+            .setSource(jsonBuilder().startObject().field("name", "Document 3").field(defaultFieldName, "POINT(50 50)").endObject())
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+        prepareIndex(defaultIndexName).setId("4")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("name", "Document 3")
+                    .field(defaultFieldName, new String[] { "POINT(-30 -30)", "POINT(50 50)" })
+                    .endObject()
+            )
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+        prepareIndex(defaultIndexName).setId("5")
+            .setSource(
+                jsonBuilder().startObject()
+                    .field("name", "Document 3")
+                    .field(defaultFieldName, new String[] { "POINT(60 60)", "POINT(50 50)" })
+                    .endObject()
+            )
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+    }
+
     protected abstract XContentBuilder createDefaultMapping() throws Exception;
 
     static String defaultFieldName = "xy";
     static String defaultIndexName = "test-points";
 
     public void testNullShape() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("aNullshape")
-            .setSource("{\"geo\": null}", XContentType.JSON)
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
         GetResponse result = client().prepareGet(defaultIndexName, "aNullshape").get();
-        assertThat(result.getField("location"), nullValue());
+        assertThat(result.getField(defaultFieldName), nullValue());
     };
 
     public void testIndexPointsFilterRectangle() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("1")
-            .setSource(jsonBuilder().startObject().field("name", "Document 1").field(defaultFieldName, "POINT(-30 -30)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("2")
-            .setSource(jsonBuilder().startObject().field("name", "Document 2").field(defaultFieldName, "POINT(-45 -50)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
         Rectangle rectangle = new Rectangle(-45, 45, 45, -45);
 
         assertNoFailuresAndResponse(
             client().prepareSearch(defaultIndexName)
                 .setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS)),
             response -> {
-                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-                assertThat(response.getHits().getHits().length, equalTo(1));
-                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                assertThat(response.getHits().getAt(0).getId(), anyOf(equalTo("1"), equalTo("4")));
+                assertThat(response.getHits().getAt(1).getId(), anyOf(equalTo("1"), equalTo("4")));
             }
         );
 
         // default query, without specifying relation (expect intersects)
-
         assertNoFailuresAndResponse(
             client().prepareSearch(defaultIndexName).setQuery(new ShapeQueryBuilder(defaultFieldName, rectangle)),
             response -> {
-                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-                assertThat(response.getHits().getHits().length, equalTo(1));
-                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                assertThat(response.getHits().getAt(0).getId(), anyOf(equalTo("1"), equalTo("4")));
+                assertThat(response.getHits().getAt(1).getId(), anyOf(equalTo("1"), equalTo("4")));
             }
         );
     }
 
-    public void testIndexPointsCircle() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("1")
-            .setSource(jsonBuilder().startObject().field("name", "Document 1").field(defaultFieldName, "POINT(-30 -30)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("2")
-            .setSource(jsonBuilder().startObject().field("name", "Document 2").field(defaultFieldName, "POINT(-45 -50)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
+    public void testIndexPointsCircle() {
         Circle circle = new Circle(-30, -30, 1);
 
         assertNoFailuresAndResponse(
             client().prepareSearch(defaultIndexName)
                 .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.INTERSECTS)),
             response -> {
-                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-                assertThat(response.getHits().getHits().length, equalTo(1));
-                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                assertThat(response.getHits().getAt(0).getId(), anyOf(equalTo("1"), equalTo("4")));
+                assertThat(response.getHits().getAt(1).getId(), anyOf(equalTo("1"), equalTo("4")));
             }
         );
     }
 
-    public void testIndexPointsPolygon() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("1")
-            .setSource(jsonBuilder().startObject().field(defaultFieldName, "POINT(-30 -30)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("2")
-            .setSource(jsonBuilder().startObject().field(defaultFieldName, "POINT(-45 -50)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
+    public void testIndexPointsPolygon() {
         Polygon polygon = new Polygon(new LinearRing(new double[] { -35, -35, -25, -25, -35 }, new double[] { -35, -25, -25, -35, -35 }));
 
         assertNoFailuresAndResponse(
@@ -153,32 +154,14 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
                 .setQuery(new ShapeQueryBuilder(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)),
             response -> {
                 SearchHits searchHits = response.getHits();
-                assertThat(searchHits.getTotalHits().value, equalTo(1L));
-                assertThat(searchHits.getAt(0).getId(), equalTo("1"));
+                assertThat(searchHits.getTotalHits().value, equalTo(2L));
+                assertThat(searchHits.getAt(0).getId(), anyOf(equalTo("1"), equalTo("4")));
+                assertThat(searchHits.getAt(1).getId(), anyOf(equalTo("1"), equalTo("4")));
             }
         );
     }
 
-    public void testIndexPointsMultiPolygon() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("1")
-            .setSource(jsonBuilder().startObject().field("name", "Document 1").field(defaultFieldName, "POINT(-30 -30)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("2")
-            .setSource(jsonBuilder().startObject().field("name", "Document 2").field(defaultFieldName, "POINT(-40 -40)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("3")
-            .setSource(jsonBuilder().startObject().field("name", "Document 3").field(defaultFieldName, "POINT(-50 -50)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
+    public void testIndexPointsMultiPolygon() {
         Polygon encloseDocument1Shape = new Polygon(
             new LinearRing(new double[] { -35, -35, -25, -25, -35 }, new double[] { -35, -25, -25, -35, -35 })
         );
@@ -192,29 +175,16 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             client().prepareSearch(defaultIndexName)
                 .setQuery(new ShapeQueryBuilder(defaultFieldName, mp).relation(ShapeRelation.INTERSECTS)),
             response -> {
-                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
-                assertThat(response.getHits().getHits().length, equalTo(2));
-                assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
-                assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                assertThat(response.getHits().getHits().length, equalTo(3));
+                assertThat(response.getHits().getAt(0).getId(), not(equalTo("3")));
+                assertThat(response.getHits().getAt(1).getId(), not(equalTo("3")));
+                assertThat(response.getHits().getAt(2).getId(), not(equalTo("3")));
             }
         );
     }
 
     public void testIndexPointsRectangle() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("1")
-            .setSource(jsonBuilder().startObject().field("name", "Document 1").field(defaultFieldName, "POINT(-30 -30)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("2")
-            .setSource(jsonBuilder().startObject().field("name", "Document 2").field(defaultFieldName, "POINT(-45 -50)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
         Rectangle rectangle = new Rectangle(-50, -40, -45, -55);
 
         assertNoFailuresAndResponse(
@@ -229,20 +199,6 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
     }
 
     public void testIndexPointsIndexedRectangle() throws Exception {
-        String mapping = Strings.toString(createDefaultMapping());
-        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
-        ensureGreen();
-
-        prepareIndex(defaultIndexName).setId("point1")
-            .setSource(jsonBuilder().startObject().field(defaultFieldName, "POINT(-30 -30)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
-        prepareIndex(defaultIndexName).setId("point2")
-            .setSource(jsonBuilder().startObject().field(defaultFieldName, "POINT(-45 -50)").endObject())
-            .setRefreshPolicy(IMMEDIATE)
-            .get();
-
         String indexedShapeIndex = "indexed_query_shapes";
         String indexedShapePath = "shape";
         String queryShapesMapping = Strings.toString(
@@ -278,7 +234,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
             response -> {
                 assertThat(response.getHits().getTotalHits().value, equalTo(1L));
                 assertThat(response.getHits().getHits().length, equalTo(1));
-                assertThat(response.getHits().getAt(0).getId(), equalTo("point2"));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
             }
         );
 
@@ -291,53 +247,122 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
                 ),
             0L
         );
+
     }
 
     public void testDistanceQuery() throws Exception {
-        indicesAdmin().prepareCreate("test_distance").setMapping("location", "type=shape").get();
-        ensureGreen();
-
-        Circle circle = new Circle(1, 0, 10);
-
-        client().index(
-            new IndexRequest("test_distance").source(
-                jsonBuilder().startObject().field("location", WellKnownText.toWKT(new Point(2, 2))).endObject()
-            ).setRefreshPolicy(IMMEDIATE)
-        ).actionGet();
-        client().index(
-            new IndexRequest("test_distance").source(
-                jsonBuilder().startObject().field("location", WellKnownText.toWKT(new Point(3, 1))).endObject()
-            ).setRefreshPolicy(IMMEDIATE)
-        ).actionGet();
-        client().index(
-            new IndexRequest("test_distance").source(
-                jsonBuilder().startObject().field("location", WellKnownText.toWKT(new Point(-20, -30))).endObject()
-            ).setRefreshPolicy(IMMEDIATE)
-        ).actionGet();
-        client().index(
-            new IndexRequest("test_distance").source(
-                jsonBuilder().startObject().field("location", WellKnownText.toWKT(new Point(20, 30))).endObject()
-            ).setRefreshPolicy(IMMEDIATE)
-        ).actionGet();
+        Circle circle = new Circle(-25, -25, 10);
 
         assertHitCount(
-            client().prepareSearch("test_distance").setQuery(new ShapeQueryBuilder("location", circle).relation(ShapeRelation.WITHIN)),
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.INTERSECTS)),
             2L
         );
 
         assertHitCount(
-            client().prepareSearch("test_distance").setQuery(new ShapeQueryBuilder("location", circle).relation(ShapeRelation.INTERSECTS)),
-            2L
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.WITHIN)),
+            1L
         );
 
         assertHitCount(
-            client().prepareSearch("test_distance").setQuery(new ShapeQueryBuilder("location", circle).relation(ShapeRelation.DISJOINT)),
-            2L
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.DISJOINT)),
+            3L
         );
 
         assertHitCount(
-            client().prepareSearch("test_distance").setQuery(new ShapeQueryBuilder("location", circle).relation(ShapeRelation.CONTAINS)),
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, circle).relation(ShapeRelation.CONTAINS)),
             0L
+        );
+    }
+
+    public void testIndexPointsQueryLinearRing() {
+        LinearRing linearRing = new LinearRing(new double[] { -50, -50 }, new double[] { 50, 50 });
+
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new ShapeQueryBuilder(defaultFieldName, linearRing)
+        );
+        assertThat(ex.getMessage(), CoreMatchers.containsString("[LINEARRING] geometries are not supported"));
+
+        ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new ShapeQueryBuilder(defaultFieldName, new GeometryCollection<>(List.of(linearRing)))
+        );
+        assertThat(ex.getMessage(), CoreMatchers.containsString("[LINEARRING] geometries are not supported"));
+    }
+
+    public void testIndexPointsQueryLine() {
+        Line line = new Line(new double[] { 100, -30 }, new double[] { -100, -30 });
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, line).relation(ShapeRelation.INTERSECTS)),
+            2L
+        );
+    }
+
+    public void testIndexPointsQueryMultiLine() {
+        MultiLine multiLine = new MultiLine(
+            List.of(
+                new Line(new double[] { 100, -30 }, new double[] { -100, -30 }),
+                new Line(new double[] { 100, -20 }, new double[] { -100, -20 })
+            )
+        );
+
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, multiLine).relation(ShapeRelation.INTERSECTS)),
+            2L
+        );
+    }
+
+    public void testIndexPointsQueryPoint() {
+        Point point = new Point(-30, -30);
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, point).relation(ShapeRelation.INTERSECTS)),
+            2L
+        );
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, point).relation(ShapeRelation.WITHIN)),
+            1L
+        );
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, point).relation(ShapeRelation.CONTAINS)),
+            2L
+        );
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, point).relation(ShapeRelation.DISJOINT)),
+            3L
+        );
+    }
+
+    public void testIndexPointsQueryMultiPoint() {
+        MultiPoint multiPoint = new MultiPoint(List.of(new Point(-30, -30), new Point(50, 50)));
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, multiPoint).relation(ShapeRelation.INTERSECTS)),
+            4L
+        );
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, multiPoint).relation(ShapeRelation.WITHIN)),
+            3L
+        );
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, multiPoint).relation(ShapeRelation.CONTAINS)),
+            1L
+        );
+        assertHitCount(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(new ShapeQueryBuilder(defaultFieldName, multiPoint).relation(ShapeRelation.DISJOINT)),
+            1L
         );
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -215,7 +215,8 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
 
         @Override
         public Query shapeQuery(Geometry shape, String fieldName, ShapeRelation relation, SearchExecutionContext context) {
-            return queryProcessor.shapeQuery(shape, fieldName, relation, context);
+            failIfNotIndexedNorDocValuesFallback(context);
+            return queryProcessor.shapeQuery(shape, fieldName, relation, isIndexed(), hasDocValues());
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverPointTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverPointTests.java
@@ -30,22 +30,11 @@ public class ShapeQueryBuilderOverPointTests extends ShapeQueryBuilderTests {
 
     @Override
     protected ShapeRelation getShapeRelation(ShapeType type) {
-        return ShapeRelation.INTERSECTS;
+        return randomFrom(ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS, ShapeRelation.DISJOINT, ShapeRelation.WITHIN);
     }
 
     @Override
     protected Geometry getGeometry() {
-        if (randomBoolean()) {
-            if (randomBoolean()) {
-                return ShapeTestUtils.randomMultiPolygon(false);
-            } else {
-                return ShapeTestUtils.randomPolygon(false);
-            }
-        } else if (randomBoolean()) {
-            // it should be a circle
-            return ShapeTestUtils.randomPolygon(false);
-        } else {
-            return ShapeTestUtils.randomRectangle();
-        }
+        return ShapeTestUtils.randomGeometry(false);
     }
 }


### PR DESCRIPTION
Lucene only supports intersects queries over XYPoint fields. Still it is still possible to represent all the spatial relationships using just that query. It is not as efficient as doing it in lucene but still performance should be good and it provides all support.

This PR adds support for docvalues only queries to the field too.