### PR TITLE
Add directory usage roles

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.plugins;
 
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.core.Nullable;
@@ -25,6 +26,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A plugin that provides alternative directory implementations.
@@ -55,6 +57,34 @@ public interface IndexStorePlugin {
          */
         default Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath, ShardRouting shardRouting) throws IOException {
             return newDirectory(indexSettings, shardPath);
+        }
+    }
+
+    enum DirectoryUsageRole {
+        DEFAULT,
+        INDEX_ONLY,
+        SEARCH_ONLY
+    }
+
+    interface WithDirectoryUsageRole {
+        /**
+         * Returns the usage role of the directory. Some codecs can optimize based on whether
+         * the directory is used exclusively for indexing or searching.
+         */
+        DirectoryUsageRole directoryUsageRole();
+
+        /**
+         * Retrieves the usage role of the specified directory if defined.
+         */
+        static Optional<DirectoryUsageRole> getDirectoryUsageRole(Directory dir) {
+            while (dir instanceof WithDirectoryUsageRole == false && dir instanceof FilterDirectory filterDirectory) {
+                dir = filterDirectory.getDelegate();
+            }
+            if (dir instanceof WithDirectoryUsageRole withRole) {
+                return Optional.of(withRole.directoryUsageRole());
+            } else {
+                return Optional.empty();
+            }
         }
     }
 


### PR DESCRIPTION
The indexing nodes in stateless should avoid eagerly loading and keeping in-memory structures like doc-values and postings of segment readers for all fields except for `_id`, `_version`, `_seq_no`, and `_primary_term`. This approach helps reduce memory usage on the indexing nodes. On search nodes, different optimizations can be applied. Ideally, we would have passed this flag explicitly, but the [Codec](https://github.com/apache/lucene/blob/2d6ad2fee6dfd96388594f4de9b37c037efe8017/lucene/core/src/java/org/apache/lucene/codecs/DocValuesFormat.java#L92) interface doesn't support it. Therefore, we need to piggyback this flag onto the Directory. In stateless mode, we will implement the `WithDirectoryUsageRole` interface for both `IndexDirectory` and `SearchDirectory` appropriately.