### PR TITLE
RestRequest parameter parsing should not cause 500 error

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -321,9 +322,15 @@ public class RestRequest implements ToXContent.Params, Traceable {
         if (hasContent() == false) {
             throw new ElasticsearchParseException("request body is required");
         } else if (xContentType.get() == null) {
-            throw new IllegalArgumentException("unknown content type");
+            throwValidationException("unknown content type");
         }
         return content();
+    }
+
+    private static void throwValidationException(String msg) {
+        ValidationException unknownContentType = new ValidationException();
+        unknownContentType.addValidationError(msg);
+        throw unknownContentType;
     }
 
     /**
@@ -585,12 +592,12 @@ public class RestRequest implements ToXContent.Params, Traceable {
         String source = param("source");
         String typeParam = param("source_content_type");
         if (source == null || typeParam == null) {
-            throw new IllegalArgumentException("source and source_content_type parameters are required");
+            throwValidationException("source and source_content_type parameters are required");
         }
         BytesArray bytes = new BytesArray(source);
         final XContentType xContentType = parseContentType(Collections.singletonList(typeParam));
         if (xContentType == null) {
-            throw new IllegalArgumentException("Unknown value for source_content_type [" + typeParam + "]");
+            throwValidationException("Unknown value for source_content_type [" + typeParam + "]");
         }
         return new Tuple<>(xContentType, bytes);
     }

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -321,7 +321,7 @@ public class RestRequest implements ToXContent.Params, Traceable {
         if (hasContent() == false) {
             throw new ElasticsearchParseException("request body is required");
         } else if (xContentType.get() == null) {
-            throw new IllegalStateException("unknown content type");
+            throw new IllegalArgumentException("unknown content type");
         }
         return content();
     }
@@ -585,12 +585,12 @@ public class RestRequest implements ToXContent.Params, Traceable {
         String source = param("source");
         String typeParam = param("source_content_type");
         if (source == null || typeParam == null) {
-            throw new IllegalStateException("source and source_content_type parameters are required");
+            throw new IllegalArgumentException("source and source_content_type parameters are required");
         }
         BytesArray bytes = new BytesArray(source);
         final XContentType xContentType = parseContentType(Collections.singletonList(typeParam));
         if (xContentType == null) {
-            throw new IllegalStateException("Unknown value for source_content_type [" + typeParam + "]");
+            throw new IllegalArgumentException("Unknown value for source_content_type [" + typeParam + "]");
         }
         return new Tuple<>(xContentType, bytes);
     }

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -130,7 +130,7 @@ public class RestRequestTests extends ESTestCase {
                 .contentOrSourceParam()
                 .v2()
         );
-        e = expectThrows(IllegalStateException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
+        e = expectThrows(IllegalArgumentException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
         assertEquals("source and source_content_type parameters are required", e.getMessage());
     }
 
@@ -246,7 +246,7 @@ public class RestRequestTests extends ESTestCase {
                 .requiredContent()
         );
         assertEquals("request body is required", e.getMessage());
-        e = expectThrows(IllegalStateException.class, () -> contentRestRequest("test", null, Collections.emptyMap()).requiredContent());
+        e = expectThrows(IllegalArgumentException.class, () -> contentRestRequest("test", null, Collections.emptyMap()).requiredContent());
         assertEquals("unknown content type", e.getMessage());
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.CheckedConsumer;
@@ -33,6 +34,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.rest.RestRequest.OPERATOR_REQUEST;
 import static org.elasticsearch.rest.RestRequest.SERVERLESS_REQUEST;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -130,8 +132,8 @@ public class RestRequestTests extends ESTestCase {
                 .contentOrSourceParam()
                 .v2()
         );
-        e = expectThrows(IllegalArgumentException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
-        assertEquals("source and source_content_type parameters are required", e.getMessage());
+        e = expectThrows(ValidationException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
+        assertThat(e.getMessage(), containsString("source and source_content_type parameters are required"));
     }
 
     public void testHasContentOrSourceParam() throws IOException {
@@ -246,8 +248,8 @@ public class RestRequestTests extends ESTestCase {
                 .requiredContent()
         );
         assertEquals("request body is required", e.getMessage());
-        e = expectThrows(IllegalArgumentException.class, () -> contentRestRequest("test", null, Collections.emptyMap()).requiredContent());
-        assertEquals("unknown content type", e.getMessage());
+        e = expectThrows(ValidationException.class, () -> contentRestRequest("test", null, Collections.emptyMap()).requiredContent());
+        assertThat(e.getMessage(), containsString("unknown content type"));
     }
 
     public void testIsServerlessRequest() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/RestRequestFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/RestRequestFilterTests.java
@@ -115,7 +115,7 @@ public class RestRequestFilterTests extends ESTestCase {
         }
         RestRequestFilter filter = () -> Collections.singleton("root.second.third");
         RestRequest filtered = filter.getFilteredRequest(restRequest);
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> filtered.content());
+        Exception e = expectThrows(IllegalArgumentException.class, () -> filtered.content());
         assertThat(e.getMessage(), containsString("unknown content type"));
     }
 


### PR DESCRIPTION
Currently, RestRequest throws IllegalStateExceptions in a few places which leads to 500 errors on the client side and e.g. turn up as warnings in the "rest.suppressed" error log. By changing them to IllegalArgumentExceptions we can change these to 400 (Bad Request) error codes.

Closes #112604