### PR TITLE
Update expert script example with termStats

### DIFF
--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -125,6 +125,11 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
             }
 
             @Override
+            public boolean needs_termStats() {
+                return false; // Return true if the script needs term statistics via get_termStats()
+            }
+
+            @Override
             public ScoreScript newInstance(DocReader docReader)
                     throws IOException {
                 DocValuesDocReader dvReader = ((DocValuesDocReader) docReader);


### PR DESCRIPTION
This commit fixes compilation of the expert script example to implement the new required method of score script making termStats available.