### PR TITLE
[8.15] Full coverage of ECS by ecs@mappings when date_detection is disabled (#112444)

### DIFF
--- a/docs/changelog/112444.yaml
+++ b/docs/changelog/112444.yaml
@@ -1,0 +1,6 @@
+pr: 112444
+summary: Full coverage of ECS by ecs@mappings when `date_detection` is disabled
+area: Mapping
+type: bug
+issues:
+ - 112398

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -155,7 +155,11 @@
               "ingested",
               "*.ingested",
               "*.start",
-              "*.end"
+              "*.end",
+              "*.indicator.first_seen",
+              "*.indicator.last_seen",
+              "*.indicator.modified_at",
+              "*threat.enrichments.matched.occurred"
             ],
             "unmatch_mapping_type": "object"
           }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -48,7 +48,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 12;
+    public static final int REGISTRY_VERSION = 14;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Full coverage of ECS by ecs@mappings when date_detection is disabled (#112444)](https://github.com/elastic/elasticsearch/pull/112444)

Two comments about the merge:
1. I merged all changes of `EcsDynamicTemplatesIT` because some are needed and the coverage is better anyway
2. I kept the same version of `StackTemplateRegistry` from the original PR, even though it bumps by two, as it may be easier to track back to what the version change is related to. I think that in terms of functionality it shouldn't matter - upgrade from 8.15.1 to 8.15.2 should trigger components update the same.

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)