### PR TITLE
Fix NPE when executing doc value queries over shape geometries with empty segments

### DIFF
--- a/docs/changelog/112139.yaml
+++ b/docs/changelog/112139.yaml
@@ -1,0 +1,6 @@
+pr: 112139
+summary: Fix NPE when executing doc value queries over shape geometries with empty
+  segments
+area: Geo
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/ShapeDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/ShapeDocValuesQuery.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -109,11 +110,7 @@ abstract class ShapeDocValuesQuery<GEOMETRY> extends Query {
 
             @Override
             public Scorer scorer(LeafReaderContext context) throws IOException {
-                final ScorerSupplier scorerSupplier = scorerSupplier(context);
-                if (scorerSupplier == null) {
-                    return null;
-                }
-                return scorerSupplier.get(Long.MAX_VALUE);
+                return scorerSupplier(context).get(Long.MAX_VALUE);
             }
 
             @Override
@@ -127,7 +124,7 @@ abstract class ShapeDocValuesQuery<GEOMETRY> extends Query {
                         // binary doc values allocate an array upfront, lets only allocate it if we are going to use it
                         final BinaryDocValues values = context.reader().getBinaryDocValues(field);
                         if (values == null) {
-                            return null;
+                            return new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty());
                         }
                         final GeometryDocValueReader reader = new GeometryDocValueReader();
                         final Component2DVisitor visitor = Component2DVisitor.getVisitor(component2D, relation, encoder);
@@ -171,11 +168,7 @@ abstract class ShapeDocValuesQuery<GEOMETRY> extends Query {
 
             @Override
             public Scorer scorer(LeafReaderContext context) throws IOException {
-                final ScorerSupplier scorerSupplier = scorerSupplier(context);
-                if (scorerSupplier == null) {
-                    return null;
-                }
-                return scorerSupplier.get(Long.MAX_VALUE);
+                return scorerSupplier(context).get(Long.MAX_VALUE);
             }
 
             @Override
@@ -189,7 +182,7 @@ abstract class ShapeDocValuesQuery<GEOMETRY> extends Query {
                         // binary doc values allocate an array upfront, lets only allocate it if we are going to use it
                         final BinaryDocValues values = context.reader().getBinaryDocValues(field);
                         if (values == null) {
-                            return null;
+                            return new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty());
                         }
                         final Component2DVisitor[] visitors = new Component2DVisitor[components2D.size()];
                         for (int i = 0; i < components2D.size(); i++) {

--- a/server/src/main/java/org/elasticsearch/lucene/spatial/ShapeDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/spatial/ShapeDocValuesQuery.java
@@ -124,7 +124,7 @@ abstract class ShapeDocValuesQuery<GEOMETRY> extends Query {
                         // binary doc values allocate an array upfront, lets only allocate it if we are going to use it
                         final BinaryDocValues values = context.reader().getBinaryDocValues(field);
                         if (values == null) {
-                            return new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty());
+                            return new ConstantScoreScorer(weight, 0f, scoreMode, DocIdSetIterator.empty());
                         }
                         final GeometryDocValueReader reader = new GeometryDocValueReader();
                         final Component2DVisitor visitor = Component2DVisitor.getVisitor(component2D, relation, encoder);
@@ -182,7 +182,7 @@ abstract class ShapeDocValuesQuery<GEOMETRY> extends Query {
                         // binary doc values allocate an array upfront, lets only allocate it if we are going to use it
                         final BinaryDocValues values = context.reader().getBinaryDocValues(field);
                         if (values == null) {
-                            return new ConstantScoreScorer(weight, score(), scoreMode, DocIdSetIterator.empty());
+                            return new ConstantScoreScorer(weight, 0f, scoreMode, DocIdSetIterator.empty());
                         }
                         final Component2DVisitor[] visitors = new Component2DVisitor[components2D.size()];
                         for (int i = 0; i < components2D.size(); i++) {

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
@@ -19,6 +19,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.NoMergeScheduler;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -30,6 +31,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geo.XShapeTestUtil;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.index.mapper.ShapeIndexer;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -52,6 +54,40 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
         XYRectangle rectangle = XShapeTestUtil.nextBox();
         Query q4 = new CartesianShapeDocValuesQuery(FIELD_NAME, ShapeField.QueryRelation.INTERSECTS, rectangle);
         QueryUtils.checkUnequal(q1, q4);
+    }
+
+    public void testEmptySegment() throws Exception {
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        // No merges
+        iwc.setMergeScheduler(NoMergeScheduler.INSTANCE);
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, iwc);
+        ShapeIndexer indexer = new CartesianShapeIndexer(FIELD_NAME);
+        Geometry geometry = new org.elasticsearch.geometry.Point(0, 0);
+        Document document = new Document();
+        List<IndexableField> fields = indexer.indexShape(geometry);
+        for (IndexableField field : fields) {
+            document.add(field);
+        }
+        BinaryShapeDocValuesField docVal = new BinaryShapeDocValuesField(FIELD_NAME, CoordinateEncoder.CARTESIAN);
+        docVal.add(fields, geometry);
+        document.add(docVal);
+        w.addDocument(document);
+        w.flush();
+        // add empty segment
+        w.addDocument(new Document());
+        w.flush();
+        final IndexReader r = DirectoryReader.open(w);
+        w.close();
+
+        IndexSearcher s = newSearcher(r);
+        XYRectangle rectangle = new XYRectangle(-10, 10, -10, 10);
+        for (ShapeField.QueryRelation relation : ShapeField.QueryRelation.values()) {
+            Query indexQuery = XYShape.newGeometryQuery(FIELD_NAME, relation, rectangle);
+            Query docValQuery = new CartesianShapeDocValuesQuery(FIELD_NAME, relation, rectangle);
+            assertQueries(s, indexQuery, docValQuery, 1);
+        }
+        IOUtils.close(r, dir);
     }
 
     public void testIndexSimpleShapes() throws Exception {


### PR DESCRIPTION
Actually the contract of ScorerSupplier#get does not allow to return a null Scorer. This causes a NPE if there is a segment with documents but no values for the field. This commit fix it by returning an empty Scorer.