### PR TITLE
[CI] Add lucene snapshot pipeline schedules for lucene_snapshot_10 branch

### DIFF
--- a/.buildkite/scripts/lucene-snapshot/update-branch.sh
+++ b/.buildkite/scripts/lucene-snapshot/update-branch.sh
@@ -2,17 +2,17 @@
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot" ]]; then
-  echo "Error: This script should only be run on the lucene_snapshot branch"
+if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot"* ]]; then
+  echo "Error: This script should only be run on lucene_snapshot branches"
   exit 1
 fi
 
-echo --- Updating lucene_snapshot branch with main
+echo --- Updating "$BUILDKITE_BRANCH" branch with main
 
 git config --global user.name elasticsearchmachine
 git config --global user.email 'infra-root+elasticsearchmachine@elastic.co'
 
-git checkout lucene_snapshot
+git checkout "$BUILDKITE_BRANCH"
 git fetch origin main
 git merge --no-edit origin/main
-git push origin lucene_snapshot
+git push origin "$BUILDKITE_BRANCH"

--- a/.buildkite/scripts/lucene-snapshot/update-es-snapshot.sh
+++ b/.buildkite/scripts/lucene-snapshot/update-es-snapshot.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot" ]]; then
-  echo "Error: This script should only be run on the lucene_snapshot branch"
+if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot"* ]]; then
+  echo "Error: This script should only be run on the lucene_snapshot branches"
   exit 1
 fi
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -125,7 +125,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#lucene"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "true"
-      branch_configuration: lucene_snapshot
+      branch_configuration: lucene_snapshot lucene_snapshot_10
       default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
@@ -140,6 +140,10 @@ spec:
       schedules:
         Periodically on lucene_snapshot:
           branch: lucene_snapshot
+          cronline: "0 2 * * * America/New_York"
+          message: "Builds a new lucene snapshot 1x per day"
+        Periodically on lucene_snapshot_10:
+          branch: lucene_snapshot_10
           cronline: "0 2 * * * America/New_York"
           message: "Builds a new lucene snapshot 1x per day"
 ---
@@ -169,7 +173,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#lucene"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "true"
-      branch_configuration: lucene_snapshot
+      branch_configuration: lucene_snapshot lucene_snapshot_10
       default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
@@ -186,6 +190,10 @@ spec:
           branch: lucene_snapshot
           cronline: "0 6 * * * America/New_York"
           message: "Merges main into lucene_snapshot branch 1x per day"
+        Periodically on lucene_snapshot_10:
+          branch: lucene_snapshot_10
+          cronline: "0 6 * * * America/New_York"
+          message: "Merges main into lucene_snapshot_10 branch 1x per day"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -213,7 +221,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
         SLACK_NOTIFICATIONS_CHANNEL: "#lucene"
         SLACK_NOTIFICATIONS_ALL_BRANCHES: "true"
-      branch_configuration: lucene_snapshot
+      branch_configuration: lucene_snapshot lucene_snapshot_10
       default_branch: lucene_snapshot
       teams:
         elasticsearch-team: {}
@@ -230,6 +238,10 @@ spec:
           branch: lucene_snapshot
           cronline: "0 9,12,15,18 * * * America/New_York"
           message: "Runs tests against lucene_snapshot branch several times per day"
+        Periodically on lucene_snapshot_10:
+          branch: lucene_snapshot_10
+          cronline: "0 9,12,15,18 * * * America/New_York"
+          message: "Runs tests against lucene_snapshot_10 branch several times per day"
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
As requested in ES-9217. We need to build and test Lucene 10 snapshots the same way that we currently do Lucene 9.

- Update pipeline schedules to also build lucene_snapshot_10 branch
- Update lucene snapshot scripts to support multiple branches