### PR TITLE
handle 100-continue and oversized streaming request

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -33,7 +33,6 @@ import java.util.function.Predicate;
  * A wrapper around {@link HttpObjectAggregator}. Provides optional content aggregation based on
  * predicate. {@link HttpObjectAggregator} also handles Expect: 100-continue and oversized content.
  * Unfortunately, Netty does not provide handlers for oversized messages beyond HttpObjectAggregator.
- * These details are tight to {@link HttpObjectAggregator} and {@link io.netty.handler.codec.MessageAggregator}.
  * </p>
  * <p>
  * This wrapper cherry-pick methods from underlying handlers.

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -8,15 +8,10 @@
 
 package org.elasticsearch.http.netty4;
 
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequest;
@@ -29,27 +24,15 @@ import org.elasticsearch.http.netty4.internal.HttpHeadersAuthenticatorUtils;
 import java.util.function.Predicate;
 
 /**
- * <p>
  * A wrapper around {@link HttpObjectAggregator}. Provides optional content aggregation based on
  * predicate. {@link HttpObjectAggregator} also handles Expect: 100-continue and oversized content.
  * Unfortunately, Netty does not provide handlers for oversized messages beyond HttpObjectAggregator.
- * </p>
- * <p>
- * This wrapper cherry-pick methods from underlying handlers.
- * {@link HttpObjectAggregator#newContinueResponse(HttpMessage, int, ChannelPipeline)} provides
- * handling for Expect: 100-continue. {@link HttpObjectAggregator#handleOversizedMessage(ChannelHandlerContext, HttpMessage)}
- * provides handling for requests that already in fly and reached limit, for example chunked encoding.
- * </p>
- *
  */
 public class Netty4HttpAggregator extends HttpObjectAggregator {
     private static final Predicate<HttpPreRequest> IGNORE_TEST = (req) -> req.uri().startsWith("/_test/request-stream") == false;
 
     private final Predicate<HttpPreRequest> decider;
     private boolean aggregating = true;
-    private long currentContentLength = 0;
-    private HttpRequest currentRequest;
-    private boolean handlingOversized = false;
     private boolean ignoreContentAfterContinueResponse = false;
 
     public Netty4HttpAggregator(int maxContentLength) {
@@ -75,7 +58,7 @@ public class Netty4HttpAggregator extends HttpObjectAggregator {
         }
     }
 
-    private void handle(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
+    private void handle(ChannelHandlerContext ctx, HttpObject msg) {
         if (msg instanceof HttpRequest request) {
             var continueResponse = newContinueResponse(request, maxContentLength(), ctx.pipeline());
             if (continueResponse != null) {
@@ -90,34 +73,11 @@ public class Netty4HttpAggregator extends HttpObjectAggregator {
                 }
                 HttpUtil.set100ContinueExpected(request, false);
             }
-            currentRequest = request;
-            currentContentLength = 0;
             ignoreContentAfterContinueResponse = false;
             ctx.fireChannelRead(msg);
-
         } else {
             var httpContent = (HttpContent) msg;
             if (ignoreContentAfterContinueResponse) {
-                httpContent.release();
-                return;
-            }
-            currentContentLength += httpContent.content().readableBytes();
-            if (currentContentLength > maxContentLength()) {
-                if (handlingOversized == false) {
-                    handlingOversized = true;
-                    // magic: passing full request into handleOversizedMessage will close connection
-                    var fullReq = new DefaultFullHttpRequest(
-                        currentRequest.protocolVersion(),
-                        currentRequest.method(),
-                        currentRequest.uri(),
-                        Unpooled.EMPTY_BUFFER,
-                        currentRequest.headers(),
-                        EmptyHttpHeaders.INSTANCE
-                    );
-                    handleOversizedMessage(ctx, fullReq);
-                }
-                // if we're already handling oversized message connection will be closed soon
-                // we can discard following content
                 httpContent.release();
             } else {
                 ctx.fireChannelRead(msg);


### PR DESCRIPTION
Extend Netty4HttpAggregator to handle 100-continue, 413/417 for partial content. I reuse public API from MessageAggregator that handles 100-continue. For known content length I dont close connection after 413/417. For chunked content there is no limit, rest handler will decide when to stop.

Added integ tests.