### PR TITLE
Yet more unsupported locales for Kerb tests

### DIFF
--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -86,7 +86,8 @@ public abstract class KerberosTestCase extends ESTestCase {
         "sd",
         "mni",
         "sat",
-        "sa"
+        "sa",
+        "bgc"
     );
 
     @BeforeClass


### PR DESCRIPTION
Adds more locales, in addition to https://github.com/elastic/elasticsearch/pull/109670 (see the original PR for context). 

Closes: https://github.com/elastic/elasticsearch/issues/112533
Closes: https://github.com/elastic/elasticsearch/issues/112534
