### PR TITLE
[8.9] [DOC] geo_shape field type supports geo_hex aggregation (#112448)

### DIFF
--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -18,9 +18,8 @@ Documents using this type can be used:
 ** a <<query-dsl-geo-shape-query,`geo_shape` query>> (for example, intersecting polygons).
 * to aggregate documents by geographic grids:
 ** either <<search-aggregations-bucket-geohashgrid-aggregation,`geo_hash`>>
-** or <<search-aggregations-bucket-geotilegrid-aggregation,`geo_tile`>>.
-
-Grid aggregations over `geo_hex` grids are not supported for `geo_shape` fields.
+** or <<search-aggregations-bucket-geotilegrid-aggregation,`geo_tile`>>
+** or <<search-aggregations-bucket-geohexgrid-aggregation,`geo_hex`>>
 
 [[geo-shape-mapping-options]]
 [discrete]


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [DOC] geo_shape field type supports geo_hex aggregation (#112448)