### PR TITLE
Revert "[ML] Return both modelId and inferenceId (#111490)"

### DIFF
--- a/docs/changelog/112508.yaml
+++ b/docs/changelog/112508.yaml
@@ -1,5 +1,5 @@
 pr: 112508
-summary: "Revert \"[ML] Return both `modelId` and `inferenceId\"`"
+summary: "[ML] Create Inference API will no longer return model_id and now only return inference_id"
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/112508.yaml
+++ b/docs/changelog/112508.yaml
@@ -1,0 +1,5 @@
+pr: 112508
+summary: "Revert \"[ML] Return both `modelId` and `inferenceId\"`"
+area: Machine Learning
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelConfigurations.java
@@ -126,7 +126,6 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
         if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
             builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
         } else {
-            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
             builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
         }
         builder.field(TaskType.NAME, taskType.toString());
@@ -143,7 +142,6 @@ public class ModelConfigurations implements ToFilteredXContentObject, VersionedN
         if (params.paramAsBoolean(USE_ID_FOR_INDEX, false)) {
             builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
         } else {
-            builder.field(INDEX_ONLY_ID_FIELD_NAME, inferenceEntityId);
             builder.field(INFERENCE_ID_FIELD_NAME, inferenceEntityId);
         }
         builder.field(TaskType.NAME, taskType.toString());


### PR DESCRIPTION
Both `model_id` and `inference_id` were returned from the inference API to support backwards compatibility while kibana migrates to `inference_id`.

Now that the migration is complete, we will stop returning `model_id`.

This reverts commit 3b8970cf12484d5c1ea3e484e60c34e083887988.
