### PR TITLE
Allow `copy_to` on `text` field when `stored: true`

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -442,7 +442,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        if (storeSource == false && copyTo.copyToFields().isEmpty() != true) {
+        if (copyTo.copyToFields().isEmpty() != true) {
             throw new IllegalArgumentException(
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -442,7 +442,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        if (copyTo.copyToFields().isEmpty() != true) {
+        if (storeSource == false && copyTo.copyToFields().isEmpty() != true) {
             throw new IllegalArgumentException(
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -197,9 +197,8 @@ text with copy_to:
               mode: synthetic
             properties:
               text:
-                type: text
+                type: match_only_text
                 copy_to: text_copy
-                store: true
               text_copy:
                 type: text
                 store: true

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -196,10 +196,10 @@ text with copy_to:
             _source:
               mode: synthetic
             properties:
-              text:
+              kubernetes_event_message:
                 type: match_only_text
-                copy_to: text_copy
-              text_copy:
+                copy_to: message
+              message:
                 type: text
                 store: true
 
@@ -208,14 +208,14 @@ text with copy_to:
         index:   test-text-copy-to
         id:      1
         body:
-          text: the quick brown fox
+          kubernetes_event_message: the quick brown fox
 
   - do:
       index:
         index: test-text-copy-to
         id:      2
         body:
-          text: jumped over the lazy dog
+          kubernetes_event_message: jumped over the lazy dog
 
   - do:
       mget:
@@ -226,15 +226,15 @@ text with copy_to:
   - match: {docs.0._id: "1"}
   - match:
       docs.0._source:
-        text: the quick brown fox
-        text_copy: the quick brown fox
+        kubernetes_event_message: the quick brown fox
+        message: the quick brown fox
 
   - match: {docs.1._index: "test-text-copy-to"}
   - match: {docs.1._id: "2"}
   - match:
       docs.1._source:
-        text: jumped over the lazy dog
-        text_copy: jumped over the lazy dog
+        kubernetes_event_message: jumped over the lazy dog
+        message: jumped over the lazy dog
 
 ---
 force_synthetic_source_ok:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -184,6 +184,60 @@ stored text:
         text: jumped over the lazy dog
 
 ---
+text with copy_to:
+  - requires:
+      cluster_features: ["gte_v8.5.0"]
+      reason: introduced in 8.5.0
+  - do:
+      indices.create:
+        index: test-text-copy-to
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              text:
+                type: text
+                copy_to: text_copy
+                store: true
+              text_copy:
+                type: text
+                store: true
+
+  - do:
+      index:
+        index:   test-text-copy-to
+        id:      1
+        body:
+          text: the quick brown fox
+
+  - do:
+      index:
+        index: test-text-copy-to
+        id:      2
+        body:
+          text: jumped over the lazy dog
+
+  - do:
+      mget:
+        index: test-text-copy-to
+        body:
+          ids:    [1, 2]
+  - match: {docs.0._index: "test-text-copy-to"}
+  - match: {docs.0._id: "1"}
+  - match:
+      docs.0._source:
+        text: the quick brown fox
+        text_copy: the quick brown fox
+
+  - match: {docs.1._index: "test-text-copy-to"}
+  - match: {docs.1._id: "2"}
+  - match:
+      docs.1._source:
+        text: jumped over the lazy dog
+        text_copy: jumped over the lazy dog
+
+---
 force_synthetic_source_ok:
   - requires:
       cluster_features: ["gte_v8.4.0"]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -197,8 +197,9 @@ text with copy_to:
               mode: synthetic
             properties:
               kubernetes_event_message:
-                type: match_only_text
                 copy_to: message
+                type: text
+                store: true
               message:
                 type: text
                 store: true

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1453,7 +1453,7 @@ public final class TextFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        if (copyTo.copyToFields().isEmpty() != true) {
+        if (store == false && copyTo.copyToFields().isEmpty() != true) {
             throw new IllegalArgumentException(
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1453,6 +1453,11 @@ public final class TextFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
+        if (store == false && copyTo.copyToFields().isEmpty() != true) {
+            throw new IllegalArgumentException(
+                "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
+            );
+        }
         if (store) {
             return new StringStoredFieldFieldLoader(fullPath(), leafName()) {
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1453,11 +1453,6 @@ public final class TextFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        if (copyTo.copyToFields().isEmpty() != true) {
-            throw new IllegalArgumentException(
-                "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
-            );
-        }
         if (store) {
             return new StringStoredFieldFieldLoader(fullPath(), leafName()) {
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1453,7 +1453,7 @@ public final class TextFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        if (store == false && copyTo.copyToFields().isEmpty() != true) {
+        if (copyTo.copyToFields().isEmpty() != true) {
             throw new IllegalArgumentException(
                 "field [" + fullPath() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );


### PR DESCRIPTION
This PR is going to be used as a temporary solution for an esbench test. It won't be merged.

The goal here is to enable usage of `copy_to` for (some) `text` fields. The `elastic/security`
track uses `copy_to` to copy the contents of `kubernetes.event.message` to `message`.

We will change the `elastic/security` track only for the sake of a test like follows:

```
kubernetes.event.message {
   type: text,
   copy_to: message,
   store: true
}
...
message {
   type: text,
   store: true
}
```

This should be enough to make sure we are actually using a stored field for `kubernetes.event.message` which uses `copy_to` (as it will be once `copy_to` is actually supported).

This allows us to run the benchmark with minimal Elasticsearch changes and mimic the actual solution we will have once `copy_to` support is implemented.