### PR TITLE
[8.15] Fix toReleaseVersion() when called on the current version id (#112242)

### DIFF
--- a/docs/changelog/112242.yaml
+++ b/docs/changelog/112242.yaml
@@ -1,0 +1,5 @@
+pr: 112242
+summary: Fix toReleaseVersion() when called on the current version id
+area: Infra/Core
+type: bug
+issues: [111900]

--- a/server/src/main/java/org/elasticsearch/ReleaseVersions.java
+++ b/server/src/main/java/org/elasticsearch/ReleaseVersions.java
@@ -41,7 +41,7 @@ public class ReleaseVersions {
 
     private static final Pattern VERSION_LINE = Pattern.compile("(\\d+\\.\\d+\\.\\d+),(\\d+)");
 
-    public static IntFunction<String> generateVersionsLookup(Class<?> versionContainer) {
+    public static IntFunction<String> generateVersionsLookup(Class<?> versionContainer, int current) {
         if (USES_VERSIONS == false) return Integer::toString;
 
         try {
@@ -52,6 +52,9 @@ public class ReleaseVersions {
             }
 
             NavigableMap<Integer, List<Version>> versions = new TreeMap<>();
+            // add the current version id, which won't be in the csv
+            versions.put(current, List.of(Version.CURRENT));
+
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(versionsFile, StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
@@ -121,8 +124,8 @@ public class ReleaseVersions {
                     // too hard to guess what version this id might be for using the next version - just use it directly
                     upperBound = upperRange.getValue().get(0).toString();
                 } else {
-                    // likely a version created after the last release tagged version - ok
-                    upperBound = "snapshot[" + id + "]";
+                    // a newer version than all we know about? Can't map it...
+                    upperBound = "[" + id + "]";
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/ReleaseVersions.java
+++ b/server/src/main/java/org/elasticsearch/ReleaseVersions.java
@@ -53,7 +53,7 @@ public class ReleaseVersions {
 
             NavigableMap<Integer, List<Version>> versions = new TreeMap<>();
             // add the current version id, which won't be in the csv
-            versions.put(current, List.of(Version.CURRENT));
+            versions.computeIfAbsent(current, k -> new ArrayList<>()).add(Version.CURRENT);
 
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(versionsFile, StandardCharsets.UTF_8))) {
                 String line;

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -332,7 +332,7 @@ public class TransportVersions {
         return VERSION_IDS.values();
     }
 
-    static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(TransportVersions.class);
+    static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(TransportVersions.class, LATEST_DEFINED.id());
 
     // no instance
     private TransportVersions() {}

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -220,7 +220,7 @@ public class IndexVersions {
         return VERSION_IDS.values();
     }
 
-    static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(IndexVersions.class);
+    static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(IndexVersions.class, LATEST_DEFINED.id());
 
     // no instance
     private IndexVersions() {}

--- a/server/src/test/java/org/elasticsearch/ReleaseVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/ReleaseVersionsTests.java
@@ -17,19 +17,20 @@ import static org.hamcrest.Matchers.equalTo;
 public class ReleaseVersionsTests extends ESTestCase {
 
     public void testReleaseVersions() {
-        IntFunction<String> versions = ReleaseVersions.generateVersionsLookup(ReleaseVersionsTests.class);
+        IntFunction<String> versions = ReleaseVersions.generateVersionsLookup(ReleaseVersionsTests.class, 23);
 
         assertThat(versions.apply(10), equalTo("8.0.0"));
         assertThat(versions.apply(14), equalTo("8.1.0-8.1.1"));
         assertThat(versions.apply(21), equalTo("8.2.0"));
         assertThat(versions.apply(22), equalTo("8.2.1"));
+        assertThat(versions.apply(23), equalTo(Version.CURRENT.toString()));
     }
 
     public void testReturnsRange() {
-        IntFunction<String> versions = ReleaseVersions.generateVersionsLookup(ReleaseVersionsTests.class);
+        IntFunction<String> versions = ReleaseVersions.generateVersionsLookup(ReleaseVersionsTests.class, 23);
 
         assertThat(versions.apply(17), equalTo("8.1.2-8.2.0"));
         assertThat(versions.apply(9), equalTo("0.0.0"));
-        assertThat(versions.apply(24), equalTo("8.2.2-snapshot[24]"));
+        assertThat(versions.apply(24), equalTo(new Version(Version.CURRENT.id + 100) + "-[24]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -186,6 +186,10 @@ public class TransportVersionTests extends ESTestCase {
         assertThat(Collections.max(TransportVersions.getAllVersions()), is(TransportVersion.current()));
     }
 
+    public void testToReleaseVersion() {
+        assertThat(TransportVersion.current().toReleaseVersion(), equalTo(Version.CURRENT.toString()));
+    }
+
     public void testToString() {
         assertEquals("5000099", TransportVersion.fromId(5_00_00_99).toString());
         assertEquals("2030099", TransportVersion.fromId(2_03_00_99).toString());

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -19,6 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -187,7 +188,7 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testToReleaseVersion() {
-        assertThat(TransportVersion.current().toReleaseVersion(), equalTo(Version.CURRENT.toString()));
+        assertThat(TransportVersion.current().toReleaseVersion(), endsWith(Version.CURRENT.toString()));
     }
 
     public void testToString() {


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Fix toReleaseVersion() when called on the current version id (#112242)