### PR TITLE
Update resolve index missing type definition

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -37,6 +37,16 @@
         ],
         "default":"open",
         "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+      },
+      "ignore_unavailable":{
+        "type":"boolean",
+        "description":"Whether specified concrete indices should be ignored when unavailable (missing or closed)",
+        "default":false
+      },
+      "allow_no_indices":{
+        "type":"boolean",
+        "description":"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
+        "default":true
       }
     }
   }


### PR DESCRIPTION
This PR adds the missing type definition for `ignore_unavailable` and `allow_no_indices` query param` which are [accepted by ES](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-resolve-index-api.html#resolve-index-api-query-params) but the definition is missing.