### PR TITLE
[8.14] [DOCS] Wrap document/field restriction tip in IMPORTANT block (#112146)

### DIFF
--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -54,8 +54,11 @@ specify any field restrictions. If you assign a user both roles, `role_a` gives
 the user access to all documents and `role_b` gives the user access to all
 fields.
 
+[IMPORTANT]
+===========
 If you need to restrict access to both documents and fields, consider splitting
 documents by index instead.
+===========
 
 include::role-templates.asciidoc[]
 include::set-security-user.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Wrap document/field restriction tip in IMPORTANT block (#112146)