### PR TITLE
[8.15] Fix missing header in put_geoip_database JSON spec (#112581)

### DIFF
--- a/docs/changelog/112581.yaml
+++ b/docs/changelog/112581.yaml
@@ -1,0 +1,5 @@
+pr: 112581
+summary: Fix missing header in `put_geoip_database` JSON spec
+area: Ingest Node
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[


### PR DESCRIPTION
Backports the following commits to 8.15:

* #112581 