### PR TITLE
[DOCS] Fixed some Alibabacloud AI Search and Amazon Bedrock inference docs

### DIFF
--- a/docs/reference/inference/service-alibabacloud-ai-search.asciidoc
+++ b/docs/reference/inference/service-alibabacloud-ai-search.asciidoc
@@ -25,7 +25,7 @@ include::inference-shared.asciidoc[tag=task-type]
 Available task types:
 
 * `text_embedding`,
-* `sparse_embedding`.
+* `sparse_embedding`,
 * `rerank`.
 --
 

--- a/docs/reference/inference/service-amazon-bedrock.asciidoc
+++ b/docs/reference/inference/service-amazon-bedrock.asciidoc
@@ -123,14 +123,6 @@ Alternative to `temperature`. Limits samples to the top-K most likely words, bal
 Should not be used if `temperature` is specified.
 
 =====
-+
-.`task_settings` for the `text_embedding` task type
-[%collapsible%closed]
-=====
-
-There are no `task_settings` available for the `text_embedding` task type.
-
-=====
 
 [discrete]
 [[inference-example-amazonbedrock]]


### PR DESCRIPTION
Some inference docs improve.
The Amazon Bedrock inference page looks like this, so I deleted the parameterless task type.

<img width="846" alt="2024-08-29 16 33 37" src="https://github.com/user-attachments/assets/99e72e75-34d7-4d40-a5fd-5f69e4b08bf4">
