### PR TITLE
Mute ThreadContextTests.testDropWarningsExceedingMaxSettings

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -638,6 +638,7 @@ public class ThreadContextTests extends ESTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/112256")
     public void testDropWarningsExceedingMaxSettings() {
         Settings settings = Settings.builder()
             .put(HttpTransportSettings.SETTING_HTTP_MAX_WARNING_HEADER_COUNT.getKey(), 1)


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/112256
