### PR TITLE
Avoid cluster state parameter for ActiveShardsObserver

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
@@ -8,10 +8,11 @@
 
 package org.elasticsearch.action.support;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -122,21 +123,21 @@ public record ActiveShardCount(int value) implements Writeable {
      * Returns true iff the given cluster state's routing table contains enough active
      * shards for the given indices to meet the required shard count represented by this instance.
      */
-    public boolean enoughShardsActive(final ClusterState clusterState, final String... indices) {
+    public boolean enoughShardsActive(final Metadata metadata, final RoutingTable routingTable, final String... indices) {
         if (this == ActiveShardCount.NONE) {
             // not waiting for any active shards
             return true;
         }
 
         for (final String indexName : indices) {
-            final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
+            final IndexMetadata indexMetadata = metadata.index(indexName);
             if (indexMetadata == null) {
                 // its possible the index was deleted while waiting for active shard copies,
                 // in this case, we'll just consider it that we have enough active shard copies
                 // and we can stop waiting
                 continue;
             }
-            final IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(indexName);
+            final IndexRoutingTable indexRoutingTable = routingTable.index(indexName);
             if (indexRoutingTable == null && indexMetadata.getState() == IndexMetadata.State.CLOSE) {
                 // its possible the index was closed while waiting for active shard copies,
                 // in this case, we'll just consider it that we have enough active shard copies

--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardsObserver.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardsObserver.java
@@ -54,7 +54,7 @@ public enum ActiveShardsObserver {
         }
 
         final ClusterState state = clusterService.state();
-        if (activeShardCount.enoughShardsActive(state, indexNames)) {
+        if (activeShardCount.enoughShardsActive(state.metadata(), state.routingTable(), indexNames)) {
             listener.onResponse(true);
             return;
         }
@@ -82,7 +82,7 @@ public enum ActiveShardsObserver {
                     listener.onResponse(false);
                 }
             },
-            newState -> activeShardCount.enoughShardsActive(newState, indexNames),
+            newState -> activeShardCount.enoughShardsActive(newState.metadata(), newState.routingTable(), indexNames),
             timeout
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -87,11 +87,11 @@ public class ActiveShardCountTests extends ESTestCase {
         final int numberOfReplicas = randomIntBetween(4, 7);
         final ActiveShardCount waitForActiveShards = ActiveShardCount.NONE;
         ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     public void testEnoughShardsActiveLevelOne() {
@@ -109,13 +109,13 @@ public class ActiveShardCountTests extends ESTestCase {
         final int numberOfReplicas = randomIntBetween(4, 7);
         final ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
         ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas, createCustomRoleStrategy(1));
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startLessThanWaitOnShards(clusterState, indexName, 1);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     public void testEnoughShardsActiveCustomLevelWithSearchOnlyRole() {
@@ -125,15 +125,15 @@ public class ActiveShardCountTests extends ESTestCase {
         final int activeShardCount = randomIntBetween(2, numberOfReplicas);
         final ActiveShardCount waitForActiveShards = ActiveShardCount.from(activeShardCount);
         ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas, createCustomRoleStrategy(1));
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startLessThanWaitOnShards(clusterState, indexName, activeShardCount - 2);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startWaitOnShards(clusterState, indexName, activeShardCount);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     public void testEnoughShardsActiveWithNoSearchOnlyRoles() {
@@ -147,13 +147,13 @@ public class ActiveShardCountTests extends ESTestCase {
             numberOfReplicas,
             createCustomRoleStrategy(numberOfReplicas + 1)
         );
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startLessThanWaitOnShards(clusterState, indexName, 1);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     private static ShardRoutingRoleStrategy createCustomRoleStrategy(int indexShardCount) {
@@ -177,15 +177,15 @@ public class ActiveShardCountTests extends ESTestCase {
         final int activeShardCount = randomIntBetween(2, numberOfReplicas);
         final ActiveShardCount waitForActiveShards = ActiveShardCount.from(activeShardCount);
         ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startLessThanWaitOnShards(clusterState, indexName, activeShardCount - 2);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startWaitOnShards(clusterState, indexName, activeShardCount - 1);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     public void testEnoughShardsActiveLevelAll() {
@@ -195,13 +195,13 @@ public class ActiveShardCountTests extends ESTestCase {
         // both values should represent "all"
         final ActiveShardCount waitForActiveShards = randomBoolean() ? ActiveShardCount.from(numberOfReplicas + 1) : ActiveShardCount.ALL;
         ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startLessThanWaitOnShards(clusterState, indexName, numberOfReplicas - randomIntBetween(1, numberOfReplicas));
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     public void testEnoughShardsActiveValueBased() {
@@ -230,7 +230,7 @@ public class ActiveShardCountTests extends ESTestCase {
 
         final ClusterState clusterState = initializeWithClosedIndex(indexName, numberOfShards, numberOfReplicas);
         for (ActiveShardCount waitForActiveShards : Arrays.asList(ActiveShardCount.DEFAULT, ActiveShardCount.ALL, ActiveShardCount.ONE)) {
-            assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+            assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         }
     }
 
@@ -240,11 +240,11 @@ public class ActiveShardCountTests extends ESTestCase {
         final int numberOfReplicas = randomIntBetween(4, 7);
         assert waitForActiveShards == ActiveShardCount.ONE || waitForActiveShards == ActiveShardCount.DEFAULT;
         ClusterState clusterState = initializeWithNewIndex(indexName, numberOfShards, numberOfReplicas);
-        assertFalse(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertFalse(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startPrimaries(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
         clusterState = startAllShards(clusterState, indexName);
-        assertTrue(waitForActiveShards.enoughShardsActive(clusterState, indexName));
+        assertTrue(waitForActiveShards.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), indexName));
     }
 
     private ClusterState initializeWithNewIndex(String indexName, int numShards, int numReplicas) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -52,7 +52,7 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
             logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
-        if (ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName()) == false) {
+        if (ActiveShardCount.ALL.enoughShardsActive(clusterState.metadata(), clusterState.routingTable(), index.getName()) == false) {
             logger.debug(
                 "[{}] lifecycle action for index [{}] cannot make progress because not all shards are active",
                 getKey().action(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForActiveShardsStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForActiveShardsStep.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ParseField;
@@ -51,6 +52,7 @@ public class WaitForActiveShardsStep extends ClusterStateWaitStep {
     @Override
     public Result isConditionMet(Index index, ClusterState clusterState) {
         Metadata metadata = clusterState.metadata();
+        RoutingTable routingTable = clusterState.routingTable();
         IndexMetadata originalIndexMeta = metadata.index(index);
 
         if (originalIndexMeta == null) {
@@ -137,9 +139,9 @@ public class WaitForActiveShardsStep extends ClusterStateWaitStep {
         }
 
         ActiveShardCount activeShardCount = ActiveShardCount.parseString(waitForActiveShardsSettingValue);
-        boolean enoughShardsActive = activeShardCount.enoughShardsActive(clusterState, rolledIndexName);
+        boolean enoughShardsActive = activeShardCount.enoughShardsActive(metadata, routingTable, rolledIndexName);
 
-        IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(rolledIndexName);
+        IndexRoutingTable indexRoutingTable = routingTable.index(rolledIndexName);
         int currentActiveShards = 0;
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             currentActiveShards += indexRoutingTable.shard(i).activeShards().size();


### PR DESCRIPTION
Avoids the `ClusterState` type as a method parameter in favor of the more specific `Metadata` and `RoutingTable` ones.

Relates https://github.com/elastic/elasticsearch/pull/112466