### PR TITLE
Fix missing header in put_geoip_database JSON spec

### DIFF
--- a/docs/changelog/112581.yaml
+++ b/docs/changelog/112581.yaml
@@ -1,0 +1,5 @@
+pr: 112581
+summary: Fix missing header in `put_geoip_database` JSON spec
+area: Ingest Node
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[


### PR DESCRIPTION
This is currently breaking the Python client code generation, which expects a Content-Type header when a body is required.

I don't think a changelog entry is warranted - what label should I use?