### PR TITLE
[8.15] Include network disconnect info in troubleshooting docs (#112323)

### DIFF
--- a/docs/reference/modules/discovery/fault-detection.asciidoc
+++ b/docs/reference/modules/discovery/fault-detection.asciidoc
@@ -300,7 +300,6 @@ To reconstruct the output, base64-decode the data and decompress it using
 ----
 cat shardlock.log | sed -e 's/.*://' | base64 --decode | gzip --decompress
 ----
-//end::troubleshooting[]
 
 [discrete]
 ===== Diagnosing other network disconnections
@@ -345,3 +344,4 @@ packet capture simultaneously from the nodes at both ends of an unstable
 connection and analyse it alongside the {es} logs from those nodes to determine
 if traffic between the nodes is being disrupted by another device on the
 network.
+//end::troubleshooting[]


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Include network disconnect info in troubleshooting docs (#112323)