### PR TITLE
Omit the executor when creating TimeSeriesIndexSearcher

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesIndexSearcher.java
@@ -63,10 +63,7 @@ public class TimeSeriesIndexSearcher {
                 searcher.getSimilarity(),
                 searcher.getQueryCache(),
                 searcher.getQueryCachingPolicy(),
-                false,
-                searcher.getExecutor(),
-                1,
-                -1
+                false
             );
         } catch (IOException e) {
             // IOException from wrapping the index searcher which should never happen.


### PR DESCRIPTION
This is a leftover from #111099: now that we use a single thread pool, we don't require offloading, which was the only reason to carry around the executor in the time series index searcher, given that the number of slices is always 1 and it does not support concurrency. Furthermore, providing the executor introduces some risks of potential concurrency caused by non-slice based operations that can't be disabled. This commit removes the executor constructor argument and effectively disable any concurrency in TimeSeriesIndexSearcher.