### PR TITLE
ESQL: Remove `LogicalPlan` from old serialization

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -23,24 +23,9 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.index.EsIndex;
-import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
-import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
-import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
-import org.elasticsearch.xpack.esql.plan.logical.Eval;
-import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
-import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
-import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.Lookup;
-import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
-import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
-import org.elasticsearch.xpack.esql.plan.logical.Project;
-import org.elasticsearch.xpack.esql.plan.logical.TopN;
-import org.elasticsearch.xpack.esql.plan.logical.join.Join;
-import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
-import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -132,25 +117,7 @@ public final class PlanNamedTypes {
             of(PhysicalPlan.class, ProjectExec.class, PlanNamedTypes::writeProjectExec, PlanNamedTypes::readProjectExec),
             of(PhysicalPlan.class, RowExec.class, PlanNamedTypes::writeRowExec, PlanNamedTypes::readRowExec),
             of(PhysicalPlan.class, ShowExec.class, PlanNamedTypes::writeShowExec, PlanNamedTypes::readShowExec),
-            of(PhysicalPlan.class, TopNExec.class, PlanNamedTypes::writeTopNExec, PlanNamedTypes::readTopNExec),
-            // Logical Plan Nodes - a subset of plans that end up being actually serialized
-            of(LogicalPlan.class, Aggregate.ENTRY),
-            of(LogicalPlan.class, Dissect.ENTRY),
-            of(LogicalPlan.class, EsRelation.ENTRY),
-            of(LogicalPlan.class, Eval.ENTRY),
-            of(LogicalPlan.class, Enrich.ENTRY),
-            of(LogicalPlan.class, EsqlProject.ENTRY),
-            of(LogicalPlan.class, Filter.ENTRY),
-            of(LogicalPlan.class, Grok.ENTRY),
-            of(LogicalPlan.class, InlineStats.ENTRY),
-            of(LogicalPlan.class, Join.ENTRY),
-            of(LogicalPlan.class, Limit.ENTRY),
-            of(LogicalPlan.class, LocalRelation.ENTRY),
-            of(LogicalPlan.class, Lookup.ENTRY),
-            of(LogicalPlan.class, MvExpand.ENTRY),
-            of(LogicalPlan.class, OrderBy.ENTRY),
-            of(LogicalPlan.class, Project.ENTRY),
-            of(LogicalPlan.class, TopN.ENTRY)
+            of(PhysicalPlan.class, TopNExec.class, PlanNamedTypes::writeTopNExec, PlanNamedTypes::readTopNExec)
         );
         return declared;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -38,24 +38,6 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Gre
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
-import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
-import org.elasticsearch.xpack.esql.plan.logical.Dissect;
-import org.elasticsearch.xpack.esql.plan.logical.Enrich;
-import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
-import org.elasticsearch.xpack.esql.plan.logical.Eval;
-import org.elasticsearch.xpack.esql.plan.logical.Filter;
-import org.elasticsearch.xpack.esql.plan.logical.Grok;
-import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
-import org.elasticsearch.xpack.esql.plan.logical.Limit;
-import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.Lookup;
-import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
-import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
-import org.elasticsearch.xpack.esql.plan.logical.Project;
-import org.elasticsearch.xpack.esql.plan.logical.TopN;
-import org.elasticsearch.xpack.esql.plan.logical.join.Join;
-import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
-import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -126,40 +108,6 @@ public class PlanNamedTypesTests extends ESTestCase {
             .stream()
             .filter(e -> e.categoryClass().isAssignableFrom(PhysicalPlan.class))
             .map(PlanNameRegistry.Entry::name)
-            .toList();
-        assertMap(actual, matchesList(expected));
-    }
-
-    // List of known serializable logical plan nodes - this should be kept up to date or retrieved
-    // programmatically.
-    public static final List<Class<? extends LogicalPlan>> LOGICAL_PLAN_NODE_CLS = List.of(
-        Aggregate.class,
-        Dissect.class,
-        Enrich.class,
-        EsRelation.class,
-        EsqlProject.class,
-        Eval.class,
-        Filter.class,
-        Grok.class,
-        InlineStats.class,
-        Join.class,
-        Limit.class,
-        LocalRelation.class,
-        Lookup.class,
-        MvExpand.class,
-        OrderBy.class,
-        Project.class,
-        TopN.class
-    );
-
-    // Tests that all logical plan nodes have a suitably named serialization entry.
-    public void testLogicalPlanEntries() {
-        var expected = LOGICAL_PLAN_NODE_CLS.stream().map(Class::getSimpleName).toList();
-        var actual = PlanNamedTypes.namedTypeEntries()
-            .stream()
-            .filter(e -> e.categoryClass().isAssignableFrom(LogicalPlan.class))
-            .map(PlanNameRegistry.Entry::name)
-            .sorted()
             .toList();
         assertMap(actual, matchesList(expected));
     }


### PR DESCRIPTION
This removes `LogicalPlan` subclasses from `PlanNamedTypes` because it is no longer used.
