### PR TITLE
Fix native library loading zstd with jna

### DIFF
--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaNativeLibraryProvider.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaNativeLibraryProvider.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.nativeaccess.jna;
 
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.nativeaccess.lib.JavaLibrary;
 import org.elasticsearch.nativeaccess.lib.Kernel32Library;
 import org.elasticsearch.nativeaccess.lib.LinuxCLibrary;
@@ -25,7 +26,7 @@ import java.util.function.Supplier;
 public class JnaNativeLibraryProvider extends NativeLibraryProvider {
 
     static {
-        System.setProperty("jna.library.path", LoaderHelper.platformLibDir.toString());
+        setJnaLibraryPath();
     }
 
     public JnaNativeLibraryProvider() {
@@ -48,6 +49,11 @@ public class JnaNativeLibraryProvider extends NativeLibraryProvider {
                 notImplemented()
             )
         );
+    }
+
+    @SuppressForbidden(reason = "jna library path must be set for load library to work with our own libs")
+    private static void setJnaLibraryPath() {
+        System.setProperty("jna.library.path", LoaderHelper.platformLibDir.toString());
     }
 
     private static Supplier<NativeLibrary> notImplemented() {

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaNativeLibraryProvider.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaNativeLibraryProvider.java
@@ -11,6 +11,7 @@ package org.elasticsearch.nativeaccess.jna;
 import org.elasticsearch.nativeaccess.lib.JavaLibrary;
 import org.elasticsearch.nativeaccess.lib.Kernel32Library;
 import org.elasticsearch.nativeaccess.lib.LinuxCLibrary;
+import org.elasticsearch.nativeaccess.lib.LoaderHelper;
 import org.elasticsearch.nativeaccess.lib.MacCLibrary;
 import org.elasticsearch.nativeaccess.lib.NativeLibrary;
 import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
@@ -22,6 +23,10 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class JnaNativeLibraryProvider extends NativeLibraryProvider {
+
+    static {
+        System.setProperty("jna.library.path", LoaderHelper.platformLibDir.toString());
+    }
 
     public JnaNativeLibraryProvider() {
         super(

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/LoaderHelper.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/LoaderHelper.java
@@ -16,7 +16,7 @@ import java.nio.file.Paths;
  * A utility for loading libraries from Elasticsearch's platform specific lib dir.
  */
 public class LoaderHelper {
-    private static final Path platformLibDir = findPlatformLibDir();
+    public static final Path platformLibDir = findPlatformLibDir();
 
     private static Path findPlatformLibDir() {
         // tests don't have an ES install, so the platform dir must be passed in explicitly


### PR DESCRIPTION
Recent refactoring of native library paths broke jna loading zstd. This commit fixes jna to set the jna.library.path during init so that jna calls to load libraries still work.

Closes https://github.com/elastic/elasticsearch/issues/112182