### PR TITLE
Change subobjects yaml tests to use composable index templates.

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/91_metrics_no_subobjects.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/91_metrics_no_subobjects.yml
@@ -6,20 +6,21 @@
       reason: added in 8.3.0
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            dynamic_templates:
-              - no_subobjects:
-                  match: metrics
-                  mapping:
-                    type: object
-                    subobjects: false
-                    properties:
-                      host.name:
-                        type: keyword
+          template:
+            mappings:
+              dynamic_templates:
+                - no_subobjects:
+                    match: metrics
+                    mapping:
+                      type: object
+                      subobjects: false
+                      properties:
+                        host.name:
+                          type: keyword
 
   - do:
       allowed_warnings_regex:
@@ -70,15 +71,16 @@
       reason: added in 8.3.0
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            subobjects: false
-            properties:
-              host.name:
-                type: keyword
+          template:
+            mappings:
+              subobjects: false
+              properties:
+                host.name:
+                  type: keyword
 
   - do:
       allowed_warnings_regex:
@@ -129,22 +131,23 @@
       reason: added in 8.4.0
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            _source:
-              mode: synthetic
-            dynamic_templates:
-              - no_subobjects:
-                  match: metrics
-                  mapping:
-                    type: object
-                    subobjects: false
-                    properties:
-                      host.name:
-                        type: keyword
+          template:
+            mappings:
+              _source:
+                mode: synthetic
+              dynamic_templates:
+                - no_subobjects:
+                    match: metrics
+                    mapping:
+                      type: object
+                      subobjects: false
+                      properties:
+                        host.name:
+                          type: keyword
 
   - do:
       allowed_warnings_regex:
@@ -196,17 +199,18 @@
       reason: added in 8.4.0
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            _source:
-              mode: synthetic
-            subobjects: false
-            properties:
-              host.name:
-                type: keyword
+          template:
+            mappings:
+              _source:
+                mode: synthetic
+              subobjects: false
+              properties:
+                host.name:
+                  type: keyword
 
   - do:
       allowed_warnings_regex:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/92_metrics_auto_subobjects.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/92_metrics_auto_subobjects.yml
@@ -6,20 +6,21 @@
       reason: requires supporting subobjects auto setting
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            dynamic_templates:
-              - no_subobjects:
-                  match: metrics
-                  mapping:
-                    type: object
-                    subobjects: auto
-                    properties:
-                      host.name:
-                        type: keyword
+          template:
+            mappings:
+              dynamic_templates:
+                - no_subobjects:
+                    match: metrics
+                    mapping:
+                      type: object
+                      subobjects: auto
+                      properties:
+                        host.name:
+                          type: keyword
 
   - do:
       allowed_warnings_regex:
@@ -70,15 +71,16 @@
       reason: requires supporting subobjects auto setting
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            subobjects: auto
-            properties:
-              host.name:
-                type: keyword
+          template:
+            mappings:
+              subobjects: auto
+              properties:
+                host.name:
+                  type: keyword
 
   - do:
       allowed_warnings_regex:
@@ -129,22 +131,23 @@
       reason: added in 8.4.0
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            _source:
-              mode: synthetic
-            dynamic_templates:
-              - no_subobjects:
-                  match: metrics
-                  mapping:
-                    type: object
-                    subobjects: auto
-                    properties:
-                      host.name:
-                        type: keyword
+          template:
+            mappings:
+              _source:
+                mode: synthetic
+              dynamic_templates:
+                - no_subobjects:
+                    match: metrics
+                    mapping:
+                      type: object
+                      subobjects: auto
+                      properties:
+                        host.name:
+                          type: keyword
 
   - do:
       allowed_warnings_regex:
@@ -196,17 +199,18 @@
       reason: added in 8.4.0
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: test
         body:
           index_patterns: test-*
-          mappings:
-            _source:
-              mode: synthetic
-            subobjects: auto
-            properties:
-              host.name:
-                type: keyword
+          template:
+            mappings:
+              _source:
+                mode: synthetic
+              subobjects: auto
+              properties:
+                host.name:
+                  type: keyword
 
   - do:
       allowed_warnings_regex:


### PR DESCRIPTION
Currently the legacy templates are being used which are deprecated.