### PR TITLE
Prevent scaledFloat test from using too small scale factors

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -101,9 +101,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
   method: testSnapshotRestore {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111799
-- class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
-  method: testScaledFloat
-  issue: https://github.com/elastic/elasticsearch/issues/112003
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/80_random_rerank_retriever/Random rerank retriever predictably shuffles results}
   issue: https://github.com/elastic/elasticsearch/issues/111999

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -220,7 +220,8 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
     public void testScaledFloat() throws IOException {
         double value = randomBoolean() ? randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true) : randomFloat();
-        double scalingFactor = randomDoubleBetween(0, Double.MAX_VALUE, false);
+        // Scale factors less than about 5.6e-309 will result in NaN (due to 1/scaleFactor being infinity)
+        double scalingFactor = randomDoubleBetween(1e-308, Double.MAX_VALUE, false);
         new Test("scaled_float").expectedType("double")
             .randomIgnoreMalformedUnlessSynthetic()
             .randomDocValuesUnlessSynthetic()


### PR DESCRIPTION
Scale factors less than about 5.6e-309 will result in NaN (due to 1/scaleFactor being infinity). We could fix this better, by detecting that the scaled result of 0L can never be scaled back to any original value other than 0.0D itself (due to irretrievable loss of precision). That would require making a simple conditional check in about three places in the ScaledFloatFieldMapper class where the scaling-back is done.

But as a quick fix, we just avoid this case in the tests for now.

Fixes #112003