### PR TITLE
Speedup reading ClusterFeatures from the wire

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterFeatures.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterFeatures.java
@@ -140,11 +140,10 @@ public class ClusterFeatures implements Diffable<ClusterFeatures>, ChunkedToXCon
         out.writeMap(nodeFeatureSetIndexes, StreamOutput::writeVInt);
     }
 
+    @SuppressWarnings("unchecked")
     private static Map<String, Set<String>> readCanonicalSets(StreamInput in) throws IOException {
-        List<Set<String>> featureSets = in.readCollectionAsList(i -> i.readCollectionAsImmutableSet(StreamInput::readString));
-        Map<String, Integer> nodeIndexes = in.readMap(StreamInput::readVInt);
-
-        return nodeIndexes.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> featureSets.get(e.getValue())));
+        Set<String>[] featureSets = in.readArray(i -> i.readCollectionAsImmutableSet(StreamInput::readString), Set[]::new);
+        return in.readImmutableMap(streamInput -> featureSets[streamInput.readVInt()]);
     }
 
     public static ClusterFeatures readFrom(StreamInput in) throws IOException {


### PR DESCRIPTION
This shows up as rather heavy at times, we can speed it up by skipping collecting the temporary map and reading the lookup into an array instead of a list.
