### PR TITLE
Some speedups around ListSetting

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -456,7 +456,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     );
     public static final Setting.AffixSetting<List<String>> INDEX_ROUTING_INITIAL_RECOVERY_GROUP_SETTING = Setting.prefixKeySetting(
         "index.routing.allocation.initial_recovery.",
-        key -> Setting.stringListSetting(key)
+        Setting::stringListSetting
     );
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.Nullable;
@@ -19,7 +20,10 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -767,7 +771,13 @@ public class Strings {
      * @param xContentBuilder builder containing an object to converted to a string
      */
     public static String toString(XContentBuilder xContentBuilder) {
-        return BytesReference.bytes(xContentBuilder).utf8ToString();
+        xContentBuilder.close();
+        OutputStream stream = xContentBuilder.getOutputStream();
+        if (stream instanceof ByteArrayOutputStream baos) {
+            return baos.toString(StandardCharsets.UTF_8);
+        } else {
+            return ((BytesStream) stream).bytes().utf8ToString();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1696,7 +1696,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<List<String>> stringListSetting(String key, List<String> defValue, Property... properties) {
-        return new ListSetting<>(key, null, s -> defValue, Setting::parseableStringToList, v -> {}, properties) {
+        return new ListSetting<>(key, null, s -> defValue, s -> parseableStringToList(s, Function.identity()), v -> {}, properties) {
             @Override
             public List<String> get(Settings settings) {
                 checkDeprecation(settings);
@@ -1735,7 +1735,13 @@ public class Setting<T> implements ToXContentObject {
         final Function<String, T> singleValueParser,
         final Property... properties
     ) {
-        return listSetting(key, fallbackSetting, singleValueParser, (s) -> parseableStringToList(fallbackSetting.getRaw(s)), properties);
+        return listSetting(
+            key,
+            fallbackSetting,
+            singleValueParser,
+            s -> parseableStringToList(fallbackSetting.getRaw(s), Function.identity()),
+            properties
+        );
     }
 
     public static <T> Setting<List<T>> listSetting(
@@ -1759,12 +1765,17 @@ public class Setting<T> implements ToXContentObject {
         if (defaultStringValue.apply(Settings.EMPTY) == null) {
             throw new IllegalArgumentException("default value function must not return null");
         }
-        Function<String, List<T>> parser = (s) -> parseableStringToList(s).stream().map(singleValueParser).toList();
-
-        return new ListSetting<>(key, fallbackSetting, defaultStringValue, parser, validator, properties);
+        return new ListSetting<>(
+            key,
+            fallbackSetting,
+            defaultStringValue,
+            s -> parseableStringToList(s, singleValueParser),
+            validator,
+            properties
+        );
     }
 
-    private static List<String> parseableStringToList(String parsableString) {
+    private static <T> List<T> parseableStringToList(String parsableString, Function<String, T> singleValueParser) {
         if ("[]".equals(parsableString)) {
             return List.of();
         }
@@ -1773,7 +1784,7 @@ public class Setting<T> implements ToXContentObject {
             xContentParser.nextToken();
             return XContentParserUtils.parseList(xContentParser, p -> {
                 XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, p.currentToken(), p);
-                return p.text();
+                return singleValueParser.apply(p.text());
             });
         } catch (IOException e) {
             throw new IllegalArgumentException("failed to parse array", e);
@@ -2079,7 +2090,7 @@ public class Setting<T> implements ToXContentObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(key);
+        return key.hashCode();
     }
 
     /**
@@ -2088,8 +2099,7 @@ public class Setting<T> implements ToXContentObject {
      * {@link #getConcreteSetting(String)} is used to pull the updater.
      */
     public static <T> AffixSetting<T> prefixKeySetting(String prefix, Function<String, Setting<T>> delegateFactory) {
-        BiFunction<String, String, Setting<T>> delegateFactoryWithNamespace = (ns, k) -> delegateFactory.apply(k);
-        return affixKeySetting(new AffixKey(prefix, null, null), delegateFactoryWithNamespace);
+        return affixKeySetting(prefix, null, delegateFactory);
     }
 
     /**
@@ -2177,7 +2187,7 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public int hashCode() {
-            return Objects.hash(key);
+            return key.hashCode();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -30,26 +30,26 @@ public final class HttpTransportSettings {
     public static final Setting<String> SETTING_CORS_ALLOW_ORIGIN = new Setting<>(
         "http.cors.allow-origin",
         "",
-        (value) -> value,
+        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<Integer> SETTING_CORS_MAX_AGE = intSetting("http.cors.max-age", 1728000, Property.NodeScope);
     public static final Setting<String> SETTING_CORS_ALLOW_METHODS = new Setting<>(
         "http.cors.allow-methods",
         "OPTIONS,HEAD,GET,POST,PUT,DELETE",
-        (value) -> value,
+        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<String> SETTING_CORS_ALLOW_HEADERS = new Setting<>(
         "http.cors.allow-headers",
         "X-Requested-With,Content-Type,Content-Length,Authorization,Accept,User-Agent,X-Elastic-Client-Meta",
-        (value) -> value,
+        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<String> SETTING_CORS_EXPOSE_HEADERS = new Setting<>(
         "http.cors.expose-headers",
         "X-elastic-product",
-        (value) -> value,
+        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<Boolean> SETTING_CORS_ALLOW_CREDENTIALS = Setting.boolSetting(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/AnonymousUser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/AnonymousUser.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.security.SecurityField.setting;
 
@@ -25,7 +26,7 @@ public class AnonymousUser extends ReservedUser {
     public static final Setting<String> USERNAME_SETTING = new Setting<>(
         setting("authc.anonymous.username"),
         DEFAULT_ANONYMOUS_USERNAME,
-        s -> s,
+        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<List<String>> ROLES_SETTING = Setting.stringListSetting(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoService.java
@@ -25,6 +25,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -57,7 +58,7 @@ public class CryptoService {
     private static final Setting<String> ENCRYPTION_ALGO_SETTING = new Setting<>(
         SecurityField.setting("encryption.algorithm"),
         s -> DEFAULT_ENCRYPTION_ALGORITHM,
-        s -> s,
+        Function.identity(),
         Property.NodeScope
     );
     private static final Setting<Integer> ENCRYPTION_KEY_LENGTH_SETTING = Setting.intSetting(
@@ -68,7 +69,7 @@ public class CryptoService {
     private static final Setting<String> ENCRYPTION_KEY_ALGO_SETTING = new Setting<>(
         SecurityField.setting("encryption_key.algorithm"),
         DEFAULT_KEY_ALGORITH,
-        s -> s,
+        Function.identity(),
         Property.NodeScope
     );
     private static final Logger logger = LogManager.getLogger(CryptoService.class);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -327,7 +327,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             key,
             Collections.singletonList("*"),
             Function.identity(),
-            value -> EventFilterPolicy.parsePredicate(value),
+            EventFilterPolicy::parsePredicate,
             Property.NodeScope,
             Property.Dynamic
         )
@@ -339,7 +339,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             key,
             Collections.singletonList("*"),
             Function.identity(),
-            value -> EventFilterPolicy.parsePredicate(value),
+            EventFilterPolicy::parsePredicate,
             Property.NodeScope,
             Property.Dynamic
         )
@@ -351,7 +351,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             key,
             Collections.singletonList("*"),
             Function.identity(),
-            value -> EventFilterPolicy.parsePredicate(value),
+            EventFilterPolicy::parsePredicate,
             Property.NodeScope,
             Property.Dynamic
         )
@@ -363,7 +363,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             key,
             Collections.singletonList("*"),
             Function.identity(),
-            value -> EventFilterPolicy.parsePredicate(value),
+            EventFilterPolicy::parsePredicate,
             Property.NodeScope,
             Property.Dynamic
         )
@@ -375,7 +375,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             key,
             Collections.singletonList("*"),
             Function.identity(),
-            value -> EventFilterPolicy.parsePredicate(value),
+            EventFilterPolicy::parsePredicate,
             Property.NodeScope,
             Property.Dynamic
         )


### PR DESCRIPTION
Just a random cleanup from debugging test failures. There's a couple of easy to fix slow things in list setting handling here. The biggest win is from not materializing the string list for non-string type setting values during parsing and speeding up `Strings.toString`.
