### PR TITLE
[8.15] [DOCS][ESQL] Include bucket in agg functions list (#112513)

### DIFF
--- a/docs/reference/esql/processing-commands/stats.asciidoc
+++ b/docs/reference/esql/processing-commands/stats.asciidoc
@@ -2,6 +2,9 @@
 [[esql-stats-by]]
 === `STATS ... BY`
 
+The `STATS ... BY` processing command groups rows according to a common value
+and calculates one or more aggregated values over the grouped rows.
+
 **Syntax**
 
 [source,esql]
@@ -37,6 +40,10 @@ over the entire dataset.
 The following <<esql-agg-functions,aggregation functions>> are supported:
 
 include::../functions/aggregation-functions.asciidoc[tag=agg_list]
+
+The following <<esql-group-functions,grouping functions>> are supported:
+
+include::../functions/grouping-functions.asciidoc[tag=group_list]
 
 NOTE: `STATS` without any groups is much much faster than adding a group.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[DOCS][ESQL] Include bucket in agg functions list (#112513)](https://github.com/elastic/elasticsearch/pull/112513)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)