### PR TITLE
logs-apm.error-*: define log.level field as keyword

### DIFF
--- a/docs/changelog/112440.yaml
+++ b/docs/changelog/112440.yaml
@@ -1,5 +1,5 @@
 pr: 112440
-summary: "Apm: Set log.level: error on all apm error logs"
+summary: "logs-apm.error-*: define log.level field as keyword"
 area: Data streams
 type: bug
 issues: []

--- a/docs/changelog/112440.yaml
+++ b/docs/changelog/112440.yaml
@@ -1,0 +1,5 @@
+pr: 112440
+summary: "Apm: Set log.level: error on all apm error logs"
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error@mappings.yaml
@@ -6,6 +6,9 @@ _meta:
 template:
   mappings:
     properties:
+      # log.*
+      log.level:
+        type: keyword
       # error.*
       error.custom:
         type: object

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -26,9 +26,6 @@ template:
       processor.event:
         type: constant_keyword
         value: error
-      log.level:
-        type: constant_keyword
-        value: error
   settings:
     index:
       default_pipeline: logs-apm.error@default-pipeline

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -26,6 +26,9 @@ template:
       processor.event:
         type: constant_keyword
         value: error
+      log.level:
+        type: constant_keyword
+        value: error
   settings:
     index:
       default_pipeline: logs-apm.error@default-pipeline

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 8
+version: 9
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_error_logs.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_error_logs.yml
@@ -1,0 +1,26 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_events: languid
+
+---
+"Test logs-apm.error-* error log fields":
+  - do:
+      bulk:
+        index: logs-apm.error-log-level-testing
+        refresh: true
+        body:
+          # Non-empty error.exception.message used
+          - create: {}
+          - '{"@timestamp": "2017-06-22", "error": {"log": {"message": "loglevel"}, "exception": [{"message": "exception_used"}]}}'
+
+  - is_false: errors
+
+  - do:
+      search:
+        index: logs-apm.error-log-level-testing
+        body:
+          fields: ["log.level"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields: {"log.level": ["error"]} }

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_error_logs.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/20_error_logs.yml
@@ -3,7 +3,6 @@ setup:
   - do:
       cluster.health:
         wait_for_events: languid
-
 ---
 "Test logs-apm.error-* error log fields":
   - do:
@@ -11,9 +10,11 @@ setup:
         index: logs-apm.error-log-level-testing
         refresh: true
         body:
-          # Non-empty error.exception.message used
           - create: {}
-          - '{"@timestamp": "2017-06-22", "error": {"log": {"message": "loglevel"}, "exception": [{"message": "exception_used"}]}}'
+          - '{"@timestamp": "2017-06-22", "log": {"level": "error"}, "error": {"log": {"message": "loglevel"}, "exception": [{"message": "exception_used"}]}}'
+
+          - create: {}
+          - '{"@timestamp": "2017-06-22", "log": {"level": "warn"}, "error": {"log": {"message": "loglevel"}, "exception": [{"message": "exception_used"}]}}'
 
   - is_false: errors
 
@@ -22,5 +23,6 @@ setup:
         index: logs-apm.error-log-level-testing
         body:
           fields: ["log.level"]
-  - length: { hits.hits: 1 }
-  - match: { hits.hits.0.fields: {"log.level": ["error"]} }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0.fields: { "log.level": ["error"] } }
+  - match: { hits.hits.1.fields: { "log.level": ["warn"] } }


### PR DESCRIPTION
This commit defines a new mapping `log.level` as a `keyword` for all apm error logs.

Part of elastic/apm-server#13956