### PR TITLE
Unmute SQL CSV spec tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -128,42 +128,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: "test {p0=esql/26_aggs_bucket/friendlier BUCKET interval: monthly #110916}"
   issue: https://github.com/elastic/elasticsearch/issues/111902
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcCsvSpecIT
-  method: test {agg-ordering.testHistogramDateTimeWithCountAndOrder_1}
-  issue: https://github.com/elastic/elasticsearch/issues/111918
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcCsvSpecIT
-  method: test {agg-ordering.testHistogramDateTimeWithCountAndOrder_2}
-  issue: https://github.com/elastic/elasticsearch/issues/111919
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcCsvSpecIT
-  method: test {agg-ordering.testHistogramDateTimeWithCountAndOrder_2}
-  issue: https://github.com/elastic/elasticsearch/issues/111919
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcCsvSpecIT
-  method: test {date.testDateParseHaving}
-  issue: https://github.com/elastic/elasticsearch/issues/111921
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcCsvSpecIT
-  method: test {datetime.testDateTimeParseHaving}
-  issue: https://github.com/elastic/elasticsearch/issues/111922
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcCsvSpecIT
-  method: test {agg-ordering.testHistogramDateTimeWithCountAndOrder_1}
-  issue: https://github.com/elastic/elasticsearch/issues/111918
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcCsvSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/111923
-- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.JdbcCsvSpecIT
-  method: test {datetime.testDateTimeParseHaving}
-  issue: https://github.com/elastic/elasticsearch/issues/111922
-- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.JdbcCsvSpecIT
-  method: test {agg-ordering.testHistogramDateTimeWithCountAndOrder_1}
-  issue: https://github.com/elastic/elasticsearch/issues/111918
-- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.JdbcCsvSpecIT
-  method: test {date.testDateParseHaving}
-  issue: https://github.com/elastic/elasticsearch/issues/111921
-- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.JdbcCsvSpecIT
-  method: test {agg-ordering.testHistogramDateTimeWithCountAndOrder_2}
-  issue: https://github.com/elastic/elasticsearch/issues/111919
-- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.JdbcCsvSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/111923
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcCsvSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/111923
 - class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
   method: testScaledFloat
   issue: https://github.com/elastic/elasticsearch/issues/112003


### PR DESCRIPTION
Unmute SQL CSV Spec tests fixed by https://github.com/elastic/elasticsearch/pull/111938