### PR TITLE
Support docvalues only query in shape field

### DIFF
--- a/docs/changelog/112199.yaml
+++ b/docs/changelog/112199.yaml
@@ -1,0 +1,5 @@
+pr: 112199
+summary: Support docvalues only query in shape field
+area: Geo
+type: enhancement
+issues: []

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -51,16 +51,18 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
 
     @Override
     protected XContentBuilder createDefaultMapping() throws Exception {
-        XContentBuilder xcb = XContentFactory.jsonBuilder()
+        final boolean isIndexed = randomBoolean();
+        final boolean hasDocValues = isIndexed == false || randomBoolean();
+        return XContentFactory.jsonBuilder()
             .startObject()
             .startObject("properties")
             .startObject(defaultFieldName)
             .field("type", "shape")
+            .field("index", isIndexed)
+            .field("doc_values", hasDocValues)
             .endObject()
             .endObject()
             .endObject();
-
-        return xcb;
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryProcessor.java
@@ -14,51 +14,26 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.LuceneGeometriesUtils;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.index.IndexVersions;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.query.QueryShardException;
-import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.spatial.CartesianShapeDocValuesQuery;
-import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
 
 public class ShapeQueryProcessor {
 
-    public Query shapeQuery(
-        Geometry geometry,
-        String fieldName,
-        ShapeRelation relation,
-        SearchExecutionContext context,
-        boolean hasDocValues
-    ) {
-        validateIsShapeFieldType(fieldName, context);
-        // CONTAINS queries are not supported by VECTOR strategy for indices created before version 7.5.0 (Lucene 8.3.0);
-        if (relation == ShapeRelation.CONTAINS && context.indexVersionCreated().before(IndexVersions.V_7_5_0)) {
-            throw new QueryShardException(context, ShapeRelation.CONTAINS + " query relation not supported for Field [" + fieldName + "].");
-        }
+    public Query shapeQuery(Geometry geometry, String fieldName, ShapeRelation relation, boolean indexed, boolean hasDocValues) {
+        assert indexed || hasDocValues;
         if (geometry == null || geometry.isEmpty()) {
             return new MatchNoDocsQuery();
         }
-        final XYGeometry[] luceneGeometries;
-        try {
-            luceneGeometries = LuceneGeometriesUtils.toXYGeometry(geometry, t -> {});
-        } catch (IllegalArgumentException e) {
-            throw new QueryShardException(context, "Exception creating query on Field [" + fieldName + "] " + e.getMessage(), e);
-        }
-        Query query = XYShape.newGeometryQuery(fieldName, relation.getLuceneRelation(), luceneGeometries);
-        if (hasDocValues) {
-            final Query queryDocValues = new CartesianShapeDocValuesQuery(fieldName, relation.getLuceneRelation(), luceneGeometries);
-            query = new IndexOrDocValuesQuery(query, queryDocValues);
+        final XYGeometry[] luceneGeometries = LuceneGeometriesUtils.toXYGeometry(geometry, t -> {});
+        Query query;
+        if (indexed) {
+            query = XYShape.newGeometryQuery(fieldName, relation.getLuceneRelation(), luceneGeometries);
+            if (hasDocValues) {
+                final Query queryDocValues = new CartesianShapeDocValuesQuery(fieldName, relation.getLuceneRelation(), luceneGeometries);
+                query = new IndexOrDocValuesQuery(query, queryDocValues);
+            }
+        } else {
+            query = new CartesianShapeDocValuesQuery(fieldName, relation.getLuceneRelation(), luceneGeometries);
         }
         return query;
-    }
-
-    private void validateIsShapeFieldType(String fieldName, SearchExecutionContext context) {
-        MappedFieldType fieldType = context.getFieldType(fieldName);
-        if (fieldType instanceof ShapeFieldMapper.ShapeFieldType == false) {
-            throw new QueryShardException(
-                context,
-                "Expected " + ShapeFieldMapper.CONTENT_TYPE + " field type for Field [" + fieldName + "] but found " + fieldType.typeName()
-            );
-        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/CircleProcessorTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.geometry.utils.CircleUtils;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
@@ -39,7 +38,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType;
-import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper.ShapeFieldType;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryProcessor;
 
 import java.io.IOException;
@@ -244,17 +242,13 @@ public class CircleProcessorTests extends ESTestCase {
         int numSides = randomIntBetween(4, 1000);
         Geometry geometry = CircleUtils.createRegularShapePolygon(circle, numSides);
 
-        MappedFieldType shapeType = new ShapeFieldType(fieldName, true, true, Orientation.RIGHT, null, Collections.emptyMap());
-
         ShapeQueryProcessor processor = new ShapeQueryProcessor();
-        SearchExecutionContext mockedContext = mock(SearchExecutionContext.class);
-        when(mockedContext.getFieldType(any())).thenReturn(shapeType);
-        Query sameShapeQuery = processor.shapeQuery(geometry, fieldName, ShapeRelation.INTERSECTS, mockedContext, true);
+        Query sameShapeQuery = processor.shapeQuery(geometry, fieldName, ShapeRelation.INTERSECTS, true, true);
         Query centerPointQuery = processor.shapeQuery(
             new Point(circle.getLon(), circle.getLat()),
             fieldName,
             ShapeRelation.INTERSECTS,
-            mockedContext,
+            true,
             true
         );
 


### PR DESCRIPTION
We currently only support queries if the field is indexed but there is not technical reason not to support queries if the field has only doc values. Therefore this commit adds that possibility.