### PR TITLE
Stop rebuilding ClusterFeatures on every CS update

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -984,7 +984,9 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
                 routingTable,
                 nodes,
                 compatibilityVersions,
-                new ClusterFeatures(nodeFeatures),
+                previous != null && getNodeFeatures(previous.clusterFeatures).equals(nodeFeatures)
+                    ? previous.clusterFeatures
+                    : new ClusterFeatures(nodeFeatures),
                 blocks,
                 customs.build(),
                 fromDiff,


### PR DESCRIPTION
If the node-features maps are equal, then the instances are equal and there's no point in rebuilding which entails rebuilding the costly `allNodeFeatures` field in them eventually.