### PR TITLE
ESQL: Port more PhysicalPlan to NamedWriteable

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -206,6 +206,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_ADD_INDEX_MODE_CONCRETE_INDICES = def(8_736_00_0);
     public static final TransportVersion UNASSIGNED_PRIMARY_COUNT_ON_CLUSTER_HEALTH = def(8_737_00_0);
     public static final TransportVersion ESQL_AGGREGATE_EXEC_TRACKS_INTERMEDIATE_ATTRS = def(8_738_00_0);
+    public static final TransportVersion ESQL_FIELD_EXTRACT_DOC_VALUES = def(8_739_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -206,7 +206,6 @@ public class TransportVersions {
     public static final TransportVersion ESQL_ADD_INDEX_MODE_CONCRETE_INDICES = def(8_736_00_0);
     public static final TransportVersion UNASSIGNED_PRIMARY_COUNT_ON_CLUSTER_HEALTH = def(8_737_00_0);
     public static final TransportVersion ESQL_AGGREGATE_EXEC_TRACKS_INTERMEDIATE_ATTRS = def(8_738_00_0);
-    public static final TransportVersion ESQL_FIELD_EXTRACT_DOC_VALUES = def(8_739_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -9,19 +9,12 @@ package org.elasticsearch.xpack.esql.io.stream;
 
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteable;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.iterable.Iterables;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.index.EsIndex;
-import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -50,8 +43,6 @@ import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.Entry.of;
 
@@ -92,11 +83,11 @@ public final class PlanNamedTypes {
             of(PhysicalPlan.class, EsQueryExec.ENTRY),
             of(PhysicalPlan.class, EsSourceExec.ENTRY),
             of(PhysicalPlan.class, EvalExec.ENTRY),
-            of(PhysicalPlan.class, EnrichExec.class, PlanNamedTypes::writeEnrichExec, PlanNamedTypes::readEnrichExec),
+            of(PhysicalPlan.class, EnrichExec.ENTRY),
             of(PhysicalPlan.class, ExchangeExec.ENTRY),
             of(PhysicalPlan.class, ExchangeSinkExec.ENTRY),
             of(PhysicalPlan.class, ExchangeSourceExec.ENTRY),
-            of(PhysicalPlan.class, FieldExtractExec.class, PlanNamedTypes::writeFieldExtractExec, PlanNamedTypes::readFieldExtractExec),
+            of(PhysicalPlan.class, FieldExtractExec.ENTRY),
             of(PhysicalPlan.class, FilterExec.class, PlanNamedTypes::writeFilterExec, PlanNamedTypes::readFilterExec),
             of(PhysicalPlan.class, FragmentExec.class, PlanNamedTypes::writeFragmentExec, PlanNamedTypes::readFragmentExec),
             of(PhysicalPlan.class, GrokExec.class, PlanNamedTypes::writeGrokExec, PlanNamedTypes::readGrokExec),
@@ -114,72 +105,6 @@ public final class PlanNamedTypes {
     }
 
     // -- physical plan nodes
-    static EnrichExec readEnrichExec(PlanStreamInput in) throws IOException {
-        final Source source = Source.readFrom(in);
-        final PhysicalPlan child = in.readPhysicalPlanNode();
-        final NamedExpression matchField = in.readNamedWriteable(NamedExpression.class);
-        final String policyName = in.readString();
-        final String matchType = (in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) ? in.readString() : "match";
-        final String policyMatchField = in.readString();
-        final Map<String, String> concreteIndices;
-        final Enrich.Mode mode;
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
-            mode = in.readEnum(Enrich.Mode.class);
-            concreteIndices = in.readMap(StreamInput::readString, StreamInput::readString);
-        } else {
-            mode = Enrich.Mode.ANY;
-            EsIndex esIndex = new EsIndex(in);
-            if (esIndex.concreteIndices().size() != 1) {
-                throw new IllegalStateException("expected a single concrete enrich index; got " + esIndex.concreteIndices());
-            }
-            concreteIndices = Map.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, Iterables.get(esIndex.concreteIndices(), 0));
-        }
-        return new EnrichExec(
-            source,
-            child,
-            mode,
-            matchType,
-            matchField,
-            policyName,
-            policyMatchField,
-            concreteIndices,
-            in.readNamedWriteableCollectionAsList(NamedExpression.class)
-        );
-    }
-
-    static void writeEnrichExec(PlanStreamOutput out, EnrichExec enrich) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writePhysicalPlanNode(enrich.child());
-        out.writeNamedWriteable(enrich.matchField());
-        out.writeString(enrich.policyName());
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
-            out.writeString(enrich.matchType());
-        }
-        out.writeString(enrich.policyMatchField());
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
-            out.writeEnum(enrich.mode());
-            out.writeMap(enrich.concreteIndices(), StreamOutput::writeString, StreamOutput::writeString);
-        } else {
-            if (enrich.concreteIndices().keySet().equals(Set.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY))) {
-                String concreteIndex = enrich.concreteIndices().get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                new EsIndex(concreteIndex, Map.of(), Map.of(concreteIndex, IndexMode.STANDARD)).writeTo(out);
-            } else {
-                throw new IllegalStateException("expected a single concrete enrich index; got " + enrich.concreteIndices());
-            }
-        }
-        out.writeNamedWriteableCollection(enrich.enrichFields());
-    }
-
-    static FieldExtractExec readFieldExtractExec(PlanStreamInput in) throws IOException {
-        return new FieldExtractExec(Source.readFrom(in), in.readPhysicalPlanNode(), in.readNamedWriteableCollectionAsList(Attribute.class));
-    }
-
-    static void writeFieldExtractExec(PlanStreamOutput out, FieldExtractExec fieldExtractExec) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writePhysicalPlanNode(fieldExtractExec.child());
-        out.writeNamedWriteableCollection(fieldExtractExec.attributesToExtract());
-    }
-
     static FilterExec readFilterExec(PlanStreamInput in) throws IOException {
         return new FilterExec(Source.readFrom(in), in.readPhysicalPlanNode(), in.readNamedWriteable(Expression.class));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertFieldExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/InsertFieldExtraction.java
@@ -59,7 +59,7 @@ public class InsertFieldExtraction extends Rule<PhysicalPlan, PhysicalPlan> {
             // add extractor
             if (missing.isEmpty() == false) {
                 // collect source attributes and add the extractor
-                var extractor = new FieldExtractExec(p.source(), p.child(), List.copyOf(missing));
+                var extractor = new FieldExtractExec(p.source(), p.child(), List.copyOf(missing), Set.of());
                 p = p.replaceChild(extractor);
             }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
@@ -6,20 +6,37 @@
  */
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
 public class EnrichExec extends UnaryExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "EnrichExec",
+        EnrichExec::readFrom
+    );
 
     private final Enrich.Mode mode;
     private final String matchType;
@@ -30,9 +47,6 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
     private final List<NamedExpression> enrichFields;
 
     /**
-     *
-     * @param source
-     * @param child
      * @param matchField the match field in the source data
      * @param policyName the enrich policy name
      * @param policyMatchField the match field name in the policy
@@ -58,6 +72,68 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
         this.policyMatchField = policyMatchField;
         this.concreteIndices = concreteIndices;
         this.enrichFields = enrichFields;
+    }
+
+    private static EnrichExec readFrom(StreamInput in) throws IOException {
+        final Source source = Source.readFrom((PlanStreamInput) in);
+        final PhysicalPlan child = ((PlanStreamInput) in).readPhysicalPlanNode();
+        final NamedExpression matchField = in.readNamedWriteable(NamedExpression.class);
+        final String policyName = in.readString();
+        final String matchType = (in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) ? in.readString() : "match";
+        final String policyMatchField = in.readString();
+        final Map<String, String> concreteIndices;
+        final Enrich.Mode mode;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
+            mode = in.readEnum(Enrich.Mode.class);
+            concreteIndices = in.readMap(StreamInput::readString, StreamInput::readString);
+        } else {
+            mode = Enrich.Mode.ANY;
+            EsIndex esIndex = new EsIndex(in);
+            if (esIndex.concreteIndices().size() != 1) {
+                throw new IllegalStateException("expected a single concrete enrich index; got " + esIndex.concreteIndices());
+            }
+            concreteIndices = Map.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, Iterables.get(esIndex.concreteIndices(), 0));
+        }
+        return new EnrichExec(
+            source,
+            child,
+            mode,
+            matchType,
+            matchField,
+            policyName,
+            policyMatchField,
+            concreteIndices,
+            in.readNamedWriteableCollectionAsList(NamedExpression.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
+        out.writeNamedWriteable(matchField());
+        out.writeString(policyName());
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
+            out.writeString(matchType());
+        }
+        out.writeString(policyMatchField());
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
+            out.writeEnum(mode());
+            out.writeMap(concreteIndices(), StreamOutput::writeString, StreamOutput::writeString);
+        } else {
+            if (concreteIndices().keySet().equals(Set.of(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY))) {
+                String concreteIndex = concreteIndices().get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+                new EsIndex(concreteIndex, Map.of(), Map.of(concreteIndex, IndexMode.STANDARD)).writeTo(out);
+            } else {
+                throw new IllegalStateException("expected a single concrete enrich index; got " + concreteIndices());
+            }
+        }
+        out.writeNamedWriteableCollection(enrichFields());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
@@ -26,12 +26,14 @@ public abstract class PhysicalPlan extends QueryPlan<PhysicalPlan> {
         return List.of(
             AggregateExec.ENTRY,
             DissectExec.ENTRY,
+            EnrichExec.ENTRY,
             EsQueryExec.ENTRY,
             EsSourceExec.ENTRY,
             EvalExec.ENTRY,
             ExchangeExec.ENTRY,
             ExchangeSinkExec.ENTRY,
-            ExchangeSourceExec.ENTRY
+            ExchangeSourceExec.ENTRY,
+            FieldExtractExec.ENTRY
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExecSerializationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class EnrichExecSerializationTests extends AbstractPhysicalPlanSerializationTests<EnrichExec> {
+    public static EnrichExec randomEnrichExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        Enrich.Mode mode = randomFrom(Enrich.Mode.values());
+        String matchType = randomAlphaOfLength(3);
+        NamedExpression matchField = FieldAttributeTests.createFieldAttribute(0, false);
+        String policyName = randomAlphaOfLength(4);
+        String policyMatchField = randomAlphaOfLength(5);
+        Map<String, String> concreteIndices = randomMap(1, 4, () -> Tuple.tuple(randomAlphaOfLength(3), randomAlphaOfLength(5)));
+        List<NamedExpression> enrichFields = randomFieldAttributes(1, 4, false).stream().map(f -> (NamedExpression) f).toList();
+        return new EnrichExec(source, child, mode, matchType, matchField, policyName, policyMatchField, concreteIndices, enrichFields);
+    }
+
+    @Override
+    protected EnrichExec createTestInstance() {
+        return randomEnrichExec(0);
+    }
+
+    @Override
+    protected EnrichExec mutateInstance(EnrichExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        Enrich.Mode mode = instance.mode();
+        String matchType = instance.matchType();
+        NamedExpression matchField = instance.matchField();
+        String policyName = instance.policyName();
+        String policyMatchField = instance.policyMatchField();
+        Map<String, String> concreteIndices = instance.concreteIndices();
+        List<NamedExpression> enrichFields = instance.enrichFields();
+        switch (between(0, 7)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> mode = randomValueOtherThan(mode, () -> randomFrom(Enrich.Mode.values()));
+            case 2 -> matchType = randomValueOtherThan(matchType, () -> randomAlphaOfLength(3));
+            case 3 -> matchField = randomValueOtherThan(matchField, () -> FieldAttributeTests.createFieldAttribute(0, false));
+            case 4 -> policyName = randomValueOtherThan(policyName, () -> randomAlphaOfLength(4));
+            case 5 -> policyMatchField = randomValueOtherThan(policyMatchField, () -> randomAlphaOfLength(5));
+            case 6 -> concreteIndices = randomValueOtherThan(
+                concreteIndices,
+                () -> randomMap(1, 4, () -> Tuple.tuple(randomAlphaOfLength(3), randomAlphaOfLength(5)))
+            );
+            case 7 -> enrichFields = randomValueOtherThan(
+                enrichFields,
+                () -> randomFieldAttributes(1, 4, false).stream().map(f -> (NamedExpression) f).toList()
+            );
+        }
+        return new EnrichExec(
+            instance.source(),
+            child,
+            mode,
+            matchType,
+            matchField,
+            policyName,
+            policyMatchField,
+            concreteIndices,
+            enrichFields
+        );
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExecSerializationTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class FieldExtractExecSerializationTests extends AbstractPhysicalPlanSerializationTests<FieldExtractExec> {
+    public static FieldExtractExec randomFieldExtractExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        List<Attribute> attributesToExtract = randomFieldAttributes(1, 4, false);
+        Set<Attribute> docValuesAttributes = new HashSet<>(randomFieldAttributes(1, 4, false));
+        return new FieldExtractExec(source, child, attributesToExtract, docValuesAttributes);
+    }
+
+    @Override
+    protected FieldExtractExec createTestInstance() {
+        return randomFieldExtractExec(0);
+    }
+
+    @Override
+    protected FieldExtractExec mutateInstance(FieldExtractExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        List<Attribute> attributesToExtract = instance.attributesToExtract();
+        Set<Attribute> docValuesAttributes = instance.docValuesAttributes();
+        switch (between(0, 2)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> attributesToExtract = randomValueOtherThan(attributesToExtract, () -> randomFieldAttributes(1, 4, false));
+            case 2 -> docValuesAttributes = randomValueOtherThan(
+                docValuesAttributes,
+                () -> new HashSet<>(randomFieldAttributes(1, 4, false))
+            );
+        }
+        return new FieldExtractExec(instance.source(), child, attributesToExtract, docValuesAttributes);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExecSerializationTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExecSerializationTests.java
@@ -20,7 +20,7 @@ public class FieldExtractExecSerializationTests extends AbstractPhysicalPlanSeri
         Source source = randomSource();
         PhysicalPlan child = randomChild(depth);
         List<Attribute> attributesToExtract = randomFieldAttributes(1, 4, false);
-        Set<Attribute> docValuesAttributes = new HashSet<>(randomFieldAttributes(1, 4, false));
+        Set<Attribute> docValuesAttributes = Set.of(); // These are never serialized
         return new FieldExtractExec(source, child, attributesToExtract, docValuesAttributes);
     }
 
@@ -33,14 +33,11 @@ public class FieldExtractExecSerializationTests extends AbstractPhysicalPlanSeri
     protected FieldExtractExec mutateInstance(FieldExtractExec instance) throws IOException {
         PhysicalPlan child = instance.child();
         List<Attribute> attributesToExtract = instance.attributesToExtract();
-        Set<Attribute> docValuesAttributes = instance.docValuesAttributes();
-        switch (between(0, 2)) {
-            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
-            case 1 -> attributesToExtract = randomValueOtherThan(attributesToExtract, () -> randomFieldAttributes(1, 4, false));
-            case 2 -> docValuesAttributes = randomValueOtherThan(
-                docValuesAttributes,
-                () -> new HashSet<>(randomFieldAttributes(1, 4, false))
-            );
+        Set<Attribute> docValuesAttributes = Set.of(); // These are never serialized
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            attributesToExtract = randomValueOtherThan(attributesToExtract, () -> randomFieldAttributes(1, 4, false));
         }
         return new FieldExtractExec(instance.source(), child, attributesToExtract, docValuesAttributes);
     }


### PR DESCRIPTION
This lines ESQL up better with the rest of Elasticsearch. Slowly, slowly. It also fixes a bug in serializing the field extractor.
