### PR TITLE
Add workaround in SpatialPushDownGeoPointIT to avoid lucene issue

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -70,9 +70,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/110801
 - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
   method: testSystemPropertyDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/110949
-- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoPointIT
-  method: testPushedDownQueriesSingleValue
   issue: https://github.com/elastic/elasticsearch/issues/111084
 - class: org.elasticsearch.multi_node.GlobalCheckpointSyncActionIT
   issue: https://github.com/elastic/elasticsearch/issues/111124

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -70,7 +70,7 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/110801
 - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
   method: testSystemPropertyDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/111084
+  issue: https://github.com/elastic/elasticsearch/issues/110949
 - class: org.elasticsearch.multi_node.GlobalCheckpointSyncActionIT
   issue: https://github.com/elastic/elasticsearch/issues/111124
 - class: org.elasticsearch.cluster.PrevalidateShardPathIT

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownGeoPointIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownGeoPointIT.java
@@ -7,10 +7,13 @@
 
 package org.elasticsearch.xpack.esql.spatial;
 
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 
 public class SpatialPushDownGeoPointIT extends SpatialPushDownTestCase {
+
+    private static final double LAT_MAX_VALUE = GeoEncodingUtils.decodeLatitude(Integer.MAX_VALUE - 3);
 
     @Override
     protected String fieldType() {
@@ -19,7 +22,9 @@ public class SpatialPushDownGeoPointIT extends SpatialPushDownTestCase {
 
     @Override
     protected Geometry getIndexGeometry() {
-        return GeometryTestUtils.randomPoint();
+        // This is to overcome lucene bug https://github.com/apache/lucene/issues/13703.
+        // Once it is fixed we can remove this workaround.
+        return randomValueOtherThanMany(p -> p.getLat() >= LAT_MAX_VALUE, GeometryTestUtils::randomPoint);
     }
 
     @Override


### PR DESCRIPTION
Currently lucene has a bug where points close to the north pole would not be match by certain geometries if narrow enough. Therefore we avoid indexing points at those latitudes to prevent flakiness on the test.

closes https://github.com/elastic/elasticsearch/issues/111084