### PR TITLE
Use internal reader when building SecurityIndexReaderWrapper filter query

### DIFF
--- a/docs/changelog/112141.yaml
+++ b/docs/changelog/112141.yaml
@@ -1,0 +1,5 @@
+pr: 112141
+summary: Use internal reader when building `SecurityIndexReaderWrapper` filter query
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
@@ -30,7 +30,6 @@ import org.elasticsearch.xpack.core.security.user.User;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -165,7 +165,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
                 DocumentPermissions.filteredBy(singleton(new BytesArray(termQuery)))
             );
             SecurityIndexReaderWrapper wrapper = new SecurityIndexReaderWrapper(
-                s -> searchExecutionContext,
+                (r, s) -> searchExecutionContext,
                 bitsetCache,
                 securityContext,
                 licenseState,
@@ -272,7 +272,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         final MockLicenseState licenseState = mock(MockLicenseState.class);
         when(licenseState.isAllowed(DOCUMENT_LEVEL_SECURITY_FEATURE)).thenReturn(true);
         SecurityIndexReaderWrapper wrapper = new SecurityIndexReaderWrapper(
-            s -> searchExecutionContext,
+            (r, s) -> searchExecutionContext,
             bitsetCache,
             securityContext,
             licenseState,


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/112130

When using wildcards to match fields in a `multi_match` query within a DLS query in a role, the fields are not properly expanded because there is no index reader that can read the index mapping to expand the wildcards.

This happens because a [searcher](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java#L685) is needed to read the mappings to figure out what fields are available for an index.

The searcher is expected to be supplied by the Security plugin [when it calls](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java#L1492) `IndexModule::setReaderWrapper` to override the `IndexReader` factory. Currently it passes `null` for the searcher parameter, which makes expansions of wildcard fields impossible.

This PR changes that by providing the reader that wrapped by `SecurityIndexReaderWrapper` when the filter query is built to be able to resolve wildcard fields. 