### PR TITLE
Avoid passing in the cluster state parameter to methods related to index creation

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataDataStreamsService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionMultiListener;
@@ -134,7 +135,7 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
             );
             final String trialSourceIndexName = trialRolloverNames.sourceName();
             final String trialRolloverIndexName = trialRolloverNames.rolloverName();
-            MetadataRolloverService.validateIndexName(clusterState, trialRolloverIndexName);
+            MetadataCreateIndexService.validateIndexName(trialRolloverIndexName, clusterState.metadata(), clusterState.routingTable());
 
             assert metadata.dataStreams().containsKey(rolloverRequest.getRolloverTarget()) : "Auto-rollover applies only to data streams";
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -179,10 +179,6 @@ public class MetadataRolloverService {
         };
     }
 
-    public static void validateIndexName(ClusterState state, String index) {
-        MetadataCreateIndexService.validateIndexName(index, state);
-    }
-
     /**
      * Returns the names that rollover would use, but does not perform the actual rollover
      */
@@ -252,7 +248,8 @@ public class MetadataRolloverService {
         final Boolean isHidden = IndexMetadata.INDEX_HIDDEN_SETTING.exists(createIndexRequest.settings())
             ? IndexMetadata.INDEX_HIDDEN_SETTING.get(createIndexRequest.settings())
             : null;
-        MetadataCreateIndexService.validateIndexName(rolloverIndexName, currentState); // fails if the index already exists
+        MetadataCreateIndexService.validateIndexName(rolloverIndexName, metadata, currentState.routingTable()); // fails if the index
+                                                                                                                // already exists
         checkNoDuplicatedAliasInIndexTemplate(metadata, rolloverIndexName, aliasName, isHidden);
         if (onlyValidate) {
             return new RolloverResult(rolloverIndexName, sourceIndexName, currentState);
@@ -328,7 +325,8 @@ public class MetadataRolloverService {
         final Tuple<String, Long> nextIndexAndGeneration = dataStream.nextWriteIndexAndGeneration(metadata, dataStreamIndices);
         final String newWriteIndexName = nextIndexAndGeneration.v1();
         final long newGeneration = nextIndexAndGeneration.v2();
-        MetadataCreateIndexService.validateIndexName(newWriteIndexName, currentState); // fails if the index already exists
+        MetadataCreateIndexService.validateIndexName(newWriteIndexName, metadata, currentState.routingTable()); // fails if the index
+                                                                                                                // already exists
         if (onlyValidate) {
             return new RolloverResult(newWriteIndexName, isLazyCreation ? NON_EXISTENT_SOURCE : originalWriteIndex.getName(), currentState);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadataStats;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataDataStreamsService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionMultiListener;
@@ -179,7 +180,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         );
         final String trialSourceIndexName = trialRolloverNames.sourceName();
         final String trialRolloverIndexName = trialRolloverNames.rolloverName();
-        MetadataRolloverService.validateIndexName(clusterState, trialRolloverIndexName);
+        MetadataCreateIndexService.validateIndexName(trialRolloverIndexName, metadata, clusterState.routingTable());
 
         boolean isDataStream = metadata.dataStreams().containsKey(rolloverRequest.getRolloverTarget());
         if (rolloverRequest.isLazy()) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -167,7 +167,7 @@ public class MetadataCreateIndexService {
     /**
      * Validate the name for an index against some static rules and a cluster state.
      */
-    public static void validateIndexName(String index, ClusterState state) {
+    public static void validateIndexName(String index, Metadata metadata, RoutingTable routingTable) {
         validateIndexOrAliasName(index, InvalidIndexNameException::new);
         if (index.toLowerCase(Locale.ROOT).equals(index) == false) {
             throw new InvalidIndexNameException(index, "must be lowercase");
@@ -175,13 +175,13 @@ public class MetadataCreateIndexService {
 
         // NOTE: dot-prefixed index names are validated after template application, not here
 
-        if (state.routingTable().hasIndex(index)) {
-            throw new ResourceAlreadyExistsException(state.routingTable().index(index).getIndex());
+        if (routingTable.hasIndex(index)) {
+            throw new ResourceAlreadyExistsException(routingTable.index(index).getIndex());
         }
-        if (state.metadata().hasIndex(index)) {
-            throw new ResourceAlreadyExistsException(state.metadata().index(index).getIndex());
+        if (metadata.hasIndex(index)) {
+            throw new ResourceAlreadyExistsException(metadata.index(index).getIndex());
         }
-        if (state.metadata().hasAlias(index)) {
+        if (metadata.hasAlias(index)) {
             throw new InvalidIndexNameException(index, "already exists as alias");
         }
     }
@@ -344,7 +344,7 @@ public class MetadataCreateIndexService {
         normalizeRequestSetting(request);
         logger.trace("executing IndexCreationTask for [{}] against cluster state version [{}]", request, currentState.version());
 
-        validate(request, currentState);
+        validate(request, currentState.metadata(), currentState.routingTable());
 
         final Index recoverFromIndex = request.recoverFrom();
         final IndexMetadata sourceMetadata = recoverFromIndex == null ? null : currentState.metadata().getIndexSafe(recoverFromIndex);
@@ -1069,7 +1069,9 @@ public class MetadataCreateIndexService {
         if (sourceMetadata != null) {
             assert request.resizeType() != null;
             prepareResizeIndexSettings(
-                currentState,
+                currentState.metadata(),
+                currentState.blocks(),
+                currentState.routingTable(),
                 indexSettingsBuilder,
                 request.recoverFrom(),
                 request.index(),
@@ -1084,7 +1086,7 @@ public class MetadataCreateIndexService {
          * We can not validate settings until we have applied templates, otherwise we do not know the actual settings
          * that will be used to create this index.
          */
-        shardLimitValidator.validateShardLimit(indexSettings, currentState);
+        shardLimitValidator.validateShardLimit(indexSettings, currentState.nodes(), currentState.metadata());
         validateSoftDeleteSettings(indexSettings);
         validateTranslogRetentionSettings(indexSettings);
         validateStoreTypeSetting(indexSettings);
@@ -1363,8 +1365,8 @@ public class MetadataCreateIndexService {
         }
     }
 
-    private void validate(CreateIndexClusterStateUpdateRequest request, ClusterState state) {
-        validateIndexName(request.index(), state);
+    private void validate(CreateIndexClusterStateUpdateRequest request, Metadata metadata, RoutingTable routingTable) {
+        validateIndexName(request.index(), metadata, routingTable);
         validateIndexSettings(request.index(), request.settings(), forbidPrivateIndexSettings);
     }
 
@@ -1428,8 +1430,15 @@ public class MetadataCreateIndexService {
      *
      * @return the list of nodes at least one instance of the source index shards are allocated
      */
-    static List<String> validateShrinkIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
-        IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
+    static List<String> validateShrinkIndex(
+        Metadata metadata,
+        ClusterBlocks clusterBlocks,
+        RoutingTable routingTable,
+        String sourceIndex,
+        String targetIndexName,
+        Settings targetIndexSettings
+    ) {
+        IndexMetadata sourceMetadata = validateResize(metadata, clusterBlocks, sourceIndex, targetIndexName, targetIndexSettings);
         if (sourceMetadata.isSearchableSnapshot()) {
             throw new IllegalArgumentException("can't shrink searchable snapshot index [" + sourceIndex + ']');
         }
@@ -1441,7 +1450,7 @@ public class MetadataCreateIndexService {
         }
 
         // now check that index is all on one node
-        final IndexRoutingTable table = state.routingTable().index(sourceIndex);
+        final IndexRoutingTable table = routingTable.index(sourceIndex);
         Map<String, AtomicInteger> nodesToNumRouting = new HashMap<>();
         int numShards = sourceMetadata.getNumberOfShards();
         for (ShardRouting routing : table.shardsWithState(ShardRoutingState.STARTED)) {
@@ -1461,16 +1470,28 @@ public class MetadataCreateIndexService {
         return nodesToAllocateOn;
     }
 
-    static void validateSplitIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
-        IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
+    static void validateSplitIndex(
+        Metadata metadata,
+        ClusterBlocks clusterBlocks,
+        String sourceIndex,
+        String targetIndexName,
+        Settings targetIndexSettings
+    ) {
+        IndexMetadata sourceMetadata = validateResize(metadata, clusterBlocks, sourceIndex, targetIndexName, targetIndexSettings);
         if (sourceMetadata.isSearchableSnapshot()) {
             throw new IllegalArgumentException("can't split searchable snapshot index [" + sourceIndex + ']');
         }
         IndexMetadata.selectSplitShard(0, sourceMetadata, INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings));
     }
 
-    static void validateCloneIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
-        IndexMetadata sourceMetadata = validateResize(state, sourceIndex, targetIndexName, targetIndexSettings);
+    static void validateCloneIndex(
+        Metadata metadata,
+        ClusterBlocks clusterBlocks,
+        String sourceIndex,
+        String targetIndexName,
+        Settings targetIndexSettings
+    ) {
+        IndexMetadata sourceMetadata = validateResize(metadata, clusterBlocks, sourceIndex, targetIndexName, targetIndexSettings);
         if (sourceMetadata.isSearchableSnapshot()) {
             for (Setting<?> nonCloneableSetting : Arrays.asList(INDEX_STORE_TYPE_SETTING, INDEX_RECOVERY_TYPE_SETTING)) {
                 if (nonCloneableSetting.exists(targetIndexSettings) == false) {
@@ -1487,16 +1508,22 @@ public class MetadataCreateIndexService {
         IndexMetadata.selectCloneShard(0, sourceMetadata, INDEX_NUMBER_OF_SHARDS_SETTING.get(targetIndexSettings));
     }
 
-    static IndexMetadata validateResize(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
-        if (state.metadata().hasIndex(targetIndexName)) {
-            throw new ResourceAlreadyExistsException(state.metadata().index(targetIndexName).getIndex());
+    static IndexMetadata validateResize(
+        Metadata metadata,
+        ClusterBlocks clusterBlocks,
+        String sourceIndex,
+        String targetIndexName,
+        Settings targetIndexSettings
+    ) {
+        if (metadata.hasIndex(targetIndexName)) {
+            throw new ResourceAlreadyExistsException(metadata.index(targetIndexName).getIndex());
         }
-        final IndexMetadata sourceMetadata = state.metadata().index(sourceIndex);
+        final IndexMetadata sourceMetadata = metadata.index(sourceIndex);
         if (sourceMetadata == null) {
             throw new IndexNotFoundException(sourceIndex);
         }
 
-        IndexAbstraction source = state.metadata().getIndicesLookup().get(sourceIndex);
+        IndexAbstraction source = metadata.getIndicesLookup().get(sourceIndex);
         assert source != null;
         if (source.getParentDataStream() != null && source.getParentDataStream().getWriteIndex().equals(sourceMetadata.getIndex())) {
             throw new IllegalArgumentException(
@@ -1509,7 +1536,7 @@ public class MetadataCreateIndexService {
             );
         }
         // ensure index is read-only
-        if (state.blocks().indexBlocked(ClusterBlockLevel.WRITE, sourceIndex) == false) {
+        if (clusterBlocks.indexBlocked(ClusterBlockLevel.WRITE, sourceIndex) == false) {
             throw new IllegalStateException("index " + sourceIndex + " must be read-only to resize index. use \"index.blocks.write=true\"");
         }
 
@@ -1522,7 +1549,9 @@ public class MetadataCreateIndexService {
     }
 
     static void prepareResizeIndexSettings(
-        final ClusterState currentState,
+        final Metadata metadata,
+        final ClusterBlocks clusterBlocks,
+        final RoutingTable routingTable,
         final Settings.Builder indexSettingsBuilder,
         final Index resizeSourceIndex,
         final String resizeIntoName,
@@ -1530,20 +1559,22 @@ public class MetadataCreateIndexService {
         final boolean copySettings,
         final IndexScopedSettings indexScopedSettings
     ) {
-        final IndexMetadata sourceMetadata = currentState.metadata().index(resizeSourceIndex.getName());
+        final IndexMetadata sourceMetadata = metadata.index(resizeSourceIndex.getName());
         if (type == ResizeType.SHRINK) {
             final List<String> nodesToAllocateOn = validateShrinkIndex(
-                currentState,
+                metadata,
+                clusterBlocks,
+                routingTable,
                 resizeSourceIndex.getName(),
                 resizeIntoName,
                 indexSettingsBuilder.build()
             );
             indexSettingsBuilder.put(INDEX_SHRINK_INITIAL_RECOVERY_KEY, Strings.arrayToCommaDelimitedString(nodesToAllocateOn.toArray()));
         } else if (type == ResizeType.SPLIT) {
-            validateSplitIndex(currentState, resizeSourceIndex.getName(), resizeIntoName, indexSettingsBuilder.build());
+            validateSplitIndex(metadata, clusterBlocks, resizeSourceIndex.getName(), resizeIntoName, indexSettingsBuilder.build());
             indexSettingsBuilder.putNull(INDEX_SHRINK_INITIAL_RECOVERY_KEY);
         } else if (type == ResizeType.CLONE) {
-            validateCloneIndex(currentState, resizeSourceIndex.getName(), resizeIntoName, indexSettingsBuilder.build());
+            validateCloneIndex(metadata, clusterBlocks, resizeSourceIndex.getName(), resizeIntoName, indexSettingsBuilder.build());
             indexSettingsBuilder.putNull(INDEX_SHRINK_INITIAL_RECOVERY_KEY);
         } else {
             throw new IllegalStateException("unknown resize type is " + type);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1100,7 +1100,7 @@ public class MetadataIndexStateService {
                 }
             }
 
-            shardLimitValidator.validateShardLimit(currentState, indices);
+            shardLimitValidator.validateShardLimit(currentState.nodes(), currentState.metadata(), indices);
             if (indicesToOpen.isEmpty()) {
                 return currentState;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -255,7 +255,12 @@ public class MetadataUpdateSettingsService {
                 final int updatedNumberOfReplicas = IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(openSettings);
                 if (preserveExisting == false) {
                     // Verify that this won't take us over the cluster shard limit.
-                    shardLimitValidator.validateShardLimitOnReplicaUpdate(currentState, request.indices(), updatedNumberOfReplicas);
+                    shardLimitValidator.validateShardLimitOnReplicaUpdate(
+                        currentState.nodes(),
+                        currentState.metadata(),
+                        request.indices(),
+                        updatedNumberOfReplicas
+                    );
 
                     /*
                      * We do not update the in-sync allocation IDs as they will be removed upon the first index operation

--- a/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.health.node;
 
-import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Setting;
@@ -124,8 +125,18 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
         var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
         return mergeIndicators(
             verbose,
-            calculateFrom(shardLimitsMetadata.maxShardsPerNode(), state, ShardLimitValidator::checkShardLimitForNormalNodes),
-            calculateFrom(shardLimitsMetadata.maxShardsPerNodeFrozen(), state, ShardLimitValidator::checkShardLimitForFrozenNodes)
+            calculateFrom(
+                shardLimitsMetadata.maxShardsPerNode(),
+                state.nodes(),
+                state.metadata(),
+                ShardLimitValidator::checkShardLimitForNormalNodes
+            ),
+            calculateFrom(
+                shardLimitsMetadata.maxShardsPerNodeFrozen(),
+                state.nodes(),
+                state.metadata(),
+                ShardLimitValidator::checkShardLimitForFrozenNodes
+            )
         );
     }
 
@@ -173,13 +184,18 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
         );
     }
 
-    static StatusResult calculateFrom(int maxShardsPerNodeSetting, ClusterState state, ShardsCapacityChecker checker) {
-        var result = checker.check(maxShardsPerNodeSetting, 5, 1, state);
+    static StatusResult calculateFrom(
+        int maxShardsPerNodeSetting,
+        DiscoveryNodes discoveryNodes,
+        Metadata metadata,
+        ShardsCapacityChecker checker
+    ) {
+        var result = checker.check(maxShardsPerNodeSetting, 5, 1, discoveryNodes, metadata);
         if (result.canAddShards() == false) {
             return new StatusResult(HealthStatus.RED, result);
         }
 
-        result = checker.check(maxShardsPerNodeSetting, 10, 1, state);
+        result = checker.check(maxShardsPerNodeSetting, 10, 1, discoveryNodes, metadata);
         if (result.canAddShards() == false) {
             return new StatusResult(HealthStatus.YELLOW, result);
         }
@@ -225,6 +241,12 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
 
     @FunctionalInterface
     interface ShardsCapacityChecker {
-        ShardLimitValidator.Result check(int maxConfiguredShardsPerNode, int numberOfNewShards, int replicas, ClusterState state);
+        ShardLimitValidator.Result check(
+            int maxConfiguredShardsPerNode,
+            int numberOfNewShards,
+            int replicas,
+            DiscoveryNodes discoveryNodes,
+            Metadata metadata
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -8,10 +8,11 @@
 
 package org.elasticsearch.indices;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.ValidationException;
@@ -95,16 +96,22 @@ public class ShardLimitValidator {
      * Checks whether an index can be created without going over the cluster shard limit.
      *
      * @param settings       the settings of the index to be created
-     * @param state          the current cluster state
+     * @param discoveryNodes the nodes in the cluster
+     * @param metadata       the cluster state metadata
      * @throws ValidationException if creating this index would put the cluster over the cluster shard limit
      */
-    public void validateShardLimit(final Settings settings, final ClusterState state) {
+    public void validateShardLimit(final Settings settings, final DiscoveryNodes discoveryNodes, final Metadata metadata) {
         final int numberOfShards = INDEX_NUMBER_OF_SHARDS_SETTING.get(settings);
         final int numberOfReplicas = IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings);
         final int shardsToCreate = numberOfShards * (1 + numberOfReplicas);
         final boolean frozen = FROZEN_GROUP.equals(INDEX_SETTING_SHARD_LIMIT_GROUP.get(settings));
 
-        final var result = checkShardLimitOnBothGroups(frozen == false ? shardsToCreate : 0, frozen ? shardsToCreate : 0, state);
+        final var result = checkShardLimitOnBothGroups(
+            frozen == false ? shardsToCreate : 0,
+            frozen ? shardsToCreate : 0,
+            discoveryNodes,
+            metadata
+        );
         if (result.canAddShards == false) {
             final ValidationException e = new ValidationException();
             e.addValidationError(errorMessageFrom(result));
@@ -116,15 +123,16 @@ public class ShardLimitValidator {
      * Validates whether a list of indices can be opened without going over the cluster shard limit.  Only counts indices which are
      * currently closed and will be opened, ignores indices which are already open.
      *
-     * @param currentState The current cluster state.
-     * @param indicesToOpen The indices which are to be opened.
+     * @param discoveryNodes The nodes in the cluster
+     * @param metadata       The cluster state metadata
+     * @param indicesToOpen  The indices which are to be opened.
      * @throws ValidationException If this operation would take the cluster over the limit and enforcement is enabled.
      */
-    public void validateShardLimit(ClusterState currentState, Index[] indicesToOpen) {
+    public void validateShardLimit(DiscoveryNodes discoveryNodes, Metadata metadata, Index[] indicesToOpen) {
         int frozen = 0;
         int normal = 0;
         for (Index index : indicesToOpen) {
-            IndexMetadata imd = currentState.metadata().index(index);
+            IndexMetadata imd = metadata.index(index);
             if (imd.getState().equals(IndexMetadata.State.CLOSE)) {
                 int totalNewShards = imd.getNumberOfShards() * (1 + imd.getNumberOfReplicas());
                 if (FROZEN_GROUP.equals(INDEX_SETTING_SHARD_LIMIT_GROUP.get(imd.getSettings()))) {
@@ -135,7 +143,7 @@ public class ShardLimitValidator {
             }
         }
 
-        var result = checkShardLimitOnBothGroups(normal, frozen, currentState);
+        var result = checkShardLimitOnBothGroups(normal, frozen, discoveryNodes, metadata);
         if (result.canAddShards == false) {
             ValidationException ex = new ValidationException();
             ex.addValidationError(errorMessageFrom(result));
@@ -143,12 +151,12 @@ public class ShardLimitValidator {
         }
     }
 
-    public void validateShardLimitOnReplicaUpdate(ClusterState currentState, Index[] indices, int replicas) {
+    public void validateShardLimitOnReplicaUpdate(DiscoveryNodes discoveryNodes, Metadata metadata, Index[] indices, int replicas) {
         int frozen = 0;
         int normal = 0;
         for (Index index : indices) {
-            IndexMetadata imd = currentState.metadata().index(index);
-            int totalNewShards = getTotalNewShards(index, currentState, replicas);
+            IndexMetadata imd = metadata.index(index);
+            int totalNewShards = getTotalNewShards(index, metadata, replicas);
             if (FROZEN_GROUP.equals(INDEX_SETTING_SHARD_LIMIT_GROUP.get(imd.getSettings()))) {
                 frozen += totalNewShards;
             } else {
@@ -156,7 +164,7 @@ public class ShardLimitValidator {
             }
         }
 
-        var result = checkShardLimitOnBothGroups(normal, frozen, currentState);
+        var result = checkShardLimitOnBothGroups(normal, frozen, discoveryNodes, metadata);
         if (result.canAddShards == false) {
             ValidationException ex = new ValidationException();
             ex.addValidationError(errorMessageFrom(result));
@@ -164,8 +172,8 @@ public class ShardLimitValidator {
         }
     }
 
-    private static int getTotalNewShards(Index index, ClusterState currentState, int updatedNumberOfReplicas) {
-        IndexMetadata indexMetadata = currentState.metadata().index(index);
+    private static int getTotalNewShards(Index index, Metadata metadata, int updatedNumberOfReplicas) {
+        IndexMetadata indexMetadata = metadata.index(index);
         int shardsInIndex = indexMetadata.getNumberOfShards();
         int oldNumberOfReplicas = indexMetadata.getNumberOfReplicas();
         int replicaIncrease = updatedNumberOfReplicas - oldNumberOfReplicas;
@@ -181,21 +189,22 @@ public class ShardLimitValidator {
      *
      * @param newShards       The number of normal shards to be added by this operation
      * @param newFrozenShards The number of frozen shards to be added by this operation
-     * @param state           The current cluster state
+     * @param discoveryNodes  The nodes in the cluster
+     * @param metadata        The cluster state metadata
      */
-    private Result checkShardLimitOnBothGroups(int newShards, int newFrozenShards, ClusterState state) {
+    private Result checkShardLimitOnBothGroups(int newShards, int newFrozenShards, DiscoveryNodes discoveryNodes, Metadata metadata) {
         // we verify the two limits independently. This also means that if they have mixed frozen and other data-roles nodes, such a mixed
         // node can have both 1000 normal and 3000 frozen shards. This is the trade-off to keep the simplicity of the counts. We advocate
         // against such mixed nodes for production use anyway.
-        int frozenNodeCount = nodeCount(state, ShardLimitValidator::hasFrozen);
-        int normalNodeCount = nodeCount(state, ShardLimitValidator::hasNonFrozen);
+        int frozenNodeCount = nodeCount(discoveryNodes, ShardLimitValidator::hasFrozen);
+        int normalNodeCount = nodeCount(discoveryNodes, ShardLimitValidator::hasNonFrozen);
 
-        var result = checkShardLimit(newShards, state, getShardLimitPerNode(), normalNodeCount, NORMAL_GROUP);
+        var result = checkShardLimit(newShards, metadata, getShardLimitPerNode(), normalNodeCount, NORMAL_GROUP);
         // fail-fast: in case there's no room on the `normal` nodes, just return the result of that check.
         if (result.canAddShards() == false) {
             return result;
         }
-        return checkShardLimit(newFrozenShards, state, shardLimitPerNodeFrozen.get(), frozenNodeCount, FROZEN_GROUP);
+        return checkShardLimit(newFrozenShards, metadata, shardLimitPerNodeFrozen.get(), frozenNodeCount, FROZEN_GROUP);
     }
 
     /**
@@ -205,20 +214,21 @@ public class ShardLimitValidator {
      * @param maxConfiguredShardsPerNode The maximum available number of shards to be allocated within a node
      * @param numberOfNewShards          The number of primary shards that we want to be able to add to the cluster
      * @param replicas                   The number of replicas of the primary shards that we want to be able to add to the cluster
-     * @param state                      The cluster state, used to get cluster settings and to get the number of open shards already in
-     *                                   the cluster
+     * @param discoveryNodes             The nodes in the cluster, used to get the number of open shard already in the cluster
+     * @param metadata                   The cluster state metadata, used to get the cluster settings
      */
     public static Result checkShardLimitForNormalNodes(
         int maxConfiguredShardsPerNode,
         int numberOfNewShards,
         int replicas,
-        ClusterState state
+        DiscoveryNodes discoveryNodes,
+        Metadata metadata
     ) {
         return checkShardLimit(
             numberOfNewShards * (1 + replicas),
-            state,
+            metadata,
             maxConfiguredShardsPerNode,
-            nodeCount(state, ShardLimitValidator::hasNonFrozen),
+            nodeCount(discoveryNodes, ShardLimitValidator::hasNonFrozen),
             NORMAL_GROUP
         );
     }
@@ -230,27 +240,28 @@ public class ShardLimitValidator {
      * @param maxConfiguredShardsPerNode The maximum available number of shards to be allocated within a node
      * @param numberOfNewShards          The number of primary shards that we want to be able to add to the cluster
      * @param replicas                   The number of replicas of the primary shards that we want to be able to add to the cluster
-     * @param state                      The cluster state, used to get cluster settings and to get the number of open shards already in
-     *                                   the cluster
+     * @param discoveryNodes             The nodes in the cluster, used to get the number of open shard already in the cluster
+     * @param metadata                   The cluster state metadata, used to get the cluster settings
      */
     public static Result checkShardLimitForFrozenNodes(
         int maxConfiguredShardsPerNode,
         int numberOfNewShards,
         int replicas,
-        ClusterState state
+        DiscoveryNodes discoveryNodes,
+        Metadata metadata
     ) {
         return checkShardLimit(
             numberOfNewShards * (1 + replicas),
-            state,
+            metadata,
             maxConfiguredShardsPerNode,
-            nodeCount(state, ShardLimitValidator::hasFrozen),
+            nodeCount(discoveryNodes, ShardLimitValidator::hasFrozen),
             FROZEN_GROUP
         );
     }
 
-    private static Result checkShardLimit(int newShards, ClusterState state, int maxConfiguredShardsPerNode, int nodeCount, String group) {
+    private static Result checkShardLimit(int newShards, Metadata metadata, int maxConfiguredShardsPerNode, int nodeCount, String group) {
         int maxShardsInCluster = maxConfiguredShardsPerNode * nodeCount;
-        int currentOpenShards = state.getMetadata().getTotalOpenIndexShards();
+        int currentOpenShards = metadata.getTotalOpenIndexShards();
 
         // Only enforce the shard limit if we have at least one data node, so that we don't block
         // index creation during cluster setup
@@ -261,8 +272,7 @@ public class ShardLimitValidator {
         if ((currentOpenShards + newShards) > maxShardsInCluster) {
             Predicate<IndexMetadata> indexMetadataPredicate = imd -> imd.getState().equals(IndexMetadata.State.OPEN)
                 && group.equals(INDEX_SETTING_SHARD_LIMIT_GROUP.get(imd.getSettings()));
-            long currentFilteredShards = state.metadata()
-                .indices()
+            long currentFilteredShards = metadata.indices()
                 .values()
                 .stream()
                 .filter(indexMetadataPredicate)
@@ -276,8 +286,8 @@ public class ShardLimitValidator {
         return new Result(true, Optional.empty(), newShards, maxShardsInCluster, group);
     }
 
-    private static int nodeCount(ClusterState state, Predicate<DiscoveryNode> nodePredicate) {
-        return (int) state.getNodes().getDataNodes().values().stream().filter(nodePredicate).count();
+    private static int nodeCount(DiscoveryNodes discoveryNodes, Predicate<DiscoveryNode> nodePredicate) {
+        return (int) discoveryNodes.getDataNodes().values().stream().filter(nodePredicate).count();
     }
 
     private static boolean hasFrozen(DiscoveryNode node) {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -1343,7 +1343,7 @@ public final class RestoreService implements ClusterStateApplier {
                 if (currentIndexMetadata == null) {
                     // Index doesn't exist - create it and start recovery
                     // Make sure that the index we are about to create has a valid name
-                    ensureValidIndexName(currentState, snapshotIndexMetadata, renamedIndexName);
+                    ensureValidIndexName(currentState.metadata(), currentState.routingTable(), snapshotIndexMetadata, renamedIndexName);
                     shardLimitValidator.validateShardLimit(
                         snapshotIndexMetadata.getSettings(),
                         currentState.nodes(),
@@ -1793,9 +1793,14 @@ public final class RestoreService implements ClusterStateApplier {
         return indexMdBuilder;
     }
 
-    private void ensureValidIndexName(ClusterState currentState, IndexMetadata snapshotIndexMetadata, String renamedIndexName) {
+    private void ensureValidIndexName(
+        Metadata metadata,
+        RoutingTable routingTable,
+        IndexMetadata snapshotIndexMetadata,
+        String renamedIndexName
+    ) {
         final boolean isHidden = snapshotIndexMetadata.isHidden();
-        MetadataCreateIndexService.validateIndexName(renamedIndexName, currentState);
+        MetadataCreateIndexService.validateIndexName(renamedIndexName, metadata, routingTable);
         createIndexService.validateDotIndex(renamedIndexName, isHidden);
         createIndexService.validateIndexSettings(renamedIndexName, snapshotIndexMetadata.getSettings(), false);
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -1344,7 +1344,11 @@ public final class RestoreService implements ClusterStateApplier {
                     // Index doesn't exist - create it and start recovery
                     // Make sure that the index we are about to create has a valid name
                     ensureValidIndexName(currentState, snapshotIndexMetadata, renamedIndexName);
-                    shardLimitValidator.validateShardLimit(snapshotIndexMetadata.getSettings(), currentState);
+                    shardLimitValidator.validateShardLimit(
+                        snapshotIndexMetadata.getSettings(),
+                        currentState.nodes(),
+                        currentState.metadata()
+                    );
 
                     final IndexMetadata.Builder indexMdBuilder = restoreToCreateNewIndex(
                         snapshotIndexMetadata,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1421,6 +1421,6 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
     }
 
     private void validateSplitIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
-        MetadataCreateIndexService.validateSplitIndex(state.metadata(), state.blocks(), "target", "source", targetIndexSettings);
+        MetadataCreateIndexService.validateSplitIndex(state.metadata(), state.blocks(), sourceIndex, targetIndexName, targetIndexSettings);
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -170,18 +170,14 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
 
         assertEquals(
             "index [source] already exists",
-            expectThrows(
-                ResourceAlreadyExistsException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(state, "target", "source", Settings.EMPTY)
-            ).getMessage()
+            expectThrows(ResourceAlreadyExistsException.class, () -> validateShrinkIndex(state, "target", "source", Settings.EMPTY))
+                .getMessage()
         );
 
         assertEquals(
             "no such index [no_such_index]",
-            expectThrows(
-                IndexNotFoundException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(state, "no_such_index", "target", Settings.EMPTY)
-            ).getMessage()
+            expectThrows(IndexNotFoundException.class, () -> validateShrinkIndex(state, "no_such_index", "target", Settings.EMPTY))
+                .getMessage()
         );
 
         Settings targetSettings = Settings.builder().put("index.number_of_shards", 1).build();
@@ -189,7 +185,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "can't shrink an index with only one shard",
             expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(
+                () -> validateShrinkIndex(
                     createClusterState("source", 1, 0, Settings.builder().put("index.blocks.write", true).build()),
                     "source",
                     "target",
@@ -202,7 +198,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "the number of target shards [10] must be less that the number of source shards [5]",
             expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(
+                () -> validateShrinkIndex(
                     createClusterState("source", 5, 0, Settings.builder().put("index.blocks.write", true).build()),
                     "source",
                     "target",
@@ -215,7 +211,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "index source must be read-only to resize index. use \"index.blocks.write=true\"",
             expectThrows(
                 IllegalStateException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(
+                () -> validateShrinkIndex(
                     createClusterState("source", randomIntBetween(2, 100), randomIntBetween(0, 10), Settings.EMPTY),
                     "source",
                     "target",
@@ -228,7 +224,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "index source must have all shards allocated on the same node to shrink index",
             expectThrows(
                 IllegalStateException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(state, "source", "target", targetSettings)
+                () -> validateShrinkIndex(state, "source", "target", targetSettings)
 
             ).getMessage()
         );
@@ -236,7 +232,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "the number of source shards [8] must be a multiple of [3]",
             expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataCreateIndexService.validateShrinkIndex(
+                () -> validateShrinkIndex(
                     createClusterState("source", 8, randomIntBetween(0, 10), Settings.builder().put("index.blocks.write", true).build()),
                     "source",
                     "target",
@@ -267,12 +263,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         do {
             targetShards = randomIntBetween(1, numShards / 2);
         } while (isShrinkable(numShards, targetShards) == false);
-        MetadataCreateIndexService.validateShrinkIndex(
-            clusterState,
-            "source",
-            "target",
-            Settings.builder().put("index.number_of_shards", targetShards).build()
-        );
+        validateShrinkIndex(clusterState, "source", "target", Settings.builder().put("index.number_of_shards", targetShards).build());
     }
 
     public void testValidateSplitIndex() {
@@ -287,25 +278,21 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
 
         assertEquals(
             "index [source] already exists",
-            expectThrows(
-                ResourceAlreadyExistsException.class,
-                () -> MetadataCreateIndexService.validateSplitIndex(state, "target", "source", targetSettings)
-            ).getMessage()
+            expectThrows(ResourceAlreadyExistsException.class, () -> validateSplitIndex(state, "target", "source", targetSettings))
+                .getMessage()
         );
 
         assertEquals(
             "no such index [no_such_index]",
-            expectThrows(
-                IndexNotFoundException.class,
-                () -> MetadataCreateIndexService.validateSplitIndex(state, "no_such_index", "target", targetSettings)
-            ).getMessage()
+            expectThrows(IndexNotFoundException.class, () -> validateSplitIndex(state, "no_such_index", "target", targetSettings))
+                .getMessage()
         );
 
         assertEquals(
             "the number of source shards [10] must be less that the number of target shards [5]",
             expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataCreateIndexService.validateSplitIndex(
+                () -> validateSplitIndex(
                     createClusterState("source", 10, 0, Settings.builder().put("index.blocks.write", true).build()),
                     "source",
                     "target",
@@ -318,7 +305,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "index source must be read-only to resize index. use \"index.blocks.write=true\"",
             expectThrows(
                 IllegalStateException.class,
-                () -> MetadataCreateIndexService.validateSplitIndex(
+                () -> validateSplitIndex(
                     createClusterState("source", randomIntBetween(2, 100), randomIntBetween(0, 10), Settings.EMPTY),
                     "source",
                     "target",
@@ -331,7 +318,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             "the number of source shards [3] must be a factor of [4]",
             expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataCreateIndexService.validateSplitIndex(
+                () -> validateSplitIndex(
                     createClusterState("source", 3, randomIntBetween(0, 10), Settings.builder().put("index.blocks.write", true).build()),
                     "source",
                     "target",
@@ -367,12 +354,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         routingTable = ESAllocationTestCase.startInitializingShardsAndReroute(service, clusterState, "source").routingTable();
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
 
-        MetadataCreateIndexService.validateSplitIndex(
-            clusterState,
-            "source",
-            "target",
-            Settings.builder().put("index.number_of_shards", targetShards).build()
-        );
+        validateSplitIndex(clusterState, "source", "target", Settings.builder().put("index.number_of_shards", targetShards).build());
     }
 
     public void testPrepareResizeIndexSettings() {
@@ -528,7 +510,9 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             additionalIndexScopedSettings.stream()
         ).collect(Collectors.toSet());
         MetadataCreateIndexService.prepareResizeIndexSettings(
-            clusterState,
+            clusterState.metadata(),
+            clusterState.blocks(),
+            clusterState.routingTable(),
             indexSettingsBuilder,
             clusterState.metadata().index(indexName).getIndex(),
             "target",
@@ -576,9 +560,10 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
     }
 
     private static void validateIndexName(MetadataCreateIndexService metadataCreateIndexService, String indexName, String errorMessage) {
+        ClusterState state = ClusterState.builder(ClusterName.DEFAULT).build();
         InvalidIndexNameException e = expectThrows(
             InvalidIndexNameException.class,
-            () -> MetadataCreateIndexService.validateIndexName(indexName, ClusterState.builder(ClusterName.DEFAULT).build())
+            () -> MetadataCreateIndexService.validateIndexName(indexName, state.metadata(), state.routingTable())
         );
         assertThat(e.getMessage(), endsWith(errorMessage));
     }
@@ -1422,5 +1407,20 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         } finally {
             threadPool.shutdown();
         }
+    }
+
+    private List<String> validateShrinkIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
+        return MetadataCreateIndexService.validateShrinkIndex(
+            state.metadata(),
+            state.blocks(),
+            state.routingTable(),
+            sourceIndex,
+            targetIndexName,
+            targetIndexSettings
+        );
+    }
+
+    private void validateSplitIndex(ClusterState state, String sourceIndex, String targetIndexName, Settings targetIndexSettings) {
+        MetadataCreateIndexService.validateSplitIndex(state.metadata(), state.blocks(), "target", "source", targetIndexSettings);
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -168,11 +168,11 @@ public class ShardLimitValidatorTests extends ESTestCase {
 
         final Index[] indices = getIndices(state);
         final ShardLimitValidator shardLimitValidator = createTestShardLimitService(shardsPerNode, group);
-        shardLimitValidator.validateShardLimitOnReplicaUpdate(state, indices, nodesInCluster - 1);
+        shardLimitValidator.validateShardLimitOnReplicaUpdate(state.nodes(), state.metadata(), indices, nodesInCluster - 1);
 
         ValidationException exception = expectThrows(
             ValidationException.class,
-            () -> shardLimitValidator.validateShardLimitOnReplicaUpdate(state, indices, nodesInCluster)
+            () -> shardLimitValidator.validateShardLimitOnReplicaUpdate(state.nodes(), state.metadata(), indices, nodesInCluster)
         );
         assertEquals(
             "Validation Failed: 1: this action would add ["

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -267,7 +267,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             return;
         }
         try {
-            MetadataCreateIndexService.validateIndexName(downsampleIndexName, state);
+            MetadataCreateIndexService.validateIndexName(downsampleIndexName, state.metadata(), state.routingTable());
         } catch (ResourceAlreadyExistsException e) {
             // ignore index already exists
         }


### PR DESCRIPTION
Avoids the `ClusterState` type as a method parameter in favor of the more specific `Metadata`, `RoutingTable`, and `ClusterBlocks` ones.
