### PR TITLE
Fix test configuration for merge policy in LatLonShapeDocValuesQueryTests and CartesianShapeDocValuesQueryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -171,12 +171,6 @@ tests:
 - class: org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshotTests
   method: testToXContent
   issue: https://github.com/elastic/elasticsearch/issues/112325
-- class: org.elasticsearch.lucene.spatial.LatLonShapeDocValuesQueryTests
-  method: testEmptySegment
-  issue: https://github.com/elastic/elasticsearch/issues/112413
-- class: org.elasticsearch.lucene.spatial.CartesianShapeDocValuesQueryTests
-  method: testEmptySegment
-  issue: https://github.com/elastic/elasticsearch/issues/112414
 - class: org.elasticsearch.search.retriever.RankDocRetrieverBuilderIT
   method: testRankDocsRetrieverWithNestedQuery
   issue: https://github.com/elastic/elasticsearch/issues/112421

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
@@ -18,7 +18,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.NoMergeScheduler;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -59,7 +59,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
     public void testEmptySegment() throws Exception {
         IndexWriterConfig iwc = newIndexWriterConfig();
         // No merges
-        iwc.setMergeScheduler(NoMergeScheduler.INSTANCE);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, iwc);
         ShapeIndexer indexer = new CartesianShapeIndexer(FIELD_NAME);

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
@@ -20,7 +20,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.NoMergeScheduler;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -60,7 +60,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
     public void testEmptySegment() throws Exception {
         IndexWriterConfig iwc = newIndexWriterConfig();
         // No merges
-        iwc.setMergeScheduler(NoMergeScheduler.INSTANCE);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, iwc);
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, FIELD_NAME);


### PR DESCRIPTION
Set he merge policy and not the mer scheduler to NoMerges to avoid misconfiguration due to randomization.

fixes https://github.com/elastic/elasticsearch/issues/112413
fixes https://github.com/elastic/elasticsearch/issues/112414