### PR TITLE
Fix connection timeout for OpenIdConnectAuthenticator get Userinfo

### DIFF
--- a/docs/changelog/112230.yaml
+++ b/docs/changelog/112230.yaml
@@ -1,0 +1,5 @@
+pr: 112230
+summary: Fix connection timeout for `OpenIdConnectAuthenticator` get Userinfo
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -718,7 +718,7 @@ public class OpenIdConnectAuthenticator {
                 connectionManager.setMaxTotal(realmConfig.getSetting(HTTP_MAX_CONNECTIONS));
                 final RequestConfig requestConfig = RequestConfig.custom()
                     .setConnectTimeout(Math.toIntExact(realmConfig.getSetting(HTTP_CONNECT_TIMEOUT).getMillis()))
-                    .setConnectionRequestTimeout(Math.toIntExact(realmConfig.getSetting(HTTP_CONNECTION_READ_TIMEOUT).getSeconds()))
+                    .setConnectionRequestTimeout(Math.toIntExact(realmConfig.getSetting(HTTP_CONNECTION_READ_TIMEOUT).getMillis()))
                     .setSocketTimeout(Math.toIntExact(realmConfig.getSetting(HTTP_SOCKET_TIMEOUT).getMillis()))
                     .build();
 


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/111191, https://github.com/elastic/elasticsearch/issues/111396, https://github.com/elastic/elasticsearch/issues/100783, https://github.com/elastic/elasticsearch/issues/109871

In `OpenIdConnectAuthenticator ` a `CloseableHttpAsyncClient` is used to fetch user info, the http client in turn uses a connection pool. When [requesting a connection](https://github.com/xSke/CoreServer/blob/master/src/org/apache/http/impl/nio/conn/PoolingNHttpClientConnectionManager.java#L185) from the pool, the timeout was set to 5 milliseconds instead of 5000 milliseconds as intended. This is probably the reason for the almost immediate timeouts (look at the timestamps [here](https://gradle-enterprise.elastic.co/s/nlvhazkr7ekra/tests/task/:x-pack:qa:oidc-op-tests:javaRestTest/details/org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT/testAuthenticateWithCodeFlowUsingHttpProxy/1/output)) when trying to create a connection.

The issue was introduced [here](https://github.com/elastic/elasticsearch/pull/37787/files#diff-4281a02d35ad71b7fa8a1ebf8ec230868920e1fac58dc8ec2df2100e5761302eR548) so it's been like that as long as this has existed and it doesn't appear to be intentional. 