### PR TITLE
Allow pathRestricted param in RestGetDataStreamsAction

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
@@ -66,6 +66,7 @@ public class RestGetDataStreamsAction extends BaseRestHandler {
             "include_defaults",
             "timeout",
             "master_timeout",
+            RestRequest.PATH_RESTRICTED,
             IndicesOptions.WildcardOptions.EXPAND_WILDCARDS,
             IndicesOptions.ConcreteTargetOptions.IGNORE_UNAVAILABLE,
             IndicesOptions.WildcardOptions.ALLOW_NO_INDICES,


### PR DESCRIPTION
This is a follow-up of #112303 which prohibited this parameter.
This resulted in test failures on serverless.