### PR TITLE
[8.14] [DOCS] Fixes indentation issue on PUT trained models docs page. (#112538)

### DIFF
--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -588,7 +588,7 @@ Refer to <<tokenization-properties>> to review the properties of the
 `tokenization` object.
 =====
 
-`text_similarity`::::
+`text_similarity`:::
 (Object, optional)
 include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-similarity]
 +


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Fixes indentation issue on PUT trained models docs page. (#112538)