### PR TITLE
[8.15] Make sure file accesses in DnRoleMapper are done in stack frames with permissions (#112400)

### DIFF
--- a/docs/changelog/112400.yaml
+++ b/docs/changelog/112400.yaml
@@ -1,0 +1,5 @@
+pr: 112400
+summary: Make sure file accesses in `DnRoleMapper` are done in stack frames with permissions
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapper.java
@@ -114,7 +114,9 @@ public class DnRoleMapper extends AbstractRoleMapperClearRealmCache {
         }
 
         try {
-            Settings settings = Settings.builder().loadFromPath(path).build();
+            // create this here so it's in an allowed stack frame
+            var file = Files.newInputStream(path);
+            Settings settings = Settings.builder().loadFromStream(path.getFileName().toString(), file, false).build();
 
             Map<DN, Set<String>> dnToRoles = new HashMap<>();
             Set<String> roles = settings.names();


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Make sure file accesses in DnRoleMapper are done in stack frames with permissions (#112400)