### PR TITLE
[ML] Adds Explain Functionality to LTR Rescoring

### DIFF
--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/LearningToRankRescorerIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/LearningToRankRescorerIT.java
@@ -17,8 +17,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -182,6 +180,7 @@ public class LearningToRankRescorerIT extends InferenceTestCase {
             "hits.hits._explanation",
             responseAsMap(response)
         );
+
         assertThat(explainValues.size(), equalTo(3));
         for (Map<String, Object> hit : explainValues) {
             assertThat(hit.get("description"), equalTo("rescored using LTR model ltr-model"));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorer.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -129,8 +130,58 @@ public class LearningToRankRescorer implements Rescorer {
     @Override
     public Explanation explain(int topLevelDocId, IndexSearcher searcher, RescoreContext rescoreContext, Explanation sourceExplanation)
         throws IOException {
-        // TODO: Call infer again but with individual feature importance values and explaining the model (which features are used, etc.)
-        return null;
+        if (sourceExplanation == null) {
+            return Explanation.noMatch("no match found");
+        }
+
+        LearningToRankRescorerContext ltrContext = (LearningToRankRescorerContext) rescoreContext;
+        LocalModel localModelDefinition = ltrContext.regressionModelDefinition;
+
+        if (localModelDefinition == null) {
+            throw new IllegalStateException("local model reference is null, missing rewriteAndFetch before rescore phase?");
+        }
+
+        List<LeafReaderContext> leaves = ltrContext.executionContext.searcher().getIndexReader().leaves();
+
+        int endDoc = 0;
+        int readerUpto = -1;
+        LeafReaderContext currentSegment = null;
+
+        while (topLevelDocId >= endDoc) {
+            readerUpto++;
+            currentSegment = leaves.get(readerUpto);
+            endDoc = currentSegment.docBase + currentSegment.reader().maxDoc();
+        }
+
+        assert currentSegment != null : "Unexpected null segment";
+
+        int targetDoc = topLevelDocId - currentSegment.docBase;
+
+        List<FeatureExtractor> featureExtractors = ltrContext.buildFeatureExtractors(searcher);
+        int featureSize = featureExtractors.stream().mapToInt(fe -> fe.featureNames().size()).sum();
+
+        Map<String, Object> features = Maps.newMapWithExpectedSize(featureSize);
+
+        for (FeatureExtractor featureExtractor : featureExtractors) {
+            featureExtractor.setNextReader(currentSegment);
+            featureExtractor.addFeatures(features, targetDoc);
+        }
+
+        // Predicting the value
+        var ltrScore = ((Number) localModelDefinition.inferLtr(features, ltrContext.learningToRankConfig).predictedValue()).floatValue();
+
+        List<Explanation> featureExplanations = new ArrayList<>();
+        for (String featureName : features.keySet()) {
+            Number featureValue = Objects.requireNonNullElse((Number) features.get(featureName), 0);
+            featureExplanations.add(Explanation.match(featureValue, "feature value for [" + featureName + "]"));
+        }
+
+        return Explanation.match(
+            ltrScore,
+            "rescored using LTR model " + ltrContext.regressionModelDefinition.getModelId(),
+            Explanation.match(sourceExplanation.getValue(), "first pass query score", sourceExplanation),
+            Explanation.match(0f, "extracted features", featureExplanations)
+        );
     }
 
     /** Returns a new {@link TopDocs} with the topN from the incoming one, or the same TopDocs if the number of hits is already &lt;=


### PR DESCRIPTION
Adds explain functionality to LTR rescoring.

The explanations will be output (using the `explain=true` flag in the query) and will be per result hit describing the query and the features used in the rescoring as well as the weights that contributed to the rescoring:
```
                "_explanation": {
                    "value": 20,
                    "description": "rescored using LTR model ltr-model",
                    "details": [
                        {
                            "value": 1,
                            "description": "first pass query score",
                            "details": [
                                {
                                    "value": 1,
                                    "description": "*:*",
                                    "details": []
                                }
                            ]
                        },
                        {
                            "value": 0,
                            "description": "extracted features",
                            "details": [
                                {
                                    "value": 1,
                                    "description": "feature value for [type_tv]",
                                    "details": []
                                },
                                {
                                    "value": 300,
                                    "description": "feature value for [cost]",
                                    "details": []
                                },
                                {
                                    "value": 2,
                                    "description": "feature value for [two]",
                                    "details": []
                                }
                            ]
                        }
                    ]
                }
```
