### PR TITLE
[plugin/apm-data] Use component-templates to configure fallback to ILM

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.app-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.app-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for logs-apm.app if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: logs-apm.app_logs-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for logs-apm.error if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: logs-apm.error_logs-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.app-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.app-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.app if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.app_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.internal-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.internal-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.internal if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.internal_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.10m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.10m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_destination.10m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_destination_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.1m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.1m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_destination.1m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_destination_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.60m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.60m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_destination.60m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_destination_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.10m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.10m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_summary.10m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_summary_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.1m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.1m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_summary.1m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_summary_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.60m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.60m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_summary.60m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_summary_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.10m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.10m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_transaction.10m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_transaction_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.1m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.1m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_transaction.1m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_transaction_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.60m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.60m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_transaction.60m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_transaction_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.10m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.10m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.transaction.10m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.transaction_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.1m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.1m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.transaction.1m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.transaction_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.60m-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.60m-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.transaction.60m if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.transaction_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for traces-apm if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.traces-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.rum-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.rum-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for traces-apm.rum if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.rum_traces-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.sampled-fallback@lifecycle.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.sampled-fallback@lifecycle.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for traces-apm.sampled if DSL not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.sampled_traces-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
@@ -12,6 +12,7 @@ composed_of:
 - apm@settings
 - apm-10d@lifecycle
 - logs-apm@settings
+- logs-apm.app-fallback@lifecycle
 - logs@custom
 - logs-apm.app@custom
 - ecs@mappings
@@ -23,6 +24,3 @@ template:
     index:
       default_pipeline: logs-apm.app@default-pipeline
       final_pipeline: apm@pipeline
-      lifecycle:
-        name: logs-apm.app_logs-default_policy
-        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -14,6 +14,7 @@ composed_of:
 - apm-10d@lifecycle
 - logs-apm@settings
 - logs-apm.error@mappings
+- logs-apm.error-fallback@lifecycle
 - logs@custom
 - logs-apm.error@custom
 - ecs@mappings
@@ -30,6 +31,3 @@ template:
     index:
       default_pipeline: logs-apm.error@default-pipeline
       final_pipeline: apm@pipeline
-      lifecycle:
-        name: logs-apm.error_logs-default_policy
-        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
@@ -13,6 +13,7 @@ composed_of:
 - apm-90d@lifecycle
 - metrics-apm@mappings
 - metrics-apm@settings
+- metrics-apm.app-fallback@lifecycle
 - metrics@custom
 - metrics-apm.app@custom
 - ecs@mappings
@@ -24,6 +25,3 @@ template:
     index:
       default_pipeline: metrics-apm.app@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.app_metrics-default_policy
-        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
@@ -14,6 +14,7 @@ composed_of:
 - apm-90d@lifecycle
 - metrics-apm@mappings
 - metrics-apm@settings
+- metrics-apm.internal-fallback@lifecycle
 - metrics@custom
 - metrics-apm.internal@custom
 - ecs@mappings
@@ -25,9 +26,6 @@ template:
     index:
       default_pipeline: metrics-apm.internal@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.internal_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.dataset:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_destination@mappings
+- metrics-apm.service_destination.10m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_destination.10m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_destination_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
@@ -15,6 +15,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_destination@mappings
+- metrics-apm.service_destination.1m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_destination.1m@custom
 - ecs@mappings
@@ -26,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_destination_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_destination@mappings
+- metrics-apm.service_destination.60m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_destination.60m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_destination_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_summary@mappings
+- metrics-apm.service_summary.10m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_summary.10m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_summary_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
@@ -15,6 +15,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_summary@mappings
+- metrics-apm.service_summary.1m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_summary.1m@custom
 - ecs@mappings
@@ -26,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_summary_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_summary@mappings
+- metrics-apm.service_summary.60m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_summary.60m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_summary_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_transaction@mappings
+- metrics-apm.service_transaction.10m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_transaction.10m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_transaction_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
@@ -15,6 +15,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_transaction@mappings
+- metrics-apm.service_transaction.1m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_transaction.1m@custom
 - ecs@mappings
@@ -26,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_transaction_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_transaction@mappings
+- metrics-apm.service_transaction.60m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.service_transaction.60m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.service_transaction_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.transaction@mappings
+- metrics-apm.transaction.10m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.transaction.10m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.transaction_10m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
@@ -15,6 +15,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.transaction@mappings
+- metrics-apm.transaction.1m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.transaction.1m@custom
 - ecs@mappings
@@ -26,9 +27,6 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.transaction_1m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
@@ -16,6 +16,7 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.transaction@mappings
+- metrics-apm.transaction.60m-fallback@lifecycle
 - metrics@custom
 - metrics-apm.transaction.60m@custom
 - ecs@mappings
@@ -27,9 +28,6 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
-      lifecycle:
-        name: metrics-apm.transaction_60m_metrics-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       metricset.interval:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
@@ -14,6 +14,7 @@ composed_of:
 - apm-90d@lifecycle
 - traces-apm@mappings
 - traces-apm.rum@mappings
+- traces-apm.rum-fallback@lifecycle
 - traces@custom
 - traces-apm.rum@custom
 - ecs@mappings
@@ -25,9 +26,6 @@ template:
     index:
       default_pipeline: traces-apm.rum@default-pipeline
       final_pipeline: traces-apm@pipeline
-      lifecycle:
-        name: traces-apm.rum_traces-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
@@ -11,6 +11,7 @@ composed_of:
 - traces@mappings
 - apm@mappings
 - apm@settings
+- traces-apm.sampled-fallback@lifecycle
 - traces@custom
 - traces-apm.sampled@custom
 - ecs@mappings
@@ -20,11 +21,6 @@ ignore_missing_component_templates:
 template:
   lifecycle:
     data_retention: 1h
-  settings:
-    index:
-      lifecycle:
-        name: traces-apm.sampled_traces-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
@@ -13,6 +13,7 @@ composed_of:
 - apm@settings
 - apm-10d@lifecycle
 - traces-apm@mappings
+- traces-apm-fallback@lifecycle
 - traces@custom
 - traces-apm@custom
 - ecs@mappings
@@ -24,9 +25,6 @@ template:
     index:
       default_pipeline: traces-apm@default-pipeline
       final_pipeline: traces-apm@pipeline
-      lifecycle:
-        name: traces-apm.traces-default_policy
-        prefer_ilm: false
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -26,6 +26,26 @@ component-templates:
   - traces@mappings
   - traces-apm@mappings
   - traces-apm.rum@mappings
+  # Fallback to ILM if DSL configurations are not present
+  - logs-apm.app-fallback@lifecycle
+  - logs-apm.error-fallback@lifecycle
+  - metrics-apm.app-fallback@lifecycle
+  - metrics-apm.internal-fallback@lifecycle
+  - metrics-apm.service_destination.10m-fallback@lifecycle
+  - metrics-apm.service_destination.1m-fallback@lifecycle
+  - metrics-apm.service_destination.60m-fallback@lifecycle
+  - metrics-apm.service_summary.10m-fallback@lifecycle
+  - metrics-apm.service_summary.1m-fallback@lifecycle
+  - metrics-apm.service_summary.60m-fallback@lifecycle
+  - metrics-apm.service_transaction.10m-fallback@lifecycle
+  - metrics-apm.service_transaction.1m-fallback@lifecycle
+  - metrics-apm.service_transaction.60m-fallback@lifecycle
+  - metrics-apm.transaction.10m-fallback@lifecycle
+  - metrics-apm.transaction.1m-fallback@lifecycle
+  - metrics-apm.transaction.60m-fallback@lifecycle
+  - traces-apm-fallback@lifecycle
+  - traces-apm.rum-fallback@lifecycle
+  - traces-apm.sampled-fallback@lifecycle
 
 index-templates:
   - logs-apm.app@template


### PR DESCRIPTION
Moves fallback for ILM to component templates which will allow users to override DSL configurations as required even for versions > 8.15.0

PR is tested: https://github.com/elastic/apm-server/issues/13898#issuecomment-2324253473