### PR TITLE
Match query support for semantic_text fields - POC DO NOT MERGE

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -195,6 +195,8 @@ public class TransportVersions {
     public static final TransportVersion ESQL_PROFILE_SLEEPS = def(8_725_00_0);
     public static final TransportVersion ZDT_NANOS_SUPPORT = def(8_726_00_0);
     public static final TransportVersion LTR_SERVERLESS_RELEASE = def(8_727_00_0);
+    public static final TransportVersion INFERENCE_FIELD_METADATA_STORE_QUERY_NAME = def(8_728_00_0);
+
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadata.java
@@ -40,12 +40,7 @@ public final class InferenceFieldMetadata implements SimpleDiffable<InferenceFie
     private final String[] sourceFields;
     private final String queryName;
 
-    public InferenceFieldMetadata(
-        String name,
-        String inferenceId,
-        String[] sourceFields,
-        String queryName
-    ) {
+    public InferenceFieldMetadata(String name, String inferenceId, String[] sourceFields, String queryName) {
         this.name = Objects.requireNonNull(name);
         this.inferenceId = Objects.requireNonNull(inferenceId);
         this.sourceFields = Objects.requireNonNull(sourceFields);

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -800,6 +800,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             allowExpensiveQueries,
             scriptService,
             null,
+            null,
             null
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -52,6 +52,7 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
             null,
             null,
             null,
+            null,
             null
         );
         this.indexLongFieldRange = indexLongFieldRange;

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilderService.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilderService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.rest.RestStatus;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public class QueryBuilderService {
+    private final Map<String, BiFunction<String, String, AbstractQueryBuilder<?>>> functionMap;
+
+    QueryBuilderService(Map<String, BiFunction<String, String, AbstractQueryBuilder<?>>> functionMap) {
+        this.functionMap = functionMap;
+    }
+
+    public AbstractQueryBuilder<?> getQueryBuilder(String queryName, String fieldName, String query) {
+        BiFunction<String, String, AbstractQueryBuilder<?>> function = functionMap.get(queryName);
+        if (function == null) {
+            throw new ElasticsearchStatusException(
+                "No query builder registered for query [" + queryName + "]",
+                RestStatus.INTERNAL_SERVER_ERROR
+            );
+        }
+
+        return function.apply(fieldName, query);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilderServiceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilderServiceBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.plugins.SearchPlugin;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+public class QueryBuilderServiceBuilder {
+    private PluginsService pluginsService;
+
+    public QueryBuilderServiceBuilder pluginsService(PluginsService pluginsService) {
+        this.pluginsService = pluginsService;
+        return this;
+    }
+
+    public QueryBuilderService build() {
+        Objects.requireNonNull(pluginsService);
+
+        ImmutableOpenMap.Builder<String, BiFunction<String, String, AbstractQueryBuilder<?>>> functionMapBuilder = ImmutableOpenMap
+            .builder();
+        List<SearchPlugin> searchPlugins = pluginsService.filterPlugins(SearchPlugin.class).toList();
+        for (SearchPlugin searchPlugin : searchPlugins) {
+            // TODO: Detect query name conflicts before adding to map
+            functionMapBuilder.putAllFromMap(searchPlugin.getQueryBuilders());
+        }
+
+        return new QueryBuilderService(functionMapBuilder.build());
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -65,6 +65,7 @@ public class QueryRewriteContext {
     protected Predicate<String> allowedFields;
     private final ResolvedIndices resolvedIndices;
     private final PointInTimeBuilder pit;
+    private final QueryBuilderService queryBuilderService;
 
     public QueryRewriteContext(
         final XContentParserConfiguration parserConfiguration,
@@ -81,7 +82,8 @@ public class QueryRewriteContext {
         final BooleanSupplier allowExpensiveQueries,
         final ScriptCompiler scriptService,
         final ResolvedIndices resolvedIndices,
-        final PointInTimeBuilder pit
+        final PointInTimeBuilder pit,
+        final QueryBuilderService queryBuilderService
     ) {
 
         this.parserConfiguration = parserConfiguration;
@@ -100,6 +102,7 @@ public class QueryRewriteContext {
         this.scriptService = scriptService;
         this.resolvedIndices = resolvedIndices;
         this.pit = pit;
+        this.queryBuilderService = queryBuilderService;
     }
 
     public QueryRewriteContext(final XContentParserConfiguration parserConfiguration, final Client client, final LongSupplier nowInMillis) {
@@ -118,6 +121,7 @@ public class QueryRewriteContext {
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -127,7 +131,8 @@ public class QueryRewriteContext {
         final Client client,
         final LongSupplier nowInMillis,
         final ResolvedIndices resolvedIndices,
-        final PointInTimeBuilder pit
+        final PointInTimeBuilder pit,
+        final QueryBuilderService queryBuilderService
     ) {
         this(
             parserConfiguration,
@@ -144,7 +149,8 @@ public class QueryRewriteContext {
             null,
             null,
             resolvedIndices,
-            pit
+            pit,
+            queryBuilderService
         );
     }
 
@@ -405,5 +411,9 @@ public class QueryRewriteContext {
     @Nullable
     public PointInTimeBuilder getPointInTimeBuilder() {
         return pit;
+    }
+
+    public QueryBuilderService getQueryBuilderService() {
+        return queryBuilderService;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -270,6 +270,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
             allowExpensiveQueries,
             scriptService,
             null,
+            null,
             null
         );
         this.shardId = shardId;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1762,7 +1762,7 @@ public class IndicesService extends AbstractLifecycleComponent
      * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
      */
     public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis, ResolvedIndices resolvedIndices, PointInTimeBuilder pit) {
-        return new QueryRewriteContext(parserConfig, client, nowInMillis, resolvedIndices, pit);
+        return new QueryRewriteContext(parserConfig, client, nowInMillis, resolvedIndices, pit, queryBuilderService);
     }
 
     public DataRewriteContext getDataRewriteContext(LongSupplier nowInMillis) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -110,6 +110,8 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.CoordinatorRewriteContextProvider;
 import org.elasticsearch.index.query.DataRewriteContext;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilderService;
+import org.elasticsearch.index.query.QueryBuilderServiceBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.recovery.RecoveryStats;
 import org.elasticsearch.index.refresh.RefreshStats;
@@ -262,6 +264,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final TimestampFieldMapperService timestampFieldMapperService;
     private final CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator;
     private final MapperMetrics mapperMetrics;
+    private final QueryBuilderService queryBuilderService;
 
     @Override
     protected void doStart() {
@@ -378,6 +381,7 @@ public class IndicesService extends AbstractLifecycleComponent
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ALLOW_EXPENSIVE_QUERIES, this::setAllowExpensiveQueries);
 
         this.timestampFieldMapperService = new TimestampFieldMapperService(settings, threadPool, this);
+        this.queryBuilderService = new QueryBuilderServiceBuilder().pluginsService(pluginsService).build();
     }
 
     private static final String DANGLING_INDICES_UPDATE_THREAD_NAME = "DanglingIndices#updateTask";

--- a/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParser;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
@@ -125,6 +126,10 @@ public interface SearchPlugin {
      */
     default List<QuerySpec<?>> getQueries() {
         return emptyList();
+    }
+
+    default Map<String, BiFunction<String, String, AbstractQueryBuilder<?>>> getQueryBuilders() {
+        return Map.of();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -1741,7 +1741,9 @@ public class TransportSearchActionTests extends ESTestCase {
             NodeClient client = new NodeClient(settings, threadPool);
 
             SearchService searchService = mock(SearchService.class);
-            when(searchService.getRewriteContext(any(), any(), any())).thenReturn(new QueryRewriteContext(null, null, null, null, null));
+            when(searchService.getRewriteContext(any(), any(), any())).thenReturn(
+                new QueryRewriteContext(null, null, null, null, null, null)
+            );
             ClusterService clusterService = new ClusterService(
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -689,7 +689,12 @@ public class IndexMetadataTests extends ESTestCase {
     }
 
     private static InferenceFieldMetadata randomInferenceFieldMetadata(String name) {
-        return new InferenceFieldMetadata(name, randomIdentifier(), randomSet(1, 5, ESTestCase::randomIdentifier).toArray(String[]::new));
+        return new InferenceFieldMetadata(
+            name,
+            randomIdentifier(),
+            randomSet(1, 5, ESTestCase::randomIdentifier).toArray(String[]::new),
+            randomIdentifier()
+        );
     }
 
     private IndexMetadataStats randomIndexStats(int numberOfShards) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadataTests.java
@@ -61,12 +61,14 @@ public class InferenceFieldMetadataTests extends AbstractXContentTestCase<Infere
         String name = randomAlphaOfLengthBetween(3, 10);
         String inferenceId = randomIdentifier();
         String[] inputFields = generateRandomStringArray(5, 10, false, false);
-        return new InferenceFieldMetadata(name, inferenceId, inputFields);
+        String queryName = randomIdentifier();
+        return new InferenceFieldMetadata(name, inferenceId, inputFields, queryName);
     }
 
     public void testNullCtorArgsThrowException() {
-        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata(null, "inferenceId", new String[0]));
-        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", null, new String[0]));
-        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", "inferenceId", null));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata(null, "inferenceId", new String[0], "queryName"));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", null, new String[0], "queryName"));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", "inferenceId", null, "queryName"));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", "inferenceId", new String[0], null));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupInferenceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupInferenceFieldMapperTests.java
@@ -46,10 +46,12 @@ public class MappingLookupInferenceFieldMapperTests extends MapperServiceTestCas
         InferenceFieldMetadata inferenceFieldMetadata = inferenceFieldMetadataMap.get("inference_field");
         assertThat(inferenceFieldMetadata.getInferenceId(), equalTo(TestInferenceFieldMapper.INFERENCE_ID));
         assertThat(inferenceFieldMetadata.getSourceFields(), arrayContaining("inference_field"));
+        assertThat(inferenceFieldMetadata.getQueryName(), equalTo(TestInferenceFieldMapper.QUERY_NAME));
 
         inferenceFieldMetadata = inferenceFieldMetadataMap.get("another_inference_field");
         assertThat(inferenceFieldMetadata.getInferenceId(), equalTo(TestInferenceFieldMapper.INFERENCE_ID));
         assertThat(inferenceFieldMetadata.getSourceFields(), arrayContaining("another_inference_field"));
+        assertThat(inferenceFieldMetadata.getQueryName(), equalTo(TestInferenceFieldMapper.QUERY_NAME));
     }
 
     public void testInferenceFieldMapperWithCopyTo() throws Exception {
@@ -79,6 +81,7 @@ public class MappingLookupInferenceFieldMapperTests extends MapperServiceTestCas
             inferenceFieldMetadata.getSourceFields(),
             arrayContainingInAnyOrder("another_non_inference_field", "inference_field", "non_inference_field")
         );
+        assertThat(inferenceFieldMetadata.getQueryName(), equalTo(TestInferenceFieldMapper.QUERY_NAME));
     }
 
     private static class TestInferenceFieldMapperPlugin extends Plugin implements MapperPlugin {
@@ -94,6 +97,7 @@ public class MappingLookupInferenceFieldMapperTests extends MapperServiceTestCas
         public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n));
         public static final String INFERENCE_ID = "test_inference_id";
         public static final String CONTENT_TYPE = "test_inference_field";
+        public static final String QUERY_NAME = "test_query_name";
 
         TestInferenceFieldMapper(String simpleName) {
             super(simpleName, new TestInferenceFieldMapperFieldType(simpleName), MultiFields.empty(), CopyTo.empty());
@@ -101,7 +105,7 @@ public class MappingLookupInferenceFieldMapperTests extends MapperServiceTestCas
 
         @Override
         public InferenceFieldMetadata getMetadata(Set<String> sourcePaths) {
-            return new InferenceFieldMetadata(fullPath(), INFERENCE_ID, sourcePaths.toArray(new String[0]));
+            return new InferenceFieldMetadata(fullPath(), INFERENCE_ID, sourcePaths.toArray(new String[0]), QUERY_NAME);
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -618,7 +618,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 () -> true,
                 scriptService,
                 createMockResolvedIndices(),
-                null
+                null,
+                null // TODO: Create real query builder service here
             );
         }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceRegistry;
@@ -98,6 +99,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -334,6 +336,11 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
 
     public List<QuerySpec<?>> getQueries() {
         return List.of(new QuerySpec<>(SemanticQueryBuilder.NAME, SemanticQueryBuilder::new, SemanticQueryBuilder::fromXContent));
+    }
+
+    @Override
+    public Map<String, BiFunction<String, String, AbstractQueryBuilder<?>>> getQueryBuilders() {
+        return Map.of(SemanticQueryBuilder.NAME, SemanticQueryBuilder::new);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ml.inference.results.MlTextEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+import org.elasticsearch.xpack.inference.queries.SemanticQueryBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -290,7 +291,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         String[] copyFields = sourcePaths.toArray(String[]::new);
         // ensure consistent order
         Arrays.sort(copyFields);
-        return new InferenceFieldMetadata(fullPath(), fieldType().inferenceId, copyFields);
+        return new InferenceFieldMetadata(fullPath(), fieldType().inferenceId, copyFields, SemanticQueryBuilder.NAME);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
@@ -101,7 +101,7 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
             new BulkItemRequest[0]
         );
         request.setInferenceFieldMap(
-            Map.of("foo", new InferenceFieldMetadata("foo", "bar", generateRandomStringArray(5, 10, false, false)))
+            Map.of("foo", new InferenceFieldMetadata("foo", "bar", generateRandomStringArray(5, 10, false, false), "baz"))
         );
         filter.apply(task, TransportShardBulkAction.ACTION_NAME, request, actionListener, actionFilterChain);
         awaitLatch(chainExecuted, 10, TimeUnit.SECONDS);
@@ -135,11 +135,11 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
         Map<String, InferenceFieldMetadata> inferenceFieldMap = Map.of(
             "field1",
-            new InferenceFieldMetadata("field1", model.getInferenceEntityId(), new String[] { "field1" }),
+            new InferenceFieldMetadata("field1", model.getInferenceEntityId(), new String[] { "field1" }, "queryName"),
             "field2",
-            new InferenceFieldMetadata("field2", "inference_0", new String[] { "field2" }),
+            new InferenceFieldMetadata("field2", "inference_0", new String[] { "field2" }, "queryName"),
             "field3",
-            new InferenceFieldMetadata("field3", "inference_0", new String[] { "field3" })
+            new InferenceFieldMetadata("field3", "inference_0", new String[] { "field3" }, "queryName")
         );
         BulkItemRequest[] items = new BulkItemRequest[10];
         for (int i = 0; i < items.length; i++) {
@@ -193,7 +193,7 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
         Map<String, InferenceFieldMetadata> inferenceFieldMap = Map.of(
             "field1",
-            new InferenceFieldMetadata("field1", model.getInferenceEntityId(), new String[] { "field1" })
+            new InferenceFieldMetadata("field1", model.getInferenceEntityId(), new String[] { "field1" }, "queryName")
         );
         BulkItemRequest[] items = new BulkItemRequest[3];
         items[0] = new BulkItemRequest(0, new IndexRequest("index").source("field1", "I am a failure"));
@@ -219,7 +219,7 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
         for (int i = 0; i < numInferenceFields; i++) {
             String field = randomAlphaOfLengthBetween(5, 10);
             String inferenceId = randomFrom(inferenceModelMap.keySet());
-            inferenceFieldMap.put(field, new InferenceFieldMetadata(field, inferenceId, new String[] { field }));
+            inferenceFieldMap.put(field, new InferenceFieldMetadata(field, inferenceId, new String[] { field }, "queryName"));
         }
 
         int numRequests = atLeast(100);


### PR DESCRIPTION
POC implementation of `match` query support for `semantic_text` fields. The technical goal of this POC is to update the `match` query rewrite logic such that it is rewritten to a `semantic` query when we detect that we are querying a `semantic_text` field.

There were two big challenges implementing this POC:

- Rewriting to a `semantic` query *must* happen on the coordinating node, where mappings are not available
- `match` query code lives in `server`, while `semantic` query code lives in the `inference` plugin

I solved these challenges in the POC by adding the name of the query that should be used to query the inference field to `InferenceFieldMetadata`. Since this is stored in index metadata, it is available on the coordinating node. I also added `QueryBuilderService`, which stores query builder creation functions for query builders that can be created using a field name and query string. `QueryBuilderService` is then populated using the `getQueryBuilders` plugin hook. I added `QueryBuilderService` to `QueryRewriteContext`, making it available to the `match` query during rewrite on the coordinating node. The query name from `InferenceFieldMetadata` is then used to create the proper query builder using `QueryBuilderService`.

Because of scoring incompatibility issues, the `match` query can be used to query `semantic_text` fields only when that is the only field type being queried. That is to say, you can't query a `text` field and `semantic_text` field using the same `match` query.

Putting it all together, it means you can now do things like this:

```json
PUT _inference/sparse_embedding/my-elser-endpoint
{
  "service": "elser",
  "service_settings": {
    "num_allocations": 1,
    "num_threads": 1
  },
  "task_settings": {}
}

PUT my-index-1
{
    "mappings": {
        "properties": {
            "inference_field": {
                "type": "semantic_text",
                "inference_id": "my-elser-endpoint"
            },
            "text_field": {
                "type": "text"
            }
        }
    }
}

PUT my-index-2
{
    "mappings": {
        "properties": {
            "inference_field": {
                "type": "text"
            },
            "text_field": {
                "type": "text"
            }
        }
    }
}

POST my-index-1/_doc/1
{
  "inference_field": "a test value",
  "text_field": "a test value"
}

POST my-index-2/_doc/1
{
  "inference_field": "a test value",
  "text_field": "a test value"
}

GET my-index-1/_search
{
  "query": {
    "match": {
      "inference_field": "test"
    }
  }
}

GET my-index-1/_search
{
  "query": {
    "match": {
      "text_field": "test"
    }
  }
}

// Fails due to combination of text & semantic_text fields
GET my-index-*/_search
{
  "query": {
    "match": {
      "inference_field": "test"
    }
  }
}
```
