### PR TITLE
Add UpdateForV10 annotation

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/UpdateForV10.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/UpdateForV10.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to identify a block of code (a whole class, a method, or a field) that needs to be reviewed (for cleanup, remove or change)
+ * before releasing 10.0
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.LOCAL_VARIABLE, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
+public @interface UpdateForV10 {
+}


### PR DESCRIPTION
In preparation for the next major release of Elasticsearch, this commit adds the UpdateForV10 annotation.

We're already starting to use this over in the lucene_snapshot_10 branch, so best upstream it to _main_ where it may be used elsewhere when refactoring and/or cleaning up code marked UpdateForV9.