### PR TITLE
[8.15] Prevent synthetic field loaders accessing stored fields from using stale data (#112173)

### DIFF
--- a/docs/changelog/112173.yaml
+++ b/docs/changelog/112173.yaml
@@ -1,0 +1,7 @@
+pr: 112173
+summary: Prevent synthetic field loaders accessing stored fields from using stale
+  data
+area: Mapping
+type: bug
+issues:
+ - 112156

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -447,7 +447,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new StringStoredFieldFieldLoader(fieldType().storedFieldNameForSyntheticSource(), leafName(), null) {
+        return new StringStoredFieldFieldLoader(fieldType().storedFieldNameForSyntheticSource(), leafName()) {
             @Override
             protected void write(XContentBuilder b, Object value) throws IOException {
                 b.value((String) value);

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -584,7 +584,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
             );
         }
         if (fieldType.stored()) {
-            return new StringStoredFieldFieldLoader(fullPath(), leafName(), null) {
+            return new StringStoredFieldFieldLoader(fullPath(), leafName()) {
                 @Override
                 protected void write(XContentBuilder b, Object value) throws IOException {
                     b.value((String) value);

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -1204,3 +1204,54 @@ nested object with stored array:
   - match: { hits.hits.1._source.nested_array_stored.0.b.1.c: 100 }
   - match: { hits.hits.1._source.nested_array_stored.1.b.0.c: 20 }
   - match: { hits.hits.1._source.nested_array_stored.1.b.1.c: 200 }
+
+---
+# 112156
+stored field under object with store_array_source:
+  - requires:
+      cluster_features: ["mapper.track_ignored_source"]
+      reason: requires tracking ignored source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              sort.field: "name"
+              sort.order: "asc"
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              name:
+                type: keyword
+              obj:
+                store_array_source: true
+                properties:
+                  foo:
+                    type: keyword
+                    store: true
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{ "create": { } }'
+          - '{ "name": "B", "obj": null }'
+          - '{ "create": { } }'
+          - '{ "name": "A", "obj": [ { "foo": "hello_from_the_other_side" } ] }'
+
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: test
+        sort: name
+
+  - match:  { hits.total.value: 2 }
+  - match: { hits.hits.0._source.name: A }
+  - match: { hits.hits.0._source.obj: [ { "foo": "hello_from_the_other_side" } ] }
+  - match: { hits.hits.1._source.name: B }
+  - match: { hits.hits.1._source.obj: null }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -859,7 +859,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
 
         @Override
         public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-            return new StringStoredFieldFieldLoader(fullPath(), leafName(), null) {
+            return new StringStoredFieldFieldLoader(fullPath(), leafName()) {
                 @Override
                 protected void write(XContentBuilder b, Object value) throws IOException {
                     BytesRef ref = (BytesRef) value;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -107,7 +107,17 @@ public abstract class IgnoreMalformedStoredValues {
 
         @Override
         public Stream<Map.Entry<String, SourceLoader.SyntheticFieldLoader.StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of(Map.entry(name(fieldName), values -> this.values = values));
+            return Stream.of(Map.entry(name(fieldName), new SourceLoader.SyntheticFieldLoader.StoredFieldLoader() {
+                @Override
+                public void advanceToDoc(int docId) {
+                    values = emptyList();
+                }
+
+                @Override
+                public void load(List<Object> newValues) {
+                    values = newValues;
+                }
+            }));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
@@ -104,7 +104,6 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
                 values.write(b);
                 ignoreMalformedValues.write(b);
                 b.endArray();
-                return;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesSyntheticFieldLoaderLayer.java
@@ -13,60 +13,30 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static java.util.Collections.emptyList;
 
 /**
  * Load {@code _source} fields from {@link SortedSetDocValues}.
  */
-public abstract class SortedSetDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
-    private static final Logger logger = LogManager.getLogger(SortedSetDocValuesSyntheticFieldLoader.class);
+public abstract class SortedSetDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.Layer {
+    private static final Logger logger = LogManager.getLogger(SortedSetDocValuesSyntheticFieldLoaderLayer.class);
 
     private final String name;
-    private final String simpleName;
     private DocValuesFieldValues docValues = NO_VALUES;
-
-    /**
-     * Optionally loads stored fields values.
-     */
-    @Nullable
-    private final String storedValuesName;
-    private List<Object> storedValues = emptyList();
-
-    /**
-     * Optionally loads malformed values from stored fields.
-     */
-    private final IgnoreMalformedStoredValues ignoreMalformedValues;
 
     /**
      * Build a loader from doc values and, optionally, a stored field.
      * @param name the name of the field to load from doc values
-     * @param simpleName the name to give the field in the rendered {@code _source}
-     * @param storedValuesName the name of a stored field to load or null if there aren't any stored field for this field
-     * @param loadIgnoreMalformedValues should we load values skipped by {@code ignore_malformed}
      */
-    public SortedSetDocValuesSyntheticFieldLoader(
-        String name,
-        String simpleName,
-        @Nullable String storedValuesName,
-        boolean loadIgnoreMalformedValues
-    ) {
+    public SortedSetDocValuesSyntheticFieldLoaderLayer(String name) {
         this.name = name;
-        this.simpleName = simpleName;
-        this.storedValuesName = storedValuesName;
-        this.ignoreMalformedValues = loadIgnoreMalformedValues
-            ? IgnoreMalformedStoredValues.stored(name)
-            : IgnoreMalformedStoredValues.empty();
     }
 
     @Override
@@ -76,13 +46,7 @@ public abstract class SortedSetDocValuesSyntheticFieldLoader implements SourceLo
 
     @Override
     public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        if (storedValuesName == null) {
-            return ignoreMalformedValues.storedFieldLoaders();
-        }
-        return Stream.concat(
-            Stream.of(Map.entry(storedValuesName, values -> this.storedValues = values)),
-            ignoreMalformedValues.storedFieldLoaders()
-        );
+        return Stream.of();
     }
 
     @Override
@@ -112,48 +76,17 @@ public abstract class SortedSetDocValuesSyntheticFieldLoader implements SourceLo
 
     @Override
     public boolean hasValue() {
-        return docValues.count() > 0 || storedValues.isEmpty() == false || ignoreMalformedValues.count() > 0;
+        return docValues.count() > 0;
+    }
+
+    @Override
+    public long valueCount() {
+        return docValues.count();
     }
 
     @Override
     public void write(XContentBuilder b) throws IOException {
-        int total = docValues.count() + storedValues.size() + ignoreMalformedValues.count();
-        switch (total) {
-            case 0:
-                return;
-            case 1:
-                b.field(simpleName);
-                if (docValues.count() > 0) {
-                    assert docValues.count() == 1;
-                    assert storedValues.isEmpty();
-                    assert ignoreMalformedValues.count() == 0;
-                    docValues.write(b);
-                } else if (storedValues.isEmpty() == false) {
-                    assert docValues.count() == 0;
-                    assert storedValues.size() == 1;
-                    assert ignoreMalformedValues.count() == 0;
-                    BytesRef converted = convert((BytesRef) storedValues.get(0));
-                    b.utf8Value(converted.bytes, converted.offset, converted.length);
-                    storedValues = emptyList();
-                } else {
-                    assert docValues.count() == 0;
-                    assert storedValues.isEmpty();
-                    assert ignoreMalformedValues.count() == 1;
-                    ignoreMalformedValues.write(b);
-                }
-                return;
-            default:
-                b.startArray(simpleName);
-                docValues.write(b);
-                for (Object v : storedValues) {
-                    BytesRef converted = convert((BytesRef) v);
-                    b.utf8Value(converted.bytes, converted.offset, converted.length);
-                }
-                storedValues = emptyList();
-                ignoreMalformedValues.write(b);
-                b.endArray();
-                return;
-        }
+        docValues.write(b);
     }
 
     private interface DocValuesFieldValues {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -185,6 +185,10 @@ public interface SourceLoader {
 
             @Override
             public void write(LeafStoredFieldLoader storedFieldLoader, int docId, XContentBuilder b) throws IOException {
+                for (var fieldLevelStoredFieldLoader : storedFieldLoaders.values()) {
+                    fieldLevelStoredFieldLoader.advanceToDoc(docId);
+                }
+
                 // Maps the names of existing objects to lists of ignored fields they contain.
                 Map<String, List<IgnoredSourceFieldMapper.NameValue>> objectsWithIgnoredFields = null;
 
@@ -322,6 +326,15 @@ public interface SourceLoader {
          * Sync for stored field values.
          */
         interface StoredFieldLoader {
+            /**
+             * Signals the loader that values for this document will be loaded next.
+             * Allows loader to discard cached data for previous document.
+             */
+            void advanceToDoc(int docId);
+
+            /**
+             * Loads values read from a corresponding stored field into this loader.
+             */
             void load(List<Object> values);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringStoredFieldFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringStoredFieldFieldLoader.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReader;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -22,64 +21,49 @@ import static java.util.Collections.emptyList;
 public abstract class StringStoredFieldFieldLoader implements SourceLoader.SyntheticFieldLoader {
     private final String name;
     private final String simpleName;
+
     private List<Object> values = emptyList();
 
-    @Nullable
-    private final String extraStoredName;
-    private List<Object> extraValues = emptyList();
-
-    public StringStoredFieldFieldLoader(String name, String simpleName, @Nullable String extraStoredName) {
+    public StringStoredFieldFieldLoader(String name, String simpleName) {
         this.name = name;
         this.simpleName = simpleName;
-        this.extraStoredName = extraStoredName;
     }
 
     @Override
     public final Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        Stream<Map.Entry<String, StoredFieldLoader>> standard = Stream.of(Map.entry(name, values -> this.values = values));
-        if (extraStoredName == null) {
-            return standard;
-        }
-        return Stream.concat(standard, Stream.of(Map.entry(extraStoredName, values -> this.extraValues = values)));
+        return Stream.of(Map.entry(name, new SourceLoader.SyntheticFieldLoader.StoredFieldLoader() {
+            @Override
+            public void advanceToDoc(int docId) {
+                values = emptyList();
+            }
+
+            @Override
+            public void load(List<Object> newValues) {
+                values = newValues;
+            }
+        }));
     }
 
     @Override
     public final boolean hasValue() {
-        return values.isEmpty() == false || extraValues.isEmpty() == false;
+        return values.isEmpty() == false;
     }
 
     @Override
     public final void write(XContentBuilder b) throws IOException {
-        int size = values.size() + extraValues.size();
-        switch (size) {
+        switch (values.size()) {
             case 0:
                 return;
             case 1:
                 b.field(simpleName);
-                if (values.size() > 0) {
-                    assert values.size() == 1;
-                    assert extraValues.isEmpty();
-                    write(b, values.get(0));
-                } else {
-                    assert values.isEmpty();
-                    assert extraValues.size() == 1;
-                    write(b, extraValues.get(0));
-                }
-                values = emptyList();
-                extraValues = emptyList();
+                write(b, values.get(0));
                 return;
             default:
                 b.startArray(simpleName);
                 for (Object value : values) {
                     write(b, value);
                 }
-                for (Object value : extraValues) {
-                    write(b, value);
-                }
                 b.endArray();
-                values = emptyList();
-                extraValues = emptyList();
-                return;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1459,7 +1459,7 @@ public final class TextFieldMapper extends FieldMapper {
             );
         }
         if (store) {
-            return new StringStoredFieldFieldLoader(fullPath(), leafName(), null) {
+            return new StringStoredFieldFieldLoader(fullPath(), leafName()) {
                 @Override
                 protected void write(XContentBuilder b, Object value) throws IOException {
                     b.value((String) value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedSortedSetDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedSortedSetDocValuesSyntheticFieldLoader.java
@@ -12,12 +12,14 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.mapper.SortedSetDocValuesSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Stream;
 
-public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SortedSetDocValuesSyntheticFieldLoader {
+public class FlattenedSortedSetDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
     private DocValuesFieldValues docValues = NO_VALUES;
     private final String fieldFullPath;
     private final String keyedFieldFullPath;
@@ -31,7 +33,6 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SortedSetDo
      * @param leafName                the name of the leaf field to use in the rendered {@code _source}
      */
     public FlattenedSortedSetDocValuesSyntheticFieldLoader(String fieldFullPath, String keyedFieldFullPath, String leafName) {
-        super(fieldFullPath, leafName, null, false);
         this.fieldFullPath = fieldFullPath;
         this.keyedFieldFullPath = keyedFieldFullPath;
         this.leafName = leafName;
@@ -40,6 +41,11 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SortedSetDo
     @Override
     public String fieldName() {
         return fieldFullPath;
+    }
+
+    @Override
+    public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+        return Stream.empty();
     }
 
     @Override
@@ -67,16 +73,6 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SortedSetDo
         b.startObject(leafName);
         docValues.write(b);
         b.endObject();
-    }
-
-    @Override
-    protected BytesRef convert(BytesRef value) {
-        return value;
-    }
-
-    @Override
-    protected BytesRef preserve(BytesRef value) {
-        return BytesRef.deepCopyOf(value);
     }
 
     private interface DocValuesFieldValues {

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoaderTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CompositeSyntheticFieldLoaderTests extends ESTestCase {
+    public void testComposingMultipleStoredFields() throws IOException {
+        var sut = new CompositeSyntheticFieldLoader(
+            "foo",
+            "bar.baz.foo",
+            List.of(new CompositeSyntheticFieldLoader.StoredFieldLayer("foo.one") {
+                @Override
+                protected void writeValue(Object value, XContentBuilder b) throws IOException {
+                    b.value((long) value);
+                }
+            }, new CompositeSyntheticFieldLoader.StoredFieldLayer("foo.two") {
+                @Override
+                protected void writeValue(Object value, XContentBuilder b) throws IOException {
+                    b.value((long) value);
+                }
+            })
+        );
+
+        var storedFieldLoaders = sut.storedFieldLoaders().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        storedFieldLoaders.get("foo.one").advanceToDoc(0);
+        storedFieldLoaders.get("foo.one").load(List.of(45L, 46L));
+        storedFieldLoaders.get("foo.two").advanceToDoc(0);
+        storedFieldLoaders.get("foo.two").load(List.of(1L));
+
+        var result = XContentBuilder.builder(XContentType.JSON.xContent());
+        result.startObject();
+        sut.write(result);
+        result.endObject();
+
+        assertEquals("""
+            {"foo":[45,46,1]}""", Strings.toString(result));
+    }
+
+    public void testLoadStoredFieldAndAdvance() throws IOException {
+        var sut = new CompositeSyntheticFieldLoader(
+            "foo",
+            "bar.baz.foo",
+            List.of(new CompositeSyntheticFieldLoader.StoredFieldLayer("foo.one") {
+                @Override
+                protected void writeValue(Object value, XContentBuilder b) throws IOException {
+                    b.value((long) value);
+                }
+            })
+        );
+
+        var storedFieldLoaders = sut.storedFieldLoaders().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        storedFieldLoaders.get("foo.one").advanceToDoc(0);
+        storedFieldLoaders.get("foo.one").load(List.of(45L));
+
+        var result = XContentBuilder.builder(XContentType.JSON.xContent());
+        result.startObject();
+        sut.write(result);
+        result.endObject();
+
+        assertEquals("""
+            {"foo":45}""", Strings.toString(result));
+
+        storedFieldLoaders.get("foo.one").advanceToDoc(1);
+
+        var empty = XContentBuilder.builder(XContentType.JSON.xContent());
+        empty.startObject();
+        sut.write(result);
+        empty.endObject();
+
+        assertEquals("{}", Strings.toString(empty));
+    }
+
+    public void testComposingMultipleDocValuesFields() throws IOException {
+        var sut = new CompositeSyntheticFieldLoader("foo", "bar.baz.foo", List.of(new CompositeSyntheticFieldLoader.Layer() {
+            @Override
+            public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+                return Stream.empty();
+            }
+
+            @Override
+            public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
+                return (docId -> true);
+            }
+
+            @Override
+            public boolean hasValue() {
+                return true;
+            }
+
+            @Override
+            public void write(XContentBuilder b) throws IOException {
+                b.value(45L);
+                b.value(46L);
+            }
+
+            @Override
+            public String fieldName() {
+                return "";
+            }
+
+            @Override
+            public long valueCount() {
+                return 2;
+            }
+        }, new CompositeSyntheticFieldLoader.Layer() {
+            @Override
+            public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+                return Stream.empty();
+            }
+
+            @Override
+            public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
+                return (docId -> true);
+            }
+
+            @Override
+            public boolean hasValue() {
+                return true;
+            }
+
+            @Override
+            public void write(XContentBuilder b) throws IOException {
+                b.value(1L);
+            }
+
+            @Override
+            public String fieldName() {
+                return "";
+            }
+
+            @Override
+            public long valueCount() {
+                return 1;
+            }
+        }));
+
+        sut.docValuesLoader(null, new int[0]).advanceToDoc(0);
+
+        var result = XContentBuilder.builder(XContentType.JSON.xContent());
+        result.startObject();
+        sut.write(result);
+        result.endObject();
+
+        assertEquals("""
+            {"foo":[45,46,1]}""", Strings.toString(result));
+    }
+
+    public void testComposingStoredFieldsWithDocValues() throws IOException {
+        var sut = new CompositeSyntheticFieldLoader(
+            "foo",
+            "bar.baz.foo",
+            List.of(new CompositeSyntheticFieldLoader.StoredFieldLayer("foo.one") {
+                @Override
+                protected void writeValue(Object value, XContentBuilder b) throws IOException {
+                    b.value((long) value);
+                }
+            }, new CompositeSyntheticFieldLoader.Layer() {
+                @Override
+                public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+                    return Stream.empty();
+                }
+
+                @Override
+                public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
+                    return (docId -> true);
+                }
+
+                @Override
+                public boolean hasValue() {
+                    return true;
+                }
+
+                @Override
+                public void write(XContentBuilder b) throws IOException {
+                    b.value(1L);
+                }
+
+                @Override
+                public String fieldName() {
+                    return "";
+                }
+
+                @Override
+                public long valueCount() {
+                    return 1;
+                }
+            })
+        );
+
+        var storedFieldLoaders = sut.storedFieldLoaders().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        storedFieldLoaders.get("foo.one").advanceToDoc(0);
+        storedFieldLoaders.get("foo.one").load(List.of(45L, 46L));
+
+        sut.docValuesLoader(null, new int[0]).advanceToDoc(0);
+
+        var result = XContentBuilder.builder(XContentType.JSON.xContent());
+        result.startObject();
+        sut.write(result);
+        result.endObject();
+
+        assertEquals("""
+            {"foo":[45,46,1]}""", Strings.toString(result));
+    }
+
+    public void testFieldName() {
+        var sut = new CompositeSyntheticFieldLoader("foo", "bar.baz.foo");
+        assertEquals("bar.baz.foo", sut.fieldName());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -3245,7 +3245,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
             @Override
             public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-                return new StringStoredFieldFieldLoader(fullPath(), leafName(), null) {
+                return new StringStoredFieldFieldLoader(fullPath(), leafName()) {
                     @Override
                     protected void write(XContentBuilder b, Object value) throws IOException {
                         BytesRef ref = (BytesRef) value;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -528,7 +528,7 @@ public class HistogramFieldMapper extends FieldMapper {
         );
     }
 
-    private class HistogramSyntheticFieldLoader implements CompositeSyntheticFieldLoader.SyntheticFieldLoaderLayer {
+    private class HistogramSyntheticFieldLoader implements CompositeSyntheticFieldLoader.Layer {
         private final InternalHistogramValue value = new InternalHistogramValue();
         private BytesRef binaryValue;
 

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -720,21 +720,19 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         return new CompositeSyntheticFieldLoader(
             leafName(),
             fullPath(),
-            new AggregateMetricSyntheticFieldLoader(fullPath(), leafName(), metrics),
+            new AggregateMetricSyntheticFieldLoader(fullPath(), metrics),
             new CompositeSyntheticFieldLoader.MalformedValuesLayer(fullPath())
         );
     }
 
-    public static class AggregateMetricSyntheticFieldLoader implements CompositeSyntheticFieldLoader.SyntheticFieldLoaderLayer {
+    public static class AggregateMetricSyntheticFieldLoader implements CompositeSyntheticFieldLoader.Layer {
         private final String name;
-        private final String simpleName;
         private final EnumSet<Metric> metrics;
         private final Map<Metric, SortedNumericDocValues> metricDocValues = new EnumMap<>(Metric.class);
         private final Set<Metric> metricHasValue = EnumSet.noneOf(Metric.class);
 
-        protected AggregateMetricSyntheticFieldLoader(String name, String simpleName, EnumSet<Metric> metrics) {
+        protected AggregateMetricSyntheticFieldLoader(String name, EnumSet<Metric> metrics) {
             this.name = name;
-            this.simpleName = simpleName;
             this.metrics = metrics;
         }
 

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -41,13 +41,14 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.SearchAfterTermsEnum;
-import org.elasticsearch.index.mapper.SortedSetDocValuesSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.SortedSetDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TermBasedFieldType;
@@ -457,7 +458,7 @@ public class VersionStringFieldMapper extends FieldMapper {
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedSetDocValuesSyntheticFieldLoader(fullPath(), leafName(), null, false) {
+        return new CompositeSyntheticFieldLoader(leafName(), fullPath(), new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
             @Override
             protected BytesRef convert(BytesRef value) {
                 return VersionEncoder.decodeVersion(value);
@@ -468,6 +469,6 @@ public class VersionStringFieldMapper extends FieldMapper {
                 // Convert copies the underlying bytes
                 return value;
             }
-        };
+        });
     }
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -61,6 +61,7 @@ import org.elasticsearch.index.fielddata.plain.StringBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.BinaryFieldMapper.CustomBinaryDocValuesField;
 import org.elasticsearch.index.mapper.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -87,8 +88,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static java.util.Collections.emptyList;
 
 /**
  * A {@link FieldMapper} for indexing fields with ngrams for efficient wildcard matching
@@ -1003,21 +1002,33 @@ public class WildcardFieldMapper extends FieldMapper {
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new WildcardSyntheticFieldLoader();
+
+        var loader = new WildcardSyntheticFieldLoader();
+        if (ignoreAbove != Defaults.IGNORE_ABOVE) {
+            return new CompositeSyntheticFieldLoader(
+                leafName(),
+                fullPath(),
+                loader,
+                new CompositeSyntheticFieldLoader.StoredFieldLayer(originalName()) {
+                    @Override
+                    protected void writeValue(Object value, XContentBuilder b) throws IOException {
+                        BytesRef r = (BytesRef) value;
+                        b.utf8Value(r.bytes, r.offset, r.length);
+                    }
+                }
+            );
+        }
+
+        return new CompositeSyntheticFieldLoader(leafName(), fullPath(), loader);
     }
 
-    private class WildcardSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+    private class WildcardSyntheticFieldLoader implements CompositeSyntheticFieldLoader.Layer {
         private final ByteArrayStreamInput docValuesStream = new ByteArrayStreamInput();
         private int docValueCount;
         private BytesRef docValueBytes;
 
-        private List<Object> storedValues = emptyList();
-
         @Override
         public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            if (ignoreAbove != Defaults.IGNORE_ABOVE) {
-                return Stream.of(Map.entry(originalName(), storedValues -> this.storedValues = storedValues));
-            }
             return Stream.empty();
         }
 
@@ -1044,33 +1055,21 @@ public class WildcardFieldMapper extends FieldMapper {
 
         @Override
         public boolean hasValue() {
-            return docValueCount > 0 || storedValues.isEmpty() == false;
+            return docValueCount > 0;
+        }
+
+        @Override
+        public long valueCount() {
+            return docValueCount;
         }
 
         @Override
         public void write(XContentBuilder b) throws IOException {
-            switch (docValueCount + storedValues.size()) {
-                case 0:
-                    return;
-                case 1:
-                    b.field(leafName());
-                    break;
-                default:
-                    b.startArray(leafName());
-            }
             for (int i = 0; i < docValueCount; i++) {
                 int length = docValuesStream.readVInt();
                 b.utf8Value(docValueBytes.bytes, docValuesStream.getPosition(), length);
                 docValuesStream.skipBytes(length);
             }
-            for (Object o : storedValues) {
-                BytesRef r = (BytesRef) o;
-                b.utf8Value(r.bytes, r.offset, r.length);
-            }
-            if (docValueCount + storedValues.size() > 1) {
-                b.endArray();
-            }
-            storedValues = emptyList();
         }
 
         @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Prevent synthetic field loaders accessing stored fields from using stale data (#112173)](https://github.com/elastic/elasticsearch/pull/112173)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)