### PR TITLE
Allow YamlTemplateRegistry to fallback to TemplateResources

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
@@ -50,7 +50,7 @@ public class ResourceUtils {
     static String loadResourceWithFallback(Class<?> clazz, String name) throws IOException {
         InputStream is = null;
         if (clazz.getModule().isNamed()) {
-            is = TemplateResources.class.getResourceAsStream("/"+clazz.getModule().getName()+name);
+            is = TemplateResources.class.getResourceAsStream("/" + clazz.getModule().getName() + name);
         }
         if (is == null) {
             is = clazz.getResourceAsStream(name);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
@@ -36,10 +36,24 @@ public class ResourceUtils {
         }
     }
 
+    /**
+     * loadResourceWithFallback loads template resources from TemplateResource class. It expects
+     * the loader to be a named Java module and the template resources to contain required templates
+     * with a folder named with the module name. If the specified resource name is not found in
+     * template resource then the plugin's resources is used as a fallback.
+     *
+     * @param clazz the runtime class of the source plugin
+     * @param name the relative path of the resource with leading `/`
+     * @return the loaded resource as string
+     * @throws IOException
+     */
     static String loadResourceWithFallback(Class<?> clazz, String name) throws IOException {
-        InputStream is = clazz.getResourceAsStream(name);
+        InputStream is = null;
+        if (clazz.getModule().isNamed()) {
+            is = TemplateResources.class.getResourceAsStream("/"+clazz.getModule().getName()+name);
+        }
         if (is == null) {
-            is = TemplateResources.class.getResourceAsStream("/"+clazz.getPackageName()+name);
+            is = clazz.getResourceAsStream(name);
         }
         if (is == null) {
             throw new IOException("Resource [" + name + "] not found in classpath.");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
@@ -7,12 +7,15 @@
 
 package org.elasticsearch.xpack.core.template;
 
+import org.elasticsearch.xpack.core.template.resources.TemplateResources;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class ResourceUtils {
+
     static byte[] loadVersionedResourceUTF8(Class<?> clazz, String name, int version, String versionProperty) {
         return loadVersionedResourceUTF8(clazz, name, version, versionProperty, Map.of());
     }
@@ -25,7 +28,7 @@ public class ResourceUtils {
         Map<String, String> variables
     ) {
         try {
-            String content = loadResource(clazz, name);
+            String content = loadResourceWithFallback(clazz, name);
             content = TemplateUtils.replaceVariables(content, String.valueOf(version), versionProperty, variables);
             return content.getBytes(StandardCharsets.UTF_8);
         } catch (IOException e) {
@@ -33,8 +36,11 @@ public class ResourceUtils {
         }
     }
 
-    public static String loadResource(Class<?> clazz, String name) throws IOException {
+    static String loadResourceWithFallback(Class<?> clazz, String name) throws IOException {
         InputStream is = clazz.getResourceAsStream(name);
+        if (is == null) {
+            is = TemplateResources.class.getResourceAsStream("/"+clazz.getPackageName()+name);
+        }
         if (is == null) {
             throw new IOException("Resource [" + name + "] not found in classpath.");
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/YamlTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/YamlTemplateRegistry.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.core.template.ResourceUtils.loadResource;
+import static org.elasticsearch.xpack.core.template.ResourceUtils.loadResourceWithFallback;
 import static org.elasticsearch.xpack.core.template.ResourceUtils.loadVersionedResourceUTF8;
 
 /**
@@ -64,7 +64,7 @@ public abstract class YamlTemplateRegistry extends IndexTemplateRegistry {
         try {
             final Map<String, Object> resources = XContentHelper.convertToMap(
                 YamlXContent.yamlXContent,
-                loadResource(this.getClass(), "/resources.yaml"),
+                loadResourceWithFallback(this.getClass(), "/resources.yaml"),
                 false
             );
             version = (((Number) resources.get("version")).intValue());


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

The PR refactors `YamlTemplateRegistry` to load from TemplateResources for locating resource files and fallbacks to the plugin-module itself if it can't locate the file in the TemplateResources (more details are in the java doc). It also introduces a convention to use the named-module's name as the folder name in the `TemplateResource` to keep interfaces a bit simple.

### Related to

https://github.com/elastic/elasticsearch/issues/112137
https://github.com/elastic/apm-server/issues/13898