### PR TITLE
[ML] Update inference interfaces for streaming

### DIFF
--- a/docs/changelog/112234.yaml
+++ b/docs/changelog/112234.yaml
@@ -1,5 +1,0 @@
-pr: 112234
-summary: Update inference interfaces for streaming
-area: Machine Learning
-type: enhancement
-issues: []

--- a/docs/changelog/112234.yaml
+++ b/docs/changelog/112234.yaml
@@ -1,0 +1,5 @@
+pr: 112234
+summary: Update inference interfaces for streaming
+area: Machine Learning
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceResults.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceResults.java
@@ -13,17 +13,18 @@ import org.elasticsearch.common.xcontent.ChunkedToXContent;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Flow;
 
 public interface InferenceServiceResults extends NamedWriteable, ChunkedToXContent {
 
     /**
-     * Transform the result to match the format required for the TransportCoordinatedInferenceAction.
+     * <p>Transform the result to match the format required for the TransportCoordinatedInferenceAction.
      * For the inference plugin TextEmbeddingResults, the {@link #transformToLegacyFormat()} transforms the
      * results into an intermediate format only used by the plugin's return value. It doesn't align with what the
      * TransportCoordinatedInferenceAction expects. TransportCoordinatedInferenceAction expects an ml plugin
-     * TextEmbeddingResults.
+     * TextEmbeddingResults.</p>
      *
-     * For other results like SparseEmbeddingResults, this method can be a pass through to the transformToLegacyFormat.
+     * <p>For other results like SparseEmbeddingResults, this method can be a pass through to the transformToLegacyFormat.</p>
      */
     List<? extends InferenceResults> transformToCoordinationFormat();
 
@@ -37,4 +38,21 @@ public interface InferenceServiceResults extends NamedWriteable, ChunkedToXConte
      * Convert the result to a map to aid with test assertions
      */
     Map<String, Object> asMap();
+
+    /**
+     * Returns {@code true} if these results are streamed as chunks, or {@code false} if these results contain the entire payload.
+     * Defaults to {@code false}.
+     */
+    default boolean isStreaming() {
+        return false;
+    }
+
+    /**
+     * When {@link #isStreaming()} is {@code true}, the InferenceAction.Results will subscribe to this publisher.
+     * Implementations should follow the {@link java.util.concurrent.Flow.Publisher} spec to stream the chunks.
+     */
+    default Flow.Publisher<ChunkedToXContent> publisher() {
+        assert isStreaming() == false : "This must be implemented when isStreaming() == true";
+        throw new UnsupportedOperationException("This must be implemented when isStreaming() == true");
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.TimeValue;
@@ -40,6 +41,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Flow;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -389,6 +391,24 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
 
         public InferenceServiceResults getResults() {
             return results;
+        }
+
+        /**
+         * Returns {@code true} if these results are streamed as chunks, or {@code false} if these results contain the entire payload.
+         * Currently set to false while it is being implemented.
+         */
+        public boolean isStreaming() {
+            return false;
+        }
+
+        /**
+         * When {@link #isStreaming()} is {@code true}, the RestHandler will subscribe to this publisher.
+         * When the RestResponse is finished with the current chunk, it will request the next chunk using the subscription.
+         * If the RestResponse is closed, it will cancel the subscription.
+         */
+        public Flow.Publisher<ChunkedToXContent> publisher() {
+            assert isStreaming() == false : "This must be implemented when isStreaming() == true";
+            throw new UnsupportedOperationException("This must be implemented when isStreaming() == true");
         }
 
         @Override


### PR DESCRIPTION
Using InferenceServiceResults and InferenceAction to stream ChunkedToXContent through to the Rest handler.
