### PR TITLE
Expose global retention settings

### DIFF
--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -253,8 +253,17 @@ Functionality in preview:[]. Contains the configuration for the data stream life
 =====
 `data_retention`::
 (string)
+If defined, it represents the retention requested by the data stream owner for this data stream.
+
+`effective_retention`::
+(string)
 If defined, every document added to this data stream will be stored at least for this time frame. Any time after this
-duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.
+duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely. The
+effective retention is calculated as described in the <<effective-retention-calculation, tutorial>>.
+
+`retention_determined_by`::
+(string)
+The source of the retention, it can be one of three values, `data_stream_configuration`, `default_retention` or `max_retention`.
 
 `rollover`::
 (object)
@@ -268,6 +277,22 @@ param `include_defaults` is set to `true`. The contents of this field are subjec
 If `true`, the next write to this data stream will trigger a rollover first and the document will be
 indexed in the new backing index. If the rollover fails the indexing request will fail too.
 ====
+
+`global_retention`::
+(object)
+Contains the global max and default retention. Global retention is only retrieved when the request sets `include_defaults` to `true`.
++
+.Properties of `global_retention`
+[%collapsible%open]
+====
+`max_retention`::
+(string)
+The effective retention of data streams managed by the data stream lifecycle cannot exceed this value.
+
+`default_retention`::
+(string)
+This will be the effective retention of data streams managed by the data stream lifecycle that do not specify `data_retention`.
+=====
 
 [[get-data-stream-api-example]]
 ==== {api-examples-title}

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
@@ -223,7 +223,8 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
         return new GetDataStreamAction.Response(
             dataStreamInfos,
             request.includeDefaults() ? clusterSettings.get(DataStreamLifecycle.CLUSTER_LIFECYCLE_DEFAULT_ROLLOVER_SETTING) : null,
-            globalRetentionSettings.get()
+            globalRetentionSettings.get(),
+            request.includeDefaults()
         );
     }
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
@@ -55,6 +55,6 @@ public class RestGetDataStreamsAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Set.of(DataStreamLifecycle.EFFECTIVE_RETENTION_REST_API_CAPABILITY);
+        return Set.of(DataStreamLifecycle.EFFECTIVE_RETENTION_REST_API_CAPABILITY, "data_stream_global_retention");
     }
 }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -1151,10 +1151,52 @@ setup:
   - is_true: acknowledged
 
 ---
+"Get data stream api check the exposure of global retention":
+  - requires:
+      reason: "Global retention was exposed in 8.16+"
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: GET
+          path: /_data_stream/{index}
+          capabilities: [ 'data_stream_global_retention' ]
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+        include_defaults: true
+  - match: { global_retention: { } }
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            data_streams.lifecycle.retention.default: "7d"
+            data_streams.lifecycle.retention.max: "90d"
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+        include_defaults: true
+  - match: { global_retention.default_retention: "7d" }
+  - match: { global_retention.max_retention: "90d" }
+
+  - do:
+      indices.get_data_stream:
+        name: "*"
+  - is_false: global_retention
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            data_streams.lifecycle.retention.max: null
+            data_streams.lifecycle.retention.default: null
+
+---
 "Create data stream with match all template":
   - requires:
       cluster_features: ["gte_v8.16.0"]
-      reason: "data streams supoprt for match all templates only supported in 8.16"
+      reason: "data streams support for match all templates only supported in 8.16"
 
   - do:
       allowed_warnings:

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -195,6 +195,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_PROFILE_SLEEPS = def(8_725_00_0);
     public static final TransportVersion ZDT_NANOS_SUPPORT = def(8_726_00_0);
     public static final TransportVersion LTR_SERVERLESS_RELEASE = def(8_727_00_0);
+    public static final TransportVersion EXPOSE_DATA_STREAM_GLOBAL_RETENTION = def(8_728_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -550,10 +550,6 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
             return globalRetention;
         }
 
-        public boolean includeGlobalRetention() {
-            return includeGlobalRetention;
-        }
-
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(dataStreams);


### PR DESCRIPTION
In this PR we expose the global retention via the `GET _data_stream` API.

```
GET /_data_stream/my-data-stream?include_defaults
{
 "global_retention": {
      "default_retention": "7d",
      "max_retention": "365d"
  }, 
  "data_streams": [...]
}
```