### PR TITLE
ES|QL: Fix function metadata tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -195,15 +195,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/112382
 - class: org.elasticsearch.xpack.eql.EqlClientYamlIT
   issue: https://github.com/elastic/elasticsearch/issues/112617
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {meta.CountFunctions}
-  issue: https://github.com/elastic/elasticsearch/issues/112659
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {meta.CountFunctions SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/112660
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {meta.CountFunctions ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/112661
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/meta.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/meta.csv-spec
@@ -516,5 +516,5 @@ countFunctions#[skip:-8.15.99]
 meta functions |  stats  a = count(*), b = count(*), c = count(*) |  mv_expand c;
 
 a:long | b:long | c:long
-116    | 116    | 116
+117    | 117    | 117
 ;


### PR DESCRIPTION
Just a race condition while merging two PRs (#112055 and #112350). 

Fixes #112659
Fixes #112660
Fixes #112661