### PR TITLE
(Doc+) Inference Pipeline ignores Mapping Analyzers

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -31,6 +31,7 @@ include::common-options.asciidoc[]
 `field_map` fields. For NLP models, use the `input_output` option. For 
 {dfanalytics} models, use the `target_field` and `field_map` option.
 * Each {infer} input field must be single strings, not arrays of strings.
+* The `input_field` is processed as is and ignores any <<mapping,index mapping>>'s <<analysis-intro,analyzers>> at time of {infer} run.
 ==================================================
 
 [discrete]

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -31,7 +31,7 @@ include::common-options.asciidoc[]
 `field_map` fields. For NLP models, use the `input_output` option. For 
 {dfanalytics} models, use the `target_field` and `field_map` option.
 * Each {infer} input field must be single strings, not arrays of strings.
-* The `input_field` is processed as is and ignores any <<mapping,index mapping>>'s <<analysis-intro,analyzers>> at time of {infer} run.
+* The `input_field` is processed as is and ignores any <<mapping,index mapping>>'s <<analysis,analyzers>> at time of {infer} run.
 ==================================================
 
 [discrete]


### PR DESCRIPTION
👋 howdy, team!

From internal feedback from Devs @demjened @Mikep86 (will cross-link after), this updates that inference processors within ingest pipelines run before mapping analyzers effectively ignoring them. So if users want analyzers to take effect, they would need to select the analyzer's ingest pipeline process equivalent and run it higher in flow than the inference processor.

TIA! Stef