### PR TITLE
SQL: Fix UCASE/LCASE tests

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/case-functions.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/case-functions.sql-spec
@@ -21,7 +21,7 @@ ucaseInline3
 SELECT UCASE(' elastic ') upper;
 
 multipleGroupingsAndOrderingByGroupsWithFunctions_1
-SELECT first_name f, last_name l, gender g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp GROUP BY gender, l, f, c ORDER BY c DESC, first_name, l ASC, g;
+SELECT first_name f, last_name l, gender g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp WHERE emp_no IN (10003, 10009, 10023, 10024, 10025, 10029, 10030, 10033, 10034, 10035) GROUP BY gender, l, f, c ORDER BY c DESC, first_name, l ASC, g;
 
 multipleGroupingsAndOrderingByGroupsWithFunctions_2
-SELECT first_name f, last_name l, LCASE(gender) g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp GROUP BY f, LCASE(gender), l, c ORDER BY c DESC, first_name, l ASC, g;
+SELECT first_name f, last_name l, LCASE(gender) g, CONCAT(UCASE(first_name), LCASE(last_name)) c FROM test_emp WHERE emp_no IN (10003, 10009, 10023, 10024, 10025, 10029, 10030, 10033, 10034, 10035) GROUP BY f, LCASE(gender), l, c ORDER BY c DESC, first_name, l ASC, g;


### PR DESCRIPTION
Tests for upper/lower case functions (`UCASE()`/`LCASE()`) are not completely deterministic, due to Locale randomization.
In particular, when using Turkish locale all the UCASE(`i`) will result in `İ` instead of `I`

This change makes two tests more deterministic by including only values that don't include a `i`

Fixes https://github.com/elastic/elasticsearch/issues/112535