### PR TITLE
Mute SharedBlobCacheServiceTests.testGetMultiThreaded

### DIFF
--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -444,6 +444,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
      * Exercise SharedBlobCacheService#get in multiple threads to trigger any assertion errors.
      * @throws IOException
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/112305")
     public void testGetMultiThreaded() throws IOException {
         final int threads = between(2, 10);
         final int regionCount = between(1, 20);


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/112305
