### PR TITLE
Make throwNoText throw XContentParseException to return 4xx status code

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -110,7 +110,7 @@ public class JsonXContentParser extends AbstractXContentParser {
     }
 
     private void throwOnNoText() {
-        throw new IllegalStateException("Can't get text on a " + currentToken() + " at " + getTokenLocation());
+        throw new XContentParseException("Can't get text on a " + currentToken() + " at " + getTokenLocation());
     }
 
     @Override


### PR DESCRIPTION
Fixes #112296 

This change throws XContentParseException instead of IllegalStateException to send 4xx status code to the client.

## Checklist 

- [x] Signed the Contributor License Agreement (CLA)
- [x] Followed the contributor guidelines
- [x] Built and tested your changes locally using `gradle check`.
- [x] Your pull request is against the main branch
- [x] Verified that your submission targets an OS and architecture we support