### PR TITLE
[DOCS] Fix User agent processor properties

### DIFF
--- a/docs/reference/ingest/processors/user-agent.asciidoc
+++ b/docs/reference/ingest/processors/user-agent.asciidoc
@@ -20,7 +20,7 @@ The ingest-user-agent module ships by default with the regexes.yaml made availab
 | `field`                | yes       | -                                                                                               | The field containing the user agent string.
 | `target_field`         | no        | user_agent                                                                                      | The field that will be filled with the user agent details.
 | `regex_file`           | no        | -                                                                                               | The name of the file in the `config/ingest-user-agent` directory containing the regular expressions for parsing the user agent string. Both the directory and the file have to be created before starting Elasticsearch. If not specified, ingest-user-agent will use the regexes.yaml from uap-core it ships with (see below).
-| `properties`           | no        | [`name`, `major`, `minor`, `patch`, `build`, `os`, `os_name`, `os_major`, `os_minor`, `device`] | Controls what properties are added to `target_field`.
+| `properties`           | no        | [`name`, `os`, `device`, `original`, `version`] | Controls what properties are added to `target_field`.
 | `extract_device_type`  | no        | `false`                                                                                         | beta:[] Extracts device type from the user agent string on a best-effort basis.
 | `ignore_missing`       | no        | `false`                                                                                         | If `true` and `field` does not exist, the processor quietly exits without modifying the document
 |======


### PR DESCRIPTION
As far as I can tell, the properties are defined here:

https://github.com/elastic/elasticsearch/blob/a36d90cf34d5d190e8a0830c99cc04be66da0af8/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java#L253-L259
