### PR TITLE
Avoid cache io field volatile accesses

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -912,6 +912,11 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             return io;
         }
 
+        // for use in tests *only*
+        SharedBytes.IO testOnlyNonVolatileIO() {
+            return io;
+        }
+
         /**
          * Optimistically try to read from the region
          * @return true if successful, i.e., not evicted and data available, false if evicted

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -903,6 +903,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         private void volatileIO(SharedBytes.IO io) {
             VH_IO.setVolatile(this, io);
         }
+
         /**
          * Optimistically try to read from the region
          * @return true if successful, i.e., not evicted and data available, false if evicted

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -906,7 +906,10 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             VH_IO.setVolatile(this, io);
         }
 
-        private SharedBytes.IO nonVolatileIO() { return io; }
+        private SharedBytes.IO nonVolatileIO() {
+            return io;
+        }
+
         /**
          * Optimistically try to read from the region
          * @return true if successful, i.e., not evicted and data available, false if evicted

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -149,7 +149,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
         }
     }
 
-    private static boolean tryEvict(SharedBlobCacheService<Object>.CacheFileRegion region1) {
+    private static boolean tryEvict(SharedBlobCacheService.CacheFileRegion<Object> region1) {
         if (randomBoolean()) {
             return region1.tryEvict();
         } else {
@@ -486,7 +486,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                         ready.await();
                         for (int i = 0; i < iterations; ++i) {
                             try {
-                                SharedBlobCacheService<String>.CacheFileRegion cacheFileRegion;
+                                SharedBlobCacheService.CacheFileRegion<String> cacheFileRegion;
                                 try {
                                     cacheFileRegion = cacheService.get(cacheKeys[i], fileLength, regions[i]);
                                 } catch (AlreadyClosedException e) {
@@ -865,7 +865,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
         try (
             NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
-            var cacheService = new SharedBlobCacheService<>(
+            var cacheService = new SharedBlobCacheService<Object>(
                 environment,
                 settings,
                 taskQueue.getThreadPool(),
@@ -873,7 +873,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                 BlobCacheMetrics.NOOP
             )
         ) {
-            final Map<Object, SharedBlobCacheService<Object>.CacheFileRegion> cacheEntries = new HashMap<>();
+            final Map<Object, SharedBlobCacheService.CacheFileRegion<Object>> cacheEntries = new HashMap<>();
 
             assertThat("All regions are free", cacheService.freeRegionCount(), equalTo(numRegions));
             assertThat("Cache has no entries", cacheService.maybeEvictLeastUsed(), is(false));

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -497,6 +497,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                                     if (yield[i] == 0) {
                                         Thread.yield();
                                     }
+                                    assertNotNull(cacheFileRegion.testOnlyNonVolatileIO());
                                     cacheFileRegion.decRef();
                                 }
                                 if (evict[i] == 0) {


### PR DESCRIPTION
The blob cache has an io field per region that is declared volatile, since it is originally null
and then later initialized. However, during "tryRead" we do not need the volatile access.
This commit changes the field to be non-volatile and use proper volatile accesses only
when needed.

Alternative to #112134