### PR TITLE
Release stream chunk queue on bad request

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -60,7 +60,7 @@ public class Netty4HttpRequest implements HttpRequest {
                 EmptyHttpHeaders.INSTANCE
             ),
             new AtomicBoolean(false),
-            false,
+            true,
             contentStream,
             null
         );
@@ -115,6 +115,7 @@ public class Netty4HttpRequest implements HttpRequest {
     public void release() {
         if (pooled && released.compareAndSet(false, true)) {
             request.release();
+            content.close();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -12,11 +12,12 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 
 /**
  * A super-interface for different HTTP content implementations
  */
-public sealed interface HttpBody permits HttpBody.Full, HttpBody.Stream {
+public sealed interface HttpBody extends Releasable permits HttpBody.Full, HttpBody.Stream {
 
     static Full fromBytesReference(BytesReference bytesRef) {
         return new ByteRefHttpBody(bytesRef);
@@ -55,6 +56,9 @@ public sealed interface HttpBody permits HttpBody.Full, HttpBody.Stream {
      */
     non-sealed interface Full extends HttpBody {
         BytesReference bytes();
+
+        @Override
+        default void close() {}
     }
 
     /**


### PR DESCRIPTION
Some bad http requests never reach rest handler. In case of partial rest request there might be few http chunks in the stream queue that will leak. This PR release queued requests on `HttpRequest.close()`, which is invoked on `dispatchBadRequest` in `RestController`.