### PR TITLE
Add index mode to internal field-caps response

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -202,6 +202,8 @@ public class TransportVersions {
     public static final TransportVersion REPOSITORIES_TELEMETRY = def(8_732_00_0);
     public static final TransportVersion ML_INFERENCE_ALIBABACLOUD_SEARCH_ADDED = def(8_733_00_0);
 
+    public static final TransportVersion FIELD_CAPS_RESPONSE_INDEX_MODE = def(8_734_00_0);
+
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -116,7 +116,7 @@ class FieldCapabilitiesFetcher {
         final MappingMetadata mapping = indexService.getMetadata().mapping();
         String indexMappingHash;
         if (includeEmptyFields || enableFieldHasValue == false) {
-            indexMappingHash = mapping != null ? mapping.getSha256() + ":" + indexMode : null;
+            indexMappingHash = mapping != null ? mapping.getSha256() + indexMode : null;
         } else {
             // even if the mapping is the same if we return only fields with values we need
             // to make sure that we consider all the shard-mappings pair, that is why we

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexMode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,18 +34,21 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
     private final Map<String, IndexFieldCapabilities> responseMap;
     private final boolean canMatch;
     private final transient TransportVersion originVersion;
+    private final IndexMode indexMode;
 
     public FieldCapabilitiesIndexResponse(
         String indexName,
         @Nullable String indexMappingHash,
         Map<String, IndexFieldCapabilities> responseMap,
-        boolean canMatch
+        boolean canMatch,
+        IndexMode indexMode
     ) {
         this.indexName = indexName;
         this.indexMappingHash = indexMappingHash;
         this.responseMap = responseMap;
         this.canMatch = canMatch;
         this.originVersion = TransportVersion.current();
+        this.indexMode = indexMode;
     }
 
     FieldCapabilitiesIndexResponse(StreamInput in) throws IOException {
@@ -57,6 +61,11 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
         } else {
             this.indexMappingHash = null;
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.FIELD_CAPS_RESPONSE_INDEX_MODE)) {
+            this.indexMode = IndexMode.readFrom(in);
+        } else {
+            this.indexMode = IndexMode.STANDARD;
+        }
     }
 
     @Override
@@ -67,9 +76,12 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
         if (out.getTransportVersion().onOrAfter(MAPPING_HASH_VERSION)) {
             out.writeOptionalString(indexMappingHash);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.FIELD_CAPS_RESPONSE_INDEX_MODE)) {
+            IndexMode.writeTo(indexMode, out);
+        }
     }
 
-    private record CompressedGroup(String[] indices, String mappingHash, int[] fields) {}
+    private record CompressedGroup(String[] indices, IndexMode indexMode, String mappingHash, int[] fields) {}
 
     static List<FieldCapabilitiesIndexResponse> readList(StreamInput input) throws IOException {
         if (input.getTransportVersion().before(MAPPING_HASH_VERSION)) {
@@ -92,10 +104,12 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
     private static void collectCompressedResponses(StreamInput input, int groups, ArrayList<FieldCapabilitiesIndexResponse> responses)
         throws IOException {
         final CompressedGroup[] compressedGroups = new CompressedGroup[groups];
+        final boolean readIndexMode = input.getTransportVersion().onOrAfter(TransportVersions.FIELD_CAPS_RESPONSE_INDEX_MODE);
         for (int i = 0; i < groups; i++) {
             final String[] indices = input.readStringArray();
+            final IndexMode indexMode = readIndexMode ? IndexMode.readFrom(input) : IndexMode.STANDARD;
             final String mappingHash = input.readString();
-            compressedGroups[i] = new CompressedGroup(indices, mappingHash, input.readIntArray());
+            compressedGroups[i] = new CompressedGroup(indices, indexMode, mappingHash, input.readIntArray());
         }
         final IndexFieldCapabilities[] ifcLookup = input.readArray(IndexFieldCapabilities::readFrom, IndexFieldCapabilities[]::new);
         for (CompressedGroup compressedGroup : compressedGroups) {
@@ -105,7 +119,7 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
                 ifc.put(val.name(), val);
             }
             for (String index : compressedGroup.indices) {
-                responses.add(new FieldCapabilitiesIndexResponse(index, compressedGroup.mappingHash, ifc, true));
+                responses.add(new FieldCapabilitiesIndexResponse(index, compressedGroup.mappingHash, ifc, true, compressedGroup.indexMode));
             }
         }
     }
@@ -117,7 +131,7 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
             final String mappingHash = input.readString();
             final Map<String, IndexFieldCapabilities> ifc = input.readMap(IndexFieldCapabilities::readFrom);
             for (String index : indices) {
-                responses.add(new FieldCapabilitiesIndexResponse(index, mappingHash, ifc, true));
+                responses.add(new FieldCapabilitiesIndexResponse(index, mappingHash, ifc, true, IndexMode.STANDARD));
             }
         }
     }
@@ -164,6 +178,9 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
         output.writeCollection(groupedResponsesMap.values(), (o, fieldCapabilitiesIndexResponses) -> {
             o.writeCollection(fieldCapabilitiesIndexResponses, (oo, r) -> oo.writeString(r.indexName));
             var first = fieldCapabilitiesIndexResponses.get(0);
+            if (output.getTransportVersion().onOrAfter(TransportVersions.FIELD_CAPS_RESPONSE_INDEX_MODE)) {
+                IndexMode.writeTo(first.indexMode, o);
+            }
             o.writeString(first.indexMappingHash);
             o.writeVInt(first.responseMap.size());
             for (IndexFieldCapabilities ifc : first.responseMap.values()) {
@@ -190,6 +207,10 @@ public final class FieldCapabilitiesIndexResponse implements Writeable {
     @Nullable
     public String getIndexMappingHash() {
         return indexMappingHash;
+    }
+
+    public IndexMode getIndexMode() {
+        return indexMode;
     }
 
     public boolean canMatch() {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -174,7 +174,13 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             if (resp.canMatch() && resp.getIndexMappingHash() != null) {
                 FieldCapabilitiesIndexResponse curr = indexMappingHashToResponses.putIfAbsent(resp.getIndexMappingHash(), resp);
                 if (curr != null) {
-                    resp = new FieldCapabilitiesIndexResponse(resp.getIndexName(), curr.getIndexMappingHash(), curr.get(), true);
+                    resp = new FieldCapabilitiesIndexResponse(
+                        resp.getIndexName(),
+                        curr.getIndexMappingHash(),
+                        curr.get(),
+                        true,
+                        curr.getIndexMode()
+                    );
                 }
             }
             if (request.includeEmptyFields()) {
@@ -186,7 +192,13 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                     }
                     Map<String, IndexFieldCapabilities> mergedCaps = new HashMap<>(a.get());
                     mergedCaps.putAll(b.get());
-                    return new FieldCapabilitiesIndexResponse(a.getIndexName(), a.getIndexMappingHash(), mergedCaps, true);
+                    return new FieldCapabilitiesIndexResponse(
+                        a.getIndexName(),
+                        a.getIndexMappingHash(),
+                        mergedCaps,
+                        true,
+                        a.getIndexMode()
+                    );
                 });
             }
             if (fieldCapTask.isCancelled()) {
@@ -249,7 +261,13 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                     for (FieldCapabilitiesIndexResponse resp : response.getIndexResponses()) {
                         String indexName = RemoteClusterAware.buildRemoteIndexName(clusterAlias, resp.getIndexName());
                         handleIndexResponse.accept(
-                            new FieldCapabilitiesIndexResponse(indexName, resp.getIndexMappingHash(), resp.get(), resp.canMatch())
+                            new FieldCapabilitiesIndexResponse(
+                                indexName,
+                                resp.getIndexMappingHash(),
+                                resp.get(),
+                                resp.canMatch(),
+                                resp.getIndexMode()
+                            )
                         );
                     }
                     for (FieldCapabilitiesFailure failure : response.getFailures()) {

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -12,6 +12,8 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -492,6 +494,25 @@ public enum IndexMode {
                     + "]"
             );
         };
+    }
+
+    public static IndexMode readFrom(StreamInput in) throws IOException {
+        int mode = in.readByte();
+        return switch (mode) {
+            case 0 -> STANDARD;
+            case 1 -> TIME_SERIES;
+            case 2 -> LOGSDB;
+            default -> throw new IllegalStateException("unexpected index mode [" + mode + "]");
+        };
+    }
+
+    public static void writeTo(IndexMode indexMode, StreamOutput out) throws IOException {
+        final int code = switch (indexMode) {
+            case STANDARD -> 0;
+            case TIME_SERIES -> 1;
+            case LOGSDB -> 2;
+        };
+        out.writeByte((byte) code);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.fieldcaps;
 
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.test.ESTestCase;
 
@@ -60,9 +61,10 @@ public class FieldCapabilitiesIndexResponseTests extends ESTestCase {
         final List<FieldCapabilitiesIndexResponse> responses = new ArrayList<>();
         for (Map.Entry<String, List<String>> e : mappingHashToIndices.entrySet()) {
             Map<String, IndexFieldCapabilities> fieldCaps = randomFieldCaps();
+            var indexMode = randomFrom(IndexMode.values());
             String mappingHash = e.getKey();
             for (String index : e.getValue()) {
-                responses.add(new FieldCapabilitiesIndexResponse(index, mappingHash, fieldCaps, true));
+                responses.add(new FieldCapabilitiesIndexResponse(index, mappingHash, fieldCaps, true, indexMode));
             }
         }
         return responses;
@@ -73,7 +75,8 @@ public class FieldCapabilitiesIndexResponseTests extends ESTestCase {
         int numIndices = between(0, 10);
         for (int i = 0; i < numIndices; i++) {
             String index = "index_without_mapping_hash_" + i;
-            responses.add(new FieldCapabilitiesIndexResponse(index, null, randomFieldCaps(), randomBoolean()));
+            var indexMode = randomFrom(IndexMode.values());
+            responses.add(new FieldCapabilitiesIndexResponse(index, null, randomFieldCaps(), randomBoolean(), indexMode));
         }
         return responses;
     }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
@@ -49,7 +50,9 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         List<FieldCapabilitiesIndexResponse> responses = new ArrayList<>();
         int numResponse = randomIntBetween(0, 10);
         for (int i = 0; i < numResponse; i++) {
-            responses.add(new FieldCapabilitiesIndexResponse("index_" + i, null, randomFieldCaps(), randomBoolean()));
+            responses.add(
+                new FieldCapabilitiesIndexResponse("index_" + i, null, randomFieldCaps(), randomBoolean(), randomFrom(IndexMode.values()))
+            );
         }
         int numUnmatched = randomIntBetween(0, 3);
         Set<ShardId> shardIds = new HashSet<>();
@@ -69,21 +72,38 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         List<FieldCapabilitiesIndexResponse> newResponses = new ArrayList<>(response.getIndexResponses());
         int mutation = response.getIndexResponses().isEmpty() ? 0 : randomIntBetween(0, 3);
         switch (mutation) {
-            case 0 -> newResponses.add(new FieldCapabilitiesIndexResponse("extra_index", null, randomFieldCaps(), randomBoolean()));
+            case 0 -> newResponses.add(
+                new FieldCapabilitiesIndexResponse("extra_index", null, randomFieldCaps(), randomBoolean(), randomFrom(IndexMode.values()))
+            );
             case 1 -> {
                 int toRemove = randomInt(newResponses.size() - 1);
                 newResponses.remove(toRemove);
             }
             case 2 -> {
                 int toReplace = randomInt(newResponses.size() - 1);
-                newResponses.set(toReplace, new FieldCapabilitiesIndexResponse("new_index", null, randomFieldCaps(), randomBoolean()));
+                newResponses.set(
+                    toReplace,
+                    new FieldCapabilitiesIndexResponse(
+                        "new_index",
+                        null,
+                        randomFieldCaps(),
+                        randomBoolean(),
+                        randomFrom(IndexMode.values())
+                    )
+                );
             }
             case 3 -> {
                 int toReplace = randomInt(newResponses.size() - 1);
                 FieldCapabilitiesIndexResponse resp = newResponses.get(toReplace);
                 newResponses.set(
                     toReplace,
-                    new FieldCapabilitiesIndexResponse(resp.getIndexName(), UUIDs.randomBase64UUID(), resp.get(), true)
+                    new FieldCapabilitiesIndexResponse(
+                        resp.getIndexName(),
+                        UUIDs.randomBase64UUID(),
+                        resp.get(),
+                        true,
+                        randomFrom(IndexMode.values())
+                    )
                 );
             }
         }
@@ -194,9 +214,10 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
                         "blue_field",
                         new IndexFieldCapabilities("blue_field", "long", false, true, true, false, null, Map.of())
                     ),
-                    true
+                    true,
+                    IndexMode.STANDARD
                 ),
-                new FieldCapabilitiesIndexResponse("index_02", null, Map.of(), false),
+                new FieldCapabilitiesIndexResponse("index_02", null, Map.of(), false, IndexMode.STANDARD),
                 new FieldCapabilitiesIndexResponse(
                     "index_03",
                     null,
@@ -206,7 +227,8 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
                         "_seq_no",
                         new IndexFieldCapabilities("_seq_no", "long", true, true, true, false, null, Map.of())
                     ),
-                    true
+                    true,
+                    IndexMode.STANDARD
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
@@ -54,7 +55,8 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         int numResponse = randomIntBetween(0, 10);
         for (int i = 0; i < numResponse; i++) {
             Map<String, IndexFieldCapabilities> fieldCaps = FieldCapabilitiesIndexResponseTests.randomFieldCaps();
-            responses.add(new FieldCapabilitiesIndexResponse("index_" + i, null, fieldCaps, randomBoolean()));
+            var indexMode = randomFrom(IndexMode.values());
+            responses.add(new FieldCapabilitiesIndexResponse("index_" + i, null, fieldCaps, randomBoolean(), indexMode));
         }
         randomResponse = new FieldCapabilitiesResponse(responses, Collections.emptyList());
         return randomResponse;
@@ -267,9 +269,10 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
                         "blue_field",
                         new IndexFieldCapabilities("blue_field", "long", false, true, true, false, null, Map.of())
                     ),
-                    true
+                    true,
+                    IndexMode.STANDARD
                 ),
-                new FieldCapabilitiesIndexResponse("index_02", null, Map.of(), false),
+                new FieldCapabilitiesIndexResponse("index_02", null, Map.of(), false, IndexMode.STANDARD),
                 new FieldCapabilitiesIndexResponse(
                     "index_03",
                     null,
@@ -279,7 +282,8 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
                         "_seq_no",
                         new IndexFieldCapabilities("_seq_no", "long", true, true, true, false, null, Map.of())
                     ),
-                    true
+                    true,
+                    IndexMode.STANDARD
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -890,7 +891,13 @@ public class RequestDispatcherTests extends ESAllocationTestCase {
                 indicesWithMappingHash.computeIfAbsent(index, k -> new ArrayList<>()).add(index);
             } else {
                 indexResponses.add(
-                    new FieldCapabilitiesIndexResponse(index, null, FieldCapabilitiesIndexResponseTests.randomFieldCaps(), true)
+                    new FieldCapabilitiesIndexResponse(
+                        index,
+                        null,
+                        FieldCapabilitiesIndexResponseTests.randomFieldCaps(),
+                        true,
+                        randomFrom(IndexMode.values())
+                    )
                 );
             }
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2122,7 +2122,9 @@ public class AnalyzerTests extends ESTestCase {
     }
 
     private static LogicalPlan analyzeWithEmptyFieldCapsResponse(String query) throws IOException {
-        List<FieldCapabilitiesIndexResponse> idxResponses = List.of(new FieldCapabilitiesIndexResponse("idx", "idx", Map.of(), true));
+        List<FieldCapabilitiesIndexResponse> idxResponses = List.of(
+            new FieldCapabilitiesIndexResponse("idx", "idx", Map.of(), true, IndexMode.STANDARD)
+        );
         FieldCapabilitiesResponse caps = new FieldCapabilitiesResponse(idxResponses, List.of());
         IndexResolution resolution = new IndexResolver(null).mergedMappings("test*", caps);
         var analyzer = analyzer(resolution, TEST_VERIFIER, configuration(query));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -491,7 +492,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
                     var f = new IndexFieldCapabilities(e.getKey(), e.getValue(), false, false, false, false, null, Map.of());
                     fieldCaps.put(e.getKey(), f);
                 }
-                var indexResponse = new FieldCapabilitiesIndexResponse(alias, null, fieldCaps, true);
+                var indexResponse = new FieldCapabilitiesIndexResponse(alias, null, fieldCaps, true, IndexMode.STANDARD);
                 response = new FieldCapabilitiesResponse(List.of(indexResponse), List.of());
             } else {
                 response = new FieldCapabilitiesResponse(List.of(), List.of());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/PlanExecutorMetricsTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -151,7 +152,8 @@ public class PlanExecutorMetricsTests extends ESTestCase {
                         Map.entry("foo", new IndexFieldCapabilities("foo", "integer", false, true, true, false, null, Map.of())),
                         Map.entry("bar", new IndexFieldCapabilities("bar", "long", false, true, true, false, null, Map.of()))
                     ),
-                    true
+                    true,
+                    IndexMode.STANDARD
                 )
             );
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.type;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -46,7 +47,8 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
                 idx,
                 idx,
                 Map.of(field, new IndexFieldCapabilities(field, esTypeName, false, true, true, false, metricType, Map.of())),
-                true
+                true,
+                IndexMode.TIME_SERIES
             )
         );
 


### PR DESCRIPTION
We need the index mode from resolved indices for the METRICS command and future LOGS command in ES|QL. This change adds the index mode to the internal field-caps index response, which is not user-facing. ES|QL will use this output, and the overhead should be minimal, as we serialize one index_mode per mapping_hash group.