### PR TITLE
Rework fix for stale data in synthetic source to improve performance

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoader.java
@@ -14,10 +14,8 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.stream.Stream;
 
-public abstract class BinaryDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+public abstract class BinaryDocValuesSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
     private final String name;
     private BinaryDocValues values;
     private boolean hasValue;
@@ -27,11 +25,6 @@ public abstract class BinaryDocValuesSyntheticFieldLoader implements SourceLoade
     }
 
     protected abstract void writeValue(XContentBuilder b, BytesRef value) throws IOException;
-
-    @Override
-    public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        return Stream.of();
-    }
 
     @Override
     public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
@@ -51,12 +51,6 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
     public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
         return parts.stream().flatMap(Layer::storedFieldLoaders).map(e -> Map.entry(e.getKey(), new StoredFieldLoader() {
             @Override
-            public void advanceToDoc(int docId) {
-                storedFieldLoadersHaveValues = false;
-                e.getValue().advanceToDoc(docId);
-            }
-
-            @Override
             public void load(List<Object> newValues) {
                 storedFieldLoadersHaveValues = true;
                 e.getValue().load(newValues);
@@ -79,8 +73,6 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
         }
 
         return docId -> {
-            this.docValuesLoadersHaveValues = false;
-
             boolean hasDocs = false;
             for (var loader : loaders) {
                 hasDocs |= loader.advanceToDoc(docId);
@@ -117,6 +109,18 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
             part.write(b);
         }
         b.endArray();
+        softReset();
+    }
+
+    private void softReset() {
+        storedFieldLoadersHaveValues = false;
+        docValuesLoadersHaveValues = false;
+    }
+
+    @Override
+    public void reset() {
+        softReset();
+        parts.forEach(SourceLoader.SyntheticFieldLoader::reset);
     }
 
     @Override
@@ -137,6 +141,19 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
          * @return
          */
         long valueCount();
+    }
+
+    public interface DocValuesLayer extends Layer {
+        @Override
+        default Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+            return Stream.empty();
+        }
+
+        @Override
+        default void reset() {
+            // Not applicable to loaders using only doc values
+            // since DocValuesLoader#advanceToDoc will reset the state anyway.
+        }
     }
 
     /**
@@ -177,17 +194,7 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
 
         @Override
         public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of(Map.entry(fieldName, new SourceLoader.SyntheticFieldLoader.StoredFieldLoader() {
-                @Override
-                public void advanceToDoc(int docId) {
-                    values = emptyList();
-                }
-
-                @Override
-                public void load(List<Object> newValues) {
-                    values = newValues;
-                }
-            }));
+            return Stream.of(Map.entry(fieldName, newValues -> values = newValues));
         }
 
         @Override
@@ -205,6 +212,12 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
             for (Object v : values) {
                 writeValue(v, b);
             }
+            reset();
+        }
+
+        @Override
+        public void reset() {
+            values = emptyList();
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocCountFieldMapper.java
@@ -20,8 +20,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
-import java.util.stream.Stream;
 
 /** Mapper for the doc_count field. */
 public class DocCountFieldMapper extends MetadataFieldMapper {
@@ -139,14 +137,9 @@ public class DocCountFieldMapper extends MetadataFieldMapper {
         return reader.postings(TERM);
     }
 
-    private static class SyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+    private static class SyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
         private PostingsEnum postings;
         private boolean hasValue;
-
-        @Override
-        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.empty();
-        }
 
         @Override
         public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -79,6 +79,8 @@ public abstract class IgnoreMalformedStoredValues {
      */
     public abstract void write(XContentBuilder b) throws IOException;
 
+    public abstract void reset();
+
     private static final Empty EMPTY = new Empty();
 
     private static class Empty extends IgnoreMalformedStoredValues {
@@ -94,6 +96,9 @@ public abstract class IgnoreMalformedStoredValues {
 
         @Override
         public void write(XContentBuilder b) throws IOException {}
+
+        @Override
+        public void reset() {}
     }
 
     private static class Stored extends IgnoreMalformedStoredValues {
@@ -107,17 +112,7 @@ public abstract class IgnoreMalformedStoredValues {
 
         @Override
         public Stream<Map.Entry<String, SourceLoader.SyntheticFieldLoader.StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of(Map.entry(name(fieldName), new SourceLoader.SyntheticFieldLoader.StoredFieldLoader() {
-                @Override
-                public void advanceToDoc(int docId) {
-                    values = emptyList();
-                }
-
-                @Override
-                public void load(List<Object> newValues) {
-                    values = newValues;
-                }
-            }));
+            return Stream.of(Map.entry(name(fieldName), newValues -> values = newValues));
         }
 
         @Override
@@ -134,6 +129,11 @@ public abstract class IgnoreMalformedStoredValues {
                     b.value(v);
                 }
             }
+            reset();
+        }
+
+        @Override
+        public void reset() {
             values = emptyList();
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -79,6 +79,9 @@ public abstract class IgnoreMalformedStoredValues {
      */
     public abstract void write(XContentBuilder b) throws IOException;
 
+    /**
+     * Remove stored values for this document and return to clean state to process next document.
+     */
     public abstract void reset();
 
     private static final Empty EMPTY = new Empty();

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.index.mapper.SourceFieldMetrics.NOOP;
 
@@ -393,7 +392,7 @@ public class NestedObjectMapper extends ObjectMapper {
         );
     }
 
-    private class NestedSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+    private class NestedSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
         private final org.elasticsearch.index.fieldvisitor.StoredFieldLoader storedFieldLoader;
         private final SourceLoader sourceLoader;
         private final Supplier<BitSetProducer> parentBitSetProducer;
@@ -413,11 +412,6 @@ public class NestedObjectMapper extends ObjectMapper {
             this.sourceLoader = sourceLoader;
             this.parentBitSetProducer = parentBitSetProducer;
             this.childFilter = childFilter;
-        }
-
-        @Override
-        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
@@ -107,6 +107,11 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
         }
     }
 
+    @Override
+    public void reset() {
+        ignoreMalformedValues.reset();
+    }
+
     private interface Values {
         int count();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesSyntheticFieldLoaderLayer.java
@@ -19,13 +19,11 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * Load {@code _source} fields from {@link SortedSetDocValues}.
  */
-public abstract class SortedSetDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.Layer {
+public abstract class SortedSetDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
     private static final Logger logger = LogManager.getLogger(SortedSetDocValuesSyntheticFieldLoaderLayer.class);
 
     private final String name;
@@ -42,11 +40,6 @@ public abstract class SortedSetDocValuesSyntheticFieldLoaderLayer implements Com
     @Override
     public String fieldName() {
         return name;
-    }
-
-    @Override
-    public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        return Stream.of();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringStoredFieldFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringStoredFieldFieldLoader.java
@@ -31,17 +31,7 @@ public abstract class StringStoredFieldFieldLoader implements SourceLoader.Synth
 
     @Override
     public final Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        return Stream.of(Map.entry(name, new SourceLoader.SyntheticFieldLoader.StoredFieldLoader() {
-            @Override
-            public void advanceToDoc(int docId) {
-                values = emptyList();
-            }
-
-            @Override
-            public void load(List<Object> newValues) {
-                values = newValues;
-            }
-        }));
+        return Stream.of(Map.entry(name, newValues -> values = newValues));
     }
 
     @Override
@@ -65,6 +55,12 @@ public abstract class StringStoredFieldFieldLoader implements SourceLoader.Synth
                 }
                 b.endArray();
         }
+        reset();
+    }
+
+    @Override
+    public void reset() {
+        values = emptyList();
     }
 
     protected abstract void write(XContentBuilder b, Object value) throws IOException;

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedSortedSetDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedSortedSetDocValuesSyntheticFieldLoader.java
@@ -16,10 +16,8 @@ import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.stream.Stream;
 
-public class FlattenedSortedSetDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
     private DocValuesFieldValues docValues = NO_VALUES;
     private final String fieldFullPath;
     private final String keyedFieldFullPath;
@@ -41,11 +39,6 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader implements SourceLo
     @Override
     public String fieldName() {
         return fieldFullPath;
-    }
-
-    @Override
-    public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-        return Stream.empty();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -2173,7 +2173,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         return new DocValuesSyntheticFieldLoader(indexCreatedVersion);
     }
 
-    private class IndexedSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+    private class IndexedSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
         private FloatVectorValues values;
         private ByteVectorValues byteVectorValues;
         private boolean hasValue;
@@ -2186,11 +2186,6 @@ public class DenseVectorFieldMapper extends FieldMapper {
         private IndexedSyntheticFieldLoader(IndexVersion indexCreatedVersion, VectorSimilarity vectorSimilarity) {
             this.indexCreatedVersion = indexCreatedVersion;
             this.vectorSimilarity = vectorSimilarity;
-        }
-
-        @Override
-        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of();
         }
 
         @Override
@@ -2254,18 +2249,13 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
     }
 
-    private class DocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+    private class DocValuesSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
         private BinaryDocValues values;
         private boolean hasValue;
         private final IndexVersion indexCreatedVersion;
 
         private DocValuesSyntheticFieldLoader(IndexVersion indexCreatedVersion) {
             this.indexCreatedVersion = indexCreatedVersion;
-        }
-
-        @Override
-        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of();
         }
 
         @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -528,14 +527,9 @@ public class HistogramFieldMapper extends FieldMapper {
         );
     }
 
-    private class HistogramSyntheticFieldLoader implements CompositeSyntheticFieldLoader.Layer {
+    private class HistogramSyntheticFieldLoader implements CompositeSyntheticFieldLoader.DocValuesLayer {
         private final InternalHistogramValue value = new InternalHistogramValue();
         private BytesRef binaryValue;
-
-        @Override
-        public Stream<Map.Entry<String, SourceLoader.SyntheticFieldLoader.StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of();
-        }
 
         @Override
         public SourceLoader.SyntheticFieldLoader.DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf)

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -72,7 +72,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -725,7 +724,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         );
     }
 
-    public static class AggregateMetricSyntheticFieldLoader implements CompositeSyntheticFieldLoader.Layer {
+    public static class AggregateMetricSyntheticFieldLoader implements CompositeSyntheticFieldLoader.DocValuesLayer {
         private final String name;
         private final EnumSet<Metric> metrics;
         private final Map<Metric, SortedNumericDocValues> metricDocValues = new EnumMap<>(Metric.class);
@@ -744,11 +743,6 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         @Override
         public long valueCount() {
             return hasValue() ? 1 : 0;
-        }
-
-        @Override
-        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.of();
         }
 
         @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -379,6 +379,11 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
             }
 
             @Override
+            public void reset() {
+                // NOOP
+            }
+
+            @Override
             public String fieldName() {
                 return fullPath();
             }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -87,7 +87,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * A {@link FieldMapper} for indexing fields with ngrams for efficient wildcard matching
@@ -1022,15 +1021,10 @@ public class WildcardFieldMapper extends FieldMapper {
         return new CompositeSyntheticFieldLoader(leafName(), fullPath(), loader);
     }
 
-    private class WildcardSyntheticFieldLoader implements CompositeSyntheticFieldLoader.Layer {
+    private class WildcardSyntheticFieldLoader implements CompositeSyntheticFieldLoader.DocValuesLayer {
         private final ByteArrayStreamInput docValuesStream = new ByteArrayStreamInput();
         private int docValueCount;
         private BytesRef docValueBytes;
-
-        @Override
-        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-            return Stream.empty();
-        }
 
         @Override
         public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {


### PR DESCRIPTION
This PR reworks #112173. Original PR is correct but benchmarks show a significant performance regression when synthesizing source in presence of hundreds of stored field. This is cased by a `SourceLoader.SyntheticFieldLoader.StoredFieldLoader#advanceToDoc` call that was executed for every stored field loader every time source was synthesized, even if the stored field was always empty.

This PR changes the approach to only perform reset of synthetic field loader only when it is known that it is needed, specifically when values were loaded but not used due to presence of ignored source values.