### PR TITLE
Fixing randomization issue for TextSimilarityRankRetrieverBuilderTests

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilderTests.java
@@ -62,7 +62,7 @@ public class TextSimilarityRankRetrieverBuilderTests extends AbstractXContentTes
             randomAlphaOfLength(10),
             randomAlphaOfLength(20),
             randomAlphaOfLength(50),
-            randomIntBetween(1, 10000),
+            randomIntBetween(100, 10000),
             randomBoolean() ? null : randomFloatBetween(-1.0f, 1.0f, true)
         );
     }


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/112531.

Due to randomly generating a `TextSimilarityRankRetrieverBuilder`, it could be the case that `rankWindowSize` < 10 (which is the default `size` parameter) causing validation errors when parsing source and the following exception

```
org.elasticsearch.action.ActionRequestValidationException: Validation Failed: 1: [rank] requires [rank_window_size: 4] be greater than or equal to [size: 10]
```
In this PR we just increase the lower bound for the randomly created retriever to be 100 to ensure that it is always greater than `size`. 