### PR TITLE
Fix "unexpected field [remote_cluster]" for CCS (RCS 1.0) when using API key that references remote_cluster

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.run-ccs.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run-ccs.gradle
@@ -14,8 +14,6 @@ boolean basicSecurityMode = Boolean.valueOf(providers.systemProperty('basicSecur
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   testDistribution = providers.systemProperty('run.distribution').orElse('default').get()
 
-
-  version = '8.14.0'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'

--- a/build-tools-internal/src/main/groovy/elasticsearch.run-ccs.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run-ccs.gradle
@@ -14,6 +14,8 @@ boolean basicSecurityMode = Boolean.valueOf(providers.systemProperty('basicSecur
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   testDistribution = providers.systemProperty('run.distribution').orElse('default').get()
 
+
+  version = '8.14.0'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'

--- a/docs/changelog/112226.yaml
+++ b/docs/changelog/112226.yaml
@@ -1,0 +1,6 @@
+pr: 112226
+summary: "Fix \"unexpected field [remote_cluster]\" for CCS (RCS 1.0) when using API\
+  \ key that references `remote_cluster`"
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -1417,32 +1417,14 @@ public final class Authentication implements ToXContentObject {
     }
 
     static BytesReference maybeRemoveRemoteClusterFromRoleDescriptors(BytesReference roleDescriptorsBytes) {
-        if (roleDescriptorsBytes == null || roleDescriptorsBytes.length() == 0) {
-            return roleDescriptorsBytes;
-        }
-
-        final Map<String, Object> roleDescriptorsMap = convertRoleDescriptorsBytesToMap(roleDescriptorsBytes);
-        final AtomicBoolean removedAtLeastOne = new AtomicBoolean(false);
-        roleDescriptorsMap.forEach((key, value) -> {
-            if (value instanceof Map) {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> roleDescriptor = (Map<String, Object>) value;
-                boolean removed = roleDescriptor.remove(RoleDescriptor.Fields.REMOTE_CLUSTER.getPreferredName()) != null;
-                if (removed) {
-                    removedAtLeastOne.set(true);
-                }
-            }
-        });
-
-        if (removedAtLeastOne.get()) {
-            return convertRoleDescriptorsMapToBytes(roleDescriptorsMap);
-        } else {
-            // No need to serialize if we did not remove anything.
-            return roleDescriptorsBytes;
-        }
+        return maybeRemoveTopLevelFromRoleDescriptors(roleDescriptorsBytes, RoleDescriptor.Fields.REMOTE_CLUSTER.getPreferredName());
     }
 
     static BytesReference maybeRemoveRemoteIndicesFromRoleDescriptors(BytesReference roleDescriptorsBytes) {
+        return maybeRemoveTopLevelFromRoleDescriptors(roleDescriptorsBytes, RoleDescriptor.Fields.REMOTE_INDICES.getPreferredName());
+    }
+
+    static BytesReference maybeRemoveTopLevelFromRoleDescriptors(BytesReference roleDescriptorsBytes, String topLevelField) {
         if (roleDescriptorsBytes == null || roleDescriptorsBytes.length() == 0) {
             return roleDescriptorsBytes;
         }
@@ -1453,7 +1435,7 @@ public final class Authentication implements ToXContentObject {
             if (value instanceof Map) {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> roleDescriptor = (Map<String, Object>) value;
-                boolean removed = roleDescriptor.remove(RoleDescriptor.Fields.REMOTE_INDICES.getPreferredName()) != null;
+                boolean removed = roleDescriptor.remove(topLevelField) != null;
                 if (removed) {
                     removedAtLeastOne.set(true);
                 }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
@@ -113,6 +113,12 @@ public class RemoteClusterSecurityBwcRestIT extends AbstractRemoteClusterSecurit
                       "privileges": ["read", "read_cross_cluster"],
                       "clusters": ["my_remote_cluster"]
                     }
+                  ],
+                  "remote_cluster": [
+                    {
+                      "privileges": ["monitor_enrich"],
+                      "clusters": ["*"]
+                    }
                   ]
                 }""");
             assertOK(adminClient().performRequest(putRoleRequest));
@@ -156,6 +162,12 @@ public class RemoteClusterSecurityBwcRestIT extends AbstractRemoteClusterSecurit
                           "names": ["remote_index1", "remote_index2"],
                           "privileges": ["read", "read_cross_cluster"],
                           "clusters": ["my_remote_*", "non_existing_remote_cluster"]
+                        }
+                      ],
+                      "remote_cluster": [
+                        {
+                          "privileges": ["monitor_enrich"],
+                          "clusters": ["*"]
                         }
                       ]
                     }


### PR DESCRIPTION
This commit will remove the "remote_cluster" from the role descriptor of API keys that is sent to elder clusters for RCS 1.0.  This will allow API keys created in 8.15.0 that reference "remote_cluster" to work when sent to an elder cluster. The API key could either explicitly reference "remote_cluster" or implicitly reference it via the limited by permissions of the superuser built in role. 

Note this in reference to the standard API key, not cross cluster API key. The cross cluster API already removes this for elder clusters.  

fixes: https://github.com/elastic/elasticsearch/issues/112222
related:  https://github.com/elastic/elasticsearch/pull/107493