### PR TITLE
ByteArrayStreamInput: Return -1 when there are no more bytes to read

### DIFF
--- a/docs/changelog/112214.yaml
+++ b/docs/changelog/112214.yaml
@@ -1,0 +1,5 @@
+pr: 112214
+summary: '`ByteArrayStreamInput:` Return -1 when there are no more bytes to read'
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -120,6 +120,9 @@ public final class ByteArrayStreamInput extends StreamInput {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        if (available() <= 0) {
+            return -1;
+        }
         int toRead = Math.min(len, available());
         readBytes(b, off, toRead);
         return toRead;

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -120,10 +120,11 @@ public final class ByteArrayStreamInput extends StreamInput {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        if (available() <= 0) {
+        final int available = limit - pos;
+        if (available <= 0) {
             return -1;
         }
-        int toRead = Math.min(len, available());
+        int toRead = Math.min(len, available);
         readBytes(b, off, toRead);
         return toRead;
     }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -723,6 +723,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
             input.readBytes(new byte[len], 0, len);
 
             assertEquals(-1, input.read());
+            assertEquals(-1, input.read(new byte[2], 0, 2));
         }
     }
 


### PR DESCRIPTION
Returning `-1` avoids readers getting stuck in a loop.

This is the same logic used for [single-byte reads](https://github.com/elastic/elasticsearch/blob/eaf27bdda38d3a94bdf099ac8e1f0ba0feab72da/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java#L44-L50).

Without that [`java.awt.Font::createFont0`](https://github.com/openjdk/jdk17/blob/master/src/java.desktop/share/classes/java/awt/Font.java#L1153) was getting stuck in a loop, when used from [`‎org.elasticsearch.xpack.esql.expression.function.RailRoadDiagram::loadFont`](https://github.com/elastic/elasticsearch/blob/44758b3823a4982e9c62598f184cf90b67ab5d2a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/RailRoadDiagram.java#L203).

---

 - Relates #112072