### PR TITLE
[8.15] (Doc+) Sparse Vectors NA to mapping analyzers (#112523)

### DIFF
--- a/docs/reference/mapping/types/sparse-vector.asciidoc
+++ b/docs/reference/mapping/types/sparse-vector.asciidoc
@@ -91,7 +91,7 @@ NOTE: `sparse_vector` fields can not be included in indices that were *created* 
 NOTE: `sparse_vector` fields only support strictly positive values.
 Negative values will be rejected.
 
-NOTE: `sparse_vector` fields do not support querying, sorting or aggregating.
+NOTE: `sparse_vector` fields do not support <<analysis,analyzers>>, querying, sorting or aggregating.
 They may only be used within specialized queries.
 The recommended query to use on these fields are <<query-dsl-sparse-vector-query, `sparse_vector`>> queries.
 They may also be used within legacy <<query-dsl-text-expansion-query,`text_expansion`>> queries.


### PR DESCRIPTION
Backports the following commits to 8.15:
 - (Doc+) Sparse Vectors NA to mapping analyzers (#112523)