### PR TITLE
Clarify comment in SearchExecutionContext#setLookupProviders

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -511,7 +511,8 @@ public class SearchExecutionContext extends QueryRewriteContext {
         SourceProvider sourceProvider,
         Function<LeafReaderContext, LeafFieldLookupProvider> fieldLookupProvider
     ) {
-        // TODO can we assert that this is only called during FetchPhase?
+        // This isn't called only during fetch phase: there's scenarios where fetch phase is executed as part of the query phase,
+        // as well as runtime fields loaded from _source that do need a source provider as part of executing the query
         this.lookup = new SearchLookup(
             this::getFieldType,
             (fieldType, searchLookup, fielddataOperation) -> indexFieldDataLookup.apply(


### PR DESCRIPTION
Remove a TODO around asserting that setLookupProviders is only called as part of the fetch phase. That is not the case, hence we are not going to address that, but it makes sense to replace the TODO with a comment that clarifies how the method may be used and called.