### PR TITLE
[8.15] RestRequest parameter parsing should not cause 500 error (#112605)

### DIFF
--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.CheckedConsumer;
@@ -32,6 +33,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.rest.RestRequest.PATH_RESTRICTED;
+import static org.elasticsearch.rest.RestRequest.OPERATOR_REQUEST;
+import static org.elasticsearch.rest.RestRequest.SERVERLESS_REQUEST;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -129,8 +133,8 @@ public class RestRequestTests extends ESTestCase {
                 .contentOrSourceParam()
                 .v2()
         );
-        e = expectThrows(IllegalStateException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
-        assertEquals("source and source_content_type parameters are required", e.getMessage());
+        e = expectThrows(ValidationException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
+        assertThat(e.getMessage(), containsString("source and source_content_type parameters are required"));
     }
 
     public void testHasContentOrSourceParam() throws IOException {
@@ -245,8 +249,8 @@ public class RestRequestTests extends ESTestCase {
                 .requiredContent()
         );
         assertEquals("request body is required", e.getMessage());
-        e = expectThrows(IllegalStateException.class, () -> contentRestRequest("test", null, Collections.emptyMap()).requiredContent());
-        assertEquals("unknown content type", e.getMessage());
+        e = expectThrows(ValidationException.class, () -> contentRestRequest("test", null, Collections.emptyMap()).requiredContent());
+        assertThat(e.getMessage(), containsString("unknown content type"));
     }
 
     public void testMarkPathRestricted() {

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -33,8 +33,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.rest.RestRequest.PATH_RESTRICTED;
-import static org.elasticsearch.rest.RestRequest.OPERATOR_REQUEST;
-import static org.elasticsearch.rest.RestRequest.SERVERLESS_REQUEST;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/RestRequestFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/RestRequestFilterTests.java
@@ -115,7 +115,7 @@ public class RestRequestFilterTests extends ESTestCase {
         }
         RestRequestFilter filter = () -> Collections.singleton("root.second.third");
         RestRequest filtered = filter.getFilteredRequest(restRequest);
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> filtered.content());
+        Exception e = expectThrows(IllegalArgumentException.class, () -> filtered.content());
         assertThat(e.getMessage(), containsString("unknown content type"));
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [RestRequest parameter parsing should not cause 500 error (#112605)](https://github.com/elastic/elasticsearch/pull/112605)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)