### PR TITLE
Fix JDK 21 lint warnings

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -108,6 +108,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
         private final EnumSet<Metric> metrics;
 
+        @SuppressWarnings("this-escape")
         public Request(TimeValue masterNodeTimeout, TaskId parentTaskId, EnumSet<Metric> metrics) {
             super(masterNodeTimeout);
             setParentTask(parentTaskId);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -54,12 +54,14 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
         this(names, DEFAULT_INDICES_OPTIONS);
     }
 
+    @SuppressWarnings("this-escape")
     public ResolveClusterActionRequest(String[] names, IndicesOptions indicesOptions) {
         this.names = names;
         this.localIndicesRequested = localIndicesPresent(names);
         this.indicesOptions = indicesOptions;
     }
 
+    @SuppressWarnings("this-escape")
     public ResolveClusterActionRequest(StreamInput in) throws IOException {
         super(in);
         if (in.getTransportVersion().before(TransportVersions.V_8_13_0)) {

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteRequestBuilder.java
@@ -30,6 +30,7 @@ public class DeleteRequestBuilder extends ReplicationRequestBuilder<DeleteReques
     private Long term;
     private WriteRequest.RefreshPolicy refreshPolicy;
 
+    @SuppressWarnings("this-escape")
     public DeleteRequestBuilder(ElasticsearchClient client, @Nullable String index) {
         super(client, TransportDeleteAction.TYPE);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -54,6 +54,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
         this(client, null);
     }
 
+    @SuppressWarnings("this-escape")
     public IndexRequestBuilder(ElasticsearchClient client, @Nullable String index) {
         super(client, TransportIndexAction.TYPE);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -68,6 +68,7 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
         this(client, null, null);
     }
 
+    @SuppressWarnings("this-escape")
     public UpdateRequestBuilder(ElasticsearchClient client, String index, String id) {
         super(client, TransportUpdateAction.TYPE);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -93,6 +93,7 @@ public abstract class AbstractClient implements Client {
     private final ThreadPool threadPool;
     private final AdminClient admin;
 
+    @SuppressWarnings("this-escape")
     public AbstractClient(Settings settings, ThreadPool threadPool) {
         this.settings = settings;
         this.threadPool = threadPool;

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -97,6 +97,7 @@ public class CodecService implements CodecProvider {
 
         private final DeduplicatingFieldInfosFormat deduplicatingFieldInfosFormat;
 
+        @SuppressWarnings("this-escape")
         protected DeduplicateFieldInfosCodec(String name, Codec delegate) {
             super(name, delegate);
             this.deduplicatingFieldInfosFormat = new DeduplicatingFieldInfosFormat(super.fieldInfosFormat());

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -26,6 +26,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
         private String leafName;
 
+        @SuppressWarnings("this-escape")
         protected Builder(String leafName) {
             setLeafName(leafName);
         }
@@ -55,6 +56,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     private final String leafName;
 
+    @SuppressWarnings("this-escape")
     public Mapper(String leafName) {
         Objects.requireNonNull(leafName);
         this.leafName = internFieldName(leafName);

--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequestBuilder.java
@@ -20,6 +20,7 @@ public class DeleteByQueryRequestBuilder extends AbstractBulkByScrollRequestBuil
         this(client, new SearchRequestBuilder(client));
     }
 
+    @SuppressWarnings("this-escape")
     private DeleteByQueryRequestBuilder(ElasticsearchClient client, SearchRequestBuilder search) {
         super(client, DeleteByQueryAction.INSTANCE, search);
         source().setFetchSource(false);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -56,6 +56,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     protected final double max;
     protected final double sum;
 
+    @SuppressWarnings("this-escape")
     public InternalStats(
         String name,
         long count,

--- a/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureResult.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/feature/RankFeatureResult.java
@@ -27,12 +27,14 @@ public class RankFeatureResult extends SearchPhaseResult {
 
     public RankFeatureResult() {}
 
+    @SuppressWarnings("this-escape")
     public RankFeatureResult(ShardSearchContextId id, SearchShardTarget shardTarget, ShardSearchRequest request) {
         this.contextId = id;
         setSearchShardTarget(shardTarget);
         setShardSearchRequest(request);
     }
 
+    @SuppressWarnings("this-escape")
     public RankFeatureResult(StreamInput in) throws IOException {
         super(in);
         contextId = new ShardSearchContextId(in);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
@@ -358,7 +358,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
                     }
                     assertEquals(size, Math.min(queue.size(), expected.length - pos));
                     int ptr = pos + ((int) queue.size() - 1);
-                    pos += queue.size();
+                    pos += Math.toIntExact(queue.size());
                     last = null;
                     while (queue.size() > pos) {
                         CompositeKey key = queue.toCompositeKey(queue.pop());

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -1408,7 +1408,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             final var blobLength = randomLongBetween(1L, cacheSize);
 
             int regions = Math.toIntExact(blobLength / regionSize);
-            regions += (blobLength % regionSize == 0L ? 0L : 1L);
+            regions += (blobLength % regionSize == 0 ? 0 : 1);
             assertThat(
                 cacheService.computeCacheFileRegionSize(blobLength, randomFrom(regions)),
                 equalTo(BlobCacheUtils.toIntBytes(regionSize))

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/YamlTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/YamlTemplateRegistry.java
@@ -50,7 +50,7 @@ public abstract class YamlTemplateRegistry extends IndexTemplateRegistry {
     private final FeatureService featureService;
     private volatile boolean enabled;
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "this-escape" })
     public YamlTemplateRegistry(
         Settings nodeSettings,
         ClusterService clusterService,

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
@@ -52,7 +52,7 @@ public class AggregatorProcessor implements Processor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_17;
+        return SourceVersion.RELEASE_21;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorProcessor.java
@@ -52,7 +52,7 @@ public class AggregatorProcessor implements Processor {
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_21;
+        return SourceVersion.RELEASE_17;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -199,6 +199,7 @@ public class EsqlFunctionRegistry {
 
     private SnapshotFunctionRegistry snapshotRegistry = null;
 
+    @SuppressWarnings("this-escape")
     public EsqlFunctionRegistry() {
         register(functions());
         buildDataTypesForStringLiteralConversion(functions());


### PR DESCRIPTION
This commit fixes lint warnings that arise when compiling with javac from JDK 21. 

This change is in preparation for an eventual bump of Elasticsearch to a minimum of JDK 21, in ES 9.0.