### PR TITLE
[8.15] Ensure rest compatibility tests are run when appropriate (#112526)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestCompatTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestCompatTestPluginFuncTest.groovy
@@ -55,8 +55,7 @@ class LegacyYamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTe
         def result = gradleRunner("yamlRestTestV${compatibleVersion}CompatTest", '--stacktrace').build()
 
         then:
-        // we set the task to be skipped if there are no matching tests in the compatibility test sourceSet
-        result.task(":yamlRestTestV${compatibleVersion}CompatTest").outcome == TaskOutcome.SKIPPED
+        result.task(":yamlRestTestV${compatibleVersion}CompatTest").outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestCompatApiTask').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestCompatTestTask').outcome == TaskOutcome.NO_SOURCE
         result.task(transformTask).outcome == TaskOutcome.NO_SOURCE
@@ -165,7 +164,7 @@ class LegacyYamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTe
         then:
         result.task(':check').outcome == TaskOutcome.UP_TO_DATE
         result.task(':checkRestCompat').outcome == TaskOutcome.UP_TO_DATE
-        result.task(":yamlRestTestV${compatibleVersion}CompatTest").outcome == TaskOutcome.SKIPPED
+        result.task(":yamlRestTestV${compatibleVersion}CompatTest").outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestCompatApiTask').outcome == TaskOutcome.NO_SOURCE
         result.task(':copyRestCompatTestTask').outcome == TaskOutcome.NO_SOURCE
         result.task(transformTask).outcome == TaskOutcome.NO_SOURCE

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.language.jvm.tasks.ProcessResources;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -213,6 +214,17 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
             .named(RestResourcesPlugin.COPY_YAML_TESTS_TASK)
             .flatMap(CopyRestTestsTask::getOutputResourceDir);
 
+        // ensure we include other non rest spec related test resources
+        project.getTasks()
+            .withType(ProcessResources.class)
+            .named(yamlCompatTestSourceSet.getProcessResourcesTaskName())
+            .configure(processResources -> {
+                processResources.from(
+                    sourceSets.getByName(YamlRestTestPlugin.YAML_REST_TEST).getResources(),
+                    spec -> { spec.exclude("rest-api-spec/**"); }
+                );
+            });
+
         // setup the test task
         TaskProvider<? extends Test> yamlRestCompatTestTask = registerTestTask(project, yamlCompatTestSourceSet);
         yamlRestCompatTestTask.configure(testTask -> {
@@ -221,7 +233,7 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
             testTask.setTestClassesDirs(
                 yamlTestSourceSet.getOutput().getClassesDirs().plus(yamlCompatTestSourceSet.getOutput().getClassesDirs())
             );
-            testTask.onlyIf("Compatibility tests are available", t -> yamlCompatTestSourceSet.getAllSource().isEmpty() == false);
+            testTask.onlyIf("Compatibility tests are available", t -> yamlCompatTestSourceSet.getOutput().isEmpty() == false);
             testTask.setClasspath(
                 yamlCompatTestSourceSet.getRuntimeClasspath()
                     // remove the "normal" api and tests

--- a/modules/aggregations/build.gradle
+++ b/modules/aggregations/build.gradle
@@ -54,6 +54,9 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search.aggregation/180_percentiles_tdigest_metric/Filtered test", "Hybrid t-digest produces different results.")
   task.skipTest("search.aggregation/420_percentile_ranks_tdigest_metric/filtered", "Hybrid t-digest produces different results.")
 
+  // Something has changed with response codes
+  task.skipTest("search.aggregation/20_terms/IP test", "Hybrid t-digest produces different results.")
+
   task.addAllowedWarningRegex("\\[types removal\\].*")
 }
 

--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.test-with-dependencies'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -23,11 +24,7 @@ dependencies {
   internalClusterTestImplementation project(":modules:mapper-extras")
 }
 
-tasks.named('yamlRestTest') {
-  usesDefaultDistribution()
-}
-
-tasks.named('javaRestTest') {
+tasks.withType(StandaloneRestIntegTestTask).configureEach {
   usesDefaultDistribution()
 }
 

--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -5,6 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -29,7 +31,7 @@ restResources {
   }
 }
 
-tasks.named('yamlRestTest') {
+tasks.withType(StandaloneRestIntegTestTask).configureEach {
   usesDefaultDistribution()
 }
 

--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -33,6 +33,11 @@ dependencies {
   internalClusterTestImplementation project(':test:fixtures:url-fixture')
 }
 
+tasks.named("yamlRestTestV7CompatTransform").configure { task ->
+  task.skipTest("repository_url/10_basic/Restore with repository-url using file://", "Error message has changed")
+  task.skipTest("repository_url/10_basic/Restore with repository-url using http://", "Error message has changed")
+}
+
 tasks.named("thirdPartyAudit").configure {
   ignoreMissingClasses(
     'javax.servlet.ServletContextEvent',


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Ensure rest compatibility tests are run when appropriate (#112526)