### PR TITLE
Fix leaking listener in Netty4HttpRequestBodyStream

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -11,6 +11,7 @@ package org.elasticsearch.http.netty4;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.concurrent.FutureListener;
 
 import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.transport.netty4.Netty4Utils;
@@ -33,9 +34,11 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     private boolean closing = false;
     private HttpBody.ChunkHandler handler;
 
+    private final FutureListener<Void> closeListener = future -> doClose();
+
     public Netty4HttpRequestBodyStream(Channel channel) {
         this.channel = channel;
-        channel.closeFuture().addListener((f) -> doClose());
+        channel.closeFuture().addListener(closeListener);
         channel.config().setAutoRead(false);
     }
 
@@ -71,6 +74,7 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     }
 
     public void handleNettyContent(HttpContent httpContent) {
+        hasLast = httpContent instanceof LastHttpContent;
         if (closing) {
             httpContent.release();
             return;
@@ -80,10 +84,6 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
             sendChunk(httpContent);
         } else {
             chunkQueue.add(httpContent);
-        }
-        if (httpContent instanceof LastHttpContent) {
-            hasLast = true;
-            channel.config().setAutoRead(true);
         }
     }
 
@@ -108,6 +108,10 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         var bytesRef = Netty4Utils.toReleasableBytesReference(httpContent.content());
         var isLast = httpContent instanceof LastHttpContent;
         handler.onNext(bytesRef, isLast);
+        if (isLast) {
+            channel.config().setAutoRead(true);
+            channel.closeFuture().removeListener(closeListener);
+        }
     }
 
     private void releaseQueuedChunks() {


### PR DESCRIPTION
Currently every instance of `Netty4HttpRequestBodyStream` will register close listener to channel, but never deregister. This PR removes listener when `LastHttpContent` is sent downstream to handler. Tested with debugger. Netty does not expose registered listeners.

Another minor change. Currently I `setAutoRead(true)` when stream receive `LastHttpContent` despite downstream state and current queueing. This PR `setAutoRead(true)` when `LastHttpContent` is sent to downstream, not on reception.