### PR TITLE
Save needlessly collecting list in InternalMappedSignificantTerms

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -71,7 +71,7 @@ public abstract class InternalMappedSignificantTerms<
     }
 
     @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Iterator<SignificantTerms.Bucket> iterator() {
         return (Iterator) buckets.iterator();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -71,8 +71,9 @@ public abstract class InternalMappedSignificantTerms<
     }
 
     @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public Iterator<SignificantTerms.Bucket> iterator() {
-        return buckets.stream().map(bucket -> (SignificantTerms.Bucket) bucket).toList().iterator();
+        return (Iterator) buckets.iterator();
     }
 
     @Override


### PR DESCRIPTION
No need to allocate a list+stream to do an unsafe(ish) cast.