### PR TITLE
ESQL: Add way for `Block` to `keepMask`

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
@@ -20,13 +20,10 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBigArrayBlock;
 import org.elasticsearch.compute.data.BooleanBigArrayVector;
-import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
-import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBigArrayBlock;
 import org.elasticsearch.compute.data.DoubleBigArrayVector;
-import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayVector;
@@ -34,39 +31,13 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBigArrayBlock;
 import org.elasticsearch.compute.data.LongBigArrayVector;
-import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OperationsPerInvocation;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.Collections;
-import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
-@Warmup(iterations = 5)
-@Measurement(iterations = 7)
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Thread)
-@Fork(1)
 public class BlockBenchmark {
-
     /**
      * All data type/block kind combinations to be loaded before the benchmark.
      * It is important to be exhaustive here so that all implementers of {@link IntBlock#getInt(int)} are actually loaded when we benchmark
@@ -114,35 +85,12 @@ public class BlockBenchmark {
     private static final int MAX_MV_ELEMENTS = 100;
     private static final int MAX_BYTES_REF_LENGTH = 255;
 
-    private static final Random random = new Random();
+    static final Random random = new Random();
 
-    private static final BlockFactory blockFactory = BlockFactory.getInstance(
-        new NoopCircuitBreaker("noop"),
-        BigArrays.NON_RECYCLING_INSTANCE
-    );
+    static final BlockFactory blockFactory = BlockFactory.getInstance(new NoopCircuitBreaker("noop"), BigArrays.NON_RECYCLING_INSTANCE);
 
-    static {
-        // Smoke test all the expected values and force loading subclasses more like prod
-        int totalPositions = 10;
-        long[] actualCheckSums = new long[NUM_BLOCKS_PER_ITERATION];
-
-        for (String paramString : RELEVANT_TYPE_BLOCK_COMBINATIONS) {
-            String[] params = paramString.split("/");
-            String dataType = params[0];
-            String blockKind = params[1];
-
-            BenchmarkBlocks data = buildBlocks(dataType, blockKind, totalPositions);
-            int[][] traversalOrders = createTraversalOrders(data.blocks, false);
-            run(dataType, data, traversalOrders, actualCheckSums);
-            assertCheckSums(data, actualCheckSums);
-        }
-    }
-
-    private record BenchmarkBlocks(Block[] blocks, long[] checkSums) {};
-
-    private static BenchmarkBlocks buildBlocks(String dataType, String blockKind, int totalPositions) {
+    static Block[] buildBlocks(String dataType, String blockKind, int totalPositions) {
         Block[] blocks = new Block[NUM_BLOCKS_PER_ITERATION];
-        long[] checkSums = new long[NUM_BLOCKS_PER_ITERATION];
 
         switch (dataType) {
             case "boolean" -> {
@@ -237,11 +185,6 @@ public class BlockBenchmark {
                         }
                     }
                 }
-
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    BooleanBlock block = (BooleanBlock) blocks[blockIndex];
-                    checkSums[blockIndex] = computeBooleanCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
-                }
             }
             case "BytesRef" -> {
                 for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
@@ -293,11 +236,6 @@ public class BlockBenchmark {
                             throw new IllegalStateException("illegal block kind [" + blockKind + "]");
                         }
                     }
-                }
-
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    BytesRefBlock block = (BytesRefBlock) blocks[blockIndex];
-                    checkSums[blockIndex] = computeBytesRefCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
                 }
             }
             case "double" -> {
@@ -386,11 +324,6 @@ public class BlockBenchmark {
                         }
                     }
                 }
-
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    DoubleBlock block = (DoubleBlock) blocks[blockIndex];
-                    checkSums[blockIndex] = computeDoubleCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
-                }
             }
             case "int" -> {
                 for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
@@ -477,11 +410,6 @@ public class BlockBenchmark {
                             throw new IllegalStateException("illegal block kind [" + blockKind + "]");
                         }
                     }
-                }
-
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    IntBlock block = (IntBlock) blocks[blockIndex];
-                    checkSums[blockIndex] = computeIntCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
                 }
             }
             case "long" -> {
@@ -570,36 +498,12 @@ public class BlockBenchmark {
                         }
                     }
                 }
-
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    LongBlock block = (LongBlock) blocks[blockIndex];
-                    checkSums[blockIndex] = computeLongCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
-                }
             }
             default -> {
                 throw new IllegalStateException("illegal data type [" + dataType + "]");
             }
         }
-
-        return new BenchmarkBlocks(blocks, checkSums);
-    }
-
-    private static int[][] createTraversalOrders(Block[] blocks, boolean randomized) {
-        int[][] orders = new int[blocks.length][];
-
-        for (int i = 0; i < blocks.length; i++) {
-            IntStream positionsStream = IntStream.range(0, blocks[i].getPositionCount());
-
-            if (randomized) {
-                List<Integer> positions = new java.util.ArrayList<>(positionsStream.boxed().toList());
-                Collections.shuffle(positions, random);
-                orders[i] = positions.stream().mapToInt(x -> x).toArray();
-            } else {
-                orders[i] = positionsStream.toArray();
-            }
-        }
-
-        return orders;
+        return blocks;
     }
 
     private static int[] randomFirstValueIndexes(int totalPositions) {
@@ -630,221 +534,5 @@ public class BlockBenchmark {
         }
 
         return nulls;
-    }
-
-    private static void run(String dataType, BenchmarkBlocks data, int[][] traversalOrders, long[] resultCheckSums) {
-        switch (dataType) {
-            case "boolean" -> {
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    BooleanBlock block = (BooleanBlock) data.blocks[blockIndex];
-
-                    resultCheckSums[blockIndex] = computeBooleanCheckSum(block, traversalOrders[blockIndex]);
-                }
-            }
-            case "BytesRef" -> {
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    BytesRefBlock block = (BytesRefBlock) data.blocks[blockIndex];
-
-                    resultCheckSums[blockIndex] = computeBytesRefCheckSum(block, traversalOrders[blockIndex]);
-                }
-            }
-            case "double" -> {
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    DoubleBlock block = (DoubleBlock) data.blocks[blockIndex];
-
-                    resultCheckSums[blockIndex] = computeDoubleCheckSum(block, traversalOrders[blockIndex]);
-                }
-            }
-            case "int" -> {
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    IntBlock block = (IntBlock) data.blocks[blockIndex];
-
-                    resultCheckSums[blockIndex] = computeIntCheckSum(block, traversalOrders[blockIndex]);
-                }
-            }
-            case "long" -> {
-                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-                    LongBlock block = (LongBlock) data.blocks[blockIndex];
-
-                    resultCheckSums[blockIndex] = computeLongCheckSum(block, traversalOrders[blockIndex]);
-                }
-            }
-            default -> {
-                throw new IllegalStateException();
-            }
-        }
-    }
-
-    private static void assertCheckSums(BenchmarkBlocks data, long[] actualCheckSums) {
-        for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
-            if (actualCheckSums[blockIndex] != data.checkSums[blockIndex]) {
-                throw new AssertionError("checksums do not match for block [" + blockIndex + "]");
-            }
-        }
-    }
-
-    private static long computeBooleanCheckSum(BooleanBlock block, int[] traversalOrder) {
-        long sum = 0;
-
-        for (int position : traversalOrder) {
-            if (block.isNull(position)) {
-                continue;
-            }
-            int start = block.getFirstValueIndex(position);
-            int end = start + block.getValueCount(position);
-            for (int i = start; i < end; i++) {
-                sum += block.getBoolean(i) ? 1 : 0;
-            }
-        }
-
-        return sum;
-    }
-
-    private static long computeBytesRefCheckSum(BytesRefBlock block, int[] traversalOrder) {
-        long sum = 0;
-        BytesRef currentValue = new BytesRef();
-
-        for (int position : traversalOrder) {
-            if (block.isNull(position)) {
-                continue;
-            }
-            int start = block.getFirstValueIndex(position);
-            int end = start + block.getValueCount(position);
-            for (int i = start; i < end; i++) {
-                block.getBytesRef(i, currentValue);
-                sum += currentValue.length > 0 ? currentValue.bytes[0] : 0;
-            }
-        }
-
-        return sum;
-    }
-
-    private static long computeDoubleCheckSum(DoubleBlock block, int[] traversalOrder) {
-        long sum = 0;
-
-        for (int position : traversalOrder) {
-            if (block.isNull(position)) {
-                continue;
-            }
-            int start = block.getFirstValueIndex(position);
-            int end = start + block.getValueCount(position);
-            for (int i = start; i < end; i++) {
-                // Use an operation that is not affected by rounding errors. Otherwise, the result may depend on the traversalOrder.
-                sum += (long) block.getDouble(i);
-            }
-        }
-
-        return sum;
-    }
-
-    private static long computeIntCheckSum(IntBlock block, int[] traversalOrder) {
-        int sum = 0;
-
-        for (int position : traversalOrder) {
-            if (block.isNull(position)) {
-                continue;
-            }
-            int start = block.getFirstValueIndex(position);
-            int end = start + block.getValueCount(position);
-            for (int i = start; i < end; i++) {
-                sum += block.getInt(i);
-            }
-        }
-
-        return sum;
-    }
-
-    private static long computeLongCheckSum(LongBlock block, int[] traversalOrder) {
-        long sum = 0;
-
-        for (int position : traversalOrder) {
-            if (block.isNull(position)) {
-                continue;
-            }
-            int start = block.getFirstValueIndex(position);
-            int end = start + block.getValueCount(position);
-            for (int i = start; i < end; i++) {
-                sum += block.getLong(i);
-            }
-        }
-
-        return sum;
-    }
-
-    private static boolean isRandom(String accessType) {
-        return accessType.equalsIgnoreCase("random");
-    }
-
-    /**
-     * Must be a subset of {@link BlockBenchmark#RELEVANT_TYPE_BLOCK_COMBINATIONS}
-     */
-    @Param(
-        {
-            "boolean/array",
-            "boolean/array-multivalue-null",
-            "boolean/big-array",
-            "boolean/big-array-multivalue-null",
-            "boolean/vector",
-            "boolean/vector-big-array",
-            "boolean/vector-const",
-            "BytesRef/array",
-            "BytesRef/array-multivalue-null",
-            "BytesRef/vector",
-            "BytesRef/vector-const",
-            "double/array",
-            "double/array-multivalue-null",
-            "double/big-array",
-            "double/big-array-multivalue-null",
-            "double/vector",
-            "double/vector-big-array",
-            "double/vector-const",
-            "int/array",
-            "int/array-multivalue-null",
-            "int/big-array",
-            "int/big-array-multivalue-null",
-            "int/vector",
-            "int/vector-big-array",
-            "int/vector-const",
-            "long/array",
-            "long/array-multivalue-null",
-            "long/big-array",
-            "long/big-array-multivalue-null",
-            "long/vector",
-            "long/vector-big-array",
-            "long/vector-const" }
-    )
-    public String dataTypeAndBlockKind;
-
-    @Param({ "sequential", "random" })
-    public String accessType;
-
-    private BenchmarkBlocks data;
-
-    private int[][] traversalOrders;
-
-    private final long[] actualCheckSums = new long[NUM_BLOCKS_PER_ITERATION];
-
-    @Setup
-    public void setup() {
-        String[] params = dataTypeAndBlockKind.split("/");
-        String dataType = params[0];
-        String blockKind = params[1];
-
-        data = buildBlocks(dataType, blockKind, BLOCK_TOTAL_POSITIONS);
-        traversalOrders = createTraversalOrders(data.blocks, isRandom(accessType));
-    }
-
-    @Benchmark
-    @OperationsPerInvocation(NUM_BLOCKS_PER_ITERATION * BLOCK_TOTAL_POSITIONS)
-    public void run() {
-        String[] params = dataTypeAndBlockKind.split("/");
-        String dataType = params[0];
-
-        run(dataType, data, traversalOrders, actualCheckSums);
-    }
-
-    @TearDown(Level.Iteration)
-    public void assertCheckSums() {
-        assertCheckSums(data, actualCheckSums);
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockKeepMaskBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockKeepMaskBenchmark.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.benchmark.compute.operator;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 7)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+public class BlockKeepMaskBenchmark extends BlockBenchmark {
+    static {
+        // Smoke test all the expected values and force loading subclasses more like prod
+        int totalPositions = 10;
+        for (String paramString : RELEVANT_TYPE_BLOCK_COMBINATIONS) {
+            String[] params = paramString.split("/");
+            String dataType = params[0];
+            String blockKind = params[1];
+            BooleanVector mask = buildMask(totalPositions);
+
+            BenchmarkBlocks data = buildBenchmarkBlocks(dataType, blockKind, mask, totalPositions);
+            Block[] results = new Block[NUM_BLOCKS_PER_ITERATION];
+            run(data, mask, results);
+            assertCheckSums(dataType, blockKind, data, results, totalPositions);
+        }
+    }
+
+    record BenchmarkBlocks(Block[] blocks, long[] checkSums) {};
+
+    static BenchmarkBlocks buildBenchmarkBlocks(String dataType, String blockKind, BooleanVector mask, int totalPositions) {
+        Block[] blocks = BlockBenchmark.buildBlocks(dataType, blockKind, totalPositions);
+        return new BenchmarkBlocks(blocks, checksumsFor(dataType, blocks, mask));
+    }
+
+    static long[] checksumsFor(String dataType, Block[] blocks, BooleanVector mask) {
+        long[] checkSums = new long[NUM_BLOCKS_PER_ITERATION];
+        switch (dataType) {
+            case "boolean" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    BooleanBlock block = (BooleanBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeBooleanCheckSum(block, mask);
+                }
+            }
+            case "BytesRef" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    BytesRefBlock block = (BytesRefBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeBytesRefCheckSum(block, mask);
+                }
+            }
+            case "double" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    DoubleBlock block = (DoubleBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeDoubleCheckSum(block, mask);
+                }
+            }
+            case "int" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    IntBlock block = (IntBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeIntCheckSum(block, mask);
+                }
+            }
+            case "long" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    LongBlock block = (LongBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeLongCheckSum(block, mask);
+                }
+            }
+            // TODO float
+            default -> throw new IllegalStateException("illegal data type [" + dataType + "]");
+        }
+        return checkSums;
+    }
+
+    static BooleanVector buildMask(int totalPositions) {
+        try (BooleanVector.FixedBuilder builder = blockFactory.newBooleanVectorFixedBuilder(totalPositions)) {
+            for (int p = 0; p < totalPositions; p++) {
+                builder.appendBoolean(p % 2 == 0);
+            }
+            return builder.build();
+        }
+    }
+
+    private static void run(BenchmarkBlocks data, BooleanVector mask, Block[] results) {
+        for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+            results[blockIndex] = data.blocks[blockIndex].keepMask(mask);
+        }
+    }
+
+    private static void assertCheckSums(String dataType, String blockKind, BenchmarkBlocks data, Block[] results, int positionCount) {
+        long[] checkSums = checksumsFor(dataType, results, blockFactory.newConstantBooleanVector(true, positionCount));
+        for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+            if (checkSums[blockIndex] != data.checkSums[blockIndex]) {
+                throw new AssertionError(
+                    "checksums do not match for block ["
+                        + blockIndex
+                        + "]["
+                        + dataType
+                        + "]["
+                        + blockKind
+                        + "]: "
+                        + checkSums[blockIndex]
+                        + " vs "
+                        + data.checkSums[blockIndex]
+                );
+            }
+        }
+    }
+
+    private static long computeBooleanCheckSum(BooleanBlock block, BooleanVector mask) {
+        long sum = 0;
+
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            if (block.isNull(p) || mask.getBoolean(p) == false) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(p);
+            int end = start + block.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                sum += block.getBoolean(i) ? 1 : 0;
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeBytesRefCheckSum(BytesRefBlock block, BooleanVector mask) {
+        long sum = 0;
+        BytesRef scratch = new BytesRef();
+
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            if (block.isNull(p) || mask.getBoolean(p) == false) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(p);
+            int end = start + block.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                BytesRef v = block.getBytesRef(i, scratch);
+                sum += v.length > 0 ? v.bytes[v.offset] : 0;
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeDoubleCheckSum(DoubleBlock block, BooleanVector mask) {
+        long sum = 0;
+
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            if (block.isNull(p) || mask.getBoolean(p) == false) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(p);
+            int end = start + block.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                sum += (long) block.getDouble(i);
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeIntCheckSum(IntBlock block, BooleanVector mask) {
+        int sum = 0;
+
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            if (block.isNull(p) || mask.getBoolean(p) == false) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(p);
+            int end = start + block.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                sum += block.getInt(i);
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeLongCheckSum(LongBlock block, BooleanVector mask) {
+        long sum = 0;
+
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            if (block.isNull(p) || mask.getBoolean(p) == false) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(p);
+            int end = start + block.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                sum += block.getLong(i);
+            }
+        }
+
+        return sum;
+    }
+
+    /**
+     * Must be a subset of {@link BlockBenchmark#RELEVANT_TYPE_BLOCK_COMBINATIONS}
+     */
+    @Param(
+        {
+            "boolean/array",
+            "boolean/array-multivalue-null",
+            "boolean/big-array",
+            "boolean/big-array-multivalue-null",
+            "boolean/vector",
+            "boolean/vector-big-array",
+            "boolean/vector-const",
+            "BytesRef/array",
+            "BytesRef/array-multivalue-null",
+            "BytesRef/vector",
+            "BytesRef/vector-const",
+            "double/array",
+            "double/array-multivalue-null",
+            "double/big-array",
+            "double/big-array-multivalue-null",
+            "double/vector",
+            "double/vector-big-array",
+            "double/vector-const",
+            "int/array",
+            "int/array-multivalue-null",
+            "int/big-array",
+            "int/big-array-multivalue-null",
+            "int/vector",
+            "int/vector-big-array",
+            "int/vector-const",
+            "long/array",
+            "long/array-multivalue-null",
+            "long/big-array",
+            "long/big-array-multivalue-null",
+            "long/vector",
+            "long/vector-big-array",
+            "long/vector-const" }
+    )
+    public String dataTypeAndBlockKind;
+
+    private BenchmarkBlocks data;
+
+    private final BooleanVector mask = buildMask(BLOCK_TOTAL_POSITIONS);
+
+    private final Block[] results = new Block[NUM_BLOCKS_PER_ITERATION];
+
+    @Setup
+    public void setup() {
+        String[] params = dataTypeAndBlockKind.split("/");
+        String dataType = params[0];
+        String blockKind = params[1];
+
+        data = buildBenchmarkBlocks(dataType, blockKind, mask, BLOCK_TOTAL_POSITIONS);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUM_BLOCKS_PER_ITERATION * BLOCK_TOTAL_POSITIONS)
+    public void run() {
+        run(data, mask, results);
+    }
+
+    @TearDown(Level.Iteration)
+    public void assertCheckSums() {
+        String[] params = dataTypeAndBlockKind.split("/");
+        String dataType = params[0];
+        String blockKind = params[1];
+        assertCheckSums(dataType, blockKind, data, results, BLOCK_TOTAL_POSITIONS);
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockReadBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockReadBenchmark.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.benchmark.compute.operator;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.*;
+import org.elasticsearch.compute.data.*;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 7)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+public class BlockReadBenchmark extends BlockBenchmark {
+    static {
+        // Smoke test all the expected values and force loading subclasses more like prod
+        int totalPositions = 10;
+        long[] actualCheckSums = new long[NUM_BLOCKS_PER_ITERATION];
+
+        for (String paramString : RELEVANT_TYPE_BLOCK_COMBINATIONS) {
+            String[] params = paramString.split("/");
+            String dataType = params[0];
+            String blockKind = params[1];
+
+            BenchmarkBlocks data = buildBenchmarkBlocks(dataType, blockKind, totalPositions);
+            int[][] traversalOrders = createTraversalOrders(data.blocks(), false);
+            run(dataType, data, traversalOrders, actualCheckSums);
+            assertCheckSums(data, actualCheckSums);
+        }
+    }
+
+    private static int[][] createTraversalOrders(Block[] blocks, boolean randomized) {
+        int[][] orders = new int[blocks.length][];
+
+        for (int i = 0; i < blocks.length; i++) {
+            IntStream positionsStream = IntStream.range(0, blocks[i].getPositionCount());
+
+            if (randomized) {
+                List<Integer> positions = new ArrayList<>(positionsStream.boxed().toList());
+                Collections.shuffle(positions, random);
+                orders[i] = positions.stream().mapToInt(x -> x).toArray();
+            } else {
+                orders[i] = positionsStream.toArray();
+            }
+        }
+
+        return orders;
+    }
+
+    record BenchmarkBlocks(Block[] blocks, long[] checkSums) {};
+
+    static BenchmarkBlocks buildBenchmarkBlocks(String dataType, String blockKind, int totalPositions) {
+        Block[] blocks = BlockBenchmark.buildBlocks(dataType, blockKind, totalPositions);
+        long[] checkSums = new long[NUM_BLOCKS_PER_ITERATION];
+        switch (dataType) {
+            case "boolean" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    BooleanBlock block = (BooleanBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeBooleanCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
+                }
+            }
+            case "BytesRef" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    BytesRefBlock block = (BytesRefBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeBytesRefCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
+                }
+            }
+            case "double" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    DoubleBlock block = (DoubleBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeDoubleCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
+                }
+            }
+            case "int" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    IntBlock block = (IntBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeIntCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
+                }
+            }
+            case "long" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    LongBlock block = (LongBlock) blocks[blockIndex];
+                    checkSums[blockIndex] = computeLongCheckSum(block, IntStream.range(0, block.getPositionCount()).toArray());
+                }
+            }
+            // TODO float
+            default -> throw new IllegalStateException("illegal data type [" + dataType + "]");
+        }
+        return new BenchmarkBlocks(blocks, checkSums);
+    }
+
+    private static void run(String dataType, BenchmarkBlocks data, int[][] traversalOrders, long[] resultCheckSums) {
+        switch (dataType) {
+            case "boolean" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    BooleanBlock block = (BooleanBlock) data.blocks[blockIndex];
+
+                    resultCheckSums[blockIndex] = computeBooleanCheckSum(block, traversalOrders[blockIndex]);
+                }
+            }
+            case "BytesRef" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    BytesRefBlock block = (BytesRefBlock) data.blocks[blockIndex];
+
+                    resultCheckSums[blockIndex] = computeBytesRefCheckSum(block, traversalOrders[blockIndex]);
+                }
+            }
+            case "double" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    DoubleBlock block = (DoubleBlock) data.blocks[blockIndex];
+
+                    resultCheckSums[blockIndex] = computeDoubleCheckSum(block, traversalOrders[blockIndex]);
+                }
+            }
+            case "int" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    IntBlock block = (IntBlock) data.blocks[blockIndex];
+
+                    resultCheckSums[blockIndex] = computeIntCheckSum(block, traversalOrders[blockIndex]);
+                }
+            }
+            case "long" -> {
+                for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+                    LongBlock block = (LongBlock) data.blocks[blockIndex];
+
+                    resultCheckSums[blockIndex] = computeLongCheckSum(block, traversalOrders[blockIndex]);
+                }
+            }
+            default -> {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    private static void assertCheckSums(BenchmarkBlocks data, long[] actualCheckSums) {
+        for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
+            if (actualCheckSums[blockIndex] != data.checkSums[blockIndex]) {
+                throw new AssertionError("checksums do not match for block [" + blockIndex + "]");
+            }
+        }
+    }
+
+    private static long computeBooleanCheckSum(BooleanBlock block, int[] traversalOrder) {
+        long sum = 0;
+
+        for (int position : traversalOrder) {
+            if (block.isNull(position)) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                sum += block.getBoolean(i) ? 1 : 0;
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeBytesRefCheckSum(BytesRefBlock block, int[] traversalOrder) {
+        long sum = 0;
+        BytesRef scratch = new BytesRef();
+
+        for (int position : traversalOrder) {
+            if (block.isNull(position)) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                BytesRef v = block.getBytesRef(i, scratch);
+                sum += v.length > 0 ? v.bytes[v.offset] : 0;
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeDoubleCheckSum(DoubleBlock block, int[] traversalOrder) {
+        long sum = 0;
+
+        for (int position : traversalOrder) {
+            if (block.isNull(position)) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                // Use an operation that is not affected by rounding errors. Otherwise, the result may depend on the traversalOrder.
+                sum += (long) block.getDouble(i);
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeIntCheckSum(IntBlock block, int[] traversalOrder) {
+        int sum = 0;
+
+        for (int position : traversalOrder) {
+            if (block.isNull(position)) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                sum += block.getInt(i);
+            }
+        }
+
+        return sum;
+    }
+
+    private static long computeLongCheckSum(LongBlock block, int[] traversalOrder) {
+        long sum = 0;
+
+        for (int position : traversalOrder) {
+            if (block.isNull(position)) {
+                continue;
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + block.getValueCount(position);
+            for (int i = start; i < end; i++) {
+                sum += block.getLong(i);
+            }
+        }
+
+        return sum;
+    }
+
+    private static boolean isRandom(String accessType) {
+        return accessType.equalsIgnoreCase("random");
+    }
+
+    /**
+     * Must be a subset of {@link BlockBenchmark#RELEVANT_TYPE_BLOCK_COMBINATIONS}
+     */
+    @Param(
+        {
+            "boolean/array",
+            "boolean/array-multivalue-null",
+            "boolean/big-array",
+            "boolean/big-array-multivalue-null",
+            "boolean/vector",
+            "boolean/vector-big-array",
+            "boolean/vector-const",
+            "BytesRef/array",
+            "BytesRef/array-multivalue-null",
+            "BytesRef/vector",
+            "BytesRef/vector-const",
+            "double/array",
+            "double/array-multivalue-null",
+            "double/big-array",
+            "double/big-array-multivalue-null",
+            "double/vector",
+            "double/vector-big-array",
+            "double/vector-const",
+            "int/array",
+            "int/array-multivalue-null",
+            "int/big-array",
+            "int/big-array-multivalue-null",
+            "int/vector",
+            "int/vector-big-array",
+            "int/vector-const",
+            "long/array",
+            "long/array-multivalue-null",
+            "long/big-array",
+            "long/big-array-multivalue-null",
+            "long/vector",
+            "long/vector-big-array",
+            "long/vector-const" }
+    )
+    public String dataTypeAndBlockKind;
+
+    @Param({ "sequential", "random" })
+    public String accessType;
+
+    private BenchmarkBlocks data;
+
+    private int[][] traversalOrders;
+
+    private final long[] actualCheckSums = new long[NUM_BLOCKS_PER_ITERATION];
+
+    @Setup
+    public void setup() {
+        String[] params = dataTypeAndBlockKind.split("/");
+        String dataType = params[0];
+        String blockKind = params[1];
+
+        data = buildBenchmarkBlocks(dataType, blockKind, BLOCK_TOTAL_POSITIONS);
+        traversalOrders = createTraversalOrders(data.blocks(), isRandom(accessType));
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUM_BLOCKS_PER_ITERATION * BLOCK_TOTAL_POSITIONS)
+    public void run() {
+        String[] params = dataTypeAndBlockKind.split("/");
+        String dataType = params[0];
+
+        run(dataType, data, traversalOrders, actualCheckSums);
+    }
+
+    @TearDown(Level.Iteration)
+    public void assertCheckSums() {
+        assertCheckSums(data, actualCheckSums);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -115,6 +115,47 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
     }
 
     @Override
+    public BooleanBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (BooleanBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (BooleanBlock.Builder builder = blockFactory().newBooleanBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendBoolean(getBoolean(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendBoolean(getBoolean(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new BooleanLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
@@ -90,6 +90,32 @@ public final class BooleanBigArrayVector extends AbstractVector implements Boole
     }
 
     @Override
+    public BooleanBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new BooleanVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new BooleanVectorBlock(this);
+            }
+            return (BooleanBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (BooleanBlock.Builder builder = blockFactory().newBooleanBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendBoolean(getBoolean(p));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new BooleanLookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -41,6 +41,9 @@ public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, Bo
     BooleanBlock filter(int... positions);
 
     @Override
+    BooleanBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -30,6 +30,9 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
     BooleanVector filter(int... positions);
 
     @Override
+    BooleanBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -52,6 +52,11 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
     }
 
     @Override
+    public BooleanBlock keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -51,6 +51,9 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
     BytesRefBlock filter(int... positions);
 
     @Override
+    BytesRefBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -37,6 +37,9 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     BytesRefVector filter(int... positions);
 
     @Override
+    BytesRefBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -63,6 +63,11 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     }
 
     @Override
+    public BytesRefBlock keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -42,6 +42,32 @@ final class ConstantDoubleVector extends AbstractVector implements DoubleVector 
     }
 
     @Override
+    public DoubleBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new DoubleVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new DoubleVectorBlock(this);
+            }
+            return (DoubleBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (DoubleBlock.Builder builder = blockFactory().newDoubleBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendDouble(value);
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         if (positions.getPositionCount() == 0) {
             return ReleasableIterator.empty();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -42,6 +42,32 @@ final class ConstantIntVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public IntBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new IntVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new IntVectorBlock(this);
+            }
+            return (IntBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (IntBlock.Builder builder = blockFactory().newIntBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendInt(value);
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         if (positions.getPositionCount() == 0) {
             return ReleasableIterator.empty();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -93,6 +93,32 @@ final class DoubleArrayVector extends AbstractVector implements DoubleVector {
     }
 
     @Override
+    public DoubleBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new DoubleVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new DoubleVectorBlock(this);
+            }
+            return (DoubleBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (DoubleBlock.Builder builder = blockFactory().newDoubleBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendDouble(getDouble(p));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new DoubleLookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -116,6 +116,47 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     }
 
     @Override
+    public DoubleBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (DoubleBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (DoubleBlock.Builder builder = blockFactory().newDoubleBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendDouble(getDouble(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendDouble(getDouble(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new DoubleLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -41,6 +41,9 @@ public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, Doub
     DoubleBlock filter(int... positions);
 
     @Override
+    DoubleBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -30,6 +30,9 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
     DoubleVector filter(int... positions);
 
     @Override
+    DoubleBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -52,6 +52,11 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
     }
 
     @Override
+    public DoubleBlock keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayBlock.java
@@ -115,6 +115,47 @@ final class FloatArrayBlock extends AbstractArrayBlock implements FloatBlock {
     }
 
     @Override
+    public FloatBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (FloatBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (FloatBlock.Builder builder = blockFactory().newFloatBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendFloat(getFloat(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendFloat(getFloat(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<FloatBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new FloatLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
@@ -93,6 +93,32 @@ final class FloatArrayVector extends AbstractVector implements FloatVector {
     }
 
     @Override
+    public FloatBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new FloatVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new FloatVectorBlock(this);
+            }
+            return (FloatBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (FloatBlock.Builder builder = blockFactory().newFloatBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendFloat(getFloat(p));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<FloatBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new FloatLookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBlock.java
@@ -41,6 +41,9 @@ public sealed interface FloatBlock extends Block permits FloatArrayBlock, FloatV
     FloatBlock filter(int... positions);
 
     @Override
+    FloatBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends FloatBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
@@ -30,6 +30,9 @@ public sealed interface FloatVector extends Vector permits ConstantFloatVector, 
     FloatVector filter(int... positions);
 
     @Override
+    FloatBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends FloatBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVectorBlock.java
@@ -52,6 +52,11 @@ public final class FloatVectorBlock extends AbstractVectorBlock implements Float
     }
 
     @Override
+    public FloatBlock keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends FloatBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -115,6 +115,47 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
     }
 
     @Override
+    public IntBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (IntBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (IntBlock.Builder builder = blockFactory().newIntBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendInt(getInt(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendInt(getInt(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new IntLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -116,6 +116,47 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     }
 
     @Override
+    public IntBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (IntBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (IntBlock.Builder builder = blockFactory().newIntBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendInt(getInt(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendInt(getInt(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new IntLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
@@ -129,6 +129,32 @@ public final class IntBigArrayVector extends AbstractVector implements IntVector
     }
 
     @Override
+    public IntBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new IntVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new IntVectorBlock(this);
+            }
+            return (IntBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (IntBlock.Builder builder = blockFactory().newIntBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendInt(getInt(p));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new IntLookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -41,6 +41,9 @@ public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorB
     IntBlock filter(int... positions);
 
     @Override
+    IntBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -30,6 +30,9 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     IntVector filter(int... positions);
 
     @Override
+    IntBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -52,6 +52,11 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
     }
 
     @Override
+    public IntBlock keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -115,6 +115,47 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
     }
 
     @Override
+    public LongBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (LongBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (LongBlock.Builder builder = blockFactory().newLongBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendLong(getLong(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendLong(getLong(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new LongLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -93,6 +93,32 @@ final class LongArrayVector extends AbstractVector implements LongVector {
     }
 
     @Override
+    public LongBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new LongVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new LongVectorBlock(this);
+            }
+            return (LongBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (LongBlock.Builder builder = blockFactory().newLongBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendLong(getLong(p));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new LongLookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -116,6 +116,47 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     }
 
     @Override
+    public LongBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (LongBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try (LongBlock.Builder builder = blockFactory().newLongBlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.appendLong(getLong(start));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.appendLong(getLong(i));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new LongLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -41,6 +41,9 @@ public sealed interface LongBlock extends Block permits LongArrayBlock, LongVect
     LongBlock filter(int... positions);
 
     @Override
+    LongBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -30,6 +30,9 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Lo
     LongVector filter(int... positions);
 
     @Override
+    LongBlock keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -52,6 +52,11 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
     }
 
     @Override
+    public LongBlock keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -140,6 +140,14 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     Block filter(int... positions);
 
     /**
+     * Build a {@link Block} the same values as this {@linkplain Block}, but replacing
+     * all values for which {@code mask.getBooleanValue(position)} returns
+     * {@code false} with {@code null}. The {@code mask} vector must be at least
+     * as long as this {@linkplain Block}.
+     */
+    Block keepMask(BooleanVector mask);
+
+    /**
      * Builds an Iterator of new {@link Block}s with the same {@link #elementType}
      * as this Block whose values are copied from positions in this Block. It has the
      * same number of {@link #getPositionCount() positions} as the {@code positions}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -140,7 +140,7 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     Block filter(int... positions);
 
     /**
-     * Build a {@link Block} the same values as this {@linkplain Block}, but replacing
+     * Build a {@link Block} with the same values as this {@linkplain Block}, but replacing
      * all values for which {@code mask.getBooleanValue(position)} returns
      * {@code false} with {@code null}. The {@code mask} vector must be at least
      * as long as this {@linkplain Block}.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
@@ -162,6 +162,23 @@ public final class CompositeBlock extends AbstractNonThreadSafeRefCounted implem
     }
 
     @Override
+    public Block keepMask(BooleanVector mask) {
+        CompositeBlock result = null;
+        final Block[] masked = new Block[blocks.length];
+        try {
+            for (int i = 0; i < blocks.length; i++) {
+                masked[i] = blocks[i].keepMask(mask);
+            }
+            result = new CompositeBlock(masked);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(masked);
+            }
+        }
+    }
+
+    @Override
     public ReleasableIterator<? extends Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         // TODO: support this
         throw new UnsupportedOperationException("can't lookup values from CompositeBlock");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -84,6 +84,11 @@ final class ConstantNullBlock extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
+    public ConstantNullBlock keepMask(BooleanVector mask) {
+        return (ConstantNullBlock) blockFactory().newConstantNullBlock(getPositionCount());
+    }
+
+    @Override
     public ReleasableIterator<ConstantNullBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return ReleasableIterator.single((ConstantNullBlock) positions.blockFactory().newConstantNullBlock(positions.getPositionCount()));
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -55,6 +55,12 @@ public final class ConstantNullVector extends AbstractVector
     }
 
     @Override
+    public ConstantNullBlock keepMask(BooleanVector mask) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
     public ReleasableIterator<ConstantNullBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         assert false : "null vector";
         throw new UnsupportedOperationException("null vector");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -51,6 +51,11 @@ public class DocBlock extends AbstractVectorBlock implements Block {
     }
 
     @Override
+    public Block keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         throw new UnsupportedOperationException("can't lookup values from DocBlock");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -238,6 +238,11 @@ public final class DocVector extends AbstractVector implements Vector {
     }
 
     @Override
+    public DocBlock keepMask(BooleanVector mask) {
+        throw new UnsupportedOperationException("can't mask DocVector because it can't contain nulls");
+    }
+
+    @Override
     public ReleasableIterator<? extends Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         throw new UnsupportedOperationException("can't lookup values from DocVector");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -126,6 +126,32 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     @Override
+    public BytesRefBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return (BytesRefBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        OrdinalBytesRefBlock result = null;
+        IntBlock filteredOrdinals = ordinals.keepMask(mask);
+        try {
+            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes);
+            bytes.incRef();
+        } finally {
+            if (result == null) {
+                filteredOrdinals.close();
+            }
+        }
+        return result;
+    }
+
+    @Override
     public ReleasableIterator<BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new BytesRefLookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -123,6 +123,15 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
+    public BytesRefBlock keepMask(BooleanVector mask) {
+        /*
+         * The implementation in OrdinalBytesRefBlock is quite fast and
+         * amounts to the same thing so we can just reuse it.
+         */
+        return asBlock().keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new BytesRefLookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -38,6 +38,14 @@ public interface Vector extends Accountable, RefCounted, Releasable {
     Vector filter(int... positions);
 
     /**
+     * Build a {@link Block} the same values as this {@link Vector}, but replacing
+     * all values for which {@code mask.getBooleanValue(position)} returns
+     * {@code false} with {@code null}. The {@code mask} vector must be at least
+     * as long as this {@linkplain Vector}.
+     */
+    Block keepMask(BooleanVector mask);
+
+    /**
      * Builds an Iterator of new {@link Block}s with the same {@link #elementType}
      * as this {@link Vector} whose values are copied from positions in this Vector.
      * It has the same number of {@link #getPositionCount() positions} as the

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -141,6 +141,50 @@ $endif$
     }
 
     @Override
+    public $Type$Block keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return ($Type$Block) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+$if(BytesRef)$
+        BytesRef scratch = new BytesRef();
+$endif$
+        try ($Type$Block.Builder builder = blockFactory().new$Type$BlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.append$Type$(get$Type$(start$if(BytesRef)$, scratch$endif$));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.append$Type$(get$Type$(i$if(BytesRef)$, scratch$endif$));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new $Type$Lookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -173,6 +173,35 @@ $endif$
     }
 
     @Override
+    public $Type$Block keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new $Type$VectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new $Type$VectorBlock(this);
+            }
+            return ($Type$Block) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+$if(BytesRef)$
+        BytesRef scratch = new BytesRef();
+$endif$
+        try ($Type$Block.Builder builder = blockFactory().new$Type$BlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.append$Type$(get$Type$(p$if(BytesRef)$, scratch$endif$));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new $Type$Lookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -116,6 +116,50 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
     }
 
     @Override
+    public $Type$Block keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return this;
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return this;
+            }
+            return ($Type$Block) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+$if(BytesRef)$
+        BytesRef scratch = new BytesRef();
+$endif$
+        try ($Type$Block.Builder builder = blockFactory().new$Type$BlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (false == mask.getBoolean(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(p);
+                if (valueCount == 0) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = getFirstValueIndex(p);
+                if (valueCount == 1) {
+                    builder.append$Type$(get$Type$(start$if(BytesRef)$, scratch$endif$));
+                    continue;
+                }
+                int end = start + valueCount;
+                builder.beginPositionEntry();
+                for (int i = start; i < end; i++) {
+                    builder.append$Type$(get$Type$(i$if(BytesRef)$, scratch$endif$));
+                }
+                builder.endPositionEntry();
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new $Type$Lookup(this, positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
@@ -159,6 +159,32 @@ $endif$
     }
 
     @Override
+    public $Type$Block keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new $Type$VectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new $Type$VectorBlock(this);
+            }
+            return ($Type$Block) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        try ($Type$Block.Builder builder = blockFactory().new$Type$BlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.append$Type$(get$Type$(p));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
     public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return new $Type$Lookup(asBlock(), positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -69,6 +69,9 @@ $endif$
     $Type$Block filter(int... positions);
 
     @Override
+    $Type$Block keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends $Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -12,8 +12,14 @@ import org.apache.lucene.util.BytesRef;
 $endif$
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.unit.ByteSizeValue;
+$if(BytesRef)$
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+$else$
 import org.elasticsearch.core.ReleasableIterator;
 
+$endif$
 /**
  * Vector implementation that stores a constant $type$ value.
  * This class is generated. Do not edit it.
@@ -58,6 +64,49 @@ $endif$
     @Override
     public $Type$Vector filter(int... positions) {
         return blockFactory().newConstant$Type$Vector(value, positions.length);
+    }
+
+    @Override
+    public $Type$Block keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new $Type$VectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new $Type$VectorBlock(this);
+            }
+            return ($Type$Block) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+$if(BytesRef)$
+        IntBlock ordinals = null;
+        BytesRefVector bytes = null;
+        try {
+            try (IntVector unmaskedOrdinals = blockFactory().newConstantIntVector(0, getPositionCount())) {
+                ordinals = unmaskedOrdinals.keepMask(mask);
+            }
+            bytes = blockFactory().newConstantBytesRefVector(value, getPositionCount());
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ordinals, bytes);
+            ordinals = null;
+            bytes = null;
+            return result;
+        } finally {
+            Releasables.close(ordinals, bytes);
+        }
+$else$
+        try ($Type$Block.Builder builder = blockFactory().new$Type$BlockBuilder(getPositionCount())) {
+            // TODO if X-ArrayBlock used BooleanVector for it's null mask then we could shuffle references here.
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.append$Type$(value);
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+$endif$
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -57,6 +57,9 @@ $endif$
     $Type$Vector filter(int... positions);
 
     @Override
+    $Type$Block keepMask(BooleanVector mask);
+
+    @Override
     ReleasableIterator<? extends $Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
 $if(int)$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -72,6 +72,11 @@ $endif$
     }
 
     @Override
+    public $Type$Block keepMask(BooleanVector mask) {
+        return vector.keepMask(mask);
+    }
+
+    @Override
     public ReleasableIterator<? extends $Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
         return vector.lookup(positions, targetBlockSize);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -188,6 +188,8 @@ public class BasicBlockTests extends ESTestCase {
 
             initialBlock = block.asVector().asBlock();
         }
+        assertKeepMask(initialBlock);
+        assertKeepMask(initialBlock.asVector());
     }
 
     public void testIntBlock() {
@@ -723,6 +725,7 @@ public class BasicBlockTests extends ESTestCase {
                     assertThat(block.getBytesRef(pos, bytes), equalTo(values[pos]));
                 }
             }
+            assertKeepMask(block);
             releaseAndAssertBreaker(block);
         }
     }
@@ -1359,12 +1362,28 @@ public class BasicBlockTests extends ESTestCase {
 
     void assertZeroPositionsAndRelease(Block block) {
         assertThat(block.getPositionCount(), is(0));
+        assertKeepMaskEmpty(block);
         releaseAndAssertBreaker(block);
     }
 
     void assertZeroPositionsAndRelease(Vector vector) {
         assertThat(vector.getPositionCount(), is(0));
+        assertKeepMaskEmpty(vector);
         releaseAndAssertBreaker(vector);
+    }
+
+    static void assertKeepMaskEmpty(Block block) {
+        try (BooleanVector mask = randomMask(between(0, 1000)); Block masked = block.keepMask(mask)) {
+            if (false == (masked == block || masked.asVector() == block.asVector())) {
+                fail("should return original block or vector");
+            }
+        }
+    }
+
+    static void assertKeepMaskEmpty(Vector vector) {
+        try (BooleanVector mask = randomMask(between(0, 1000)); Block masked = vector.keepMask(mask)) {
+            assertThat(masked.asVector(), sameInstance(vector));
+        }
     }
 
     void releaseAndAssertBreaker(Block... blocks) {
@@ -1741,6 +1760,88 @@ public class BasicBlockTests extends ESTestCase {
                 extra.accept(b);
             }
             assertThat(lookup.hasNext(), equalTo(false));
+        }
+    }
+
+    static void assertKeepMask(Vector vector) {
+        int maskPositions = vector.getPositionCount();
+        if (randomBoolean()) {
+            maskPositions += between(1, 1000);
+        }
+        try (
+            BooleanVector mask = TestBlockFactory.getNonBreakingInstance().newConstantBooleanVector(true, maskPositions);
+            Block masked = vector.keepMask(mask)
+        ) {
+            assertThat(masked.asVector(), sameInstance(vector));
+        }
+        try (
+            BooleanVector mask = TestBlockFactory.getNonBreakingInstance().newConstantBooleanVector(false, maskPositions);
+            Block masked = vector.keepMask(mask)
+        ) {
+            assertThat(masked.getPositionCount(), equalTo(vector.getPositionCount()));
+            for (int p = 0; p < vector.getPositionCount(); p++) {
+                assertTrue(masked.isNull(p));
+            }
+        }
+        try (BooleanVector mask = randomMask(maskPositions); Block masked = vector.keepMask(mask)) {
+            assertThat(masked.getPositionCount(), equalTo(vector.getPositionCount()));
+            for (int p = 0; p < vector.getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    assertFalse(masked.isNull(p));
+                    assertEquals(1, masked.getValueCount(p));
+                    assertEquals(BlockUtils.toJavaObject(vector.asBlock(), p), BlockUtils.toJavaObject(masked, p));
+                } else {
+                    assertTrue(masked.isNull(p));
+                }
+            }
+        }
+    }
+
+    static void assertKeepMask(Block block) {
+        int maskPositions = block.getPositionCount();
+        if (randomBoolean()) {
+            maskPositions += between(1, 1000);
+        }
+        try (
+            BooleanVector mask = TestBlockFactory.getNonBreakingInstance().newConstantBooleanVector(true, maskPositions);
+            Block masked = block.keepMask(mask)
+        ) {
+            if (false == (masked == block || masked.asVector() == block.asVector())) {
+                fail("should return original block or vector");
+            }
+        }
+        try (
+            BooleanVector mask = TestBlockFactory.getNonBreakingInstance().newConstantBooleanVector(false, maskPositions);
+            Block masked = block.keepMask(mask)
+        ) {
+            assertThat(masked.getPositionCount(), equalTo(block.getPositionCount()));
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                assertTrue(masked.isNull(p));
+            }
+        }
+        try (BooleanVector mask = randomMask(maskPositions); Block masked = block.keepMask(mask)) {
+            assertThat(masked.getPositionCount(), equalTo(block.getPositionCount()));
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                if (mask.getBoolean(p) && false == block.isNull(p)) {
+                    assertFalse(masked.isNull(p));
+                    assertEquals(block.getValueCount(p), masked.getValueCount(p));
+                    assertEquals(BlockUtils.toJavaObject(block, p), BlockUtils.toJavaObject(masked, p));
+                } else {
+                    assertTrue(masked.isNull(p));
+                }
+            }
+        }
+    }
+
+    /**
+     * Build a random valid "mask" of single valued boolean fields that.
+     */
+    private static BooleanVector randomMask(int positions) {
+        try (BooleanVector.Builder builder = TestBlockFactory.getNonBreakingInstance().newBooleanVectorFixedBuilder(positions)) {
+            for (int i = 0; i < positions; i++) {
+                builder.appendBoolean(randomBoolean());
+            }
+            return builder.build();
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayBlockBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayBlockBuilderTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 
 import java.io.IOException;
 
+import static org.elasticsearch.compute.data.BasicBlockTests.assertKeepMask;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -40,6 +41,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getLong(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (LongBlock copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(LongVectorBlock.class));
                     assertThat(block.asVector(), instanceOf(LongArrayVector.class));
@@ -65,6 +67,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getLong(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (LongBlock copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(LongVectorBlock.class));
                     assertThat(block.asVector(), instanceOf(LongBigArrayVector.class));
@@ -98,6 +101,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getLong(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (LongBlock copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(LongArrayBlock.class));
                     assertNull(copy.asVector());
@@ -126,6 +130,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getLong(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (LongBlock copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(LongBigArrayBlock.class));
                     assertNull(block.asVector());
@@ -158,6 +163,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getBoolean(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (var copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(BooleanVectorBlock.class));
                     assertThat(block.asVector(), instanceOf(BooleanArrayVector.class));
@@ -183,6 +189,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getBoolean(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (var copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(BooleanVectorBlock.class));
                     assertThat(block.asVector(), instanceOf(BooleanBigArrayVector.class));
@@ -216,6 +223,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getBoolean(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (var copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(BooleanArrayBlock.class));
                     assertNull(copy.asVector());
@@ -244,6 +252,7 @@ public class BigArrayBlockBuilderTests extends SerializationTestCase {
                 for (int i = 0; i < numElements; i++) {
                     assertThat(block.getBoolean(i), equalTo(elements[i]));
                 }
+                assertKeepMask(block);
                 try (var copy = serializeDeserializeBlock(block)) {
                     assertThat(copy, instanceOf(BooleanBigArrayBlock.class));
                     assertNull(block.asVector());

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.compute.data.BasicBlockTests.assertKeepMask;
+import static org.elasticsearch.compute.data.BasicBlockTests.assertKeepMaskEmpty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -54,6 +56,7 @@ public class MultiValueBlockTests extends SerializationTestCase {
         // cannot get a Vector view
         assertNull(block.asVector());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(block);
         block.close();
     }
 
@@ -80,6 +83,7 @@ public class MultiValueBlockTests extends SerializationTestCase {
         assertThat(block.getInt(block.getFirstValueIndex(0)), is(1));
         assertNull(block.asVector());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(block);
         block.close();
     }
 
@@ -89,24 +93,35 @@ public class MultiValueBlockTests extends SerializationTestCase {
             assertThat(intBlock.getPositionCount(), is(0));
             assertThat(intBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMaskEmpty(intBlock);
             intBlock.close();
 
             LongBlock longBlock = blockFactory.newLongBlockBuilder(initialSize).build();
             assertThat(longBlock.getPositionCount(), is(0));
             assertThat(longBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMaskEmpty(longBlock);
             longBlock.close();
 
             DoubleBlock doubleBlock = blockFactory.newDoubleBlockBuilder(initialSize).build();
             assertThat(doubleBlock.getPositionCount(), is(0));
             assertThat(doubleBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMaskEmpty(doubleBlock);
             doubleBlock.close();
+
+            FloatBlock floatBlock = blockFactory.newFloatBlockBuilder(initialSize).build();
+            assertThat(floatBlock.getPositionCount(), is(0));
+            assertThat(floatBlock.asVector(), is(notNullValue()));
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(floatBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMaskEmpty(floatBlock);
+            floatBlock.close();
 
             BytesRefBlock bytesRefBlock = blockFactory.newBytesRefBlockBuilder(initialSize).build();
             assertThat(bytesRefBlock.getPositionCount(), is(0));
             assertThat(bytesRefBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMaskEmpty(bytesRefBlock);
             bytesRefBlock.close();
         }
     }
@@ -118,6 +133,7 @@ public class MultiValueBlockTests extends SerializationTestCase {
             assertThat(intBlock.getValueCount(0), is(0));
             assertNull(intBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMask(intBlock);
             intBlock.close();
 
             LongBlock longBlock = blockFactory.newLongBlockBuilder(initialSize).appendNull().build();
@@ -125,6 +141,7 @@ public class MultiValueBlockTests extends SerializationTestCase {
             assertThat(longBlock.getValueCount(0), is(0));
             assertNull(longBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMask(longBlock);
             longBlock.close();
 
             DoubleBlock doubleBlock = blockFactory.newDoubleBlockBuilder(initialSize).appendNull().build();
@@ -132,13 +149,23 @@ public class MultiValueBlockTests extends SerializationTestCase {
             assertThat(doubleBlock.getValueCount(0), is(0));
             assertNull(doubleBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMask(doubleBlock);
             doubleBlock.close();
+
+            FloatBlock floatBlock = blockFactory.newFloatBlockBuilder(initialSize).appendNull().build();
+            assertThat(floatBlock.getPositionCount(), is(1));
+            assertThat(floatBlock.getValueCount(0), is(0));
+            assertNull(floatBlock.asVector());
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(floatBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMask(floatBlock);
+            floatBlock.close();
 
             BytesRefBlock bytesRefBlock = blockFactory.newBytesRefBlockBuilder(initialSize).appendNull().build();
             assertThat(bytesRefBlock.getPositionCount(), is(1));
             assertThat(bytesRefBlock.getValueCount(0), is(0));
             assertNull(bytesRefBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMask(bytesRefBlock);
             bytesRefBlock.close();
         }
     }
@@ -162,21 +189,31 @@ public class MultiValueBlockTests extends SerializationTestCase {
         assertThat(intBlock.elementType(), is(equalTo(ElementType.INT)));
         BlockValueAsserter.assertBlockValues(intBlock, blockValues);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(intBlock);
 
         Block longBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.LONG);
         assertThat(longBlock.elementType(), is(equalTo(ElementType.LONG)));
         BlockValueAsserter.assertBlockValues(longBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(longBlock);
 
         Block doubleBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.DOUBLE);
         assertThat(doubleBlock.elementType(), is(equalTo(ElementType.DOUBLE)));
         BlockValueAsserter.assertBlockValues(doubleBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(doubleBlock);
+
+        Block floatBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.DOUBLE);
+        assertThat(floatBlock.elementType(), is(equalTo(ElementType.DOUBLE)));
+        BlockValueAsserter.assertBlockValues(floatBlock, blockValues);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(floatBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(floatBlock);
 
         Block bytesRefBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.BYTES_REF);
         assertThat(bytesRefBlock.elementType(), is(equalTo(ElementType.BYTES_REF)));
         BlockValueAsserter.assertBlockValues(bytesRefBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(bytesRefBlock);
     }
 
     public void testMultiValuesAndNullsSmall() {
@@ -194,21 +231,31 @@ public class MultiValueBlockTests extends SerializationTestCase {
         assertThat(intBlock.elementType(), is(equalTo(ElementType.INT)));
         BlockValueAsserter.assertBlockValues(intBlock, blockValues);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(intBlock);
 
         Block longBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.LONG);
         assertThat(longBlock.elementType(), is(equalTo(ElementType.LONG)));
         BlockValueAsserter.assertBlockValues(longBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(longBlock);
 
         Block doubleBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.DOUBLE);
         assertThat(doubleBlock.elementType(), is(equalTo(ElementType.DOUBLE)));
         BlockValueAsserter.assertBlockValues(doubleBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(doubleBlock);
+
+        Block floatBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.FLOAT);
+        assertThat(floatBlock.elementType(), is(equalTo(ElementType.FLOAT)));
+        BlockValueAsserter.assertBlockValues(floatBlock, blockValues);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(floatBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(floatBlock);
 
         Block bytesRefBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.BYTES_REF);
         assertThat(bytesRefBlock.elementType(), is(equalTo(ElementType.BYTES_REF)));
         BlockValueAsserter.assertBlockValues(bytesRefBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(bytesRefBlock);
     }
 
     public void testMultiValuesAndNulls() {
@@ -230,21 +277,31 @@ public class MultiValueBlockTests extends SerializationTestCase {
         assertThat(intBlock.elementType(), is(equalTo(ElementType.INT)));
         BlockValueAsserter.assertBlockValues(intBlock, blockValues);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(intBlock);
 
         Block longBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.LONG);
         assertThat(longBlock.elementType(), is(equalTo(ElementType.LONG)));
         BlockValueAsserter.assertBlockValues(longBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(longBlock);
 
         Block doubleBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.DOUBLE);
         assertThat(doubleBlock.elementType(), is(equalTo(ElementType.DOUBLE)));
         BlockValueAsserter.assertBlockValues(doubleBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(doubleBlock);
+
+        Block floatBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.FLOAT);
+        assertThat(floatBlock.elementType(), is(equalTo(ElementType.FLOAT)));
+        BlockValueAsserter.assertBlockValues(floatBlock, blockValues);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(floatBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(floatBlock);
 
         Block bytesRefBlock = TestBlockBuilder.blockFromValues(blockValues, ElementType.BYTES_REF);
         assertThat(bytesRefBlock.elementType(), is(equalTo(ElementType.BYTES_REF)));
         BlockValueAsserter.assertBlockValues(bytesRefBlock, blockValues);
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+        assertKeepMask(bytesRefBlock);
     }
 
     // Tests that the use of Block builder beginPositionEntry (or not) with just a single value,
@@ -265,6 +322,8 @@ public class MultiValueBlockTests extends SerializationTestCase {
             TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.LONG),
             TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.DOUBLE),
             TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.DOUBLE),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.FLOAT),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.FLOAT),
             TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.BYTES_REF),
             TestBlockBuilder.blockFromValues(blockValues.stream().map(List::of).toList(), ElementType.BYTES_REF)
         );
@@ -273,6 +332,7 @@ public class MultiValueBlockTests extends SerializationTestCase {
                 assertThat(block.asVector(), is(notNullValue()));
                 BlockValueAsserter.assertBlockValues(block, blockValues.stream().map(List::of).toList());
                 EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, this::serializeDeserializeBlock, null, Releasable::close);
+                assertKeepMask(block);
             }
         } finally {
             Releasables.close(blocks);
@@ -312,6 +372,8 @@ public class MultiValueBlockTests extends SerializationTestCase {
             TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.LONG),
             TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.DOUBLE),
             TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.DOUBLE),
+            TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.FLOAT),
+            TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.FLOAT),
             TestBlockBuilder.blockFromSingleValues(blockValues, ElementType.BYTES_REF),
             TestBlockBuilder.blockFromValues(blockValues.stream().map(MultiValueBlockTests::mapToList).toList(), ElementType.BYTES_REF)
         );
@@ -319,6 +381,7 @@ public class MultiValueBlockTests extends SerializationTestCase {
             assertThat(block.asVector(), is(nullValue()));
             BlockValueAsserter.assertBlockValues(block, blockValues.stream().map(MultiValueBlockTests::mapToList).toList());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, this::serializeDeserializeBlock, null, Releasable::close);
+            assertKeepMask(block);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
@@ -63,6 +63,7 @@ public abstract class TestBlockBuilder implements Block.Builder {
             case INT -> new TestIntBlockBuilder(blockFactory, 0);
             case LONG -> new TestLongBlockBuilder(blockFactory, 0);
             case DOUBLE -> new TestDoubleBlockBuilder(blockFactory, 0);
+            case FLOAT -> new TestFloatBlockBuilder(blockFactory, 0);
             case BYTES_REF -> new TestBytesRefBlockBuilder(blockFactory, 0);
             case BOOLEAN -> new TestBooleanBlockBuilder(blockFactory, 0);
             default -> throw new AssertionError(type);
@@ -240,6 +241,66 @@ public abstract class TestBlockBuilder implements Block.Builder {
 
         @Override
         public DoubleBlock build() {
+            return builder.build();
+        }
+
+        @Override
+        public void close() {
+            builder.close();
+        }
+    }
+
+    private static class TestFloatBlockBuilder extends TestBlockBuilder {
+
+        private final FloatBlock.Builder builder;
+
+        TestFloatBlockBuilder(BlockFactory blockFactory, int estimatedSize) {
+            builder = blockFactory.newFloatBlockBuilder(estimatedSize);
+        }
+
+        @Override
+        public TestBlockBuilder appendObject(Object object) {
+            builder.appendFloat(((Number) object).floatValue());
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder appendNull() {
+            builder.appendNull();
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder beginPositionEntry() {
+            builder.beginPositionEntry();
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder endPositionEntry() {
+            builder.endPositionEntry();
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder copyFrom(Block block, int beginInclusive, int endExclusive) {
+            builder.copyFrom(block, beginInclusive, endExclusive);
+            return this;
+        }
+
+        @Override
+        public TestBlockBuilder mvOrdering(Block.MvOrdering mvOrdering) {
+            builder.mvOrdering(mvOrdering);
+            return this;
+        }
+
+        @Override
+        public long estimatedBytes() {
+            return builder.estimatedBytes();
+        }
+
+        @Override
+        public FloatBlock build() {
             return builder.build();
         }
 


### PR DESCRIPTION
This adds a `Block#keepMask(BooleanVector)` method that will make a new block, keeping all of the values where the vector is `true` and `null`ing all of the values where the vector is false.

This will be useful for implementing partial aggregation application like `| STATS MAX(a WHERE b > 1), MIN(j WHERE b > 2) BY bar`. Or however the syntax ends up being. We already skip `null` group keys and we can evaluate the `b > 2` bits to a mask pretty easily. It should also be useful in optimizing `CASE(a > 2, foo)` - but only when the RHS of the CASE is `null` and the LHS is a constant or constant-like.

This is something that's very optimize-able. I haven't really optimized it in this PR, but it should be possible to speed this up a ton and remove a lot of copying. Here's where the benchmarks start:
```
(dataTypeAndBlockKind)  Mode  Cnt  Score   Error  Units
             int/array  avgt    7  3.705 ± 0.153  ns/op
            int/vector  avgt    7  3.234 ± 0.078  ns/op
```

That's about the same speed as reading the block. In a few of these cases I expect we can get them to constant performance rather than per-record performance.
