### PR TITLE
optimization of sorting byte short float int fields

### DIFF
--- a/docs/changelog/112387.yaml
+++ b/docs/changelog/112387.yaml
@@ -1,0 +1,5 @@
+pr: 112387
+summary: optimization of sorting byte short float int fields
+area: sorting
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -163,9 +163,13 @@ public interface IndexFieldData<FD extends LeafFieldData> {
 
         /** Return the missing object value according to the reduced type of the comparator. */
         public Object missingObject(Object missingValue, boolean reversed) {
+            return missingObject(missingValue, reversed, reducedType());
+        }
+
+        public Object missingObject(Object missingValue, boolean reversed, SortField.Type type) {
             if (sortMissingFirst(missingValue) || sortMissingLast(missingValue)) {
                 final boolean min = sortMissingFirst(missingValue) ^ reversed;
-                return switch (reducedType()) {
+                return switch (type) {
                     case INT -> min ? Integer.MIN_VALUE : Integer.MAX_VALUE;
                     case LONG -> min ? Long.MIN_VALUE : Long.MAX_VALUE;
                     case FLOAT -> min ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
@@ -174,7 +178,7 @@ public interface IndexFieldData<FD extends LeafFieldData> {
                     default -> throw new UnsupportedOperationException("Unsupported reduced type: " + reducedType());
                 };
             } else {
-                switch (reducedType()) {
+                switch (type) {
                     case INT:
                         if (missingValue instanceof Number) {
                             return ((Number) missingValue).intValue();

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -123,7 +123,22 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
                 // longs, doubles and dates use the same type for doc-values and points.
                 sortField.setOptimizeSortWithPoints(isIndexed());
                 break;
-
+            case BYTE:
+            case SHORT:
+            case INT:
+                if (isIndexed()) {
+                    sortField = new SortedNumericSortField(getFieldName(), SortField.Type.INT, reverse, selectorType);
+                    sortField.setMissingValue(source.missingObject(missingValue, reverse, SortField.Type.INT));
+                }
+                sortField.setOptimizeSortWithPoints(isIndexed());
+                break;
+            case FLOAT:
+                if (isIndexed()) {
+                    sortField = new SortedNumericSortField(getFieldName(), SortField.Type.FLOAT, reverse, selectorType);
+                    sortField.setMissingValue(source.missingObject(missingValue, reverse, SortField.Type.FLOAT));
+                }
+                sortField.setOptimizeSortWithPoints(isIndexed());
+                break;
             default:
                 sortField.setOptimizeSortWithPoints(false);
                 break;

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -942,4 +942,15 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals(List.of(47.125F), fetchSourceValue(mapper, 47.1231234));
         assertEquals(List.of(3.140625F, 42.90625F), fetchSourceValues(mapper, 3.14, "foo", "42.9"));
     }
+
+    public void testOptimizeSortWithPoints() {
+        NumberType[] numberTypes = new NumberType[] { NumberType.BYTE, NumberType.SHORT, NumberType.FLOAT, NumberType.INTEGER };
+        boolean isIndexed = randomBoolean();
+        NumberType numberType = RandomPicks.randomFrom(random(), numberTypes);
+        NumberFieldType fieldType = new NumberFieldType("field", numberType, isIndexed);
+        IndexNumericFieldData fielddata = (IndexNumericFieldData) fieldType.fielddataBuilder(FieldDataContext.noRuntimeFields("test"))
+            .build(null, null);
+        SortField sortField = fielddata.sortField(null, MultiValueMode.MIN, null, randomBoolean());
+        assertEquals(isIndexed, sortField.getOptimizeSortWithPoints());
+    }
 }


### PR DESCRIPTION
For number type fields, Lucene already supports using point optimization for sorting performance, but due to certain limitations in ES. The sorting optimization function cannot be used for byte, short, float, and int field types. This method can be used to achieve this.