### PR TITLE
[Transform] Include reason when no nodes are found

### DIFF
--- a/docs/changelog/112409.yaml
+++ b/docs/changelog/112409.yaml
@@ -1,6 +1,6 @@
 pr: 112409
 summary: Include reason when no nodes are found
-area: "Machine Learning, Transform"
+area: "Transform"
 type: bug
 issues:
  - 112404

--- a/docs/changelog/112409.yaml
+++ b/docs/changelog/112409.yaml
@@ -1,0 +1,6 @@
+pr: 112409
+summary: Include reason when no nodes are found
+area: "Machine Learning, Transform"
+type: bug
+issues:
+ - 112404


### PR DESCRIPTION
If Discovery Node is null, it is possible that the compatible nodes had a valid reason, so we should use that in the error message.  If there was no reason, and there are no other nodes to search over, inform the user that no Discovery Nodes can be found.

Fix #112404 
