### PR TITLE
[ML]Fix the bug where the run() function of ExecutableInferenceRequest throws an exception when get inferenceEntityId.

### DIFF
--- a/docs/changelog/112135.yaml
+++ b/docs/changelog/112135.yaml
@@ -1,0 +1,4 @@
+pr: 112135 
+summary: Fix the bug where the run() function of ExecutableInferenceRequest throws an exception when get inferenceEntityId.
+area: Inference 
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableInferenceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableInferenceRequest.java
@@ -29,7 +29,7 @@ record ExecutableInferenceRequest(
 
     @Override
     public void run() {
-        var inferenceEntityId = request.createHttpRequest().inferenceEntityId();
+        var inferenceEntityId = request.getInferenceEntityId();
 
         try {
             requestSender.send(logger, request, hasFinished, responseHandler, listener);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/amazonbedrock/AmazonBedrockRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/amazonbedrock/AmazonBedrockRequest.java
@@ -37,12 +37,10 @@ public abstract class AmazonBedrockRequest implements Request {
 
     /**
      * Amazon Bedrock uses the AWS SDK, and will not create its own Http Request
-     * But, this is needed for the ExecutableInferenceRequest to get the inferenceEntityId
-     * @return NoOp request
      */
     @Override
     public final HttpRequest createHttpRequest() {
-        return new HttpRequest(new NoOpHttpRequest(), inferenceId);
+        throw new UnsupportedOperationException("Amazon Bedrock does not use Http Requests");
     }
 
     /**


### PR DESCRIPTION
when testing the inference api, we discovered that if `var inferenceEntityId = request.createHttpRequest().inferenceEntityId();` throws an exception, this exception won't be caught, so the listener.onFailure() function won't be called until timeout. This is because createHttpRequest() may validate some input parameters and throw an exception. I think we can get  the inferenceEntityId by request.getInferenceEntityId(). If there are other considerations here, please let me know.