### PR TITLE
Expose HexFormat in Painless

### DIFF
--- a/docs/changelog/112412.yaml
+++ b/docs/changelog/112412.yaml
@@ -1,0 +1,5 @@
+pr: 112412
+summary: Expose `HexFormat` in Painless
+area: Infra/Scripting
+type: enhancement
+issues: []

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.util.txt
@@ -684,6 +684,24 @@ class java.util.Hashtable {
   def clone()
 }
 
+class java.util.HexFormat {
+  HexFormat of()
+  HexFormat ofDelimiter(String)
+  HexFormat withDelimiter(String)
+  HexFormat withPrefix(String)
+  HexFormat withSuffix(String)
+  HexFormat withUpperCase()
+  HexFormat withLowerCase()
+  String delimiter()
+  String prefix()
+  String suffix()
+  boolean isUpperCase()
+  String formatHex(byte[])
+  String formatHex(byte[],int,int)
+  byte[] parseHex(CharSequence)
+  byte[] parseHex(CharSequence,int,int)
+}
+
 class java.util.IdentityHashMap {
   ()
   (Map)


### PR DESCRIPTION
Java 17 introduced a utility for parsing and formatting bytes as hexadecimal strings. This commit exposes that class in Painless.