### PR TITLE
ESQL: Reenable 26_aggs_bucket EsqlClientYamlIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -122,12 +122,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
   method: testSnapshotRestore {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111799
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: "test {p0=esql/26_aggs_bucket/friendlier BUCKET interval hourly: #110916}"
-  issue: https://github.com/elastic/elasticsearch/issues/111901
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: "test {p0=esql/26_aggs_bucket/friendlier BUCKET interval: monthly #110916}"
-  issue: https://github.com/elastic/elasticsearch/issues/111902
 - class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
   method: testScaledFloat
   issue: https://github.com/elastic/elasticsearch/issues/112003


### PR DESCRIPTION
Reenable 26_aggs_bucket EsqlClientYamlIT, fixed in #111897.

Fixes #111901, fixes #111902.