### PR TITLE
[DOCS] Rewrite "What is Elasticsearch?" (Part 1)

### DIFF
--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -66,7 +66,7 @@ If you just want to get started quickly with a minimal local setup, refer to <<r
 
 * <<getting-started, Quickstart>>. A beginner's guide to deploying your first {es} instance, indexing data, and running queries.
 * https://elastic.co/webinars/getting-started-elasticsearch[Webinar: Introduction to {es}]. Register for our live webinars to learn directly from {es} experts.
-* Visit Elastic Search Labs for tutorials that AI-powered search using the latest {es} features.
+* https://www.elastic.co/search-labs[Elastic Search Labs]. Tutorials and blogs that explore AI-powered search using the latest {es} features.
 ** Follow our tutorial https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[to build a hybrid search solution in Python].
 ** Check out the https://github.com/elastic/elasticsearch-labs?tab=readme-ov-file#elasticsearch-examples--apps[`elasticsearch-labs` repository] for a range of Python notebooks and apps for various use cases.
 

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -10,7 +10,7 @@ Use {es} to search, index, store, and analyze data of all shapes and sizes in ne
 {es} has a lot of features. Explore the full list on the https://www.elastic.co/elasticsearch/features[product webpage^].
 ====
 
-{es} is the heart of the the <<elasticsearch-intro-elastic-stack,{stack}>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
+{es} is the heart of the <<elasticsearch-intro-elastic-stack,{stack}>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
 
 {es} is used for a wide and growing range of use cases. Here are a few examples:
 

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -1,21 +1,22 @@
 [[elasticsearch-intro]]
 == What is {es}?
 
-https://github.com/elastic/elasticsearch[{es}] is a distributed, RESTful search and analytics engine, scalable data store, and vector database built in Java on top of the Apache Lucene library.
-Use {es} to search, index, store, and analyze data of all shapes and sizes in near real-time.
+https://github.com/elastic/elasticsearch[{es}] is a distributed search and analytics engine, scalable data store, and vector database built on Apache Lucene.
+It's optimized for speed and relevance on production-scale workloads.
+Use {es} to search, index, store, and analyze data of all shapes and sizes in near real time.
 
 [TIP]
 ====
 {es} has a lot of features. Explore the full list on the https://www.elastic.co/elasticsearch/features[product webpage^].
 ====
 
-{es} is the heart of the the <<elasticsearch-intro-elastic-stack,Elastic Stack>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
+{es} is the heart of the <<elasticsearch-intro-elastic-stack,Elastic Stack>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
 
 {es} is used for a wide and growing range of use cases. Here are a few examples:
 
-* *Monitor log and event data*. Store and analyze logs, metrics, and security event data for operational insights and SIEM.
-* *Build search applications*. Add search capabilities to apps or websites and build enterprise search engines over your organization's internal data sources.
-* *Vector database*. Store and search vectorized data, create vector embeddings with built-in and third-party NLP models.
+* *Monitor log and event data*. Store logs, metrics, and event data for observability and security information and event management (SIEM).
+* *Build search applications*. Add search capabilities to apps or websites, or build enterprise search engines over your organization's internal data sources.
+* *Vector database*. Store and search vectorized data, and create vector embeddings with built-in and third-party natural language processing (NLP) models.
 * *Retrieval augmented generation (RAG)*. Use {es} as a retrieval engine to augment Generative AI models.
 * *Application and security monitoring*. Monitor and analyze application performance and security data effectively.
 * *Machine learning*. Use machine learning to automatically model the behavior of your data in real time.
@@ -28,15 +29,14 @@ Refer to our https://www.elastic.co/customers/success-stories[customer success s
 [[elasticsearch-intro-elastic-stack]]
 .What is the Elastic Stack?
 *******************************
-The Elastic Stack refers to the suite of products enabled by {es}:
+{es} is the core component of the Elastic Stack, a suite of products for collecting, storing, searching, and visualizing data.
 
 * https://www.elastic.co/guide/en/kibana/current/index.html[Kibana]. A UI for visualizing and exploring data in {es}.
 * https://www.elastic.co/guide/en/elasticsearch/client/index.html[Client libraries]. Work with {es} in your preferred programming language.
 * https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash]. A server-side data processing pipeline for ingesting and transforming data from multiple sources and indexing into {es}.
-* https://www.elastic.co/guide/en/fleet/current/fleet-overview.html[Fleet and Elastic Agent.] Elastic Agents is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. Fleet is a central place to configure and monitor your Elastic Agents.
+* https://www.elastic.co/guide/en/fleet/current/fleet-overview.html[Fleet and Elastic Agent.] Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. Fleet is a central place to configure and monitor your Elastic Agents.
 * https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats]. Lightweight data shippers for sending data from edge machines to {es}.
 * https://www.elastic.co/guide/en/observability/current/apm.html[APM]. Monitor the performance of your applications.
-* https://www.elastic.co/guide/en/elasticsearch/hadoop/current/float.html[{es} Hadoop]. Use {es} as a Hadoop input/output format.
 
 https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/stack-components.html[Learn more about the Elastic Stack].
 *******************************
@@ -49,20 +49,21 @@ https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its
 To use {es}, you need a running instance of the {es} service.
 You can deploy {es} in various ways:
 
+* <<run-elasticsearch-locally,*Local dev*>>. Get started quickly with a minimal local Docker setup. 
 * https://elastic.co/guide/en/cloud/current/ec-getting-started.html[*Elastic Cloud*]. {es} is available as part of our hosted Elastic Stack offering, deployed in the cloud with your provider of choice. Sign up for a https://cloud.elastic.co/registration[14 day free trial].
+* https://www.elastic.co/docs/current/serverless[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully-managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
+
+**Advanced deployment options**
+
+* <<elasticsearch-deployment-options,*Self managed*>>. Install, configure, and run {es} on your own premises.
 * https://elastic.co/guide/en/cloud-enterprise/current/Elastic-Cloud-Enterprise-overview.html[*Elastic Cloud Enterprise*]. Deploy Elastic Cloud on public or private clouds, virtual machines, or your own premises.
 * https://elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html[*Elastic Cloud on Kubernetes*]. Deploy Elastic Cloud on Kubernetes.
-* https://www.elastic.co/docs/current/serverless[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully-managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
-* <<elasticsearch-deployment-options,*Self managed*>>. Install, configure, and run {es} on your own premises.
-+
-[TIP]
-====
-If you just want to get started quickly with a minimal local setup, refer to <<run-elasticsearch-locally,Run {es} locally>>.
-====
 
 [discrete]
 [[elasticsearch-next-steps]]
 === Learn more
+
+Here are some resources to help you get started:
 
 * <<getting-started, Quickstart>>. A beginner's guide to deploying your first {es} instance, indexing data, and running queries.
 * https://elastic.co/webinars/getting-started-elasticsearch[Webinar: Introduction to {es}]. Register for our live webinars to learn directly from {es} experts.
@@ -70,8 +71,14 @@ If you just want to get started quickly with a minimal local setup, refer to <<r
 ** Follow our tutorial https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[to build a hybrid search solution in Python].
 ** Check out the https://github.com/elastic/elasticsearch-labs?tab=readme-ov-file#elasticsearch-examples--apps[`elasticsearch-labs` repository] for a range of Python notebooks and apps for various use cases.
 
+[[how-elasticsearch-works]]
+=== How {es} works
+
+This page outlines some fundamental {es} concepts and features, including how data is stored, indexing capabilities, search and analysis features, scalability, and disaster recovery options.
+
+[discrete]
 [[documents-indices]]
-=== Documents and indices
+==== Documents and indices
 
 {es} is a distributed document store. Instead of storing information as rows of
 columnar data, {es} stores complex data structures that have been serialized
@@ -122,11 +129,82 @@ The analysis chain that is applied to a full-text field during indexing is also
 used at search time. When you query a full-text field, the query text undergoes
 the same analysis before the terms are looked up in the index.
 
+[discrete]
+[[search-analyze]]
+==== Information out: search and analyze
+
+While you can use {es} as a document store and retrieve documents and their
+metadata, the real power comes from being able to easily access the full suite
+of search capabilities built on the Apache Lucene search engine library.
+
+{es} provides a simple, coherent REST API for managing your cluster and indexing
+and searching your data. For testing purposes, you can easily submit requests
+directly from the command line or through the Developer Console in {kib}. From
+your applications, you can use the
+https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} client]
+for your language of choice: Java, JavaScript, Go, .NET, PHP, Perl, Python
+or Ruby.
+
+[discrete]
+[[search-data]]
+===== Searching your data
+
+The {es} REST APIs support structured queries, full text queries, and complex
+queries that combine the two. Structured queries are
+similar to the types of queries you can construct in SQL. For example, you
+could search the `gender` and `age` fields in your `employee` index and sort the
+matches by the `hire_date` field. Full-text queries find all documents that
+match the query string and return them sorted by _relevance_&mdash;how good a
+match they are for your search terms.
+
+In addition to searching for individual terms, you can perform phrase searches,
+similarity searches, and prefix searches, and get autocomplete suggestions.
+
+Have geospatial or other numerical data that you want to search? {es} indexes
+non-textual data in optimized data structures that support
+high-performance geo and numerical queries.
+
+You can access all of these search capabilities using {es}'s
+comprehensive JSON-style query language (<<query-dsl, Query DSL>>). You can also
+construct <<sql-overview, SQL-style queries>> to search and aggregate data
+natively inside {es}, and JDBC and ODBC drivers enable a broad range of
+third-party applications to interact with {es} via SQL.
+
+[discrete]
+[[analyze-data]]
+===== Analyzing your data
+
+{es} aggregations enable you to build complex summaries of your data and gain
+insight into key metrics, patterns, and trends. Instead of just finding the
+proverbial “needle in a haystack”, aggregations enable you to answer questions
+like:
+
+* How many needles are in the haystack?
+* What is the average length of the needles?
+* What is the median length of the needles, broken down by manufacturer?
+* How many needles were added to the haystack in each of the last six months?
+
+You can also use aggregations to answer more subtle questions, such as:
+
+* What are your most popular needle manufacturers?
+* Are there any unusual or anomalous clumps of needles?
+
+Because aggregations leverage the same data-structures used for search, they are
+also very fast. This enables you to analyze and visualize your data in real time.
+Your reports and dashboards update as your data changes so you can take action
+based on the latest information.
+
+What’s more, aggregations operate alongside search requests. You can search
+documents, filter results, and perform analytics at the same time, on the same
+data, in a single request. And because aggregations are calculated in the
+context of a particular search, you’re not just displaying a count of all
+size 70 needles, you’re displaying a count of the size 70 needles
+that match your users' search criteria--for example, all size 70 _non-stick
+embroidery_ needles.
+
+[discrete]
 [[scalability]]
-=== Scalability and resilience: clusters, nodes, and shards
-++++
-<titleabbrev>Scalability and resilience</titleabbrev>
-++++
+==== Scalability and resilience
 
 {es} is built to be always available and to scale with your needs. It does this
 by being distributed by nature. You can add servers (nodes) to a cluster to
@@ -155,7 +233,7 @@ interrupting indexing or query operations.
 
 [discrete]
 [[it-depends]]
-==== It depends...
+===== Shard size and number of shards
 
 There are a number of performance considerations and trade offs with respect
 to shard size and the number of primary shards configured for an index. The more
@@ -183,7 +261,7 @@ testing with your own data and queries].
 
 [discrete]
 [[disaster-ccr]]
-==== In case of disaster
+===== Disaster recovery
 
 A cluster's nodes need good, reliable connections to each other. To provide
 better connections, you typically co-locate the nodes in the same data center or
@@ -201,9 +279,15 @@ create secondary clusters to serve read requests in geo-proximity to your users.
 the active leader index and handles all write requests. Indices replicated to
 secondary clusters are read-only followers.
 
+[discrete]
+[[admin]]
+===== Security, management, and monitoring
+
 As with any enterprise system, you need tools to secure, manage, and
 monitor your {es} clusters. Security, monitoring, and administrative features
 that are integrated into {es} enable you to use {kibana-ref}/introduction.html[{kib}]
 as a control center for managing a cluster. Features like <<downsampling,
 downsampling>> and <<index-lifecycle-management, index lifecycle management>>
 help you intelligently manage your data over time.
+
+Refer to <<monitor-elasticsearch-cluster>> for more information.

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -22,7 +22,7 @@ Use {es} to search, index, store, and analyze data of all shapes and sizes in ne
 * *Machine learning*. Use {ml} to automatically model the behavior of your data in real-time.
 
 This is just a sample of search, observability, and security use cases enabled by {es}. 
-Refer to our https://www.elastic.co/customers/success-stories[customer success stories] for concrete examples across a range of industry verticals.
+Refer to our https://www.elastic.co/customers/success-stories[customer success stories] for concrete examples across a range of industries.
 // Link to demos, search labs chatbots
 
 [discrete]
@@ -43,11 +43,11 @@ You can deploy {es} in various ways:
 
 * <<run-elasticsearch-locally,*Local dev*>>. Get started quickly with a minimal local Docker setup. 
 * {cloud}/ec-getting-started-trial.html[*Elastic Cloud*]. {es} is available as part of our hosted Elastic Stack offering, deployed in the cloud with your provider of choice. Sign up for a https://cloud.elastic.co/registration[14 day free trial].
-* {serverless-docs}/general/sign-up-trial[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully-managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
+* {serverless-docs}/general/sign-up-trial[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
 
 **Advanced deployment options**
 
-* <<elasticsearch-deployment-options,*Self managed*>>. Install, configure, and run {es} on your own premises.
+* <<elasticsearch-deployment-options,*Self-managed*>>. Install, configure, and run {es} on your own premises.
 * {ece-ref}/Elastic-Cloud-Enterprise-overview.html[*Elastic Cloud Enterprise*]. Deploy Elastic Cloud on public or private clouds, virtual machines, or your own premises.
 * {eck-ref}/k8s-overview.html[*Elastic Cloud on Kubernetes*]. Deploy Elastic Cloud on Kubernetes.
 

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -71,14 +71,8 @@ Here are some resources to help you get started:
 ** Follow our tutorial https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[to build a hybrid search solution in Python].
 ** Check out the https://github.com/elastic/elasticsearch-labs?tab=readme-ov-file#elasticsearch-examples--apps[`elasticsearch-labs` repository] for a range of Python notebooks and apps for various use cases.
 
-[[how-elasticsearch-works]]
-=== How {es} works
-
-This page outlines some fundamental {es} concepts and features, including how data is stored, indexing capabilities, search and analysis features, scalability, and disaster recovery options.
-
-[discrete]
 [[documents-indices]]
-==== Documents and indices
+=== Documents and indices
 
 {es} is a distributed document store. Instead of storing information as rows of
 columnar data, {es} stores complex data structures that have been serialized
@@ -129,9 +123,8 @@ The analysis chain that is applied to a full-text field during indexing is also
 used at search time. When you query a full-text field, the query text undergoes
 the same analysis before the terms are looked up in the index.
 
-[discrete]
 [[search-analyze]]
-==== Information out: search and analyze
+=== Search and analyze
 
 While you can use {es} as a document store and retrieve documents and their
 metadata, the real power comes from being able to easily access the full suite
@@ -147,7 +140,7 @@ or Ruby.
 
 [discrete]
 [[search-data]]
-===== Searching your data
+==== Searching your data
 
 The {es} REST APIs support structured queries, full text queries, and complex
 queries that combine the two. Structured queries are
@@ -172,7 +165,7 @@ third-party applications to interact with {es} via SQL.
 
 [discrete]
 [[analyze-data]]
-===== Analyzing your data
+==== Analyzing your data
 
 {es} aggregations enable you to build complex summaries of your data and gain
 insight into key metrics, patterns, and trends. Instead of just finding the
@@ -202,9 +195,8 @@ size 70 needles, you’re displaying a count of the size 70 needles
 that match your users' search criteria--for example, all size 70 _non-stick
 embroidery_ needles.
 
-[discrete]
 [[scalability]]
-==== Scalability and resilience
+=== Scalability and resilience
 
 {es} is built to be always available and to scale with your needs. It does this
 by being distributed by nature. You can add servers (nodes) to a cluster to
@@ -233,7 +225,7 @@ interrupting indexing or query operations.
 
 [discrete]
 [[it-depends]]
-===== Shard size and number of shards
+==== Shard size and number of shards
 
 There are a number of performance considerations and trade offs with respect
 to shard size and the number of primary shards configured for an index. The more
@@ -261,7 +253,7 @@ testing with your own data and queries].
 
 [discrete]
 [[disaster-ccr]]
-===== Disaster recovery
+==== Disaster recovery
 
 A cluster's nodes need good, reliable connections to each other. To provide
 better connections, you typically co-locate the nodes in the same data center or
@@ -281,7 +273,7 @@ secondary clusters are read-only followers.
 
 [discrete]
 [[admin]]
-===== Security, management, and monitoring
+==== Security, management, and monitoring
 
 As with any enterprise system, you need tools to secure, manage, and
 monitor your {es} clusters. Security, monitoring, and administrative features

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -70,6 +70,58 @@ If you just want to get started quickly with a minimal local setup, refer to <<r
 ** Follow our tutorial https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[to build a hybrid search solution in Python].
 ** Check out the https://github.com/elastic/elasticsearch-labs?tab=readme-ov-file#elasticsearch-examples--apps[`elasticsearch-labs` repository] for a range of Python notebooks and apps for various use cases.
 
+[[documents-indices]]
+=== Documents and indices
+
+{es} is a distributed document store. Instead of storing information as rows of
+columnar data, {es} stores complex data structures that have been serialized
+as JSON documents. When you have multiple {es} nodes in a cluster, stored
+documents are distributed across the cluster and can be accessed immediately
+from any node.
+
+When a document is stored, it is indexed and fully searchable in <<near-real-time,near real-time>>--within 1 second. {es} uses a data structure called an
+inverted index that supports very fast full-text searches. An inverted index
+lists every unique word that appears in any document and identifies all of the
+documents each word occurs in.
+
+An index can be thought of as an optimized collection of documents and each
+document is a collection of fields, which are the key-value pairs that contain
+your data. By default, {es} indexes all data in every field and each indexed
+field has a dedicated, optimized data structure. For example, text fields are
+stored in inverted indices, and numeric and geo fields are stored in BKD trees.
+The ability to use the per-field data structures to assemble and return search
+results is what makes {es} so fast.
+
+{es} also has the ability to be schema-less, which means that documents can be
+indexed without explicitly specifying how to handle each of the different fields
+that might occur in a document. When dynamic mapping is enabled, {es}
+automatically detects and adds new fields to the index. This default
+behavior makes it easy to index and explore your data--just start
+indexing documents and {es} will detect and map booleans, floating point and
+integer values, dates, and strings to the appropriate {es} data types.
+
+You can define rules to control dynamic mapping and explicitly
+define mappings to take full control of how fields are stored and indexed.
+
+Defining your own mappings enables you to:
+
+* Distinguish between full-text string fields and exact value string fields
+* Perform language-specific text analysis
+* Optimize fields for partial matching
+* Use custom date formats
+* Use data types such as `geo_point` and `geo_shape` that cannot be automatically
+detected
+
+It’s often useful to index the same field in different ways for different
+purposes. For example, you might want to index a string field as both a text
+field for full-text search and as a keyword field for sorting or aggregating
+your data. Or, you might choose to use more than one language analyzer to
+process the contents of a string field that contains user input.
+
+The analysis chain that is applied to a full-text field during indexing is also
+used at search time. When you query a full-text field, the query text undergoes
+the same analysis before the terms are looked up in the index.
+
 [[scalability]]
 === Scalability and resilience: clusters, nodes, and shards
 ++++

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -1,7 +1,7 @@
 [[elasticsearch-intro]]
 == What is {es}?
 
-https://github.com/elastic/elasticsearch[{es}] is a distributed search and analytics engine, scalable data store, and vector database built on Apache Lucene.
+{es-repo}[{es}] is a distributed search and analytics engine, scalable data store, and vector database built on Apache Lucene.
 It's optimized for speed and relevance on production-scale workloads.
 Use {es} to search, index, store, and analyze data of all shapes and sizes in near real time.
 
@@ -10,7 +10,7 @@ Use {es} to search, index, store, and analyze data of all shapes and sizes in ne
 {es} has a lot of features. Explore the full list on the https://www.elastic.co/elasticsearch/features[product webpage^].
 ====
 
-{es} is the heart of the <<elasticsearch-intro-elastic-stack,{stack}>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
+{es} is the heart of the {estc-welcome-current}/stack-components.html[Elastic Stack] and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
 
 {es} is used for a wide and growing range of use cases. Here are a few examples:
 
@@ -30,14 +30,6 @@ Refer to our https://www.elastic.co/customers/success-stories[customer success s
 .What is the Elastic Stack?
 *******************************
 {es} is the core component of the Elastic Stack, a suite of products for collecting, storing, searching, and visualizing data.
-
-* https://www.elastic.co/guide/en/kibana/current/index.html[Kibana]. A UI for visualizing and exploring data in {es}.
-* https://www.elastic.co/guide/en/elasticsearch/client/index.html[Client libraries]. Work with {es} in your preferred programming language.
-* https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash]. A server-side data processing pipeline for ingesting and transforming data from multiple sources and indexing into {es}.
-* https://www.elastic.co/guide/en/fleet/current/fleet-overview.html[Fleet and Elastic Agent.] Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. Fleet is a central place to configure and monitor your Elastic Agents.
-* https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats]. Lightweight data shippers for sending data from edge machines to {es}.
-* https://www.elastic.co/guide/en/observability/current/apm.html[APM]. Monitor the performance of your applications.
-
 https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/stack-components.html[Learn more about the Elastic Stack].
 *******************************
 // TODO: Remove once we've moved Stack Overview to a subpage?
@@ -50,14 +42,14 @@ To use {es}, you need a running instance of the {es} service.
 You can deploy {es} in various ways:
 
 * <<run-elasticsearch-locally,*Local dev*>>. Get started quickly with a minimal local Docker setup. 
-* https://elastic.co/guide/en/cloud/current/ec-getting-started.html[*Elastic Cloud*]. {es} is available as part of our hosted Elastic Stack offering, deployed in the cloud with your provider of choice. Sign up for a https://cloud.elastic.co/registration[14 day free trial].
-* https://www.elastic.co/docs/current/serverless[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully-managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
+* {cloud}/ec-getting-started-trial.html[*Elastic Cloud*]. {es} is available as part of our hosted Elastic Stack offering, deployed in the cloud with your provider of choice. Sign up for a https://cloud.elastic.co/registration[14 day free trial].
+* {serverless-docs}/general/sign-up-trial[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully-managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
 
 **Advanced deployment options**
 
 * <<elasticsearch-deployment-options,*Self managed*>>. Install, configure, and run {es} on your own premises.
-* https://elastic.co/guide/en/cloud-enterprise/current/Elastic-Cloud-Enterprise-overview.html[*Elastic Cloud Enterprise*]. Deploy Elastic Cloud on public or private clouds, virtual machines, or your own premises.
-* https://elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html[*Elastic Cloud on Kubernetes*]. Deploy Elastic Cloud on Kubernetes.
+* {ece-ref}/Elastic-Cloud-Enterprise-overview.html[*Elastic Cloud Enterprise*]. Deploy Elastic Cloud on public or private clouds, virtual machines, or your own premises.
+* {eck-ref}/k8s-overview.html[*Elastic Cloud on Kubernetes*]. Deploy Elastic Cloud on Kubernetes.
 
 [discrete]
 [[elasticsearch-next-steps]]

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -1,180 +1,74 @@
 [[elasticsearch-intro]]
 == What is {es}?
-_**You know, for search (and analysis)**_
 
-{es} is the distributed search and analytics engine at the heart of
-the {stack}. {ls} and {beats} facilitate collecting, aggregating, and
-enriching your data and storing it in {es}. {kib} enables you to
-interactively explore, visualize, and share insights into your data and manage
-and monitor the stack. {es} is where the indexing, search, and analysis
-magic happens.
+https://github.com/elastic/elasticsearch[{es}] is a distributed, RESTful search and analytics engine, scalable data store, and vector database built in Java on top of the Apache Lucene library.
+Use {es} to search, index, store, and analyze data of all shapes and sizes in near real-time.
 
-{es} provides near real-time search and analytics for all types of data. Whether you
-have structured or unstructured text, numerical data, or geospatial data,
-{es} can efficiently store and index it in a way that supports fast searches.
-You can go far beyond simple data retrieval and aggregate information to discover
-trends and patterns in your data. And as your data and query volume grows, the
-distributed nature of {es} enables your deployment to grow seamlessly right
-along with it.
+[TIP]
+====
+{es} has a lot of features. Explore the full list on the https://www.elastic.co/elasticsearch/features[product webpage^].
+====
 
-While not _every_ problem is a search problem, {es} offers speed and flexibility
-to handle data in a wide variety of use cases:
+{es} is the heart of the the <<elasticsearch-intro-elastic-stack,Elastic Stack>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
 
-* Add a search box to an app or website
-* Store and analyze logs, metrics, and security event data
-* Use machine learning to automatically model the behavior of your data in real
-  time
-* Use {es} as a vector database to create, store, and search vector embeddings
-* Automate business workflows using {es} as a storage engine
-* Manage, integrate, and analyze spatial information using {es} as a geographic
-  information system (GIS)
-* Store and process genetic data using {es} as a bioinformatics research tool
+{es} is used for a wide and growing range of use cases. Here are a few examples:
 
-We’re continually amazed by the novel ways people use search. But whether
-your use case is similar to one of these, or you're using {es} to tackle a new
-problem, the way you work with your data, documents, and indices in {es} is
-the same.
+* *Monitor log and event data*. Store and analyze logs, metrics, and security event data for operational insights and SIEM.
+* *Build search applications*. Add search capabilities to apps or websites and build enterprise search engines over your organization's internal data sources.
+* *Vector database*. Store and search vectorized data, create vector embeddings with built-in and third-party NLP models.
+* *Retrieval augmented generation (RAG)*. Use {es} as a retrieval engine to augment Generative AI models.
+* *Application and security monitoring*. Monitor and analyze application performance and security data effectively.
+* *Machine learning*. Use machine learning to automatically model the behavior of your data in real time.
 
-[[documents-indices]]
-=== Data in: documents and indices
-
-{es} is a distributed document store. Instead of storing information as rows of
-columnar data, {es} stores complex data structures that have been serialized
-as JSON documents. When you have multiple {es} nodes in a cluster, stored
-documents are distributed across the cluster and can be accessed immediately
-from any node.
-
-When a document is stored, it is indexed and fully searchable in <<near-real-time,near real-time>>--within 1 second. {es} uses a data structure called an
-inverted index that supports very fast full-text searches. An inverted index
-lists every unique word that appears in any document and identifies all of the
-documents each word occurs in.
-
-An index can be thought of as an optimized collection of documents and each
-document is a collection of fields, which are the key-value pairs that contain
-your data. By default, {es} indexes all data in every field and each indexed
-field has a dedicated, optimized data structure. For example, text fields are
-stored in inverted indices, and numeric and geo fields are stored in BKD trees.
-The ability to use the per-field data structures to assemble and return search
-results is what makes {es} so fast.
-
-{es} also has the ability to be schema-less, which means that documents can be
-indexed without explicitly specifying how to handle each of the different fields
-that might occur in a document. When dynamic mapping is enabled, {es}
-automatically detects and adds new fields to the index. This default
-behavior makes it easy to index and explore your data--just start
-indexing documents and {es} will detect and map booleans, floating point and
-integer values, dates, and strings to the appropriate {es} data types.
-
-Ultimately, however, you know more about your data and how you want to use it
-than {es} can. You can define rules to control dynamic mapping and explicitly
-define mappings to take full control of how fields are stored and indexed.
-
-Defining your own mappings enables you to:
-
-* Distinguish between full-text string fields and exact value string fields
-* Perform language-specific text analysis
-* Optimize fields for partial matching
-* Use custom date formats
-* Use data types such as `geo_point` and `geo_shape` that cannot be automatically
-detected
-
-It’s often useful to index the same field in different ways for different
-purposes. For example, you might want to index a string field as both a text
-field for full-text search and as a keyword field for sorting or aggregating
-your data. Or, you might choose to use more than one language analyzer to
-process the contents of a string field that contains user input.
-
-The analysis chain that is applied to a full-text field during indexing is also
-used at search time. When you query a full-text field, the query text undergoes
-the same analysis before the terms are looked up in the index.
-
-[[search-analyze]]
-=== Information out: search and analyze
-
-While you can use {es} as a document store and retrieve documents and their
-metadata, the real power comes from being able to easily access the full suite
-of search capabilities built on the Apache Lucene search engine library.
-
-{es} provides a simple, coherent REST API for managing your cluster and indexing
-and searching your data. For testing purposes, you can easily submit requests
-directly from the command line or through the Developer Console in {kib}. From
-your applications, you can use the
-https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} client]
-for your language of choice: Java, JavaScript, Go, .NET, PHP, Perl, Python
-or Ruby.
+This is just a sample of search, observability, and security use cases enabled by {es}. 
+Refer to our https://www.elastic.co/customers/success-stories[customer success stories] for concrete examples across a range of industry verticals.
+// Link to demos, search labs chatbots
 
 [discrete]
-[[search-data]]
-==== Searching your data
+[[elasticsearch-intro-elastic-stack]]
+.What is the Elastic Stack?
+*******************************
+The Elastic Stack refers to the suite of products enabled by {es}:
 
-The {es} REST APIs support structured queries, full text queries, and complex
-queries that combine the two. Structured queries are
-similar to the types of queries you can construct in SQL. For example, you
-could search the `gender` and `age` fields in your `employee` index and sort the
-matches by the `hire_date` field. Full-text queries find all documents that
-match the query string and return them sorted by _relevance_&mdash;how good a
-match they are for your search terms.
+* https://www.elastic.co/guide/en/kibana/current/index.html[Kibana]. A UI for visualizing and exploring data in {es}.
+* https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash]. A server-side data processing pipeline for ingesting and transforming data from multiple sources and indexing into {es}.
+* https://www.elastic.co/guide/en/fleet/current/fleet-overview.html[Fleet and Elastic Agent.] Elastic Agents is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. Fleet is a central place to configure and monitor your Elastic Agents.
+* https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats]. Lightweight data shippers for sending data from edge machines to {es}.
+* https://www.elastic.co/guide/en/observability/current/apm.html[APM]. Monitor the performance of your applications.
+* https://www.elastic.co/guide/en/elasticsearch/hadoop/current/float.html[{es} Hadoop]. Use {es} as a Hadoop input/output format.
 
-In addition to searching for individual terms, you can perform phrase searches,
-similarity searches, and prefix searches, and get autocomplete suggestions.
-
-Have geospatial or other numerical data that you want to search? {es} indexes
-non-textual data in optimized data structures that support
-high-performance geo and numerical queries.
-
-You can access all of these search capabilities using {es}'s
-comprehensive JSON-style query language (<<query-dsl, Query DSL>>). You can also
-construct <<sql-overview, SQL-style queries>> to search and aggregate data
-natively inside {es}, and JDBC and ODBC drivers enable a broad range of
-third-party applications to interact with {es} via SQL.
+https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/stack-components.html[Learn more about the Elastic Stack].
+*******************************
+// TODO: Remove once we've moved Stack Overview to a subpage?
 
 [discrete]
-[[analyze-data]]
-==== Analyzing your data
+[[elasticsearch-intro-deploy]]
+=== Deployment options
 
-{es} aggregations enable you to build complex summaries of your data and gain
-insight into key metrics, patterns, and trends. Instead of just finding the
-proverbial “needle in a haystack”, aggregations enable you to answer questions
-like:
+To use {es}, you need a running instance of the {es} service.
+You can deploy {es} in various ways:
 
-* How many needles are in the haystack?
-* What is the average length of the needles?
-* What is the median length of the needles, broken down by manufacturer?
-* How many needles were added to the haystack in each of the last six months?
-
-You can also use aggregations to answer more subtle questions, such as:
-
-* What are your most popular needle manufacturers?
-* Are there any unusual or anomalous clumps of needles?
-
-Because aggregations leverage the same data-structures used for search, they are
-also very fast. This enables you to analyze and visualize your data in real time.
-Your reports and dashboards update as your data changes so you can take action
-based on the latest information.
-
-What’s more, aggregations operate alongside search requests. You can search
-documents, filter results, and perform analytics at the same time, on the same
-data, in a single request. And because aggregations are calculated in the
-context of a particular search, you’re not just displaying a count of all
-size 70 needles, you’re displaying a count of the size 70 needles
-that match your users' search criteria--for example, all size 70 _non-stick
-embroidery_ needles.
+* https://elastic.co/guide/en/cloud/current/ec-getting-started.html[*Elastic Cloud*]. {es} is available as part of our hosted Elastic Stack offering, deployed in the cloud with your provider of choice. Sign up for a https://cloud.elastic.co/registration[14 day free trial].
+* https://elastic.co/guide/en/cloud-enterprise/current/Elastic-Cloud-Enterprise-overview.html[*Elastic Cloud Enterprise*]. Deploy Elastic Cloud on public or private clouds, virtual machines, or your own premises.
+* https://elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html[*Elastic Cloud on Kubernetes*]. Deploy Elastic Cloud on Kubernetes.
+* https://www.elastic.co/docs/current/serverless[*Elastic Cloud Serverless* (technical preview)]. Create serverless projects for autoscaled and fully-managed {es} deployments. Sign up for a https://cloud.elastic.co/serverless-registration[14 day free trial].
+* <<elasticsearch-deployment-options,*Self managed*>>. Install, configure, and run {es} on your own premises.
++
+[TIP]
+====
+If you just want to get started quickly with a minimal local setup, refer to <<run-elasticsearch-locally,Run {es} locally>>.
+====
 
 [discrete]
-[[more-features]]
-===== But wait, there’s more
+[[elasticsearch-next-steps]]
+=== Learn more
 
-Want to automate the analysis of your time series data? You can use
-{ml-docs}/ml-ad-overview.html[machine learning] features to create accurate
-baselines of normal behavior in your data and identify anomalous patterns. With
-machine learning, you can detect:
-
-* Anomalies related to temporal deviations in values, counts, or frequencies
-* Statistical rarity
-* Unusual behaviors for a member of a population
-
-And the best part? You can do this without having to specify algorithms, models,
-or other data science-related configurations.
+* <<getting-started, Quickstart>>. A beginner's guide to deploying your first {es} instance, indexing data, and running queries.
+* https://elastic.co/webinars/getting-started-elasticsearch[Webinar: Introduction to {es}]. Register for our live webinars to learn directly from {es} experts.
+* https://www.elastic.co/guide/en/elasticsearch/client/index.html[Client libraries]. Choose from a variety of official and community-supported clients to work with {es} in your preferred programming language.
+* Visit Elastic Search Labs for tutorials that AI-powered search using the latest {es} features.
+** Follow our tutorial https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[to build a hybrid search solution in Python].
+** Check out the https://github.com/elastic/elasticsearch-labs?tab=readme-ov-file#elasticsearch-examples--apps[`elasticsearch-labs` repository] for a range of Python notebooks and apps for various use cases.
 
 [[scalability]]
 === Scalability and resilience: clusters, nodes, and shards
@@ -254,10 +148,6 @@ create secondary clusters to serve read requests in geo-proximity to your users.
 {ccr-cap} is active-passive. The index on the primary cluster is
 the active leader index and handles all write requests. Indices replicated to
 secondary clusters are read-only followers.
-
-[discrete]
-[[admin]]
-==== Care and feeding
 
 As with any enterprise system, you need tools to secure, manage, and
 monitor your {es} clusters. Security, monitoring, and administrative features

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -31,6 +31,7 @@ Refer to our https://www.elastic.co/customers/success-stories[customer success s
 The Elastic Stack refers to the suite of products enabled by {es}:
 
 * https://www.elastic.co/guide/en/kibana/current/index.html[Kibana]. A UI for visualizing and exploring data in {es}.
+* https://www.elastic.co/guide/en/elasticsearch/client/index.html[Client libraries]. Work with {es} in your preferred programming language.
 * https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash]. A server-side data processing pipeline for ingesting and transforming data from multiple sources and indexing into {es}.
 * https://www.elastic.co/guide/en/fleet/current/fleet-overview.html[Fleet and Elastic Agent.] Elastic Agents is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. Fleet is a central place to configure and monitor your Elastic Agents.
 * https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats]. Lightweight data shippers for sending data from edge machines to {es}.
@@ -65,7 +66,6 @@ If you just want to get started quickly with a minimal local setup, refer to <<r
 
 * <<getting-started, Quickstart>>. A beginner's guide to deploying your first {es} instance, indexing data, and running queries.
 * https://elastic.co/webinars/getting-started-elasticsearch[Webinar: Introduction to {es}]. Register for our live webinars to learn directly from {es} experts.
-* https://www.elastic.co/guide/en/elasticsearch/client/index.html[Client libraries]. Choose from a variety of official and community-supported clients to work with {es} in your preferred programming language.
 * Visit Elastic Search Labs for tutorials that AI-powered search using the latest {es} features.
 ** Follow our tutorial https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[to build a hybrid search solution in Python].
 ** Check out the https://github.com/elastic/elasticsearch-labs?tab=readme-ov-file#elasticsearch-examples--apps[`elasticsearch-labs` repository] for a range of Python notebooks and apps for various use cases.

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -9,7 +9,7 @@ Use {es} to search, index, store, and analyze data of all shapes and sizes in ne
 {es} has a lot of features. Explore the full list on the https://www.elastic.co/elasticsearch/features[product webpage^].
 ====
 
-{es} is the heart of the the <<elasticsearch-intro-elastic-stack,Elastic Stack>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
+{es} is the heart of the the <<elasticsearch-intro-elastic-stack,{stack}>> and powers the Elastic https://www.elastic.co/enterprise-search[Search], https://www.elastic.co/observability[Observability] and https://www.elastic.co/security[Security] solutions.
 
 {es} is used for a wide and growing range of use cases. Here are a few examples:
 
@@ -18,7 +18,7 @@ Use {es} to search, index, store, and analyze data of all shapes and sizes in ne
 * *Vector database*. Store and search vectorized data, create vector embeddings with built-in and third-party NLP models.
 * *Retrieval augmented generation (RAG)*. Use {es} as a retrieval engine to augment Generative AI models.
 * *Application and security monitoring*. Monitor and analyze application performance and security data effectively.
-* *Machine learning*. Use machine learning to automatically model the behavior of your data in real time.
+* *Machine learning*. Use {ml} to automatically model the behavior of your data in real-time.
 
 This is just a sample of search, observability, and security use cases enabled by {es}. 
 Refer to our https://www.elastic.co/customers/success-stories[customer success stories] for concrete examples across a range of industry verticals.

--- a/docs/reference/modules/shard-ops.asciidoc
+++ b/docs/reference/modules/shard-ops.asciidoc
@@ -1,7 +1,7 @@
 [[shard-allocation-relocation-recovery]]
 === Shard allocation, relocation, and recovery
 
-Each <<documents-indices,index>> in Elasticsearch is divided into one or more <<scalability,shards>>. 
+Each index in Elasticsearch is divided into one or more <<scalability,shards>>. 
 Each document in an index belongs to a single shard.
 
 A cluster can contain multiple copies of a shard. Each shard has one distinguished shard copy called the _primary_, and zero or more non-primary copies called _replicas_. The primary shard copy serves as the main entry point for all indexing operations. The operations on the primary shard copy are then forwarded to its replicas.

--- a/docs/reference/modules/shard-ops.asciidoc
+++ b/docs/reference/modules/shard-ops.asciidoc
@@ -1,7 +1,7 @@
 [[shard-allocation-relocation-recovery]]
 === Shard allocation, relocation, and recovery
 
-Each index in Elasticsearch is divided into one or more <<scalability,shards>>. 
+Each index in {es} is divided into one or more <<scalability,shards>>. 
 Each document in an index belongs to a single shard.
 
 A cluster can contain multiple copies of a shard. Each shard has one distinguished shard copy called the _primary_, and zero or more non-primary copies called _replicas_. The primary shard copy serves as the main entry point for all indexing operations. The operations on the primary shard copy are then forwarded to its replicas.

--- a/docs/reference/modules/shard-ops.asciidoc
+++ b/docs/reference/modules/shard-ops.asciidoc
@@ -1,7 +1,7 @@
 [[shard-allocation-relocation-recovery]]
 === Shard allocation, relocation, and recovery
 
-Each <<documents-indices,index>> in Elasticsearch is divided into one or more <<scalability,shards>>.
+Each <<documents-indices,index>> in Elasticsearch is divided into one or more <<scalability,shards>>. 
 Each document in an index belongs to a single shard.
 
 A cluster can contain multiple copies of a shard. Each shard has one distinguished shard copy called the _primary_, and zero or more non-primary copies called _replicas_. The primary shard copy serves as the main entry point for all indexing operations. The operations on the primary shard copy are then forwarded to its replicas.

--- a/docs/reference/modules/shard-ops.asciidoc
+++ b/docs/reference/modules/shard-ops.asciidoc
@@ -1,7 +1,7 @@
 [[shard-allocation-relocation-recovery]]
 === Shard allocation, relocation, and recovery
 
-Each <<documents-indices,index>> in Elasticsearch is divided into one or more <<scalability,shards>>.  
+Each <<documents-indices,index>> in Elasticsearch is divided into one or more <<scalability,shards>>.
 Each document in an index belongs to a single shard.
 
 A cluster can contain multiple copies of a shard. Each shard has one distinguished shard copy called the _primary_, and zero or more non-primary copies called _replicas_. The primary shard copy serves as the main entry point for all indexing operations. The operations on the primary shard copy are then forwarded to its replicas.

--- a/docs/reference/modules/shard-ops.asciidoc
+++ b/docs/reference/modules/shard-ops.asciidoc
@@ -1,7 +1,7 @@
 [[shard-allocation-relocation-recovery]]
 === Shard allocation, relocation, and recovery
 
-Each index in {es} is divided into one or more <<scalability,shards>>. 
+Each <<documents-indices,index>> in Elasticsearch is divided into one or more <<scalability,shards>>.  
 Each document in an index belongs to a single shard.
 
 A cluster can contain multiple copies of a shard. Each shard has one distinguished shard copy called the _primary_, and zero or more non-primary copies called _replicas_. The primary shard copy serves as the main entry point for all indexing operations. The operations on the primary shard copy are then forwarded to its replicas.

--- a/docs/reference/search/search-your-data/near-real-time.asciidoc
+++ b/docs/reference/search/search-your-data/near-real-time.asciidoc
@@ -2,7 +2,7 @@
 
 [[near-real-time]]
 === Near real-time search
-The overview of <<documents-indices,documents and indices>> indicates that when a document is stored in {es}, it is indexed and fully searchable in _near real-time_--within 1 second. What defines near real-time search?
+When a document is stored in {es}, it is indexed and fully searchable in _near real-time_--within 1 second. What defines near real-time search?
 
 Lucene, the Java libraries on which {es} is based, introduced the concept of per-segment search. A _segment_ is similar to an inverted index, but the word _index_ in Lucene means "a collection of segments plus a commit point". After a commit, a new segment is added to the commit point and the buffer is cleared.
 


### PR DESCRIPTION
Part 1: Focus on practical info: high-level overview of deployment, use cases, helpful links. Remove outdated and messy content.

Consider all links as placeholders and please suggest alternatives.


### [URL preview ✨ ](https://elasticsearch_bk_112213.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/elasticsearch-intro.html)


### TODO

- [x] Use attributes for URLs

### Follow up work for this page

Coming in future PRs:

- Rewrite indices and shard/scalability info. (In a _How Elasticsearch works?_ subpage perhaps). Explain indices, fields, and all the under-the-hood goodness. Use a new asciidoc file for legibility instead of chunking single source page into multiple HTML pages.
- Move Elastic Stack overview from different book into this section as subpage
- Create a concise features overview as subpage (optional)



