### PR TITLE
Support for rate aggregation in STATS

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-metrics.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-metrics.csv-spec
@@ -1,6 +1,6 @@
 metricsWithoutAggs
-required_capability: metrics_syntax
-METRICS k8s | sort @timestamp DESC, cluster, pod | keep @timestamp,cluster,pod,network.bytes_in,network.cost | limit 5;
+required_capability: rate_aggregation
+FROM k8s | sort @timestamp DESC, cluster, pod | keep @timestamp,cluster,pod,network.bytes_in,network.cost | limit 5;
 
 @timestamp:datetime      | cluster:keyword | pod: keyword| network.bytes_in:long | network.cost:double
 2024-05-10T00:22:59.000Z | qa              | one         | 206                   | 6.25
@@ -11,9 +11,9 @@ METRICS k8s | sort @timestamp DESC, cluster, pod | keep @timestamp,cluster,pod,n
 ;
 
 metricsWithAggsAndSourceQuoting
-required_capability: metrics_syntax
+required_capability: rate_aggregation
 required_capability: double_quotes_source_enclosing
-METRICS "k8s" max_bytes=max(to_long(network.total_bytes_in)) BY cluster | SORT max_bytes DESC;
+FROM "k8s" | STATS max_bytes=max(to_long(network.total_bytes_in)) BY cluster | SORT max_bytes DESC;
 
 max_bytes:long | cluster: keyword
 10797          | qa        
@@ -22,49 +22,49 @@ max_bytes:long | cluster: keyword
 ;
 
 maxRateAndSourceTripleQuoting
-required_capability: metrics_syntax
+required_capability: rate_aggregation
 required_capability: double_quotes_source_enclosing
-METRICS """k8s""" max(rate(network.total_bytes_in, 1minute));
+FROM """k8s""" | STATS max(rate(network.total_bytes_in, 1minute));
 
 max(rate(network.total_bytes_in, 1minute)): double
 790.4235090751945
 ;
 
 maxCost
-required_capability: metrics_syntax
-METRICS k8s max_cost=max(rate(network.total_cost));
+required_capability: rate_aggregation
+FROM k8s | STATS max_cost=max(rate(network.total_cost));
 
 max_cost: double
 0.16151685393258428
 ;
 
 maxRateAndBytes
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in);
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in);
 
 max(rate(network.total_bytes_in, 1minute)): double | max(network.bytes_in): long
 790.4235090751945                                  | 1021
 ;
 
 `maxRateAndMarkupBytes`
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in * 1.05);
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in * 1.05);
 
 max(rate(network.total_bytes_in, 1minute)): double | max(network.bytes_in * 1.05): double
 790.4235090751945                                  | 1072.05
 ;
 
 maxRateAndBytesAndCost
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in), max(rate(network.total_cost));
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in), max(rate(network.total_cost));
 
 max(rate(network.total_bytes_in, 1minute)): double| max(network.bytes_in): long| max(rate(network.total_cost)): double
 790.4235090751945                                 | 1021                       | 0.16151685393258428
 ;
 
 sumRate
-required_capability: metrics_syntax
-METRICS k8s bytes=sum(rate(network.total_bytes_in)), sum(rate(network.total_cost)) BY cluster | SORT cluster;
+required_capability: rate_aggregation
+FROM k8s | STATS bytes=sum(rate(network.total_bytes_in)), sum(rate(network.total_cost)) BY cluster | SORT cluster;
 
 bytes: double       | sum(rate(network.total_cost)): double | cluster: keyword
 24.49149357711476   | 0.3018995503437827                    | prod
@@ -73,8 +73,8 @@ bytes: double       | sum(rate(network.total_cost)): double | cluster: keyword
 ;
 
 oneRateWithBucket
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute) | SORT time_bucket DESC | LIMIT 2;
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute) | SORT time_bucket DESC | LIMIT 2;
 
 max(rate(network.total_bytes_in)): double | time_bucket:date
 10.594594594594595                        | 2024-05-10T00:20:00.000Z
@@ -82,8 +82,8 @@ max(rate(network.total_bytes_in)): double | time_bucket:date
 ;
 
 twoRatesWithBucket
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in)), sum(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute) | SORT time_bucket DESC | LIMIT 3;
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in)), sum(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute) | SORT time_bucket DESC | LIMIT 3;
 
 max(rate(network.total_bytes_in)): double | sum(rate(network.total_bytes_in)): double | time_bucket:date
 10.594594594594595                        | 42.70864495221802                         | 2024-05-10T00:20:00.000Z
@@ -93,8 +93,8 @@ max(rate(network.total_bytes_in)): double | sum(rate(network.total_bytes_in)): d
 
 
 oneRateWithBucketAndCluster
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute), cluster | SORT time_bucket DESC, cluster | LIMIT 6;
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute), cluster | SORT time_bucket DESC, cluster | LIMIT 6;
 
 max(rate(network.total_bytes_in)): double | time_bucket:date          | cluster: keyword
 10.594594594594595                        | 2024-05-10T00:20:00.000Z  | prod
@@ -106,8 +106,8 @@ max(rate(network.total_bytes_in)): double | time_bucket:date          | cluster:
 ;
 
 BytesAndCostByBucketAndCluster
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in)), max(network.cost) BY time_bucket = bucket(@timestamp,5minute), cluster | SORT time_bucket DESC, cluster | LIMIT 6;
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in)), max(network.cost) BY time_bucket = bucket(@timestamp,5minute), cluster | SORT time_bucket DESC, cluster | LIMIT 6;
 
 max(rate(network.total_bytes_in)): double | max(network.cost): double | time_bucket:date         | cluster: keyword
 10.594594594594595                        | 10.75                     | 2024-05-10T00:20:00.000Z | prod
@@ -119,8 +119,8 @@ max(rate(network.total_bytes_in)): double | max(network.cost): double | time_buc
 ;
 
 oneRateWithBucketAndClusterThenFilter
-required_capability: metrics_syntax
-METRICS k8s max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute), cluster | WHERE cluster=="prod" | SORT time_bucket DESC | LIMIT 3;
+required_capability: rate_aggregation
+FROM k8s | STATS max(rate(network.total_bytes_in)) BY time_bucket = bucket(@timestamp,5minute), cluster | WHERE cluster=="prod" | SORT time_bucket DESC | LIMIT 3;
 
 max(rate(network.total_bytes_in)): double | time_bucket:date          | cluster: keyword
 10.594594594594595                        | 2024-05-10T00:20:00.000Z  | prod

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -256,14 +256,7 @@ public class Verifier {
                 // traverse the tree to find invalid matches
                 checkInvalidNamedExpressionUsage(exp, groupings, groupRefs, failures, 0);
             });
-            if (agg.aggregateType() == Aggregate.AggregateType.METRICS) {
-                aggs.forEach(a -> checkRateAggregates(a, 0, failures));
-            } else {
-                agg.forEachExpression(
-                    Rate.class,
-                    r -> failures.add(fail(r, "the rate aggregate[{}] can only be used within the metrics command", r.sourceText()))
-                );
-            }
+            aggs.forEach(a -> checkRateAggregates(a, 0, failures));
         } else {
             p.forEachExpression(
                 GroupingFunction.class,
@@ -278,13 +271,7 @@ public class Verifier {
         }
         if (expr instanceof Rate r) {
             if (nestedLevel != 2) {
-                failures.add(
-                    fail(
-                        expr,
-                        "the rate aggregate [{}] can only be used within the metrics command and inside another aggregate",
-                        r.sourceText()
-                    )
-                );
+                failures.add(fail(expr, "the rate aggregate [{}] can only be used inside another aggregate", r.sourceText()));
             }
         }
         for (Expression child : expr.children()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -500,14 +500,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             return new UnresolvedRelation(source, table, false, List.of(), IndexMode.STANDARD, null);
         }
         final Stats stats = stats(source, ctx.grouping, ctx.aggregates);
-        var relation = new UnresolvedRelation(
-            source,
-            table,
-            false,
-            List.of(new MetadataAttribute(source, MetadataAttribute.TSID_FIELD, DataType.KEYWORD, false)),
-            IndexMode.TIME_SERIES,
-            null
-        );
+        var relation = new UnresolvedRelation(source, table, false, List.of(), IndexMode.STANDARD, null);
         return new Aggregate(source, relation, Aggregate.AggregateType.METRICS, stats.groupings, stats.aggregates);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/UnresolvedRelation.java
@@ -10,9 +10,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.capabilities.Unresolvable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
-import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
-import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.TableIdentifier;
@@ -96,16 +93,6 @@ public class UnresolvedRelation extends LeafPlan implements Unresolvable {
     @Override
     public String unresolvedMessage() {
         return unresolvedMsg;
-    }
-
-    @Override
-    public AttributeSet references() {
-        AttributeSet refs = super.references();
-        if (indexMode == IndexMode.TIME_SERIES) {
-            refs = new AttributeSet(refs);
-            refs.add(new UnresolvedAttribute(source(), MetadataAttribute.TIMESTAMP_FIELD));
-        }
-        return refs;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
@@ -179,9 +179,14 @@ public class EsqlFeatures implements FeatureSpecification {
      */
     public static final NodeFeature RESOLVE_FIELDS_API = new NodeFeature("esql.resolve_fields_api");
 
+    /**
+     * Support rate aggregation in STATS
+     */
+    public static final NodeFeature RATE_AGGREGATION = new NodeFeature("esql.rate_aggregation");
+
     private Set<NodeFeature> snapshotBuildFeatures() {
         assert Build.current().isSnapshot() : Build.current();
-        return Set.of(METRICS_SYNTAX);
+        return Set.of(METRICS_SYNTAX, RATE_AGGREGATION);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -239,7 +239,7 @@ public class CsvTests extends ESTestCase {
                 "can't use match in csv tests",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.MATCH_OPERATOR.capabilityName())
             );
-            assumeFalse("can't load metrics in csv tests", testCase.requiredCapabilities.contains(cap(EsqlFeatures.METRICS_SYNTAX)));
+            assumeFalse("can't load metrics in csv tests", testCase.requiredCapabilities.contains(cap(EsqlFeatures.RATE_AGGREGATION)));
             assumeFalse(
                 "multiple indices aren't supported",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.UNION_TYPES.capabilityName())

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -823,50 +823,22 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
-    public void testNotAllowRateOutsideMetrics() {
-        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
-        assertThat(
-            error("FROM tests | STATS avg(rate(network.bytes_in))", tsdb),
-            equalTo("1:24: the rate aggregate[rate(network.bytes_in)] can only be used within the metrics command")
-        );
-        assertThat(
-            error("METRICS tests | STATS sum(rate(network.bytes_in))", tsdb),
-            equalTo("1:27: the rate aggregate[rate(network.bytes_in)] can only be used within the metrics command")
-        );
-        assertThat(
-            error("FROM tests | STATS rate(network.bytes_in)", tsdb),
-            equalTo("1:20: the rate aggregate[rate(network.bytes_in)] can only be used within the metrics command")
-        );
-        assertThat(
-            error("FROM tests | EVAL r = rate(network.bytes_in)", tsdb),
-            equalTo("1:23: aggregate function [rate(network.bytes_in)] not allowed outside METRICS command")
-        );
-    }
-
     public void testRateNotEnclosedInAggregate() {
         assumeTrue("requires snapshot builds", Build.current().isSnapshot());
         assertThat(
-            error("METRICS tests rate(network.bytes_in)", tsdb),
-            equalTo(
-                "1:15: the rate aggregate [rate(network.bytes_in)] can only be used within the metrics command and inside another aggregate"
-            )
+            error("FROM tests | STATS rate(network.bytes_in)", tsdb),
+            equalTo("1:20: the rate aggregate [rate(network.bytes_in)] can only be used inside another aggregate")
         );
         assertThat(
-            error("METRICS tests avg(rate(network.bytes_in)), rate(network.bytes_in)", tsdb),
-            equalTo(
-                "1:44: the rate aggregate [rate(network.bytes_in)] can only be used within the metrics command and inside another aggregate"
-            )
+            error("FROM tests | STATS avg(rate(network.bytes_in)), rate(network.bytes_in)", tsdb),
+            equalTo("1:49: the rate aggregate [rate(network.bytes_in)] can only be used inside another aggregate")
         );
-        assertThat(error("METRICS tests max(avg(rate(network.bytes_in)))", tsdb), equalTo("""
-            1:19: nested aggregations [avg(rate(network.bytes_in))] not allowed inside other aggregations\
-             [max(avg(rate(network.bytes_in)))]
-            line 1:23: the rate aggregate [rate(network.bytes_in)] can only be used within the metrics command\
-             and inside another aggregate"""));
-        assertThat(error("METRICS tests max(avg(rate(network.bytes_in)))", tsdb), equalTo("""
-            1:19: nested aggregations [avg(rate(network.bytes_in))] not allowed inside other aggregations\
-             [max(avg(rate(network.bytes_in)))]
-            line 1:23: the rate aggregate [rate(network.bytes_in)] can only be used within the metrics command\
-             and inside another aggregate"""));
+        assertThat(error("FROM tests | STATS max(avg(rate(network.bytes_in)))", tsdb), equalTo("""
+            1:24: nested aggregations [avg(rate(network.bytes_in))] not allowed inside other aggregations [max(avg(rate(network.bytes_in)))]
+            line 1:28: the rate aggregate [rate(network.bytes_in)] can only be used inside another aggregate"""));
+        assertThat(error("FROM tests | STATS max(avg(rate(network.bytes_in)))", tsdb), equalTo("""
+            1:24: nested aggregations [avg(rate(network.bytes_in))] not allowed inside other aggregations [max(avg(rate(network.bytes_in)))]
+            line 1:28: the rate aggregate [rate(network.bytes_in)] can only be used inside another aggregate"""));
     }
 
     public void testWeightedAvg() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -12,17 +12,14 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.capabilities.UnresolvedException;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.EmptyAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
-import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.fulltext.StringQueryPredicate;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.UnresolvedFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.RLike;
@@ -1674,8 +1671,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     private LogicalPlan unresolvedTSRelation(String index) {
-        List<Attribute> metadata = List.of(new MetadataAttribute(EMPTY, MetadataAttribute.TSID_FIELD, DataType.KEYWORD, false));
-        return new UnresolvedRelation(EMPTY, new TableIdentifier(EMPTY, null, index), false, metadata, IndexMode.TIME_SERIES, null);
+        return new UnresolvedRelation(EMPTY, new TableIdentifier(EMPTY, null, index), false, List.of(), IndexMode.STANDARD, null);
     }
 
     public void testMetricWithGroupKeyAsAgg() {


### PR DESCRIPTION
This change introduces support for the `rate` aggregation in regular `STATS`.

1. **Syntax**: No syntax changes are required. The following examples should work as expected:

   ```sql
   FROM metrics-index
   | STATS max(rate(counter_request)) BY cluster
   ```

   ```sql
   FROM metrics-index
   | WHERE @timestamp >= now() - 1h
   | STATS max(rate(counter_request)), max(cpu) BY cluster, bucket(@timestamp, 1minute)
   ```

2. **METRICS command**: The `METRICS` command remains unchanged for now; I'll remove it in a follow-up then re-introduce later.

3. **Handling mixed index modes**: 

When the query targets both time_series and non-time_series indices, such as:

   ```sql
   FROM metrics-index,logs-index
   | STATS max(rate(counter_request)), max(cpu) BY cluster
   ```
The current approach in this PR is unchecked and will fail at runtime. However, (1) we could compute `rate(counter_request)` only on time_series indices (e.g., `metrics-index`) while computing `max(cpu)` across all indices. Alternatively, (2) we could fail the request when mixed index types are used, but I believe the former option is more favorable. I'll address this in a follow-up after we reach an agreement.