### PR TITLE
ES|QL: better validation of GROK patterns

### DIFF
--- a/docs/changelog/112200.yaml
+++ b/docs/changelog/112200.yaml
@@ -1,0 +1,6 @@
+pr: 112200
+summary: "ES|QL: better validation of GROK patterns"
+area: ES|QL
+type: bug
+issues:
+ - 112111

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -791,6 +791,11 @@ public class StatementParserTests extends AbstractStatementParserTests {
             "line 1:22: Invalid GROK pattern [%{NUMBER:foo} %{WORD:foo}]:"
                 + " the attribute [foo] is defined multiple times with different types"
         );
+
+        expectError(
+            "row a = \"foo\" | GROK a \"(?P<justification>.+)\"",
+            "line 1:18: Invalid grok pattern [(?P<justification>.+)]: [undefined group option]"
+        );
     }
 
     public void testLikeRLike() {


### PR DESCRIPTION
Catch exceptions when building GROK with a wrong pattern, and emit a client exception with a meaningful error message.

Fixes https://github.com/elastic/elasticsearch/issues/112111