### PR TITLE
[DOCS] Rework semantic search main page

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
@@ -1,0 +1,92 @@
+[[semantic-search-deployed-nlp-model]]
+=== Tutorial: semantic search with a deployed model
+
+++++
+<titleabbrev>Semantic search with deployed model</titleabbrev>
+++++
+
+IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
+
+This guide shows you how to implement semantic search with models deployed in {es}: from selecting an NLP model, to writing queries.
+
+
+[discrete]
+[[deployed-select-nlp-model]]
+==== Select an NLP model
+
+{es} offers the usage of a {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[wide range of NLP models], including both dense and sparse vector models.
+Your choice of the language model is critical for implementing semantic search successfully.
+
+While it is possible to bring your own text embedding model, achieving good search results through model tuning is challenging.
+Selecting an appropriate model from our third-party model list is the first step.
+Training the model on your own data is essential to ensure better search results than using only BM25.
+However, the model training process requires a team of data scientists and ML experts, making it expensive and time-consuming.
+
+To address this issue, Elastic provides a pre-trained representational model called {ml-docs}/ml-nlp-elser.html[Elastic Learned Sparse EncodeR (ELSER)].
+ELSER, currently available only for English, is an out-of-domain sparse vector model that does not require fine-tuning.
+This adaptability makes it suitable for various NLP use cases out of the box.
+Unless you have a team of ML specialists, it is highly recommended to use the ELSER model.
+
+In the case of sparse vector representation, the vectors mostly consist of zero values, with only a small subset containing non-zero values.
+This representation is commonly used for textual data.
+In the case of ELSER, each document in an index and the query text itself are represented by high-dimensional sparse vectors.
+Each non-zero element of the vector corresponds to a term in the model vocabulary.
+The ELSER vocabulary contains around 30000 terms, so the sparse vectors created by ELSER contain about 30000 values, the majority of which are zero.
+Effectively the ELSER model is replacing the terms in the original query with other terms that have been learnt to exist in the documents that best match the original search terms in a training dataset, and weights to control how important each is.
+
+
+[discrete]
+[[deployed-deploy-nlp-model]]
+==== Deploy the model
+
+After you decide which model you want to use for implementing semantic search, you need to deploy the model in {es}.
+
+include::{es-ref-dir}/tab-widgets/semantic-search/deploy-nlp-model-widget.asciidoc[]
+
+
+[discrete]
+[[deployed-field-mappings]]
+==== Map a field for the text embeddings
+
+Before you start using the deployed model to generate embeddings based on your input text, you need to prepare your index mapping first.
+The mapping of the index depends on the type of model.
+
+include::{es-ref-dir}/tab-widgets/semantic-search/field-mappings-widget.asciidoc[]
+
+
+[discrete]
+[[deployed-generate-embeddings]]
+==== Generate text embeddings
+
+Once you have created the mappings for the index, you can generate text embeddings from your input text.
+This can be done by using an
+<<ingest,ingest pipeline>> with an <<inference-processor,inference processor>>.
+The ingest pipeline processes the input data and indexes it into the destination index.
+At index time, the inference ingest processor uses the trained model to infer against the data ingested through the pipeline.
+After you created the ingest pipeline with the inference processor, you can ingest your data through it to generate the model output.
+
+include::{es-ref-dir}/tab-widgets/semantic-search/generate-embeddings-widget.asciidoc[]
+
+Now it is time to perform semantic search!
+
+
+[discrete]
+[[deployed-search]]
+==== Search the data
+
+Depending on the type of model you have deployed, you can query rank features with a <<query-dsl-sparse-vector-query, sparse vector>> query, or dense vectors with a kNN search.
+
+include::{es-ref-dir}/tab-widgets/semantic-search/search-widget.asciidoc[]
+
+
+[discrete]
+[[deployed-hybrid-search]]
+==== Beyond semantic search with hybrid search
+
+In some situations, lexical search may perform better than semantic search.
+For example, when searching for single words or IDs, like product numbers.
+
+Combining semantic and lexical search into one hybrid search request using <<rrf,reciprocal rank fusion>> provides the best of both worlds.
+Not only that, but hybrid search using reciprocal rank fusion {blog-ref}improving-information-retrieval-elastic-stack-hybrid[has been shown to perform better in general].
+
+include::{es-ref-dir}/tab-widgets/semantic-search/hybrid-search-widget.asciidoc[]

--- a/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
@@ -8,7 +8,7 @@
 [IMPORTANT]
 ====
 * For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
-* This tutorial was written before the {infer} endpoint and `semantic_text` options were introduced which makes this as the most complicated option. We recommend to use another method to perform semantic search. 
+* This tutorial was written before the {infer} endpoint and `semantic_text` options were introduced. Today we have simpler options for performing semantic search. 
 ====
 
 This guide shows you how to implement semantic search with models deployed in {es}: from selecting an NLP model, to writing queries.

--- a/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
@@ -8,7 +8,8 @@
 [IMPORTANT]
 ====
 * For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
-* This tutorial was written before the {infer} endpoint and `semantic_text` options were introduced. Today we have simpler options for performing semantic search. 
+* This tutorial was written before the <<inference-apis,{infer} endpoint>> and <<semantic-text,`semantic_text` field type>> was introduced.
+Today we have simpler options for performing semantic search. 
 ====
 
 This guide shows you how to implement semantic search with models deployed in {es}: from selecting an NLP model, to writing queries.

--- a/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-deploy-model.asciidoc
@@ -5,7 +5,11 @@
 <titleabbrev>Semantic search with deployed model</titleabbrev>
 ++++
 
-IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
+[IMPORTANT]
+====
+* For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
+* This tutorial was written before the {infer} endpoint and `semantic_text` options were introduced which makes this as the most complicated option. We recommend to use another method to perform semantic search. 
+====
 
 This guide shows you how to implement semantic search with models deployed in {es}: from selecting an NLP model, to writing queries.
 

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -9,9 +9,9 @@ Embeddings are vectors that provide a numeric representation of a text.
 Pieces of content with similar meaning have similar representations.
 NLP models can be used in the {stack} various ways, you can:
 
-* deploy models in {es}
 * use the <<semantic-search-semantic-text, `semantic_text` workflow>> (recommended)
 * use the <<semantic-search-inference, {infer} API workflow>>
+* deploy models directly in {es}
 
 
 [[semantic-search-diagram]]
@@ -20,95 +20,59 @@ image::images/search/vector-search-oversimplification.png[A simplified represent
 
 At query time, {es} can use the same NLP model to convert a query into embeddings, enabling you to find documents with similar text embeddings.
 
-This guide shows you how to implement semantic search with {es}: From selecting an NLP model, to writing queries.
+
+[discrete]
+[[using-nlp-models]]
+=== Using NLP models
+
+The easiest and recommended way to use NLP models in the {stack} is the <<semantic-search-semantic-text, `semantic_text` workflow>>.
+If you want to use ELSER for semantic search or you already have a service you use, create an {infer} endpoint and an index mapping to start ingesting and querying data.
+You don't need to define model-related settings and parameters, or create {infer} ingest pipelines.
+Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation for a list of supported services.
+
+The <<semantic-search-inference, {infer} API workflow>> more complex but enables you to have more control over the {infer} endpoint configuration.
+You need to create an {infer} endpoint and provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the correct settings.
+
+You can also deploy NLP models directly in {es}.
+This is the most complex way to perform semantic search in the {stack}.
+You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[list of supported NLP models] that includes both dense and sparse vector models.
+Then deploy the selected model by using the Eland client, create an index mapping and a sufficient ingest pipeline to start ingesting and querying data.
+
+
+[discrete]
+[[using-query]]
+=== Using the right query
+
+Crafting the right query is crucial for semantic search.
+The query type you should use depends first on whether you are using the recommended `semantic_text` workflow.
+If not, it depends on the vector type in which your embeddings are stored.
+
+[cols="3*", options="header"]
+|=======================================================================================================================================================================================================
+| Field to query                    | Query to use                                      | Notes                                                                                                                                                             
+| <<semantic-text,`semantic_text`>> | <<query-dsl-semantic-query,`semantic`>> .         | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
+| <<sparse-vector,`sparse_vector`>> | <<query-dsl-sparse-vector-query,`sparse vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
+| <<dense-vector,`dense_vector`>>   | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
+|=======================================================================================================================================================================================================
+
+If you want {es} to generate embeddings for you both index and query time, use the `semantic_text` field and the `semantic` query.
+If you want to bring your own embeddings, store them in {es} and use the `sparse_vector` or `dense_vector` field type and the associated query depending on the NLP model you used for generating the embeddings.
 
 IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
 
-[discrete]
-[[semantic-search-select-nlp-model]]
-=== Select an NLP model
-
-{es} offers the usage of a
-{ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[wide range of NLP models], including both dense and sparse vector models.
-Your choice of the language model is critical for implementing semantic search successfully.
-
-While it is possible to bring your own text embedding model, achieving good search results through model tuning is challenging.
-Selecting an appropriate model from our third-party model list is the first step.
-Training the model on your own data is essential to ensure better search results than using only BM25.
-However, the model training process requires a team of data scientists and ML experts, making it expensive and time-consuming.
-
-To address this issue, Elastic provides a pre-trained representational model called {ml-docs}/ml-nlp-elser.html[Elastic Learned Sparse EncodeR (ELSER)].
-ELSER, currently available only for English, is an out-of-domain sparse vector model that does not require fine-tuning.
-This adaptability makes it suitable for various NLP use cases out of the box.
-Unless you have a team of ML specialists, it is highly recommended to use the ELSER model.
-
-In the case of sparse vector representation, the vectors mostly consist of zero values, with only a small subset containing non-zero values.
-This representation is commonly used for textual data.
-In the case of ELSER, each document in an index and the query text itself are represented by high-dimensional sparse vectors.
-Each non-zero element of the vector corresponds to a term in the model vocabulary.
-The ELSER vocabulary contains around 30000 terms, so the sparse vectors created by ELSER contain about 30000 values, the majority of which are zero.
-Effectively the ELSER model is replacing the terms in the original query with other terms that have been learnt to exist in the documents that best match the original search terms in a training dataset, and weights to control how important each is.
-
-[discrete]
-[[semantic-search-deploy-nlp-model]]
-=== Deploy the model
-
-After you decide which model you want to use for implementing semantic search, you need to deploy the model in {es}.
-
-include::{es-ref-dir}/tab-widgets/semantic-search/deploy-nlp-model-widget.asciidoc[]
-
-[discrete]
-[[semantic-search-field-mappings]]
-=== Map a field for the text embeddings
-
-Before you start using the deployed model to generate embeddings based on your input text, you need to prepare your index mapping first.
-The mapping of the index depends on the type of model.
-
-include::{es-ref-dir}/tab-widgets/semantic-search/field-mappings-widget.asciidoc[]
-
-[discrete]
-[[semantic-search-generate-embeddings]]
-=== Generate text embeddings
-
-Once you have created the mappings for the index, you can generate text embeddings from your input text.
-This can be done by using an
-<<ingest,ingest pipeline>> with an <<inference-processor,inference processor>>.
-The ingest pipeline processes the input data and indexes it into the destination index.
-At index time, the inference ingest processor uses the trained model to infer against the data ingested through the pipeline.
-After you created the ingest pipeline with the inference processor, you can ingest your data through it to generate the model output.
-
-include::{es-ref-dir}/tab-widgets/semantic-search/generate-embeddings-widget.asciidoc[]
-
-Now it is time to perform semantic search!
-
-[discrete]
-[[semantic-search-search]]
-=== Search the data
-
-Depending on the type of model you have deployed, you can query rank features with a <<query-dsl-sparse-vector-query, sparse vector>> query, or dense vectors with a kNN search.
-
-include::{es-ref-dir}/tab-widgets/semantic-search/search-widget.asciidoc[]
-
-[discrete]
-[[semantic-search-hybrid-search]]
-=== Beyond semantic search with hybrid search
-
-In some situations, lexical search may perform better than semantic search.
-For example, when searching for single words or IDs, like product numbers.
-
-Combining semantic and lexical search into one hybrid search request using
-<<rrf,reciprocal rank fusion>> provides the best of both worlds.
-Not only that, but hybrid search using reciprocal rank fusion {blog-ref}improving-information-retrieval-elastic-stack-hybrid[has been shown to perform better in general].
-
-include::{es-ref-dir}/tab-widgets/semantic-search/hybrid-search-widget.asciidoc[]
 
 [discrete]
 [[semantic-search-read-more]]
 === Read more
 
 * Tutorials:
-** <<semantic-search-elser,Semantic search with ELSER>>
+** <<semantic-search-semantic-text, Semantic search with `semantic_text`>>
+** <<semantic-search-inference, Semantic search with the {infer} API>>
+** <<semantic-search-elser,Semantic search with ELSER>> using the {infer} workflow
+** <<semantic-search-deployed-nlp-model, Semantic search with a model deployed in {es}>>
 ** {ml-docs}/ml-nlp-text-emb-vector-search-example.html[Semantic search with the msmarco-MiniLM-L-12-v3 sentence-transformer model]
+* Interactive examples:
+** The https://github.com/elastic/elasticsearch-labs[`elasticsearch-labs`] repo contains a number of interactive semantic search examples in the form of executable Python notebooks, using the {es} Python client
 * Blogs:
 ** {blog-ref}may-2023-launch-sparse-encoder-ai-model[Introducing Elastic Learned Sparse Encoder: Elastic's AI model for semantic search]
 ** {blog-ref}lexical-ai-powered-search-elastic-vector-database[How to get the best of lexical and AI-powered search with Elastic's vector database]
@@ -117,10 +81,10 @@ include::{es-ref-dir}/tab-widgets/semantic-search/hybrid-search-widget.asciidoc[
 *** {blog-ref}improving-information-retrieval-elastic-stack-benchmarking-passage-retrieval[Part 2: Benchmarking passage retrieval]
 *** {blog-ref}may-2023-launch-information-retrieval-elasticsearch-ai-model[Part 3: Introducing Elastic Learned Sparse Encoder, our new retrieval model]
 *** {blog-ref}improving-information-retrieval-elastic-stack-hybrid[Part 4: Hybrid retrieval]
-* Interactive examples:
-** The https://github.com/elastic/elasticsearch-labs[`elasticsearch-labs`] repo contains a number of interactive semantic search examples in the form of executable Python notebooks, using the {es} Python client
 
-include::semantic-search-elser.asciidoc[]
+
 include::semantic-search-semantic-text.asciidoc[]
 include::semantic-search-inference.asciidoc[]
+include::semantic-search-elser.asciidoc[]
 include::cohere-es.asciidoc[]
+include::semantic-search-deploy-model.asciidoc[]

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -25,18 +25,16 @@ At query time, {es} can use the same NLP model to convert a query into embedding
 [[using-nlp-models]]
 === Using NLP models
 
-The easiest and recommended way to use NLP models in the {stack} is the <<semantic-search-semantic-text, `semantic_text` workflow>>.
-If you want to use ELSER for semantic search or you already have a service you use, create an {infer} endpoint and an index mapping to start ingesting and querying data.
-You don't need to define model-related settings and parameters, or create {infer} ingest pipelines.
+The easiest and recommended way to use NLP models in the {stack} is through the <<semantic-search-semantic-text, `semantic_text` workflow>>.
+If you want to use ELSER for semantic search or already have a service you use, create an {infer} endpoint and an index mapping to start ingesting and querying data.
+There is no need to define model-related settings and parameters, or to create {infer} ingest pipelines.
 Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation for a list of supported services.
 
-The <<semantic-search-inference, {infer} API workflow>> more complex but enables you to have more control over the {infer} endpoint configuration.
-You need to create an {infer} endpoint and provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the correct settings.
+The <<semantic-search-inference, {infer} API workflow>> more complex but offers greater control over the {infer} endpoint configuration.
+You need to create an {infer} endpoint, provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the appropriate settings.
 
-You can also deploy NLP models directly in {es}.
-This is the most complex way to perform semantic search in the {stack}.
-You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[list of supported NLP models] that includes both dense and sparse vector models.
-Then deploy the selected model by using the Eland client, create an index mapping and a sufficient ingest pipeline to start ingesting and querying data.
+You can also deploy NLP models directly in {es}, which is the most complex way to perform semantic search in the {stack}.
+You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[list of supported dense and sparse vector models], deploy it using the Eland client, create an index mapping, and set up a suitable ingest pipeline to start ingesting and querying data.
 
 
 [discrete]

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -64,12 +64,12 @@ Which query you use and which field you target in your queries depends on your c
 If you're using the `semantic_text` workflow it's quite simple.
 If not, it depends on which type of embeddings you're working with.
 
-[cols="3*", options="header"]
+[cols="30%, 30%, 40%", options="header"]
 |=======================================================================================================================================================================================================
 | Field type to query                    | Query to use                                      | Notes                                                                                                                                                             
-| <<semantic-text,`semantic_text`>>      | <<query-dsl-semantic-query,`semantic`>>           | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
-| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse_vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
-| <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
+| <<semantic-text,`semantic_text`>>      | <<query-dsl-semantic-query,`semantic`>>           | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                               
+| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse_vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. Provide embeddings at index time.
+| <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. Provide embeddings at index time.
 |=======================================================================================================================================================================================================
 
 If you want {es} to generate embeddings at both index and query time, use the `semantic_text` field and the `semantic` query.

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -90,7 +90,10 @@ IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer 
 ** {ml-docs}/ml-nlp-text-emb-vector-search-example.html[Semantic search with the msmarco-MiniLM-L-12-v3 sentence-transformer model]
 * Interactive examples:
 ** The https://github.com/elastic/elasticsearch-labs[`elasticsearch-labs`] repo contains a number of interactive semantic search examples in the form of executable Python notebooks, using the {es} Python client
+** https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/03-ELSER.ipynb[Semantic search with ELSER using the model deployment workflow]
+** https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/09-semantic-text.ipynb[Semantic search with `semantic_text`]
 * Blogs:
+** https://www.elastic.co/search-labs/blog/semantic-search-simplified-semantic-text[{es} new semantic_text mapping: Simplifying semantic search]
 ** {blog-ref}may-2023-launch-sparse-encoder-ai-model[Introducing Elastic Learned Sparse Encoder: Elastic's AI model for semantic search]
 ** {blog-ref}lexical-ai-powered-search-elastic-vector-database[How to get the best of lexical and AI-powered search with Elastic's vector database]
 ** Information retrieval blog series:

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -10,14 +10,14 @@ Pieces of content with similar meaning have similar representations.
 
 You have several options for using NLP models in the {stack}:
 
-* use the <<semantic-search-semantic-text, `semantic_text` workflow>> (recommended)
-* use the <<semantic-search-inference, {infer} API workflow>>
+* use the `semantic_text` workflow (recommended)
+* use the {infer} API workflow
 * deploy models directly in {es}
 
+Refer to <<using-nlp-models,this section>> to choose your workflow.
 
-[[semantic-search-diagram]]
-.A simplified representation of encoding textual concepts as vectors
-image::images/search/vector-search-oversimplification.png[A simplified representation of encoding textual concepts as vectors,align="center"]
+You can also store your own embeddings in {es} as vectors.
+Refer to <<using-query,this section>> for guidance on which query type to use for semantic search.
 
 At query time, {es} can use the same NLP model to convert a query into embeddings, enabling you to find documents with similar text embeddings.
 
@@ -31,13 +31,16 @@ We recommend using this approach because it abstracts away a lot of manual work.
 All you need to do is create an {infer} endpoint and an index mapping to start ingesting, embedding, and querying data.
 There is no need to define model-related settings and parameters, or to create {infer} ingest pipelines.
 Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation for a list of supported services.
+The <<semantic-search-semantic-text, Semantic search with `semantic_text`>> tutorial shows you the process end-to-end.
 
 The <<semantic-search-inference, {infer} API workflow>> is more complex but offers greater control over the {infer} endpoint configuration.
 You need to create an {infer} endpoint, provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the appropriate settings.
+The <<semantic-search-inference, Semantic search with the {infer} API>> tutorial shows you the process end-to-end.
 
 You can also deploy NLP in {es} manually, without using an {infer} endpoint.
 This is the most complex and labor intensive workflow for performing semantic search in the {stack}.
 You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[list of supported dense and sparse vector models], deploy it using the Eland client, create an index mapping, and set up a suitable ingest pipeline to start ingesting and querying data.
+the <<semantic-search-deployed-nlp-model, Semantic search with a model deployed in {es}>> tutorial shows you the process end-to-end.
 
 
 [discrete]
@@ -52,9 +55,9 @@ If not, it depends on which type of embeddings you're working with.
 [cols="3*", options="header"]
 |=======================================================================================================================================================================================================
 | Field type to query                    | Query to use                                      | Notes                                                                                                                                                             
-| <<semantic-text,`semantic_text`>> | <<query-dsl-semantic-query,`semantic`>> .         | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
-| <<sparse-vector,`sparse_vector`>> | <<query-dsl-sparse-vector-query,`sparse vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
-| <<dense-vector,`dense_vector`>>   | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
+| <<semantic-text,`semantic_text`>> .    | <<query-dsl-semantic-query,`semantic`>> .         | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
+| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
+| <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
 |=======================================================================================================================================================================================================
 
 If you want {es} to generate embeddings for you both index and query time, use the `semantic_text` field and the `semantic` query.

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -26,6 +26,9 @@ At query time, {es} can use the same NLP model to convert a query into embedding
 [[using-nlp-models]]
 === Choose a semantic search workflow
 
+[discrete]
+==== The `semantic_text` workflow
+
 The simplest way to use NLP models in the {stack} is through the <<semantic-search-semantic-text, `semantic_text` workflow>>.
 We recommend using this approach because it abstracts away a lot of manual work.
 All you need to do is create an {infer} endpoint and an index mapping to start ingesting, embedding, and querying data.
@@ -33,9 +36,15 @@ There is no need to define model-related settings and parameters, or to create {
 Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation for a list of supported services.
 The <<semantic-search-semantic-text, Semantic search with `semantic_text`>> tutorial shows you the process end-to-end.
 
+[discrete]
+==== The {infer} API workflow
+
 The <<semantic-search-inference, {infer} API workflow>> is more complex but offers greater control over the {infer} endpoint configuration.
 You need to create an {infer} endpoint, provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the appropriate settings.
 The <<semantic-search-inference, Semantic search with the {infer} API>> tutorial shows you the process end-to-end.
+
+[discrete]
+==== Model deployment workflow
 
 You can also deploy NLP in {es} manually, without using an {infer} endpoint.
 This is the most complex and labor intensive workflow for performing semantic search in the {stack}.

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -27,7 +27,7 @@ At query time, {es} can use the same NLP model to convert a query into embedding
 === Choose a semantic search workflow
 
 [discrete]
-==== The `semantic_text` workflow
+==== `semantic_text` workflow
 
 The simplest way to use NLP models in the {stack} is through the <<semantic-search-semantic-text, `semantic_text` workflow>>.
 We recommend using this approach because it abstracts away a lot of manual work.
@@ -38,7 +38,7 @@ Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation
 The <<semantic-search-semantic-text, Semantic search with `semantic_text`>> tutorial shows you the process end-to-end.
 
 [discrete]
-==== The {infer} API workflow
+==== {infer} API workflow
 
 The <<semantic-search-inference, {infer} API workflow>> is more complex but offers greater control over the {infer} endpoint configuration.
 You need to create an {infer} endpoint, provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the appropriate settings.
@@ -68,12 +68,12 @@ If not, it depends on which type of embeddings you're working with.
 |=======================================================================================================================================================================================================
 | Field type to query                    | Query to use                                      | Notes                                                                                                                                                             
 | <<semantic-text,`semantic_text`>>      | <<query-dsl-semantic-query,`semantic`>>           | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                               
-| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse_vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. Provide embeddings at index time.
-| <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. Provide embeddings at index time.
+| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse_vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You must provide embeddings at index time.
+| <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You must provide embeddings at index time.
 |=======================================================================================================================================================================================================
 
 If you want {es} to generate embeddings at both index and query time, use the `semantic_text` field and the `semantic` query.
-If you want to bring your own embeddings, store them in {es} and use the `sparse_vector` or `dense_vector` field type and the associated query depending on the NLP model you used for generating the embeddings.
+If you want to bring your own embeddings, use the `sparse_vector` or `dense_vector` field type and the associated query depending on the NLP model you used to generate the embeddings.
 
 IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
 
@@ -85,7 +85,7 @@ IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer 
 * Tutorials:
 ** <<semantic-search-semantic-text, Semantic search with `semantic_text`>>
 ** <<semantic-search-inference, Semantic search with the {infer} API>>
-** <<semantic-search-elser,Semantic search with ELSER>> using the {infer} workflow
+** <<semantic-search-elser,Semantic search with ELSER>> using the model deployment workflow
 ** <<semantic-search-deployed-nlp-model, Semantic search with a model deployed in {es}>>
 ** {ml-docs}/ml-nlp-text-emb-vector-search-example.html[Semantic search with the msmarco-MiniLM-L-12-v3 sentence-transformer model]
 * Interactive examples:

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -55,7 +55,7 @@ If not, it depends on which type of embeddings you're working with.
 [cols="3*", options="header"]
 |=======================================================================================================================================================================================================
 | Field type to query                    | Query to use                                      | Notes                                                                                                                                                             
-| <<semantic-text,`semantic_text`>> .    | <<query-dsl-semantic-query,`semantic`>> .         | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
+| <<semantic-text,`semantic_text`>>      | <<query-dsl-semantic-query,`semantic`>>           | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
 | <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
 | <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
 |=======================================================================================================================================================================================================

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -7,7 +7,8 @@ Semantic search is a search method that helps you find data based on the intent 
 Using an NLP model enables you to extract text embeddings out of text.
 Embeddings are vectors that provide a numeric representation of a text.
 Pieces of content with similar meaning have similar representations.
-NLP models can be used in the {stack} various ways, you can:
+
+You have several options for using NLP models in the {stack}:
 
 * use the <<semantic-search-semantic-text, `semantic_text` workflow>> (recommended)
 * use the <<semantic-search-inference, {infer} API workflow>>
@@ -23,17 +24,19 @@ At query time, {es} can use the same NLP model to convert a query into embedding
 
 [discrete]
 [[using-nlp-models]]
-=== Using NLP models
+=== Choose a semantic search workflow
 
-The easiest and recommended way to use NLP models in the {stack} is through the <<semantic-search-semantic-text, `semantic_text` workflow>>.
-If you want to use ELSER for semantic search or already have a service you use, create an {infer} endpoint and an index mapping to start ingesting and querying data.
+The simplest way to use NLP models in the {stack} is through the <<semantic-search-semantic-text, `semantic_text` workflow>>.
+We recommend using this approach because it abstracts away a lot of manual work.
+All you need to do is create an {infer} endpoint and an index mapping to start ingesting, embedding, and querying data.
 There is no need to define model-related settings and parameters, or to create {infer} ingest pipelines.
 Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation for a list of supported services.
 
-The <<semantic-search-inference, {infer} API workflow>> more complex but offers greater control over the {infer} endpoint configuration.
+The <<semantic-search-inference, {infer} API workflow>> is more complex but offers greater control over the {infer} endpoint configuration.
 You need to create an {infer} endpoint, provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the appropriate settings.
 
-You can also deploy NLP models directly in {es}, which is the most complex way to perform semantic search in the {stack}.
+You can also deploy NLP in {es} manually, without using an {infer} endpoint.
+This is the most complex and labor intensive workflow for performing semantic search in the {stack}.
 You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[list of supported dense and sparse vector models], deploy it using the Eland client, create an index mapping, and set up a suitable ingest pipeline to start ingesting and querying data.
 
 
@@ -42,12 +45,13 @@ You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-
 === Using the right query
 
 Crafting the right query is crucial for semantic search.
-The query type you should use depends first on whether you are using the recommended `semantic_text` workflow.
-If not, it depends on the vector type in which your embeddings are stored.
+Which query you use and which field you target in your queries depends on your chosen workflow.
+If you're using the `semantic_text` workflow it's quite simple.
+If not, it depends on which type of embeddings you're working with.
 
 [cols="3*", options="header"]
 |=======================================================================================================================================================================================================
-| Field to query                    | Query to use                                      | Notes                                                                                                                                                             
+| Field type to query                    | Query to use                                      | Notes                                                                                                                                                             
 | <<semantic-text,`semantic_text`>> | <<query-dsl-semantic-query,`semantic`>> .         | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
 | <<sparse-vector,`sparse_vector`>> | <<query-dsl-sparse-vector-query,`sparse vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
 | <<dense-vector,`dense_vector`>>   | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -34,6 +34,7 @@ We recommend using this approach because it abstracts away a lot of manual work.
 All you need to do is create an {infer} endpoint and an index mapping to start ingesting, embedding, and querying data.
 There is no need to define model-related settings and parameters, or to create {infer} ingest pipelines.
 Refer to the <<put-inference-api, Create an {infer} endpoint API>> documentation for a list of supported services.
+
 The <<semantic-search-semantic-text, Semantic search with `semantic_text`>> tutorial shows you the process end-to-end.
 
 [discrete]
@@ -41,6 +42,7 @@ The <<semantic-search-semantic-text, Semantic search with `semantic_text`>> tuto
 
 The <<semantic-search-inference, {infer} API workflow>> is more complex but offers greater control over the {infer} endpoint configuration.
 You need to create an {infer} endpoint, provide various model-related settings and parameters, define an index mapping, and set up an {infer} ingest pipeline with the appropriate settings.
+
 The <<semantic-search-inference, Semantic search with the {infer} API>> tutorial shows you the process end-to-end.
 
 [discrete]
@@ -49,7 +51,8 @@ The <<semantic-search-inference, Semantic search with the {infer} API>> tutorial
 You can also deploy NLP in {es} manually, without using an {infer} endpoint.
 This is the most complex and labor intensive workflow for performing semantic search in the {stack}.
 You need to select an NLP model from the {ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[list of supported dense and sparse vector models], deploy it using the Eland client, create an index mapping, and set up a suitable ingest pipeline to start ingesting and querying data.
-the <<semantic-search-deployed-nlp-model, Semantic search with a model deployed in {es}>> tutorial shows you the process end-to-end.
+
+The <<semantic-search-deployed-nlp-model, Semantic search with a model deployed in {es}>> tutorial shows you the process end-to-end.
 
 
 [discrete]
@@ -65,11 +68,11 @@ If not, it depends on which type of embeddings you're working with.
 |=======================================================================================================================================================================================================
 | Field type to query                    | Query to use                                      | Notes                                                                                                                                                             
 | <<semantic-text,`semantic_text`>>      | <<query-dsl-semantic-query,`semantic`>>           | The `semantic_text` field handles generating embeddings for you at index time and query time.                                                                     
-| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
+| <<sparse-vector,`sparse_vector`>>      | <<query-dsl-sparse-vector-query,`sparse_vector`>> | The `sparse_vector` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
 | <<dense-vector,`dense_vector`>>        | <<query-dsl-knn-query,`knn`>>                     | The `knn` query can generate query embeddings for you, but you can also provide your own. You are expected to provide embeddings at index time.
 |=======================================================================================================================================================================================================
 
-If you want {es} to generate embeddings for you both index and query time, use the `semantic_text` field and the `semantic` query.
+If you want {es} to generate embeddings at both index and query time, use the `semantic_text` field and the `semantic` query.
 If you want to bring your own embeddings, store them in {es} and use the `sparse_vector` or `dense_vector` field type and the associated query depending on the NLP model you used for generating the embeddings.
 
 IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.


### PR DESCRIPTION
## Overview

This PR reworks and updates the [semantic search main page](https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search.html).
* Adds a new `Choose a semantic search workflow` section that describes the various ways users can use the Stack for semantic search and recommends the semantic text workflow
* Adds a new `Using the right query` section that helps users understand which query should be used for the different vectors
* Provides a table about the field types and the corresponding queries
* Moves the deployed ELSER and dense vector model tutorial to a sub-page (content is unchanged)
* Reorganize the sub-pages in TOC so the most important comes first
* Improves read more list at the end of the main page

### Preview

* [Semantic search](https://elasticsearch_bk_112452.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search.html)
* [Tutorial: semantic search with deployed models](https://elasticsearch_bk_112452.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-deployed-nlp-model.html)