### PR TITLE
[DOCS] Fixes indentation issue on PUT trained models docs page

### DIFF
--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -588,7 +588,7 @@ Refer to <<tokenization-properties>> to review the properties of the
 `tokenization` object.
 =====
 
-`text_similarity`::::
+`text_similarity`:::
 (Object, optional)
 include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-similarity]
 +


### PR DESCRIPTION
## Overview

This PR fixes an indentation issue on the PUT trained models API docs page.

### Preview

* [PUT trained models API docs](https://elasticsearch_bk_112538.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-trained-models.html)