### PR TITLE
Lower the memory footprint when creating DelayedBucket

### DIFF
--- a/docs/changelog/112519.yaml
+++ b/docs/changelog/112519.yaml
@@ -1,0 +1,5 @@
+pr: 112519
+summary: Lower the memory footprint when creating `DelayedBucket`
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -210,7 +210,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             }
         }
         for (List<B> sameTermBuckets : bucketMap.values()) {
-            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, new ArrayList<>(sameTermBuckets)));
+            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -198,7 +198,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         }
 
         if (sameTermBuckets.isEmpty() == false) {
-            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
+            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, new ArrayList<>(sameTermBuckets)));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -178,8 +178,8 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             assert lastBucket == null || cmp.compare(top.current(), lastBucket) >= 0;
             if (lastBucket != null && cmp.compare(top.current(), lastBucket) != 0) {
                 // the key changed so bundle up the last key's worth of buckets
-                sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
-                sameTermBuckets = new ArrayList<>();
+                sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, new ArrayList<>(sameTermBuckets)));
+                sameTermBuckets.clear();
             }
             lastBucket = top.current();
             sameTermBuckets.add(top.current());
@@ -210,7 +210,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             }
         }
         for (List<B> sameTermBuckets : bucketMap.values()) {
-            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
+            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, new ArrayList<>(sameTermBuckets)));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -171,15 +171,16 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             pq.add(new IteratorAndCurrent<>(buckets.iterator()));
         }
         // list of buckets coming from different shards that have the same key
-        List<B> sameTermBuckets = new ArrayList<>();
+        ArrayList<B> sameTermBuckets = new ArrayList<>();
         B lastBucket = null;
         while (pq.size() > 0) {
             final IteratorAndCurrent<B> top = pq.top();
             assert lastBucket == null || cmp.compare(top.current(), lastBucket) >= 0;
             if (lastBucket != null && cmp.compare(top.current(), lastBucket) != 0) {
                 // the key changed so bundle up the last key's worth of buckets
-                sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, new ArrayList<>(sameTermBuckets)));
-                sameTermBuckets.clear();
+                sameTermBuckets.trimToSize();
+                sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
+                sameTermBuckets = new ArrayList<>();
             }
             lastBucket = top.current();
             sameTermBuckets.add(top.current());
@@ -198,18 +199,20 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         }
 
         if (sameTermBuckets.isEmpty() == false) {
-            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, new ArrayList<>(sameTermBuckets)));
+            sameTermBuckets.trimToSize();
+            sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
         }
     }
 
     private void reduceLegacy(List<List<B>> bucketsList, AggregationReduceContext reduceContext, Consumer<DelayedBucket<B>> sink) {
-        final Map<Object, List<B>> bucketMap = new HashMap<>();
+        final Map<Object, ArrayList<B>> bucketMap = new HashMap<>();
         for (List<B> buckets : bucketsList) {
             for (B bucket : buckets) {
                 bucketMap.computeIfAbsent(bucket.getKey(), k -> new ArrayList<>()).add(bucket);
             }
         }
-        for (List<B> sameTermBuckets : bucketMap.values()) {
+        for (ArrayList<B> sameTermBuckets : bucketMap.values()) {
+            sameTermBuckets.trimToSize();
             sink.accept(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
         }
     }


### PR DESCRIPTION
Looking in a heapdump I noticed a lot of DelayedBucket that contained ArrayLists with just one element but still the internal structure of the ArrayList was allocating 10 elements. this can be controled when creating those buckets which should provide a nice reduction of the memory footprint.

