### PR TITLE
[8.15] [ML]Fix the bug where the run() function of ExecutableInferenceRequest throws an exception when get inferenceEntityId. (#112135)

### DIFF
--- a/docs/changelog/112135.yaml
+++ b/docs/changelog/112135.yaml
@@ -1,0 +1,4 @@
+pr: 112135 
+summary: Fix the bug where the run() function of ExecutableInferenceRequest throws an exception when get inferenceEntityId.
+area: Inference 
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableInferenceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableInferenceRequest.java
@@ -30,7 +30,7 @@ record ExecutableInferenceRequest(
 
     @Override
     public void run() {
-        var inferenceEntityId = request.createHttpRequest().inferenceEntityId();
+        var inferenceEntityId = request.getInferenceEntityId();
 
         try {
             requestSender.send(logger, request, HttpClientContext.create(), hasFinished, responseHandler, listener);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/amazonbedrock/AmazonBedrockRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/amazonbedrock/AmazonBedrockRequest.java
@@ -37,12 +37,10 @@ public abstract class AmazonBedrockRequest implements Request {
 
     /**
      * Amazon Bedrock uses the AWS SDK, and will not create its own Http Request
-     * But, this is needed for the ExecutableInferenceRequest to get the inferenceEntityId
-     * @return NoOp request
      */
     @Override
     public final HttpRequest createHttpRequest() {
-        return new HttpRequest(new NoOpHttpRequest(), inferenceId);
+        throw new UnsupportedOperationException("Amazon Bedrock does not use Http Requests");
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [ML]Fix the bug where the run() function of ExecutableInferenceRequest throws an exception when get inferenceEntityId. (#112135)