### PR TITLE
Fix tests in LegacyGeoShapeWithDocValuesQueryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -176,9 +176,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/112421
 - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
   issue: https://github.com/elastic/elasticsearch/issues/112423
-- class: org.elasticsearch.xpack.spatial.index.query.LegacyGeoShapeWithDocValuesQueryTests
-  method: testIndexPointsFromLine
-  issue: https://github.com/elastic/elasticsearch/issues/112438
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
   method: "testAggregateIntermediate {TestCase=<geo_point> #2}"
   issue: https://github.com/elastic/elasticsearch/issues/112461

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -185,9 +185,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.external.http.RequestBasedTaskRunnerTests
   method: testLoopOneAtATime
   issue: https://github.com/elastic/elasticsearch/issues/112471
-- class: org.elasticsearch.xpack.spatial.index.query.LegacyGeoShapeWithDocValuesQueryTests
-  method: testIndexPointsFromPolygon
-  issue: https://github.com/elastic/elasticsearch/issues/112464
 
 # Examples:
 #

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -219,5 +220,18 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
             .get();
 
         assertHitCount(client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)), 1L);
+    }
+
+    protected boolean ignoreLons(double[] lons) {
+        return Arrays.stream(lons).anyMatch(v -> v == 180);
+    }
+
+    public void testIndexPointsFromLine() throws Exception {
+        super.testIndexPointsFromLine();
+    }
+
+    @Override
+    public void testIndexPointsFromPolygon() throws Exception {
+        super.testIndexPointsFromPolygon();
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -225,13 +225,4 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
     protected boolean ignoreLons(double[] lons) {
         return Arrays.stream(lons).anyMatch(v -> v == 180);
     }
-
-    public void testIndexPointsFromLine() throws Exception {
-        super.testIndexPointsFromLine();
-    }
-
-    @Override
-    public void testIndexPointsFromPolygon() throws Exception {
-        super.testIndexPointsFromPolygon();
-    }
 }


### PR DESCRIPTION
Similar to what we did in https://github.com/elastic/elasticsearch/issues/86118, lets filter out points with longitude 180.

fixes https://github.com/elastic/elasticsearch/issues/112464
fixes https://github.com/elastic/elasticsearch/issues/112438

