### PR TITLE
Make slow logger's Logger instances static

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
@@ -90,7 +90,11 @@ public final class IndexingSlowLog implements IndexingOperationListener {
         Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
 
-    private final Logger indexLogger;
+    private static final Logger indexLogger = LogManager.getLogger(INDEX_INDEXING_SLOWLOG_PREFIX + ".index");
+    static {
+        Loggers.setLevel(indexLogger, Level.TRACE);
+    }
+
     private final Index index;
 
     private boolean reformat;
@@ -127,8 +131,6 @@ public final class IndexingSlowLog implements IndexingOperationListener {
 
     IndexingSlowLog(IndexSettings indexSettings, SlowLogFieldProvider slowLogFieldProvider) {
         this.slowLogFieldProvider = slowLogFieldProvider;
-        this.indexLogger = LogManager.getLogger(INDEX_INDEXING_SLOWLOG_PREFIX + ".index");
-        Loggers.setLevel(this.indexLogger, Level.TRACE);
         this.index = indexSettings.getIndex();
 
         indexSettings.getScopedSettings().addSettingsUpdateConsumer(INDEX_INDEXING_SLOWLOG_REFORMAT_SETTING, this::setReformat);

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -41,12 +41,17 @@ public final class SearchSlowLog implements SearchOperationListener {
     private long fetchDebugThreshold;
     private long fetchTraceThreshold;
 
-    private final Logger queryLogger;
-    private final Logger fetchLogger;
+    static final String INDEX_SEARCH_SLOWLOG_PREFIX = "index.search.slowlog";
+
+    private static final Logger queryLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
+    private static final Logger fetchLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
+
+    static {
+        Loggers.setLevel(queryLogger, Level.TRACE);
+        Loggers.setLevel(fetchLogger, Level.TRACE);
+    }
 
     private final SlowLogFieldProvider slowLogFieldProvider;
-
-    static final String INDEX_SEARCH_SLOWLOG_PREFIX = "index.search.slowlog";
 
     public static final Setting<Boolean> INDEX_SEARCH_SLOWLOG_INCLUDE_USER_SETTING = Setting.boolSetting(
         INDEX_SEARCH_SLOWLOG_PREFIX + ".include.user",
@@ -130,12 +135,6 @@ public final class SearchSlowLog implements SearchOperationListener {
     public SearchSlowLog(IndexSettings indexSettings, SlowLogFieldProvider slowLogFieldProvider) {
         slowLogFieldProvider.init(indexSettings);
         this.slowLogFieldProvider = slowLogFieldProvider;
-
-        this.queryLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
-        this.fetchLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
-        Loggers.setLevel(this.fetchLogger, Level.TRACE);
-        Loggers.setLevel(this.queryLogger, Level.TRACE);
-
         indexSettings.getScopedSettings()
             .addSettingsUpdateConsumer(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING, this::setQueryWarnThreshold);
         this.queryWarnThreshold = indexSettings.getValue(INDEX_SEARCH_SLOWLOG_THRESHOLD_QUERY_WARN_SETTING).nanos();


### PR DESCRIPTION
These can be made static now that they aren't index specific any longer, saving measurable time in test execution + it's just the right thing to do here.
