### PR TITLE
[Cloud Security] add privileges required for CDR misconfiguration features to work

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -394,12 +394,14 @@ class KibanaOwnedReservedRoleDescriptors {
                         TransportUpdateSettingsAction.TYPE.name()
                     )
                     .build(),
-                // For src/dest indices of the Cloud Security Posture packages that ships a
+                // For source indices of the Cloud Security Posture packages that ships a
                 // transform
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs-cloud_security_posture.findings-*", "logs-cloud_security_posture.vulnerabilities-*")
                     .privileges("read", "view_index_metadata")
                     .build(),
+                // For destination indices of the Cloud Security Posture packages that ships a
+                // transform
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(
                         "logs-cloud_security_posture.findings_latest-default*",
@@ -415,17 +417,23 @@ class KibanaOwnedReservedRoleDescriptors {
                         TransportUpdateSettingsAction.TYPE.name()
                     )
                     .build(),
+                // For source indices of the Cloud Detection & Response (CDR) packages that ships a
+                // transform
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-wiz.vulnerability-*")
+                    .indices("logs-wiz.vulnerability-*", "logs-wiz.cloud_configuration_finding-*")
                     .privileges("read", "view_index_metadata")
                     .build(),
+                // For alias indices of the Cloud Detection & Response (CDR) packages that ships a
+                // transform
                 RoleDescriptor.IndicesPrivileges.builder()
                     // manage privilege required by the index alias
-                    .indices("security_solution-*.vulnerability_latest")
+                    .indices("security_solution-*.vulnerability_latest", "security_solution-*.misconfiguration_latest")
                     .privileges("manage", TransportIndicesAliasesAction.NAME, TransportUpdateSettingsAction.TYPE.name())
                     .build(),
+                // For destination indices of the Cloud Detection & Response (CDR) packages that ships a
+                // transform
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("security_solution-*.vulnerability_latest-*")
+                    .indices("security_solution-*.vulnerability_latest-*", "security_solution-*.misconfiguration_latest-*")
                     .privileges(
                         "create_index",
                         "index",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1609,8 +1609,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
         });
 
-        Arrays.asList("logs-wiz.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13))).forEach((cspIndex) -> {
-            final IndexAbstraction indexAbstraction = mockIndexAbstraction(cspIndex);
+        Arrays.asList(
+            "logs-wiz.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-wiz.cloud_configuration_finding-" + randomAlphaOfLength(randomIntBetween(0, 13))
+        ).forEach(indexName -> {
+            final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(indexAbstraction), is(false));
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:bar").test(indexAbstraction), is(false));
             assertThat(
@@ -1643,7 +1646,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             "logs-cloud_security_posture.findings_latest-default-" + Version.CURRENT,
             "logs-cloud_security_posture.scores-default-" + Version.CURRENT,
             "logs-cloud_security_posture.vulnerabilities_latest-default" + Version.CURRENT,
-            "security_solution-*.vulnerability_latest-" + Version.CURRENT
+            "security_solution-*.vulnerability_latest-" + Version.CURRENT,
+            "security_solution-*.misconfiguration_latest-" + Version.CURRENT
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);


### PR DESCRIPTION
- follow up after https://github.com/elastic/elasticsearch/pull/112192
- contributes to https://github.com/elastic/security-team/issues/9664

### Summary
This PR updates `kibana_system` privileges to include the ones required for the Security Solution CDR Misconfigurtion latest transform to work:
- to read from source Wiz data stream as one of the data streams providing data for Cloud Detection & Response (CDR) features in Kibana
- to create a destination CDR Misconfiguration index with an alias and write data to it

Related integration PR with the transform implementation
- https://github.com/elastic/integrations/pull/10965