### PR TITLE
Stash and restore thread context for partial request

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -356,6 +356,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
             var resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
             var headers = resp.headers();
             assertEquals(RestController.ELASTIC_PRODUCT_HTTP_HEADER_VALUE, headers.get(RestController.ELASTIC_PRODUCT_HTTP_HEADER));
+            resp.release();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContextAware.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContextAware.java
@@ -10,6 +10,8 @@ package org.elasticsearch.common.util.concurrent;
 
 public interface ThreadContextAware {
     ThreadContext threadContext();
+
     void stashContext();
+
     void restoreContext();
 }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContextAware.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContextAware.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+public interface ThreadContextAware {
+    ThreadContext threadContext();
+    void stashContext();
+    void restoreContext();
+}

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -248,6 +248,7 @@ public class DefaultRestChannel extends AbstractRestChannel implements ThreadCon
 
     @Override
     public ThreadContext threadContext() {
+        assert storedContext == null;
         return threadContext;
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -120,12 +120,13 @@ public abstract class BaseRestHandler implements RestHandler {
                 assert action instanceof RequestBodyChunkConsumer;
                 var chunkConsumer = (RequestBodyChunkConsumer) action;
                 request.contentStream().setHandler((chunk, isLast) -> chunkConsumer.handleChunk(channel, chunk, isLast));
+                usageCount.increment();
+                action.accept(channel);
                 channel.stashContext();
+            } else {
+                usageCount.increment();
+                action.accept(channel);
             }
-
-            usageCount.increment();
-            // execute the action
-            action.accept(channel);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -120,6 +120,7 @@ public abstract class BaseRestHandler implements RestHandler {
                 assert action instanceof RequestBodyChunkConsumer;
                 var chunkConsumer = (RequestBodyChunkConsumer) action;
                 request.contentStream().setHandler((chunk, isLast) -> chunkConsumer.handleChunk(channel, chunk, isLast));
+                channel.stashContext();
             }
 
             usageCount.increment();

--- a/server/src/main/java/org/elasticsearch/rest/RestChannel.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestChannel.java
@@ -9,6 +9,8 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.common.io.stream.BytesStream;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.util.concurrent.ThreadContextAware;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -19,7 +21,7 @@ import java.io.OutputStream;
 /**
  * A channel used to construct bytes / builder based outputs, and send responses.
  */
-public interface RestChannel {
+public interface RestChannel extends ThreadContextAware {
 
     XContentBuilder newBuilder() throws IOException;
 
@@ -53,4 +55,20 @@ public interface RestChannel {
     boolean detailedErrorsEnabled();
 
     void sendResponse(RestResponse response);
+
+    @Override
+    default ThreadContext threadContext() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    default void stashContext() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    default void restoreContext() {
+        throw new IllegalStateException();
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -84,8 +84,8 @@ public class RestController implements HttpServerTransport.Dispatcher {
      */
     static final Set<String> SAFELISTED_MEDIA_TYPES = Set.of("application/x-www-form-urlencoded", "multipart/form-data", "text/plain");
 
-    static final String ELASTIC_PRODUCT_HTTP_HEADER = "X-elastic-product";
-    static final String ELASTIC_PRODUCT_HTTP_HEADER_VALUE = "Elasticsearch";
+    public static final String ELASTIC_PRODUCT_HTTP_HEADER = "X-elastic-product";
+    public static final String ELASTIC_PRODUCT_HTTP_HEADER_VALUE = "Elasticsearch";
     static final Set<String> RESERVED_PATHS = Set.of("/__elb_health__", "/__elb_health__/zk", "/_health", "/_health/zk");
     private static final BytesReference FAVICON_RESPONSE;
     public static final String STATUS_CODE_KEY = "es_rest_status_code";
@@ -879,6 +879,21 @@ public class RestController implements HttpServerTransport.Dispatcher {
         @Override
         public void sendResponse(RestResponse response) {
             delegate.sendResponse(response);
+        }
+
+        @Override
+        public ThreadContext threadContext() {
+            return delegate.threadContext();
+        }
+
+        @Override
+        public void stashContext() {
+            delegate.stashContext();
+        }
+
+        @Override
+        public void restoreContext() {
+            delegate.restoreContext();
         }
     }
 


### PR DESCRIPTION
Partial http request will reset thread context after handling first part - header. When we send response threadContext headers are gone. This PR adds support to stash and restore context for partial requests. I stash context after `BaseRestHandler.prepareRequest` and restore context on `(RestChannel)channel.sendResponse`. It works only for streaming requests, full requests do not stash/restore.