### PR TITLE
[7.17] Similarity is applicable for text & keyword fields (#112613)

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -5,6 +5,8 @@ A similarity (scoring / ranking model) defines how matching documents
 are scored. Similarity is per field, meaning that via the mapping one
 can define a different similarity per field.
 
+Similarity is only applicable for text type and keyword type fields.
+
 Configuring a custom similarity is considered an expert feature and the
 builtin similarities are most likely sufficient as is described in
 <<similarity>>.


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Similarity is applicable for text & keyword fields (#112613)