### PR TITLE
[main] Missing link added to fips-140-compliance.asciidoc (#112477)

### DIFF
--- a/docs/reference/security/fips-140-compliance.asciidoc
+++ b/docs/reference/security/fips-140-compliance.asciidoc
@@ -55,7 +55,8 @@ so that the JVM uses FIPS validated implementations of NIST recommended cryptogr
 
 Elasticsearch has been tested with Bouncy Castle's https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.2.4/bc-fips-1.0.2.4.jar[bc-fips 1.0.2.4]
 and https://repo1.maven.org/maven2/org/bouncycastle/bctls-fips/1.0.17/bctls-fips-1.0.17.jar[bctls-fips 1.0.17].
-Please refer to the [Support Matrix] for details on which combinations of JVM and security provider are supported in FIPS mode. Elasticsearch does not ship with a FIPS certified provider. It is the responsibility of the user
+Please refer to the {es}
+https://www.elastic.co/support/matrix#matrix_jvm[JVM support matrix] for details on which combinations of JVM and security provider are supported in FIPS mode. Elasticsearch does not ship with a FIPS certified provider. It is the responsibility of the user
 to install and configure the security provider to ensure compliance with FIPS 140-2. Using a FIPS certified provider will ensure that only
 approved cryptographic algorithms are used.
 


### PR DESCRIPTION
Backports the following commits to main:
 - Missing link added to fips-140-compliance.asciidoc (#112477)