### PR TITLE
[Cloud Security] Add privileges required for AWS SecurityHub related to CDR misconfiguration features

### DIFF
--- a/docs/changelog/112574.yaml
+++ b/docs/changelog/112574.yaml
@@ -1,0 +1,5 @@
+pr: 112574
+summary: Add privileges required for CDR misconfiguration features to work on AWS SecurityHub integration
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -420,7 +420,7 @@ class KibanaOwnedReservedRoleDescriptors {
                 // For source indices of the Cloud Detection & Response (CDR) packages that ships a
                 // transform
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-wiz.vulnerability-*", "logs-wiz.cloud_configuration_finding-*")
+                    .indices("logs-wiz.vulnerability-*", "logs-wiz.cloud_configuration_finding-*", "logs-aws.securityhub_findings-*")
                     .privileges("read", "view_index_metadata")
                     .build(),
                 // For alias indices of the Cloud Detection & Response (CDR) packages that ships a

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1611,7 +1611,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         Arrays.asList(
             "logs-wiz.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13)),
-            "logs-wiz.cloud_configuration_finding-" + randomAlphaOfLength(randomIntBetween(0, 13))
+            "logs-wiz.cloud_configuration_finding-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-aws.securityhub_findings-" + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach(indexName -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(indexAbstraction), is(false));


### PR DESCRIPTION
- contributes to https://github.com/elastic/security-team/issues/9961
- child issue of: https://github.com/elastic/integrations/issues/11038

### Summary
This PR updates `kibana_system` privileges to include the ones required for the Security Solution CDR Misconfigurtion latest transform to work on AWS SecurityHub integration:
- to read from source AWS SecurityHub Findings data stream as one of the data streams providing data for Cloud Detection & Response (CDR) features in Kibana.

The destination and alias index privileges already added in https://github.com/elastic/elasticsearch/pull/112456.