### PR TITLE
[8.15] Fix test configuration for merge policy in LatLonShapeDocValuesQueryTests and CartesianShapeDocValuesQueryTests (#112425)

### DIFF
--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CartesianShapeDocValuesQueryTests.java
@@ -19,7 +19,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.NoMergeScheduler;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -59,7 +59,7 @@ public class CartesianShapeDocValuesQueryTests extends ESTestCase {
     public void testEmptySegment() throws Exception {
         IndexWriterConfig iwc = newIndexWriterConfig();
         // No merges
-        iwc.setMergeScheduler(NoMergeScheduler.INSTANCE);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, iwc);
         ShapeIndexer indexer = new CartesianShapeIndexer(FIELD_NAME);

--- a/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/LatLonShapeDocValuesQueryTests.java
@@ -20,7 +20,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.NoMergeScheduler;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -60,7 +60,7 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
     public void testEmptySegment() throws Exception {
         IndexWriterConfig iwc = newIndexWriterConfig();
         // No merges
-        iwc.setMergeScheduler(NoMergeScheduler.INSTANCE);
+        iwc.setMergePolicy(NoMergePolicy.INSTANCE);
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, iwc);
         GeoShapeIndexer indexer = new GeoShapeIndexer(Orientation.CCW, FIELD_NAME);


### PR DESCRIPTION
Set the merge policy and not the mer scheduler to NoMerges to avoid misconfiguration due to randomization.

backport https://github.com/elastic/elasticsearch/pull/112425