### PR TITLE
Fixing randomization issue for RankDocsSortBuilderTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -121,9 +121,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJobAsync
   issue: https://github.com/elastic/elasticsearch/issues/112212
-- class: org.elasticsearch.search.retriever.rankdoc.RankDocsSortBuilderTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/112312
 - class: org.elasticsearch.search.retriever.RankDocRetrieverBuilderIT
   method: testRankDocsRetrieverWithCollapse
   issue: https://github.com/elastic/elasticsearch/issues/112254

--- a/server/src/test/java/org/elasticsearch/search/retriever/rankdoc/RankDocsSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/rankdoc/RankDocsSortBuilderTests.java
@@ -44,7 +44,7 @@ public class RankDocsSortBuilderTests extends AbstractSortTestCase<RankDocsSortB
     @Override
     protected RankDocsSortBuilder mutate(RankDocsSortBuilder original) throws IOException {
         RankDocsSortBuilder mutated = new RankDocsSortBuilder(original);
-        mutated.rankDocs(randomRankDocs(original.rankDocs().length + randomInt(100)));
+        mutated.rankDocs(randomRankDocs(original.rankDocs().length + randomIntBetween(10, 100)));
         return mutated;
     }
 


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/112312.

YetAnotherRandomizationIssue :) 

Under some weird seeds we could end up with 0-length `RankDoc` arrays for both the original and the mutated `RankDocsSortBuilder` instances. In this PR we just ensure that a 0-length mutation will not be possible. 