### PR TITLE
[Cloud Security] add CDR related data streams to kibana_system priviliges

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -420,7 +420,19 @@ class KibanaOwnedReservedRoleDescriptors {
                 // For source indices of the Cloud Detection & Response (CDR) packages that ships a
                 // transform
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-wiz.vulnerability-*", "logs-wiz.cloud_configuration_finding-*", "logs-aws.securityhub_findings-*")
+                    .indices(
+                        "logs-wiz.vulnerability-*",
+                        "logs-wiz.cloud_configuration_finding-*",
+                        "logs-google_scc.finding-*",
+                        "logs-aws.securityhub_findings-*",
+                        "logs-aws.inspector-*",
+                        "logs-amazon_security_lake.findings-*",
+                        "logs-qualys_vmdr.asset_host_detection-*",
+                        "logs-tenable_sc.vulnerability-*",
+                        "logs-tenable_io.vulnerability-*",
+                        "logs-rapid7_insightvm.vulnerability-*",
+                        "logs-carbon_black_cloud.asset_vulnerability_summary-*"
+                    )
                     .privileges("read", "view_index_metadata")
                     .build(),
                 // For alias indices of the Cloud Detection & Response (CDR) packages that ships a

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1612,7 +1612,15 @@ public class ReservedRolesStoreTests extends ESTestCase {
         Arrays.asList(
             "logs-wiz.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13)),
             "logs-wiz.cloud_configuration_finding-" + randomAlphaOfLength(randomIntBetween(0, 13)),
-            "logs-aws.securityhub_findings-" + randomAlphaOfLength(randomIntBetween(0, 13))
+            "logs-google_scc.finding-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-aws.securityhub_findings-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-aws.inspector-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-amazon_security_lake.findings-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-qualys_vmdr.asset_host_detection-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-tenable_sc.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-tenable_io.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-rapid7_insightvm.vulnerability-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "logs-carbon_black_cloud.asset_vulnerability_summary-" + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach(indexName -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
             assertThat(kibanaRole.indices().allowedIndicesMatcher("indices:foo").test(indexAbstraction), is(false));


### PR DESCRIPTION
- related to https://github.com/elastic/elasticsearch/pull/112456 and https://github.com/elastic/elasticsearch/pull/112192
- resolves https://github.com/elastic/security-team/issues/10302

### Summary
The Cloud Security team has identified some integrations that provide Cloud Detection&Response (CDR)-related data. More on this list is available at https://github.com/elastic/security-team/issues/10302. To decouple the work on adoption for these integrations for Cloud Security flows in Kibana from the stack releases, adding these existing data streams to the `kibana_system` privileges. This is required for the latest transforms to work
