### PR TITLE
[8.15] Force using the last centroid during merging (#111644)

### DIFF
--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
@@ -302,8 +302,12 @@ public class MergingDigest extends AbstractTDigest {
                 addThis = projectedW <= wLimit;
             }
             if (i == 1 || i == incomingCount - 1) {
-                // force last centroid to never merge
+                // force first and last centroid to never merge
                 addThis = false;
+            }
+            if (lastUsedCell == mean.length - 1) {
+                // use the last centroid, there's no more
+                addThis = true;
             }
 
             if (addThis) {

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
@@ -151,4 +151,14 @@ public class MergingDigestTests extends TDigestTests {
             i++;
         }
     }
+
+    public void testLargeInputSmallCompression() {
+        MergingDigest td = new MergingDigest(10);
+        for (int i = 0; i < 10_000_000; i++) {
+            td.add(between(0, 3_600_000));
+        }
+        assertTrue(td.centroidCount() < 100);
+        assertTrue(td.quantile(0.00001) < 100_000);
+        assertTrue(td.quantile(0.99999) > 3_000_000);
+    }
 }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/TDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/TDigestTests.java
@@ -152,7 +152,7 @@ public abstract class TDigestTests extends ESTestCase {
         hist2.compress();
         double x1 = hist1.quantile(0.5);
         double x2 = hist2.quantile(0.5);
-        assertEquals(Dist.quantile(0.5, data), x1, 0.2);
+        assertEquals(Dist.quantile(0.5, data), x1, 0.25);
         assertEquals(x1, x2, 0.01);
     }
 


### PR DESCRIPTION
This will backport the following commits from main to 8.15:

- Force using the last centroid during merging (#111644)