### PR TITLE
Add ESQL CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,3 +70,7 @@ server/src/main/java/org/elasticsearch/threadpool @elastic/es-core-infra
 # Security
 x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege @elastic/es-security
 x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java @elastic/es-security
+
+# Analytical engine
+x-pack/plugin/esql @elastic/es-analytical-engine
+x-pack/plugin/esql-core @elastic/es-analytical-engine


### PR DESCRIPTION
CODEOWNERS makes it easy for devs to know who to ask for review, who's the owner of some file, etc.
It also automatically adds the team as a reviewer, mainly helping with the first point, and automatically "documenting" the issue around which files were touched.

This slightly overlaps with our `Team:<team>` labels though, but while labels are more _functional_ and manual (Right now?), owners represent a more `technical` ownership, and is automatic and potentially enforcing review (Not now).

Of course, here I'm only adding it to ESQL, but it's a way to open the conversation.