### PR TITLE
SQL: make date format functions more strict

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/datetime.csv-spec
@@ -1922,3 +1922,21 @@ SELECT hire_date FROM test_emp WHERE '2005-12-14T00:00:00.000Z'::datetime BETWEE
 ------------------------
 
 ;
+
+// checking regressions after https://github.com/elastic/elasticsearch/pull/110222
+selectDateFunctionsCldr
+schema::month:s|day_of_week:s|day:s|week:s|ad:s|day_of_week2:s|month2:s|ad2:s
+SELECT DATE_FORMAT('2020-04-05T11:22:33.123Z'::date, '%M') AS month,
+DATE_FORMAT('2020-04-05T11:22:33.123Z'::date, '%W') AS day_of_week,
+DATE_FORMAT('2020-04-05T11:22:33.123Z'::date, '%w') AS day,
+DATE_FORMAT('2020-04-05T11:22:33.123Z'::date, '%v') AS week,
+DATETIME_FORMAT('2020-04-05T11:22:33.123Z'::date, 'G') AS ad,
+TO_CHAR('2020-04-05T11:22:33.123Z'::date, 'Day') AS day_of_week2,
+TO_CHAR('2020-04-05T11:22:33.123Z'::date, 'Month') AS month2,
+TO_CHAR('2020-04-05T11:22:33.123Z'::date, 'BC') AS ad2;
+
+    month     |    day_of_week  |  day    |  week   |  ad    |  day_of_week2  |  month2      |  ad2
+--------------+-----------------+---------+---------+--------+----------------+--------------+------------
+  April       |    Sunday       |  0      | 14      | AD     | "Sunday   "    |  "April    " |  AD
+;
+

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormatter.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormatter.java
@@ -42,7 +42,7 @@ class DateFormatter {
             new Builder().pattern("%e").javaPattern("d").build(),
             new Builder().pattern("%f")
                 .javaPattern("n")
-                .additionalMapper(s -> String.format(Locale.ROOT, "%06d", Math.round(Integer.parseInt(s) / 1000.0)))
+                .additionalMapper(s -> String.format(Locale.ENGLISH, "%06d", Math.round(Integer.parseInt(s) / 1000.0)))
                 .build(),
             new Builder().pattern("%H").javaPattern("HH").build(),
             new Builder().pattern("%h").javaPattern("hh").build(),
@@ -59,19 +59,28 @@ class DateFormatter {
             new Builder().pattern("%s").javaPattern("ss").build(),
             new Builder().pattern("%T").javaPattern("HH:mm:ss").build(),
             new Builder().pattern("%U")
-                .javaFormat(t -> String.format(Locale.ROOT, "%02d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekOfYear())))
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%02d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekOfYear())))
                 .build(),
-            new Builder().pattern("%u").javaFormat(t -> String.format(Locale.ROOT, "%02d", t.get(WeekFields.ISO.weekOfYear()))).build(),
+            new Builder().pattern("%u")
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%02d", t.get(WeekFields.of(DayOfWeek.MONDAY, 4).weekOfYear())))
+                .build(),
+
             new Builder().pattern("%V")
-                .javaFormat(t -> String.format(Locale.ROOT, "%02d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekOfWeekBasedYear())))
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%02d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekOfWeekBasedYear())))
                 .build(),
-            new Builder().pattern("%v").javaPattern("ww").build(),
+            new Builder().pattern("%v")
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%02d", t.get(WeekFields.of(DayOfWeek.MONDAY, 4).weekOfWeekBasedYear())))
+                .build(),
             new Builder().pattern("%W").javaPattern("EEEE").build(),
-            new Builder().pattern("%w").javaPattern("e").additionalMapper(s -> Integer.parseInt(s) == 7 ? String.valueOf(0) : s).build(),
-            new Builder().pattern("%X")
-                .javaFormat(t -> String.format(Locale.ROOT, "%04d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekBasedYear())))
+            new Builder().pattern("%w")
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%01d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).dayOfWeek()) - 1))
                 .build(),
-            new Builder().pattern("%x").javaPattern("Y").build(),
+            new Builder().pattern("%X")
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%04d", t.get(WeekFields.of(DayOfWeek.SUNDAY, 7).weekBasedYear())))
+                .build(),
+            new Builder().pattern("%x")
+                .javaFormat(t -> String.format(Locale.ENGLISH, "%04d", t.get(WeekFields.of(DayOfWeek.MONDAY, 7).weekBasedYear())))
+                .build(),
             new Builder().pattern("%Y").javaPattern("yyyy").build(),
             new Builder().pattern("%y").javaPattern("yy").build()
         );
@@ -162,7 +171,7 @@ class DateFormatter {
         }
 
         private Builder javaPattern(String javaPattern) {
-            this.javaFormat = temporalAccessor -> DateTimeFormatter.ofPattern(javaPattern, Locale.ROOT).format(temporalAccessor);
+            this.javaFormat = temporalAccessor -> DateTimeFormatter.ofPattern(javaPattern, Locale.ENGLISH).format(temporalAccessor);
             return this;
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFormatProcessor.java
@@ -85,7 +85,7 @@ public class DateTimeFormatProcessor extends BinaryDateTimeProcessor {
                     return null;
                 }
                 final String javaPattern = msToJavaPattern(pattern);
-                return DateTimeFormatter.ofPattern(javaPattern, Locale.ROOT)::format;
+                return DateTimeFormatter.ofPattern(javaPattern, Locale.ENGLISH)::format;
             }
         },
         DATE_FORMAT {
@@ -97,7 +97,7 @@ public class DateTimeFormatProcessor extends BinaryDateTimeProcessor {
         DATE_TIME_FORMAT {
             @Override
             protected Function<TemporalAccessor, String> formatterFor(String pattern) {
-                return DateTimeFormatter.ofPattern(pattern, Locale.ROOT)::format;
+                return DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH)::format;
             }
         },
         TO_CHAR {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NamedDateTimeProcessor.java
@@ -40,8 +40,8 @@ public class NamedDateTimeProcessor extends BaseDateTimeProcessor {
     }
 
     public static final String NAME = "ndt";
-    private static final DateTimeFormatter DAY_NAME_FORMATTER = DateTimeFormatter.ofPattern("EEEE", Locale.ROOT);
-    private static final DateTimeFormatter MONTH_NAME_FORMATTER = DateTimeFormatter.ofPattern("MMMM", Locale.ROOT);
+    private static final DateTimeFormatter DAY_NAME_FORMATTER = DateTimeFormatter.ofPattern("EEEE", Locale.ENGLISH);
+    private static final DateTimeFormatter MONTH_NAME_FORMATTER = DateTimeFormatter.ofPattern("MMMM", Locale.ENGLISH);
 
     private final NameExtractor extractor;
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ToCharFormatter.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/ToCharFormatter.java
@@ -41,7 +41,7 @@ class ToCharFormatter {
             of("HH12").formatFn("hh").numeric(),
             of("HH24").formatFn("HH").numeric(),
             of("MI").formatFn("mm").numeric(),
-            of("SS").formatFn("s", x -> String.format(Locale.ROOT, "%02d", parseInt(x))).numeric(),
+            of("SS").formatFn("s", x -> String.format(Locale.ENGLISH, "%02d", parseInt(x))).numeric(),
             of("MS").formatFn("n", nano -> firstDigitsOfNanos(nano, 3)).numericWithLeadingZeros(),
             of("US").formatFn("n", nano -> firstDigitsOfNanos(nano, 6)).numericWithLeadingZeros(),
             of("FF1").formatFn("n", nano -> firstDigitsOfNanos(nano, 1)).numericWithLeadingZeros(),
@@ -52,14 +52,14 @@ class ToCharFormatter {
             of("FF6").formatFn("n", nano -> firstDigitsOfNanos(nano, 6)).numericWithLeadingZeros(),
             of("SSSSS").formatFn("A", milliSecondOfDay -> String.valueOf(parseInt(milliSecondOfDay) / 1000)).numeric(),
             of("SSSS").formatFn("A", milliSecondOfDay -> String.valueOf(parseInt(milliSecondOfDay) / 1000)).numeric(),
-            of("AM").formatFn("a", x -> x.toUpperCase(Locale.ROOT)).text(),
-            of("am").formatFn("a", x -> x.toLowerCase(Locale.ROOT)).text(),
-            of("PM").formatFn("a", x -> x.toUpperCase(Locale.ROOT)).text(),
-            of("pm").formatFn("a", x -> x.toLowerCase(Locale.ROOT)).text(),
+            of("AM").formatFn("a", x -> x.toUpperCase(Locale.ENGLISH)).text(),
+            of("am").formatFn("a", x -> x.toLowerCase(Locale.ENGLISH)).text(),
+            of("PM").formatFn("a", x -> x.toUpperCase(Locale.ENGLISH)).text(),
+            of("pm").formatFn("a", x -> x.toLowerCase(Locale.ENGLISH)).text(),
             of("A.M.").formatFn("a", x -> x.charAt(0) + "." + x.charAt(1) + ".").text(),
-            of("a.m.").formatFn("a", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ROOT)).text(),
+            of("a.m.").formatFn("a", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ENGLISH)).text(),
             of("P.M.").formatFn("a", x -> x.charAt(0) + "." + x.charAt(1) + ".").text(),
-            of("p.m.").formatFn("a", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ROOT)).text(),
+            of("p.m.").formatFn("a", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ENGLISH)).text(),
             of("Y,YYY").formatFn("yyyy", year -> year.charAt(0) + "," + year.substring(1)).numericWithLeadingZeros(),
             of("YYYY").formatFn("yyyy").numeric(),
             of("YYY").formatFn("yyyy", year -> year.substring(1)).numeric(),
@@ -70,51 +70,53 @@ class ToCharFormatter {
             of("IY").formatFn(t -> lastNCharacter(absoluteWeekBasedYear(t), 2)).numeric(),
             of("I").formatFn(t -> lastNCharacter(absoluteWeekBasedYear(t), 1)).numeric(),
             of("BC").formatFn("G").text(),
-            of("bc").formatFn("G", x -> x.toLowerCase(Locale.ROOT)).text(),
+            of("bc").formatFn("G", x -> x.toLowerCase(Locale.ENGLISH)).text(),
             of("AD").formatFn("G").text(),
-            of("ad").formatFn("G", x -> x.toLowerCase(Locale.ROOT)).text(),
+            of("ad").formatFn("G", x -> x.toLowerCase(Locale.ENGLISH)).text(),
             of("B.C.").formatFn("G", x -> x.charAt(0) + "." + x.charAt(1) + ".").text(),
-            of("b.c.").formatFn("G", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ROOT)).text(),
+            of("b.c.").formatFn("G", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ENGLISH)).text(),
             of("A.D.").formatFn("G", x -> x.charAt(0) + "." + x.charAt(1) + ".").text(),
-            of("a.d.").formatFn("G", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ROOT)).text(),
-            of("MONTH").formatFn("MMMM", x -> String.format(Locale.ROOT, "%-9s", x.toUpperCase(Locale.ROOT))).text(),
-            of("Month").formatFn("MMMM", x -> String.format(Locale.ROOT, "%-9s", x)).text(),
-            of("month").formatFn("MMMM", x -> String.format(Locale.ROOT, "%-9s", x.toLowerCase(Locale.ROOT))).text(),
-            of("MON").formatFn("MMM", x -> x.toUpperCase(Locale.ROOT)).text(),
+            of("a.d.").formatFn("G", x -> (x.charAt(0) + "." + x.charAt(1) + ".").toLowerCase(Locale.ENGLISH)).text(),
+            of("MONTH").formatFn("MMMM", x -> String.format(Locale.ENGLISH, "%-9s", x.toUpperCase(Locale.ENGLISH))).text(),
+            of("Month").formatFn("MMMM", x -> String.format(Locale.ENGLISH, "%-9s", x)).text(),
+            of("month").formatFn("MMMM", x -> String.format(Locale.ENGLISH, "%-9s", x.toLowerCase(Locale.ENGLISH))).text(),
+            of("MON").formatFn("MMM", x -> x.toUpperCase(Locale.ENGLISH)).text(),
             of("Mon").formatFn("MMM").text(),
-            of("mon").formatFn("MMM", x -> x.toLowerCase(Locale.ROOT)).text(),
+            of("mon").formatFn("MMM", x -> x.toLowerCase(Locale.ENGLISH)).text(),
             of("MM").formatFn("MM").numeric(),
-            of("DAY").formatFn("EEEE", x -> String.format(Locale.ROOT, "%-9s", x.toUpperCase(Locale.ROOT))).text(),
-            of("Day").formatFn("EEEE", x -> String.format(Locale.ROOT, "%-9s", x)).text(),
-            of("day").formatFn("EEEE", x -> String.format(Locale.ROOT, "%-9s", x.toLowerCase(Locale.ROOT))).text(),
-            of("DY").formatFn("E", x -> x.toUpperCase(Locale.ROOT)).text(),
+            of("DAY").formatFn("EEEE", x -> String.format(Locale.ENGLISH, "%-9s", x.toUpperCase(Locale.ENGLISH))).text(),
+            of("Day").formatFn("EEEE", x -> String.format(Locale.ENGLISH, "%-9s", x)).text(),
+            of("day").formatFn("EEEE", x -> String.format(Locale.ENGLISH, "%-9s", x.toLowerCase(Locale.ENGLISH))).text(),
+            of("DY").formatFn("E", x -> x.toUpperCase(Locale.ENGLISH)).text(),
             of("Dy").formatFn("E").text(),
-            of("dy").formatFn("E", x -> x.toLowerCase(Locale.ROOT)).text(),
+            of("dy").formatFn("E", x -> x.toLowerCase(Locale.ENGLISH)).text(),
             of("DDD").formatFn("DDD").numeric(),
             of("IDDD").formatFn(
                 t -> String.format(
-                    Locale.ROOT,
+                    Locale.ENGLISH,
                     "%03d",
                     (t.get(WeekFields.ISO.weekOfWeekBasedYear()) - 1) * 7 + t.get(ChronoField.DAY_OF_WEEK)
                 )
             ).numeric(),
-            of("DD").formatFn("d", x -> String.format(Locale.ROOT, "%02d", parseInt(x))).numeric(),
+            of("DD").formatFn("d", x -> String.format(Locale.ENGLISH, "%02d", parseInt(x))).numeric(),
             of("ID").formatFn(t -> String.valueOf(t.get(ChronoField.DAY_OF_WEEK))).numeric(),
             of("D").formatFn(t -> String.valueOf(t.get(WeekFields.SUNDAY_START.dayOfWeek()))).numeric(),
             of("W").formatFn(t -> String.valueOf(t.get(ChronoField.ALIGNED_WEEK_OF_MONTH))).numeric(),
-            of("WW").formatFn(t -> String.format(Locale.ROOT, "%02d", t.get(ChronoField.ALIGNED_WEEK_OF_YEAR))).numeric(),
-            of("IW").formatFn(t -> String.format(Locale.ROOT, "%02d", t.get(WeekFields.ISO.weekOfWeekBasedYear()))).numeric(),
+            of("WW").formatFn(t -> String.format(Locale.ENGLISH, "%02d", t.get(ChronoField.ALIGNED_WEEK_OF_YEAR))).numeric(),
+            of("IW").formatFn(t -> String.format(Locale.ENGLISH, "%02d", t.get(WeekFields.ISO.weekOfWeekBasedYear()))).numeric(),
             of("CC").formatFn(t -> {
                 int century = yearToCentury(t.get(ChronoField.YEAR));
-                return String.format(Locale.ROOT, century < 0 ? "%03d" : "%02d", century);
+                return String.format(Locale.ENGLISH, century < 0 ? "%03d" : "%02d", century);
             }).numeric(),
             of("J").formatFn(t -> String.valueOf(t.getLong(JulianFields.JULIAN_DAY))).numeric(),
             of("Q").formatFn("Q").numeric(),
-            of("RM").formatFn("MM", month -> String.format(Locale.ROOT, "%-4s", monthToRoman(parseInt(month)))).text(),
-            of("rm").formatFn("MM", month -> String.format(Locale.ROOT, "%-4s", monthToRoman(parseInt(month)).toLowerCase(Locale.ROOT)))
-                .text(),
+            of("RM").formatFn("MM", month -> String.format(Locale.ENGLISH, "%-4s", monthToRoman(parseInt(month)))).text(),
+            of("rm").formatFn(
+                "MM",
+                month -> String.format(Locale.ENGLISH, "%-4s", monthToRoman(parseInt(month)).toLowerCase(Locale.ENGLISH))
+            ).text(),
             of("TZ").formatFn(ToCharFormatter::zoneAbbreviationOf).text(),
-            of("tz").formatFn(t -> zoneAbbreviationOf(t).toLowerCase(Locale.ROOT)).text(),
+            of("tz").formatFn(t -> zoneAbbreviationOf(t).toLowerCase(Locale.ENGLISH)).text(),
             of("TZH").acceptsLowercase(false).formatFn("ZZ", s -> s.substring(0, 3)).text(),
             of("TZM").acceptsLowercase(false).formatFn("ZZ", s -> lastNCharacter(s, 2)).text(),
             of("OF").acceptsLowercase(false).formatFn("ZZZZZ", ToCharFormatter::formatOffset).offset()
@@ -127,7 +129,7 @@ class ToCharFormatter {
         // also index the lower case version of the patterns if accepted
         for (ToCharFormatter formatter : formatters) {
             if (formatter.acceptsLowercase) {
-                formatterMap.putIfAbsent(formatter.pattern.toLowerCase(Locale.ROOT), formatter);
+                formatterMap.putIfAbsent(formatter.pattern.toLowerCase(Locale.ENGLISH), formatter);
             }
         }
         FORMATTER_MAP = formatterMap;
@@ -274,8 +276,8 @@ class ToCharFormatter {
             // the Y,YYY pattern might can cause problems with the parsing, but thankfully the last 3
             // characters is enough to calculate the suffix
             int i = parseInt(lastNCharacter(s, 3));
-            final boolean upperCase = defaultSuffix.equals(defaultSuffix.toUpperCase(Locale.ROOT));
-            return s + (upperCase ? ordinalSuffix(i).toUpperCase(Locale.ROOT) : ordinalSuffix(i));
+            final boolean upperCase = defaultSuffix.equals(defaultSuffix.toUpperCase(Locale.ENGLISH));
+            return s + (upperCase ? ordinalSuffix(i).toUpperCase(Locale.ENGLISH) : ordinalSuffix(i));
         } catch (NumberFormatException ex) {
             return s + defaultSuffix;
         }
@@ -312,11 +314,11 @@ class ToCharFormatter {
     private static String absoluteWeekBasedYear(TemporalAccessor t) {
         int year = t.get(IsoFields.WEEK_BASED_YEAR);
         year = year > 0 ? year : -(year - 1);
-        return String.format(Locale.ROOT, "%04d", year);
+        return String.format(Locale.ENGLISH, "%04d", year);
     }
 
     private static String firstDigitsOfNanos(String nano, int digits) {
-        return String.format(Locale.ROOT, "%09d", parseInt(nano)).substring(0, digits);
+        return String.format(Locale.ENGLISH, "%09d", parseInt(nano)).substring(0, digits);
     }
 
     private static String lastNCharacter(String s, int n) {
@@ -324,7 +326,7 @@ class ToCharFormatter {
     }
 
     private static String zoneAbbreviationOf(TemporalAccessor temporalAccessor) {
-        String zone = ZoneId.from(temporalAccessor).getDisplayName(TextStyle.SHORT, Locale.ROOT);
+        String zone = ZoneId.from(temporalAccessor).getDisplayName(TextStyle.SHORT, Locale.ENGLISH);
         return "Z".equals(zone) ? "UTC" : zone;
     }
 
@@ -344,7 +346,7 @@ class ToCharFormatter {
 
         public Builder formatFn(final String javaPattern, final Function<String, String> additionalMapper) {
             this.formatFn = temporalAccessor -> {
-                String formatted = DateTimeFormatter.ofPattern(javaPattern != null ? javaPattern : "'" + pattern + "'", Locale.ROOT)
+                String formatted = DateTimeFormatter.ofPattern(javaPattern != null ? javaPattern : "'" + pattern + "'", Locale.ENGLISH)
                     .format(temporalAccessor);
                 return additionalMapper == null ? formatted : additionalMapper.apply(formatted);
             };


### PR DESCRIPTION
Switching to `CLDR` locale provider (see https://github.com/elastic/elasticsearch/pull/110222) exposed some problems related to date conversion functions.
In particular, these functions are defined to mimic MySQL and PostgreSQL behavior, and tests that compare results with the corresponding queries in MySQL and PostgreSQL show a slightly different behavior with CLDR, eg. 
- days of week are returned as `Mon` instead of `Monday` with the ROOT locale; 
- calculation of week of the year considers slightly different defaults (eg. minimum number of days in the year for the first week).

This change makes the calculation more strict by 
- using ENGLISH locale 
- defining some conversion patterns not with the (apparently not so) equivalent Java pattern, but with the exact definitions given by the original specs (see https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_date-format)


The problem is not present with COMPAT locale provider, the intention of this change is to fix failures introduced by https://github.com/elastic/elasticsearch/pull/110222, but I'm doing this as a separate PR to make sure that the new implementation is also good with COMPAT and we are not introducing regressions (ie. that it works fine with both `COMPAT` and `CLDR`)