### PR TITLE
ESQL: Migrate more physical plan writeable

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -12,16 +12,13 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.iterable.Iterables;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
@@ -71,8 +68,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.Entry.of;
-import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanReader.readerFromPlanReader;
-import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanWriter.writerFromPlanWriter;
 
 /**
  * A utility class that consists solely of static methods that describe how to serialize and
@@ -108,9 +103,9 @@ public final class PlanNamedTypes {
             // Physical Plan Nodes
             of(PhysicalPlan.class, AggregateExec.ENTRY),
             of(PhysicalPlan.class, DissectExec.ENTRY),
-            of(PhysicalPlan.class, EsQueryExec.class, PlanNamedTypes::writeEsQueryExec, PlanNamedTypes::readEsQueryExec),
+            of(PhysicalPlan.class, EsQueryExec.ENTRY),
             of(PhysicalPlan.class, EsSourceExec.ENTRY),
-            of(PhysicalPlan.class, EvalExec.class, PlanNamedTypes::writeEvalExec, PlanNamedTypes::readEvalExec),
+            of(PhysicalPlan.class, EvalExec.ENTRY),
             of(PhysicalPlan.class, EnrichExec.class, PlanNamedTypes::writeEnrichExec, PlanNamedTypes::readEnrichExec),
             of(PhysicalPlan.class, ExchangeExec.class, PlanNamedTypes::writeExchangeExec, PlanNamedTypes::readExchangeExec),
             of(PhysicalPlan.class, ExchangeSinkExec.class, PlanNamedTypes::writeExchangeSinkExec, PlanNamedTypes::readExchangeSinkExec),
@@ -156,57 +151,6 @@ public final class PlanNamedTypes {
     }
 
     // -- physical plan nodes
-    static EsQueryExec readEsQueryExec(PlanStreamInput in) throws IOException {
-        return new EsQueryExec(
-            Source.readFrom(in),
-            new EsIndex(in),
-            readIndexMode(in),
-            in.readNamedWriteableCollectionAsList(Attribute.class),
-            in.readOptionalNamedWriteable(QueryBuilder.class),
-            in.readOptionalNamed(Expression.class),
-            in.readOptionalCollectionAsList(readerFromPlanReader(PlanNamedTypes::readFieldSort)),
-            in.readOptionalVInt()
-        );
-    }
-
-    static void writeEsQueryExec(PlanStreamOutput out, EsQueryExec esQueryExec) throws IOException {
-        assert esQueryExec.children().size() == 0;
-        Source.EMPTY.writeTo(out);
-        esQueryExec.index().writeTo(out);
-        writeIndexMode(out, esQueryExec.indexMode());
-        out.writeNamedWriteableCollection(esQueryExec.output());
-        out.writeOptionalNamedWriteable(esQueryExec.query());
-        out.writeOptionalNamedWriteable(esQueryExec.limit());
-        out.writeOptionalCollection(esQueryExec.sorts(), writerFromPlanWriter(PlanNamedTypes::writeFieldSort));
-        out.writeOptionalInt(esQueryExec.estimatedRowSize());
-    }
-
-    public static IndexMode readIndexMode(StreamInput in) throws IOException {
-        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_ADD_INDEX_MODE_TO_SOURCE)) {
-            return IndexMode.fromString(in.readString());
-        } else {
-            return IndexMode.STANDARD;
-        }
-    }
-
-    public static void writeIndexMode(StreamOutput out, IndexMode indexMode) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_ADD_INDEX_MODE_TO_SOURCE)) {
-            out.writeString(indexMode.getName());
-        } else if (indexMode != IndexMode.STANDARD) {
-            throw new IllegalStateException("not ready to support index mode [" + indexMode + "]");
-        }
-    }
-
-    static EvalExec readEvalExec(PlanStreamInput in) throws IOException {
-        return new EvalExec(Source.readFrom(in), in.readPhysicalPlanNode(), in.readCollectionAsList(Alias::new));
-    }
-
-    static void writeEvalExec(PlanStreamOutput out, EvalExec evalExec) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writePhysicalPlanNode(evalExec.child());
-        out.writeCollection(evalExec.fields());
-    }
-
     static EnrichExec readEnrichExec(PlanStreamInput in) throws IOException {
         final Source source = Source.readFrom(in);
         final PhysicalPlan child = in.readPhysicalPlanNode();
@@ -458,21 +402,5 @@ public final class PlanNamedTypes {
         out.writeCollection(topNExec.order());
         out.writeNamedWriteable(topNExec.limit());
         out.writeOptionalVInt(topNExec.estimatedRowSize());
-    }
-
-    // -- ancillary supporting classes of plan nodes, etc
-
-    static EsQueryExec.FieldSort readFieldSort(PlanStreamInput in) throws IOException {
-        return new EsQueryExec.FieldSort(
-            FieldAttribute.readFrom(in),
-            in.readEnum(Order.OrderDirection.class),
-            in.readEnum(Order.NullsPosition.class)
-        );
-    }
-
-    static void writeFieldSort(PlanStreamOutput out, EsQueryExec.FieldSort fieldSort) throws IOException {
-        fieldSort.field().writeTo(out);
-        out.writeEnum(fieldSort.direction());
-        out.writeEnum(fieldSort.nulls());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.index.EsIndex;
-import org.elasticsearch.xpack.esql.io.stream.PlanNamedTypes;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
@@ -67,7 +66,7 @@ public class EsRelation extends LeafPlan {
             in.readOptionalString();
             in.readOptionalString();
         }
-        IndexMode indexMode = PlanNamedTypes.readIndexMode(in);
+        IndexMode indexMode = readIndexMode(in);
         boolean frozen = in.readBoolean();
         return new EsRelation(source, esIndex, attributes, indexMode, frozen);
     }
@@ -83,7 +82,7 @@ public class EsRelation extends LeafPlan {
             out.writeOptionalString(null);
             out.writeOptionalString(null);
         }
-        PlanNamedTypes.writeIndexMode(out, indexMode());
+        writeIndexMode(out, indexMode());
         out.writeBoolean(frozen());
     }
 
@@ -173,5 +172,21 @@ public class EsRelation extends LeafPlan {
     @Override
     public String nodeString() {
         return nodeName() + "[" + index + "]" + NodeUtils.limitedToString(attrs);
+    }
+
+    public static IndexMode readIndexMode(StreamInput in) throws IOException {
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_ADD_INDEX_MODE_TO_SOURCE)) {
+            return IndexMode.fromString(in.readString());
+        } else {
+            return IndexMode.STANDARD;
+        }
+    }
+
+    public static void writeIndexMode(StreamOutput out, IndexMode indexMode) throws IOException {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_ADD_INDEX_MODE_TO_SOURCE)) {
+            out.writeString(indexMode.getName());
+        } else if (indexMode != IndexMode.STANDARD) {
+            throw new IllegalStateException("not ready to support index mode [" + indexMode + "]");
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -8,6 +8,10 @@
 package org.elasticsearch.xpack.esql.plan.physical;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -22,12 +26,21 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public class EsQueryExec extends LeafExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "EsQueryExec",
+        EsQueryExec::new
+    );
+
     public static final EsField DOC_ID_FIELD = new EsField("_doc", DataType.DOC_DATA_TYPE, Map.of(), false);
 
     private final EsIndex index;
@@ -43,13 +56,28 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
      */
     private final Integer estimatedRowSize;
 
-    public record FieldSort(FieldAttribute field, Order.OrderDirection direction, Order.NullsPosition nulls) {
+    public record FieldSort(FieldAttribute field, Order.OrderDirection direction, Order.NullsPosition nulls) implements Writeable {
         public FieldSortBuilder fieldSortBuilder() {
             FieldSortBuilder builder = new FieldSortBuilder(field.name());
             builder.order(Direction.from(direction).asOrder());
             builder.missing(Missing.from(nulls).searchOrder());
             builder.unmappedType(field.dataType().esType());
             return builder;
+        }
+
+        private static FieldSort readFrom(StreamInput in) throws IOException {
+            return new EsQueryExec.FieldSort(
+                FieldAttribute.readFrom(in),
+                in.readEnum(Order.OrderDirection.class),
+                in.readEnum(Order.NullsPosition.class)
+            );
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            field().writeTo(out);
+            out.writeEnum(direction());
+            out.writeEnum(nulls());
         }
     }
 
@@ -75,6 +103,36 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
         this.limit = limit;
         this.sorts = sorts;
         this.estimatedRowSize = estimatedRowSize;
+    }
+
+    private EsQueryExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            new EsIndex(in),
+            EsRelation.readIndexMode(in),
+            in.readNamedWriteableCollectionAsList(Attribute.class),
+            in.readOptionalNamedWriteable(QueryBuilder.class),
+            in.readOptionalNamedWriteable(Expression.class),
+            in.readOptionalCollectionAsList(FieldSort::readFrom),
+            in.readOptionalVInt()
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        index().writeTo(out);
+        EsRelation.writeIndexMode(out, indexMode());
+        out.writeNamedWriteableCollection(output());
+        out.writeOptionalNamedWriteable(query());
+        out.writeOptionalNamedWriteable(limit());
+        out.writeOptionalCollection(sorts());
+        out.writeOptionalVInt(estimatedRowSize());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public static boolean isSourceAttribute(Attribute attr) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsSourceExec.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.index.EsIndex;
-import org.elasticsearch.xpack.esql.io.stream.PlanNamedTypes;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 
@@ -55,7 +54,7 @@ public class EsSourceExec extends LeafExec {
             new EsIndex(in),
             in.readNamedWriteableCollectionAsList(Attribute.class),
             in.readOptionalNamedWriteable(QueryBuilder.class),
-            PlanNamedTypes.readIndexMode(in)
+            EsRelation.readIndexMode(in)
         );
     }
 
@@ -65,7 +64,7 @@ public class EsSourceExec extends LeafExec {
         index().writeTo(out);
         out.writeNamedWriteableCollection(output());
         out.writeOptionalNamedWriteable(query());
-        PlanNamedTypes.writeIndexMode(out, indexMode());
+        EsRelation.writeIndexMode(out, indexMode());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EvalExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EvalExec.java
@@ -7,22 +7,50 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
 public class EvalExec extends UnaryExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "EvalExec",
+        EvalExec::new
+    );
+
     private final List<Alias> fields;
 
     public EvalExec(Source source, PhysicalPlan child, List<Alias> fields) {
         super(source, child);
         this.fields = fields;
+    }
+
+    private EvalExec(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readPhysicalPlanNode(), in.readCollectionAsList(Alias::new));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
+        out.writeCollection(fields());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public List<Alias> fields() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public abstract class PhysicalPlan extends QueryPlan<PhysicalPlan> {
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return List.of(AggregateExec.ENTRY, DissectExec.ENTRY, EsSourceExec.ENTRY);
+        return List.of(AggregateExec.ENTRY, DissectExec.ENTRY, EsQueryExec.ENTRY, EsSourceExec.ENTRY, EvalExec.ENTRY);
     }
 
     public PhysicalPlan(Source source, List<PhysicalPlan> children) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -20,24 +20,9 @@ import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
-import org.elasticsearch.xpack.esql.core.type.KeywordEsField;
-import org.elasticsearch.xpack.esql.expression.Order;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mod;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
@@ -189,15 +174,6 @@ public class PlanNamedTypesTests extends ESTestCase {
         assertThat(in.readVInt(), equalTo(11_345));
     }
 
-    public void testFieldSortSimple() throws IOException {
-        var orig = new EsQueryExec.FieldSort(field("val", DataType.LONG), Order.OrderDirection.ASC, Order.NullsPosition.FIRST);
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeFieldSort(out, orig);
-        var deser = PlanNamedTypes.readFieldSort(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
     static FieldAttribute randomFieldAttributeOrNull() {
         return randomBoolean() ? randomFieldAttribute() : null;
     }
@@ -213,46 +189,6 @@ public class PlanNamedTypesTests extends ESTestCase {
             nameIdOrNull(),
             randomBoolean() // synthetic
         );
-    }
-
-    static KeywordEsField randomKeywordEsField() {
-        return new KeywordEsField(
-            randomAlphaOfLength(randomIntBetween(1, 25)), // name
-            randomProperties(),
-            randomBoolean(), // hasDocValues
-            randomIntBetween(1, 12), // precision
-            randomBoolean(), // normalized
-            randomBoolean() // alias
-        );
-    }
-
-    static EsqlBinaryComparison randomBinaryComparison() {
-        int v = randomIntBetween(0, 5);
-        var left = field(randomName(), randomDataType());
-        var right = field(randomName(), randomDataType());
-        return switch (v) {
-            case 0 -> new Equals(Source.EMPTY, left, right);
-            case 1 -> new NotEquals(Source.EMPTY, left, right);
-            case 2 -> new GreaterThan(Source.EMPTY, left, right);
-            case 3 -> new GreaterThanOrEqual(Source.EMPTY, left, right);
-            case 4 -> new LessThan(Source.EMPTY, left, right);
-            case 5 -> new LessThanOrEqual(Source.EMPTY, left, right);
-            default -> throw new AssertionError(v);
-        };
-    }
-
-    static ArithmeticOperation randomArithmeticOperation() {
-        int v = randomIntBetween(0, 4);
-        var left = field(randomName(), randomDataType());
-        var right = field(randomName(), randomDataType());
-        return switch (v) {
-            case 0 -> new Add(Source.EMPTY, left, right);
-            case 1 -> new Sub(Source.EMPTY, left, right);
-            case 2 -> new Mul(Source.EMPTY, left, right);
-            case 3 -> new Div(Source.EMPTY, left, right);
-            case 4 -> new Mod(Source.EMPTY, left, right);
-            default -> throw new AssertionError(v);
-        };
     }
 
     static NameId nameIdOrNull() {
@@ -281,10 +217,6 @@ public class PlanNamedTypesTests extends ESTestCase {
             randomBoolean(), // aggregatable
             randomBoolean() // isAlias
         );
-    }
-
-    static Map<String, EsField> randomProperties() {
-        return randomProperties(0);
     }
 
     static Map<String, EsField> randomProperties(int depth) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.plan.AbstractNodeSerializationTests;
 
 import java.util.ArrayList;
@@ -47,7 +48,8 @@ public abstract class AbstractPhysicalPlanSerializationTests<T extends PhysicalP
         entries.addAll(Attribute.getNamedWriteables());
         entries.addAll(Block.getNamedWriteables());
         entries.addAll(NamedExpression.getNamedWriteables());
-        entries.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedWriteables());
+        entries.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedWriteables()); // Query builders
+        entries.add(Add.ENTRY); // Used by the eval tests
         return new NamedWriteableRegistry(entries);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExecSerializationTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.index.EsIndexSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
+
+public class EsQueryExecSerializationTests extends AbstractPhysicalPlanSerializationTests<EsQueryExec> {
+    public static EsQueryExec randomEsQueryExec() {
+        Source source = randomSource();
+        EsIndex index = EsIndexSerializationTests.randomEsIndex();
+        IndexMode indexMode = randomFrom(IndexMode.values());
+        List<Attribute> attrs = randomFieldAttributes(1, 10, false);
+        QueryBuilder query = randomQuery();
+        Expression limit = new Literal(randomSource(), between(0, Integer.MAX_VALUE), DataType.INTEGER);
+        List<EsQueryExec.FieldSort> sorts = randomFieldSorts();
+        Integer estimatedRowSize = randomEstimatedRowSize();
+        return new EsQueryExec(source, index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+    }
+
+    public static QueryBuilder randomQuery() {
+        return randomBoolean() ? new MatchAllQueryBuilder() : new TermQueryBuilder(randomAlphaOfLength(4), randomAlphaOfLength(4));
+    }
+
+    public static List<EsQueryExec.FieldSort> randomFieldSorts() {
+        return randomList(0, 4, EsQueryExecSerializationTests::randomFieldSort);
+    }
+
+    public static EsQueryExec.FieldSort randomFieldSort() {
+        FieldAttribute field = FieldAttributeTests.createFieldAttribute(0, false);
+        Order.OrderDirection direction = randomFrom(Order.OrderDirection.values());
+        Order.NullsPosition nulls = randomFrom(Order.NullsPosition.values());
+        return new EsQueryExec.FieldSort(field, direction, nulls);
+    }
+
+    @Override
+    protected EsQueryExec createTestInstance() {
+        return randomEsQueryExec();
+    }
+
+    @Override
+    protected EsQueryExec mutateInstance(EsQueryExec instance) throws IOException {
+        EsIndex index = instance.index();
+        IndexMode indexMode = instance.indexMode();
+        List<Attribute> attrs = instance.attrs();
+        QueryBuilder query = instance.query();
+        Expression limit = instance.limit();
+        List<EsQueryExec.FieldSort> sorts = instance.sorts();
+        Integer estimatedRowSize = instance.estimatedRowSize();
+        switch (between(0, 6)) {
+            case 0 -> index = randomValueOtherThan(index, EsIndexSerializationTests::randomEsIndex);
+            case 1 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
+            case 2 -> attrs = randomValueOtherThan(attrs, () -> randomFieldAttributes(1, 10, false));
+            case 3 -> query = randomValueOtherThan(query, EsQueryExecSerializationTests::randomQuery);
+            case 4 -> limit = randomValueOtherThan(
+                limit,
+                () -> new Literal(randomSource(), between(0, Integer.MAX_VALUE), DataType.INTEGER)
+            );
+            case 5 -> sorts = randomValueOtherThan(sorts, EsQueryExecSerializationTests::randomFieldSorts);
+            case 6 -> estimatedRowSize = randomValueOtherThan(
+                estimatedRowSize,
+                AbstractPhysicalPlanSerializationTests::randomEstimatedRowSize
+            );
+        }
+        return new EsQueryExec(instance.source(), index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EvalExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EvalExecSerializationTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EvalExecSerializationTests extends AbstractPhysicalPlanSerializationTests<EvalExec> {
+    public static EvalExec randomEvalExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        List<Alias> fields = randomFields();
+        return new EvalExec(source, child, fields);
+    }
+
+    public static List<Alias> randomFields() {
+        return randomList(1, 10, EvalExecSerializationTests::randomField);
+    }
+
+    public static Alias randomField() {
+        Expression child = new Add(
+            randomSource(),
+            FieldAttributeTests.createFieldAttribute(0, true),
+            FieldAttributeTests.createFieldAttribute(0, true)
+        );
+        return new Alias(randomSource(), randomAlphaOfLength(5), child);
+    }
+
+    @Override
+    protected EvalExec createTestInstance() {
+        return randomEvalExec(0);
+    }
+
+    @Override
+    protected EvalExec mutateInstance(EvalExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        List<Alias> fields = instance.fields();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            fields = randomValueOtherThan(fields, EvalExecSerializationTests::randomFields);
+        }
+        return new EvalExec(instance.source(), child, fields);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}


### PR DESCRIPTION
Migrates a few more of our physical plan nodes to `NamedWriteable`.
