### PR TITLE
ES|QL: Fix #112117 by skipping tests in v < 8.14

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -128,12 +128,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJobAfterMissingIndex
   issue: https://github.com/elastic/elasticsearch/issues/112088
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {stats.ByTwoCalculatedSecondOverwrites SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/112117
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {stats.ByTwoCalculatedSecondOverwritesReferencingFirst SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/112118
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/preview_transforms/Test preview transform latest}
   issue: https://github.com/elastic/elasticsearch/issues/112144

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1618,7 +1618,7 @@ m:i | o:i   | l:i | s:i
 1   | 39729 | 1   | 39729
 ;
 
-byTwoCalculatedSecondOverwrites
+byTwoCalculatedSecondSameNameAsFirst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS m = MAX(salary) by l = salary + 1, l = languages + 1
 | SORT m
@@ -1633,7 +1633,7 @@ FROM employees
 74970 | 4
 ;
 
-byTwoCalculatedSecondOverwritesReferencingFirst
+byTwoCalculatedSecondShadowingAndReferencingFirst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | EVAL l = languages
 | STATS m = MAX(salary) by l = l + 1, l = l + 1


### PR DESCRIPTION
Skipping some tests in v < 8.14 because of missing syntax in previous versions.
Other tests with the same syntax (right above these two) have the same skip

Fixes https://github.com/elastic/elasticsearch/issues/112117
Fixes https://github.com/elastic/elasticsearch/issues/112118