### PR TITLE
Restore useAlternatingSort in `MergingDigest`

### DIFF
--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
@@ -92,7 +92,7 @@ public class MergingDigest extends AbstractTDigest {
     private final int[] order;
 
     // if true, alternate upward and downward merge passes
-    public boolean useAlternatingSort = false;
+    public boolean useAlternatingSort = true;
     // if true, use higher working value of compression during construction, then reduce on presentation
     public boolean useTwoLevelCompression = true;
 


### PR DESCRIPTION
This was accidentally left flipped in https://github.com/elastic/elasticsearch/pull/111644

Related to https://github.com/elastic/elasticsearch/issues/111065