### PR TITLE
[8.15] Semantic reranking should fail whenever inference ID does not exist (#112038)

### DIFF
--- a/docs/changelog/112038.yaml
+++ b/docs/changelog/112038.yaml
@@ -1,0 +1,6 @@
+pr: 112038
+summary: Semantic reranking should fail whenever inference ID does not exist
+area: Relevance
+type: bug
+issues:
+ - 111934

--- a/server/src/main/java/org/elasticsearch/search/rank/context/RankFeaturePhaseRankCoordinatorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/context/RankFeaturePhaseRankCoordinatorContext.java
@@ -74,16 +74,12 @@ public abstract class RankFeaturePhaseRankCoordinatorContext {
         RankFeatureDoc[] featureDocs = extractFeatureDocs(rankSearchResults);
 
         // generate the final `topResults` results, and pass them to fetch phase through the `rankListener`
-        if (featureDocs.length == 0) {
-            rankListener.onResponse(new RankFeatureDoc[0]);
-        } else {
-            computeScores(featureDocs, rankListener.delegateFailureAndWrap((listener, scores) -> {
-                for (int i = 0; i < featureDocs.length; i++) {
-                    featureDocs[i].score = scores[i];
-                }
-                listener.onResponse(featureDocs);
-            }));
-        }
+        computeScores(featureDocs, rankListener.delegateFailureAndWrap((listener, scores) -> {
+            for (int i = 0; i < featureDocs.length; i++) {
+                featureDocs[i].score = scores[i];
+            }
+            listener.onResponse(featureDocs);
+        }));
     }
 
     /**

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContextTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContextTests.java
@@ -61,4 +61,23 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContextTests extends E
         );
     }
 
+    public void testComputeScoresForEmpty() {
+        subject.computeScores(new RankFeatureDoc[0], new ActionListener<>() {
+            @Override
+            public void onResponse(float[] floats) {
+                assertArrayEquals(new float[0], floats, 0.0f);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail();
+            }
+        });
+        verify(mockClient).execute(
+            eq(GetInferenceModelAction.INSTANCE),
+            argThat(actionRequest -> ((GetInferenceModelAction.Request) actionRequest).getTaskType().equals(TaskType.RERANK)),
+            any()
+        );
+    }
+
 }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -38,8 +38,8 @@ setup:
         id: doc_1
         body:
           text: "As seen from Earth, a solar eclipse happens when the Moon is directly between the Earth and the Sun."
-          topic: ["science"]
-          subtopic: ["technology"]
+          topic: [ "science" ]
+          subtopic: [ "technology" ]
         refresh: true
 
   - do:
@@ -48,8 +48,8 @@ setup:
         id: doc_2
         body:
           text: "The phases of the Moon come from the position of the Moon relative to the Earth and Sun."
-          topic: ["science"]
-          subtopic: ["astronomy"]
+          topic: [ "science" ]
+          subtopic: [ "astronomy" ]
         refresh: true
 
   - do:
@@ -58,7 +58,7 @@ setup:
         id: doc_3
         body:
           text: "Sun Moon Lake is a lake in Nantou County, Taiwan. It is the largest lake in Taiwan."
-          topic: ["geography"]
+          topic: [ "geography" ]
         refresh: true
 ---
 "Simple text similarity rank retriever":
@@ -82,7 +82,7 @@ setup:
               field: text
           size: 10
 
-  - match: { hits.total.value : 2 }
+  - match: { hits.total.value: 2 }
   - length: { hits.hits: 2 }
 
   - match: { hits.hits.0._id: "doc_2" }
@@ -118,9 +118,62 @@ setup:
               field: text
           size: 10
 
-  - match: { hits.total.value : 1 }
+  - match: { hits.total.value: 1 }
   - length: { hits.hits: 1 }
 
   - match: { hits.hits.0._id: "doc_1" }
   - match: { hits.hits.0._rank: 1 }
   - close_to: { hits.hits.0._score: { value: 0.2, error: 0.001 } }
+
+
+---
+"Text similarity reranking fails if the inference ID does not exist":
+  - do:
+      catch: /Inference endpoint not found/
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          fields: [ "text", "topic" ]
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    term:
+                      topic: "science"
+              filter:
+                term:
+                  subtopic: "technology"
+              rank_window_size: 10
+              inference_id: i-dont-exist
+              inference_text: "How often does the moon hide the sun?"
+              field: text
+          size: 10
+
+---
+"Text similarity reranking fails if the inference ID does not exist and result set is empty":
+  - requires:
+      cluster_features: "gte_v8.15.1"
+      reason: bug fixed in 8.15.1
+
+  - do:
+      catch: /Inference endpoint not found/
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          fields: [ "text", "topic" ]
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    term:
+                      topic: "asdfasdf"
+              rank_window_size: 10
+              inference_id: i-dont-exist
+              inference_text: "asdfasdf"
+              field: text
+          size: 10
+


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Semantic reranking should fail whenever inference ID does not exist (#112038)