### PR TITLE
[ML] Use weights with non-zero decimal in weighted_tokens

### DIFF
--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/40_text_expansion.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/40_text_expansion.yml
@@ -75,17 +75,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.5, "words":1.5,"comforter":1.5}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.5,"machine":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.5,"are":1.5,"my":1.5,"words":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"smells":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.5,"machine":1.5,"smells":1.5}}
 
   - do:
       headers:
@@ -282,7 +282,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -307,7 +307,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -329,7 +329,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -353,7 +353,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "octopus": 1.1 }, { "comforter": 1.1 }, { "is": 1.1 }, { "the": 1.1 }, { "best": 1.1 }, { "of": 1.1 }, { "the": 1.1 }, { "bunch": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "octopus": 1.5 }, { "comforter": 1.5 }, { "is": 1.5 }, { "the": 1.5 }, { "best": 1.5 }, { "of": 1.5 }, { "the": 1.5 }, { "bunch": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/40_text_expansion.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/40_text_expansion.yml
@@ -75,17 +75,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
 
   - do:
       headers:
@@ -282,7 +282,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -307,7 +307,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -329,7 +329,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -353,7 +353,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "octopus": 1.0 }, { "comforter": 1.0 }, { "is": 1.0 }, { "the": 1.0 }, { "best": 1.0 }, { "of": 1.0 }, { "the": 1.0 }, { "bunch": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "octopus": 1.1 }, { "comforter": 1.1 }, { "is": 1.1 }, { "the": 1.1 }, { "best": 1.1 }, { "of": 1.1 }, { "the": 1.1 }, { "bunch": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/50_sparse_vector.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/50_sparse_vector.yml
@@ -67,17 +67,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.5, "words":1.5,"comforter":1.5}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.5,"machine":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.5,"are":1.5,"my":1.5,"words":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"smells":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.5,"machine":1.5,"smells":1.5}}
 
   - do:
       headers:
@@ -155,10 +155,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.1
-                comforter: 1.1
-                smells: 1.1
-                bad: 1.1
+                the: 1.5
+                comforter: 1.5
+                smells: 1.5
+                bad: 1.5
   - match: { hits.total.value: 5 }
   - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }
 
@@ -172,10 +172,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.1
-                comforter: 1.1
-                smells: 1.1
-                bad: 1.1
+                the: 1.5
+                comforter: 1.5
+                smells: 1.5
+                bad: 1.5
               prune: true
               pruning_config:
                 tokens_freq_ratio_threshold: 1

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/50_sparse_vector.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/50_sparse_vector.yml
@@ -67,17 +67,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
 
   - do:
       headers:
@@ -155,10 +155,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.0
-                comforter: 1.0
-                smells: 1.0
-                bad: 1.0
+                the: 1.1
+                comforter: 1.1
+                smells: 1.1
+                bad: 1.1
   - match: { hits.total.value: 5 }
   - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }
 
@@ -172,10 +172,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.0
-                comforter: 1.0
-                smells: 1.0
-                bad: 1.0
+                the: 1.1
+                comforter: 1.1
+                smells: 1.1
+                bad: 1.1
               prune: true
               pruning_config:
                 tokens_freq_ratio_threshold: 1

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/40_text_expansion.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/40_text_expansion.yml
@@ -75,17 +75,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.5, "words":1.5,"comforter":1.5}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.5,"machine":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.5,"are":1.5,"my":1.5,"words":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"smells":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.5,"machine":1.5,"smells":1.5}}
 
   - do:
       headers:
@@ -282,7 +282,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -307,7 +307,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -329,7 +329,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -353,7 +353,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "octopus": 1.1 }, { "comforter": 1.1 }, { "is": 1.1 }, { "the": 1.1 }, { "best": 1.1 }, { "of": 1.1 }, { "the": 1.1 }, { "bunch": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "octopus": 1.5 }, { "comforter": 1.5 }, { "is": 1.5 }, { "the": 1.5 }, { "best": 1.5 }, { "of": 1.5 }, { "the": 1.5 }, { "bunch": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/40_text_expansion.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/40_text_expansion.yml
@@ -75,17 +75,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
 
   - do:
       headers:
@@ -282,7 +282,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -307,7 +307,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -329,7 +329,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -353,7 +353,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "octopus": 1.0 }, { "comforter": 1.0 }, { "is": 1.0 }, { "the": 1.0 }, { "best": 1.0 }, { "of": 1.0 }, { "the": 1.0 }, { "bunch": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "octopus": 1.1 }, { "comforter": 1.1 }, { "is": 1.1 }, { "the": 1.1 }, { "best": 1.1 }, { "of": 1.1 }, { "the": 1.1 }, { "bunch": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/50_sparse_vector.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/50_sparse_vector.yml
@@ -66,17 +66,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
 
   - do:
       headers:
@@ -154,10 +154,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.0
-                comforter: 1.0
-                smells: 1.0
-                bad: 1.0
+                the: 1.1
+                comforter: 1.1
+                smells: 1.1
+                bad: 1.1
   - match: { hits.total.value: 5 }
   - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }
 
@@ -171,10 +171,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.0
-                comforter: 1.0
-                smells: 1.0
-                bad: 1.0
+                the: 1.1
+                comforter: 1.1
+                smells: 1.1
+                bad: 1.1
               prune: true
               pruning_config:
                 tokens_freq_ratio_threshold: 1

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/50_sparse_vector.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/50_sparse_vector.yml
@@ -66,17 +66,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.5, "words":1.5,"comforter":1.5}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.5,"machine":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.5,"are":1.5,"my":1.5,"words":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"smells":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.5,"machine":1.5,"smells":1.5}}
 
   - do:
       headers:
@@ -154,10 +154,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.1
-                comforter: 1.1
-                smells: 1.1
-                bad: 1.1
+                the: 1.5
+                comforter: 1.5
+                smells: 1.5
+                bad: 1.5
   - match: { hits.total.value: 5 }
   - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }
 
@@ -171,10 +171,10 @@ teardown:
             sparse_vector:
               field: ml.tokens
               query_vector:
-                the: 1.1
-                comforter: 1.1
-                smells: 1.1
-                bad: 1.1
+                the: 1.5
+                comforter: 1.5
+                smells: 1.5
+                bad: 1.5
               prune: true
               pruning_config:
                 tokens_freq_ratio_threshold: 1

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -74,17 +74,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.5, "words":1.5,"comforter":1.5}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.5,"machine":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.5,"are":1.5,"my":1.5,"words":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"smells":1.5}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.5,"octopus":1.5,"comforter":1.5,"is":1.5,"leaking":1.5}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.5,"machine":1.5,"smells":1.5}}
 
   - do:
       headers:
@@ -247,7 +247,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -272,7 +272,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -294,7 +294,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "comforter": 1.5 }, { "smells": 1.5 }, { "bad": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -318,7 +318,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.1 }, { "octopus": 1.1 }, { "comforter": 1.1 }, { "is": 1.1 }, { "the": 1.1 }, { "best": 1.1 }, { "of": 1.1 }, { "the": 1.1 }, { "bunch": 1.1 } ]
+                tokens: [ { "the": 1.5 }, { "octopus": 1.5 }, { "comforter": 1.5 }, { "is": 1.5 }, { "the": 1.5 }, { "best": 1.5 }, { "of": 1.5 }, { "the": 1.5 }, { "bunch": 1.5 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -74,17 +74,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.1, "words":1.1,"comforter":1.1}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.1,"machine":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.1,"are":1.1,"my":1.1,"words":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"smells":1.1}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.1,"octopus":1.1,"comforter":1.1,"is":1.1,"leaking":1.1}}
           {"index": {}}
-          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.1,"machine":1.1,"smells":1.1}}
 
   - do:
       headers:
@@ -247,7 +247,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -272,7 +272,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -294,7 +294,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "comforter": 1.1 }, { "smells": 1.1 }, { "bad": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -318,7 +318,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "octopus": 1.0 }, { "comforter": 1.0 }, { "is": 1.0 }, { "the": 1.0 }, { "best": 1.0 }, { "of": 1.0 }, { "the": 1.0 }, { "bunch": 1.0 } ]
+                tokens: [ { "the": 1.1 }, { "octopus": 1.1 }, { "comforter": 1.1 }, { "is": 1.1 }, { "the": 1.1 }, { "best": 1.1 }, { "of": 1.1 }, { "the": 1.1 }, { "bunch": 1.1 } ]
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4


### PR DESCRIPTION
Those YAML tests are used to validate the Elasticsearch specification. Unfortunately, validation is done using JavaScript and JSON which only have a number type and no integer type. Which means 1.0 is treated as 1, which gives a validation failure as the specification expects floats.