### PR TITLE
Fix trappy timeouts in `o.e.a.a.cluster.*`

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -597,8 +597,8 @@ public class DataStreamIT extends ESIntegTestCase {
             false
         );
         verifyResolvability(dataStreamName, indicesAdmin().prepareGetSettings(dataStreamName), false);
-        verifyResolvability(dataStreamName, clusterAdmin().prepareHealth(dataStreamName), false);
-        verifyResolvability(dataStreamName, clusterAdmin().prepareState().setIndices(dataStreamName), false);
+        verifyResolvability(dataStreamName, clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, dataStreamName), false);
+        verifyResolvability(dataStreamName, clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices(dataStreamName), false);
         verifyResolvability(dataStreamName, client().prepareFieldCaps(dataStreamName).setFields("*"), false);
         verifyResolvability(dataStreamName, indicesAdmin().prepareGetIndex().addIndices(dataStreamName), false);
         verifyResolvability(dataStreamName, indicesAdmin().prepareOpen(dataStreamName), false);
@@ -644,8 +644,8 @@ public class DataStreamIT extends ESIntegTestCase {
             indicesAdmin().prepareUpdateSettings(wildcardExpression).setSettings(Settings.builder().put("index.number_of_replicas", 0)),
             false
         );
-        verifyResolvability(wildcardExpression, clusterAdmin().prepareHealth(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, clusterAdmin().prepareState().setIndices(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, wildcardExpression), false);
+        verifyResolvability(wildcardExpression, clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices(wildcardExpression), false);
         verifyResolvability(wildcardExpression, client().prepareFieldCaps(wildcardExpression).setFields("*"), false);
         verifyResolvability(wildcardExpression, indicesAdmin().prepareGetIndex().addIndices(wildcardExpression), false);
         verifyResolvability(wildcardExpression, indicesAdmin().prepareOpen(wildcardExpression), false);
@@ -1594,7 +1594,7 @@ public class DataStreamIT extends ESIntegTestCase {
         client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).get();
 
         // when querying a backing index then the data stream should be included as well.
-        ClusterStateRequest request = new ClusterStateRequest().indices(".ds-metrics-foo-*000001");
+        ClusterStateRequest request = new ClusterStateRequest(TEST_REQUEST_TIMEOUT).indices(".ds-metrics-foo-*000001");
         ClusterState state = clusterAdmin().state(request).get().getState();
         assertThat(state.metadata().dataStreams().size(), equalTo(1));
         assertThat(state.metadata().dataStreams().get("metrics-foo").getName(), equalTo("metrics-foo"));

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/ResolveClusterDataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/ResolveClusterDataStreamIT.java
@@ -405,7 +405,7 @@ public class ResolveClusterDataStreamIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client(REMOTE_CLUSTER_2).admin()
                 .cluster()
-                .prepareHealth(remoteIndex2)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex2)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -917,7 +917,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         String firstGenerationIndex = getBackingIndices(dataStreamName).get(0);
         ClusterGetSettingsAction.Response response = client().execute(
             ClusterGetSettingsAction.INSTANCE,
-            new ClusterGetSettingsAction.Request()
+            new ClusterGetSettingsAction.Request(TEST_REQUEST_TIMEOUT)
         ).get();
         Settings clusterSettings = response.persistentSettings();
 
@@ -1093,7 +1093,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
         // Let's verify the merge settings
         ClusterGetSettingsAction.Response response = client().execute(
             ClusterGetSettingsAction.INSTANCE,
-            new ClusterGetSettingsAction.Request()
+            new ClusterGetSettingsAction.Request(TEST_REQUEST_TIMEOUT)
         ).get();
         Settings clusterSettings = response.persistentSettings();
 

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamsStatsTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamsStatsTests.java
@@ -131,7 +131,10 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
         assertTrue(indicesAdmin().close(new CloseIndexRequest(".ds-" + dataStreamName + "-*-000001")).actionGet().isAcknowledged());
 
         assertBusy(
-            () -> assertNotEquals(ClusterHealthStatus.RED, clusterAdmin().health(new ClusterHealthRequest()).actionGet().getStatus())
+            () -> assertNotEquals(
+                ClusterHealthStatus.RED,
+                clusterAdmin().health(new ClusterHealthRequest(TEST_REQUEST_TIMEOUT)).actionGet().getStatus()
+            )
         );
 
         DataStreamsStatsAction.Response stats = getDataStreamsStats();

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/LookAHeadTimeTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/LookAHeadTimeTests.java
@@ -118,7 +118,9 @@ public class LookAHeadTimeTests extends ESSingleNodeTestCase {
     }
 
     private void updateClusterSettings(Settings settings) {
-        clusterAdmin().updateSettings(new ClusterUpdateSettingsRequest().persistentSettings(settings)).actionGet();
+        clusterAdmin().updateSettings(
+            new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(settings)
+        ).actionGet();
     }
 
     private void updateIndexSettings(Settings settings) {

--- a/modules/lang-painless/src/internalClusterTest/java/org/elasticsearch/painless/action/CrossClusterPainlessExecuteIT.java
+++ b/modules/lang-painless/src/internalClusterTest/java/org/elasticsearch/painless/action/CrossClusterPainlessExecuteIT.java
@@ -175,7 +175,7 @@ public class CrossClusterPainlessExecuteIT extends AbstractMultiClustersTestCase
         assertFalse(
             client(REMOTE_CLUSTER).admin()
                 .cluster()
-                .prepareHealth(REMOTE_INDEX)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, REMOTE_INDEX)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -88,8 +88,8 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         ensureGreen();
 
-        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest();
-        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest();
+        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
+        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT);
 
         // Start the migration and *immediately* request the status. We're trying to detect a race condition with this test, so we need to
         // do this as fast as possible, but not before the request to start the migration completes.
@@ -170,7 +170,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             postUpgradeHookCalled.set(true);
         });
 
-        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest();
+        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
         PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
         assertThat(migrationResponse.getReason(), nullValue());
         assertThat(migrationResponse.getElasticsearchException(), nullValue());
@@ -180,7 +180,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             .collect(Collectors.toSet());
         assertThat(migratingFeatures, hasItem(FEATURE_NAME));
 
-        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest();
+        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT);
         // The feature upgrade may take longer than ten seconds when tests are running
         // in parallel, so we give assertBusy a sixty-second timeout.
         assertBusy(() -> {
@@ -196,7 +196,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertTrue("the pre-migration hook wasn't actually called", preUpgradeHookCalled.get());
         assertTrue("the post-migration hook wasn't actually called", postUpgradeHookCalled.get());
 
-        Metadata finalMetadata = clusterAdmin().prepareState().get().getState().metadata();
+        Metadata finalMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         // Check that the results metadata is what we expect.
         FeatureMigrationResults currentResults = finalMetadata.custom(FeatureMigrationResults.TYPE);
         assertThat(currentResults, notNullValue());
@@ -246,12 +246,12 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         updateIndexSettings(Settings.builder().put("index.blocks.write", true), indexName);
         ensureGreen();
 
-        client().execute(PostFeatureUpgradeAction.INSTANCE, new PostFeatureUpgradeRequest()).get();
+        client().execute(PostFeatureUpgradeAction.INSTANCE, new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT)).get();
 
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(
                 GetFeatureUpgradeStatusAction.INSTANCE,
-                new GetFeatureUpgradeStatusRequest()
+                new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT)
             ).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
@@ -299,7 +299,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             fail("cluster state update failed, see log for details");
         }
 
-        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest();
+        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
         PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
         // Make sure we actually started the migration
         assertTrue(
@@ -309,7 +309,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         // Now wait for the migration to finish (otherwise the test infra explodes)
         assertBusy(() -> {
-            GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest();
+            GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT);
             GetFeatureUpgradeStatusResponse statusResp = client().execute(GetFeatureUpgradeStatusAction.INSTANCE, getStatusRequest).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
@@ -337,8 +337,10 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         ensureGreen();
 
-        PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, new PostFeatureUpgradeRequest())
-            .get();
+        PostFeatureUpgradeResponse migrationResponse = client().execute(
+            PostFeatureUpgradeAction.INSTANCE,
+            new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT)
+        ).get();
 
         assertTrue(migrationResponse.isAccepted());
     }
@@ -349,7 +351,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(
                 GetFeatureUpgradeStatusAction.INSTANCE,
-                new GetFeatureUpgradeStatusRequest()
+                new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT)
             ).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.ERROR));
@@ -364,7 +366,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(
                 GetFeatureUpgradeStatusAction.INSTANCE,
-                new GetFeatureUpgradeStatusRequest()
+                new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT)
             ).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
@@ -426,8 +428,10 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         ensureGreen();
 
-        PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, new PostFeatureUpgradeRequest())
-            .get();
+        PostFeatureUpgradeResponse migrationResponse = client().execute(
+            PostFeatureUpgradeAction.INSTANCE,
+            new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT)
+        ).get();
         assertTrue(migrationResponse.isAccepted());
     }
 
@@ -437,7 +441,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(
                 GetFeatureUpgradeStatusAction.INSTANCE,
-                new GetFeatureUpgradeStatusRequest()
+                new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT)
             ).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.ERROR));
@@ -452,7 +456,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(
                 GetFeatureUpgradeStatusAction.INSTANCE,
-                new GetFeatureUpgradeStatusRequest()
+                new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT)
             ).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
@@ -176,7 +176,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             hooksCalled.countDown();
         });
 
-        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest();
+        PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
         PostFeatureUpgradeResponse migrationResponse = client().execute(PostFeatureUpgradeAction.INSTANCE, migrationRequest).get();
         assertThat(migrationResponse.getReason(), nullValue());
         assertThat(migrationResponse.getElasticsearchException(), nullValue());
@@ -189,7 +189,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         // wait for all the plugin methods to have been called before assertBusy since that will exponentially backoff
         assertThat(hooksCalled.await(30, TimeUnit.SECONDS), is(true));
 
-        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest();
+        GetFeatureUpgradeStatusRequest getStatusRequest = new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT);
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResponse = client().execute(GetFeatureUpgradeStatusAction.INSTANCE, getStatusRequest)
                 .get();
@@ -203,7 +203,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         assertTrue("the second plugin's pre-migration hook wasn't actually called", secondPluginPreMigrationHookCalled.get());
         assertTrue("the second plugin's post-migration hook wasn't actually called", secondPluginPostMigrationHookCalled.get());
 
-        Metadata finalMetadata = clusterAdmin().prepareState().get().getState().metadata();
+        Metadata finalMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         // Check that the results metadata is what we expect
         FeatureMigrationResults currentResults = finalMetadata.custom(FeatureMigrationResults.TYPE);
         assertThat(currentResults, notNullValue());

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/SystemIndexMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/SystemIndexMigrationIT.java
@@ -85,7 +85,7 @@ public class SystemIndexMigrationIT extends AbstractFeatureMigrationIntegTest {
         clusterService.addListener(clusterStateListener);
 
         // create task by calling API
-        final PostFeatureUpgradeRequest req = new PostFeatureUpgradeRequest();
+        final PostFeatureUpgradeRequest req = new PostFeatureUpgradeRequest(TEST_REQUEST_TIMEOUT);
         client().execute(PostFeatureUpgradeAction.INSTANCE, req);
         logger.info("migrate feature api called");
 
@@ -101,12 +101,12 @@ public class SystemIndexMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         assertBusy(() -> {
             // Wait for the node we restarted to completely rejoin the cluster
-            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+            ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat("expected restarted node to rejoin cluster", clusterState.getNodes().size(), equalTo(2));
 
             GetFeatureUpgradeStatusResponse statusResponse = client().execute(
                 GetFeatureUpgradeStatusAction.INSTANCE,
-                new GetFeatureUpgradeStatusRequest()
+                new GetFeatureUpgradeStatusRequest(TEST_REQUEST_TIMEOUT)
             ).get();
             assertThat(
                 "expected migration to fail due to restarting only data node",

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureSimpleTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureSimpleTests.java
@@ -30,7 +30,7 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
         assertNotNull(
             client().admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
                 .get()
                 .getState()
@@ -52,7 +52,7 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
         assertNotNull(
             client().admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
                 .get()
                 .getState()

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
@@ -33,7 +33,7 @@ public class AzureTwoStartedNodesTests extends AbstractAzureComputeServiceTestCa
         assertNotNull(
             client().admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
                 .get()
                 .getState()
@@ -47,7 +47,7 @@ public class AzureTwoStartedNodesTests extends AbstractAzureComputeServiceTestCa
         assertNotNull(
             client().admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
                 .get()
                 .getState()

--- a/plugins/discovery-ec2/src/internalClusterTest/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryUpdateSettingsTests.java
+++ b/plugins/discovery-ec2/src/internalClusterTest/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryUpdateSettingsTests.java
@@ -31,7 +31,7 @@ public class Ec2DiscoveryUpdateSettingsTests extends AbstractAwsTestCase {
         // We try to update a setting now
         final String expectedValue = UUIDs.randomBase64UUID(random());
         final String settingName = "cluster.routing.allocation.exclude.any_attribute";
-        final ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
+        final ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().put(settingName, expectedValue))
             .get();
 

--- a/plugins/discovery-gce/src/internalClusterTest/java/org/elasticsearch/discovery/gce/GceDiscoverTests.java
+++ b/plugins/discovery-gce/src/internalClusterTest/java/org/elasticsearch/discovery/gce/GceDiscoverTests.java
@@ -67,7 +67,7 @@ public class GceDiscoverTests extends ESIntegTestCase {
 
         ClusterStateResponse clusterStateResponse = client(masterNode).admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
             .clear()
             .setNodes(true)
@@ -79,7 +79,7 @@ public class GceDiscoverTests extends ESIntegTestCase {
         registerGceNode(secondNode);
         clusterStateResponse = client(secondNode).admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
             .clear()
             .setNodes(true)
@@ -88,13 +88,13 @@ public class GceDiscoverTests extends ESIntegTestCase {
         assertNotNull(clusterStateResponse.getState().nodes().getMasterNodeId());
 
         // wait for the cluster to form
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(2)).get());
+        assertNoTimeout(client().admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes(Integer.toString(2)).get());
         assertNumberOfNodes(2);
 
         // add one more node and wait for it to join
         final String thirdNode = internalCluster().startDataOnlyNode();
         registerGceNode(thirdNode);
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes(Integer.toString(3)).get());
+        assertNoTimeout(client().admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes(Integer.toString(3)).get());
         assertNumberOfNodes(3);
     }
 

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsTests.java
@@ -141,7 +141,7 @@ public class HdfsTests extends ESSingleNodeTestCase {
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         ensureGreen();
         assertThat(count(client, "test-idx-1"), equalTo(100L));
-        ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.getMetadata().hasIndex("test-idx-1"), equalTo(true));
         assertThat(clusterState.getMetadata().hasIndex("test-idx-2"), equalTo(false));
         final BlobStoreRepository repo = (BlobStoreRepository) getInstanceFromNode(RepositoriesService.class).repository("test-repo");

--- a/qa/restricted-loggers/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
+++ b/qa/restricted-loggers/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
@@ -29,7 +29,7 @@ public class LoggersTests extends ESTestCase {
     public void testClusterUpdateSettingsRequestValidationForLoggers() {
         assertThat(Loggers.RESTRICTED_LOGGERS, hasSize(greaterThan(0)));
 
-        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         for (String logger : Loggers.RESTRICTED_LOGGERS) {
             var validation = request.persistentSettings(Map.of("logger." + logger, org.elasticsearch.logging.Level.DEBUG)).validate();
             assertNotNull(validation);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -395,7 +395,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
         clearInterceptedActions();
         String[] concreteIndexNames = TestIndexNameExpressionResolver.newInstance()
-            .concreteIndexNames(clusterAdmin().prepareState().get().getState(), flushRequest);
+            .concreteIndexNames(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), flushRequest);
         assertIndicesSubset(Arrays.asList(concreteIndexNames), indexShardActions);
     }
 
@@ -422,7 +422,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
         clearInterceptedActions();
         String[] concreteIndexNames = TestIndexNameExpressionResolver.newInstance()
-            .concreteIndexNames(clusterAdmin().prepareState().get().getState(), refreshRequest);
+            .concreteIndexNames(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), refreshRequest);
         assertIndicesSubset(Arrays.asList(concreteIndexNames), indexShardActions);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -1053,7 +1053,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             logger.info("--> close the index, now the replica is stale");
             assertAcked(indicesAdmin().prepareClose("idx"));
 
-            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth("idx")
+            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "idx")
                 .setTimeout(TimeValue.timeValueSeconds(30))
                 .setWaitForActiveShards(ActiveShardCount.ONE)
                 .setWaitForNoInitializingShards(true)
@@ -1254,7 +1254,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         if (state == IndexMetadata.State.CLOSE) {
             assertAcked(indicesAdmin().prepareClose("idx"));
 
-            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth("idx")
+            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "idx")
                 .setTimeout(TimeValue.timeValueSeconds(30))
                 .setWaitForActiveShards(activeShardCount)
                 .setWaitForEvents(Priority.LANGUID)
@@ -1275,13 +1275,13 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
     }
 
     private String primaryNodeName() {
-        ClusterState clusterState = admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         String nodeId = clusterState.getRoutingTable().index("idx").shard(0).primaryShard().currentNodeId();
         return clusterState.getRoutingNodes().node(nodeId).node().getName();
     }
 
     private DiscoveryNode replicaNode() {
-        ClusterState clusterState = admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         String nodeId = clusterState.getRoutingTable().index("idx").shard(0).replicaShards().get(0).currentNodeId();
         return clusterState.getRoutingNodes().node(nodeId).node();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetDesiredBalanceActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetDesiredBalanceActionIT.java
@@ -37,7 +37,9 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
 
         indexData(index);
 
-        var clusterHealthResponse = clusterAdmin().health(new ClusterHealthRequest().waitForStatus(ClusterHealthStatus.GREEN)).get();
+        var clusterHealthResponse = clusterAdmin().health(
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT).waitForStatus(ClusterHealthStatus.GREEN)
+        ).get();
         assertEquals(RestStatus.OK, clusterHealthResponse.status());
 
         final var desiredBalanceResponse = safeGet(
@@ -50,7 +52,7 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
         for (var entry : shardsMap.entrySet()) {
             Integer shardId = entry.getKey();
             DesiredBalanceResponse.DesiredShards desiredShards = entry.getValue();
-            IndexShardRoutingTable shardRoutingTable = clusterAdmin().prepareState()
+            IndexShardRoutingTable shardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .routingTable()
@@ -73,7 +75,9 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
         int numberOfReplicas = 1;
         createIndex(index, numberOfShards, numberOfReplicas);
         indexData(index);
-        var clusterHealthResponse = clusterAdmin().health(new ClusterHealthRequest(index).waitForStatus(ClusterHealthStatus.YELLOW)).get();
+        var clusterHealthResponse = clusterAdmin().health(
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, index).waitForStatus(ClusterHealthStatus.YELLOW)
+        ).get();
         assertEquals(RestStatus.OK, clusterHealthResponse.status());
 
         final var desiredBalanceResponse = safeGet(
@@ -86,7 +90,7 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
         for (var entry : shardsMap.entrySet()) {
             Integer shardId = entry.getKey();
             DesiredBalanceResponse.DesiredShards desiredShards = entry.getValue();
-            IndexShardRoutingTable shardRoutingTable = clusterAdmin().prepareState()
+            IndexShardRoutingTable shardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .routingTable()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDesiredNodesActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDesiredNodesActionsIT.java
@@ -87,6 +87,8 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
         }
 
         final var equivalentUpdateRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             updateDesiredNodesRequest.getHistoryID(),
             updateDesiredNodesRequest.getVersion(),
             desiredNodesList,
@@ -105,6 +107,8 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
         updateDesiredNodes(updateDesiredNodesRequest);
 
         final var backwardsUpdateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             updateDesiredNodesRequest.getHistoryID(),
             updateDesiredNodesRequest.getVersion() - 1,
             updateDesiredNodesRequest.getNodes(),
@@ -123,6 +127,8 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
         updateDesiredNodes(updateDesiredNodesRequest);
 
         final var updateDesiredNodesRequestWithSameHistoryIdAndVersionAndDifferentSpecs = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             updateDesiredNodesRequest.getHistoryID(),
             updateDesiredNodesRequest.getVersion(),
             randomList(1, 10, DesiredNodesTestCase::randomDesiredNode),
@@ -192,6 +198,8 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
         // This test verifies that the validation doesn't throw on desired nodes
         // with a higher number of available processors than the node running the tests.
         final var updateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             UUIDs.randomBase64UUID(),
             randomIntBetween(1, 20),
             randomList(
@@ -267,7 +275,7 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
             future.actionGet();
         }
 
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final DesiredNodes latestDesiredNodes = DesiredNodes.latestFromClusterState(state);
         assertThat(latestDesiredNodes, is(nullValue()));
     }
@@ -309,6 +317,8 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
 
     private UpdateDesiredNodesRequest randomUpdateDesiredNodesRequest(Settings settings) {
         return new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             UUIDs.randomBase64UUID(),
             randomIntBetween(2, 20),
             randomList(2, 10, () -> randomDesiredNode(settings)),
@@ -318,6 +328,8 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
 
     private UpdateDesiredNodesRequest randomDryRunUpdateDesiredNodesRequest(Settings settings) {
         return new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             UUIDs.randomBase64UUID(),
             randomIntBetween(2, 20),
             randomList(2, 10, () -> randomDesiredNode(settings)),
@@ -331,7 +343,7 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
     }
 
     private DesiredNodes getLatestDesiredNodes() {
-        final GetDesiredNodesAction.Request request = new GetDesiredNodesAction.Request();
+        final GetDesiredNodesAction.Request request = new GetDesiredNodesAction.Request(TEST_REQUEST_TIMEOUT);
         final GetDesiredNodesAction.Response response = client().execute(GetDesiredNodesAction.INSTANCE, request).actionGet();
         return response.getDesiredNodes();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -141,7 +141,7 @@ public class TasksIT extends ESIntegTestCase {
         registerTaskManagerListeners(TransportClusterHealthAction.NAME);
 
         // First run the health on the master node - should produce only one task on the master node
-        internalCluster().masterClient().admin().cluster().prepareHealth().get();
+        internalCluster().masterClient().admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertEquals(1, numberOfEvents(TransportClusterHealthAction.NAME, Tuple::v1)); // counting only registration events
         // counting only unregistration events
         // When checking unregistration events there might be some delay since receiving the response from the cluster doesn't
@@ -151,7 +151,7 @@ public class TasksIT extends ESIntegTestCase {
         resetTaskManagerListeners(TransportClusterHealthAction.NAME);
 
         // Now run the health on a non-master node - should produce one task on master and one task on another node
-        internalCluster().nonMasterClient().admin().cluster().prepareHealth().get();
+        internalCluster().nonMasterClient().admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertEquals(2, numberOfEvents(TransportClusterHealthAction.NAME, Tuple::v1)); // counting only registration events
         // counting only unregistration events
         assertBusy(() -> assertEquals(2, numberOfEvents(TransportClusterHealthAction.NAME, event -> event.v1() == false)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -49,7 +49,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
 
     public void testNonLocalRequestAlwaysFindsMaster() throws Exception {
         runRepeatedlyWhileChangingMaster(() -> {
-            final ClusterStateRequestBuilder clusterStateRequestBuilder = clusterAdmin().prepareState()
+            final ClusterStateRequestBuilder clusterStateRequestBuilder = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setNodes(true)
                 .setBlocks(true)
@@ -69,7 +69,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
             final String node = randomFrom(internalCluster().getNodeNames());
             final DiscoveryNodes discoveryNodes = client(node).admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setLocal(true)
                 .setNodes(true)
@@ -98,7 +98,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
             final long waitForMetadataVersion = randomLongBetween(Math.max(1, metadataVersion - 3), metadataVersion + 5);
             final ClusterStateRequestBuilder clusterStateRequestBuilder = client(node).admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setNodes(true)
                 .setMetadata(true)
@@ -131,7 +131,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
             final long waitForMetadataVersion = randomLongBetween(Math.max(1, metadataVersion - 3), metadataVersion + 5);
             final ClusterStateResponse clusterStateResponse = client(node).admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setLocal(true)
                 .setMetadata(true)
@@ -156,7 +156,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
 
         assertBusy(
             () -> assertThat(
-                clusterAdmin().prepareState()
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setMetadata(true)
                     .setBlocks(true)
@@ -188,7 +188,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
                 assertAcked(
                     client(nonMasterNode).admin()
                         .cluster()
-                        .prepareUpdateSettings()
+                        .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                         .setPersistentSettings(Settings.builder().put(CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), value))
                 );
             }
@@ -225,17 +225,22 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
 
     public void testFailsWithBlockExceptionIfBlockedAndBlocksNotRequested() {
         internalCluster().startMasterOnlyNode(Settings.builder().put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 1).build());
-        final var state = safeGet(clusterAdmin().prepareState().clear().setBlocks(true).execute()).getState();
+        final var state = safeGet(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setBlocks(true).execute()).getState();
         assertTrue(state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         assertThat(
-            safeAwaitFailure(SubscribableListener.<ClusterStateResponse>newForked(l -> clusterAdmin().prepareState().clear().execute(l))),
+            safeAwaitFailure(
+                SubscribableListener.<ClusterStateResponse>newForked(
+                    l -> clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().execute(l)
+                )
+            ),
             instanceOf(ClusterBlockException.class)
         );
 
         internalCluster().startDataOnlyNode();
 
-        final var recoveredState = safeGet(clusterAdmin().prepareState().clear().setBlocks(randomBoolean()).execute()).getState();
+        final var recoveredState = safeGet(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setBlocks(randomBoolean()).execute())
+            .getState();
         assertFalse(recoveredState.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -64,7 +64,8 @@ public class ClusterStatsIT extends ESIntegTestCase {
 
     private void waitForNodes(int numNodes) {
         ClusterHealthResponse actionGet = clusterAdmin().health(
-            new ClusterHealthRequest(new String[] {}).waitForEvents(Priority.LANGUID).waitForNodes(Integer.toString(numNodes))
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForEvents(Priority.LANGUID)
+                .waitForNodes(Integer.toString(numNodes))
         ).actionGet();
         assertThat(actionGet.isTimedOut(), is(false));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -90,7 +90,7 @@ public class CreateIndexIT extends ESIntegTestCase {
         long timeBeforeRequest = System.currentTimeMillis();
         prepareCreate("test").get();
         long timeAfterRequest = System.currentTimeMillis();
-        ClusterStateResponse response = clusterAdmin().prepareState().get();
+        ClusterStateResponse response = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         ClusterState state = response.getState();
         assertThat(state, notNullValue());
         Metadata metadata = state.getMetadata();
@@ -296,7 +296,7 @@ public class CreateIndexIT extends ESIntegTestCase {
     }
 
     public void testRestartIndexCreationAfterFullClusterRestart() throws Exception {
-        clusterAdmin().prepareUpdateSettings()
+        clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(Settings.builder().put("cluster.routing.allocation.enable", "none"))
             .get();
         indicesAdmin().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE).setSettings(indexSettings()).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -333,7 +333,10 @@ public class SplitIndexIT extends ESIntegTestCase {
     }
 
     private static IndexMetadata indexMetadata(final Client client, final String index) {
-        final ClusterStateResponse clusterStateResponse = client.admin().cluster().state(new ClusterStateRequest()).actionGet();
+        final ClusterStateResponse clusterStateResponse = client.admin()
+            .cluster()
+            .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT))
+            .actionGet();
         return clusterStateResponse.getState().metadata().index(index);
     }
 
@@ -371,7 +374,7 @@ public class SplitIndexIT extends ESIntegTestCase {
             ensureGreen();
             assertNoResizeSourceIndexSettings("target");
 
-            final ClusterState state = clusterAdmin().prepareState().get().getState();
+            final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             DiscoveryNode mergeNode = state.nodes().get(state.getRoutingTable().index("target").shard(0).primaryShard().currentNodeId());
             logger.info("split node {}", mergeNode);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -83,7 +83,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-1");
         if (explicitWriteIndex) {
             assertTrue(oldIndex.getAliases().containsKey("test_alias"));
@@ -106,7 +106,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         assertFalse(oldIndex.getAliases().containsKey("test_alias"));
         final IndexMetadata newIndex = state.metadata().index("test_index-000003");
@@ -139,7 +139,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
         assertFalse(oldIndex.getAliases().get("test_alias").writeIndex());
@@ -187,7 +187,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         final IndexMetadata newIndex = state.metadata().index("test_index-000003");
         assertThat(newIndex.getNumberOfShards(), equalTo(1));
@@ -220,7 +220,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         final IndexMetadata newIndex = state.metadata().index("test_index-000003");
         assertThat(newIndex.getNumberOfShards(), equalTo(1));
@@ -268,7 +268,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(true));
         assertThat(response.isRolledOver(), equalTo(false));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-1");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
         final IndexMetadata newIndex = state.metadata().index("test_index-000002");
@@ -334,7 +334,7 @@ public class RolloverIT extends ESIntegTestCase {
             )
         );
 
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-0");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
         if (explicitWriteIndex) {
@@ -361,7 +361,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index");
         final IndexMetadata newIndex = state.metadata().index("test_new_index");
         assertTrue(newIndex.getAliases().containsKey("test_alias"));
@@ -452,7 +452,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("No rollover with a large max_size condition", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
@@ -466,7 +466,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("Should rollover with a small max_size condition", response.isRolledOver(), equalTo(true));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(metConditions.get(0).toString(), equalTo(new MaxSizeCondition(maxSizeValue).toString()));
@@ -488,7 +488,11 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));
             assertThat("No rollover with an empty index", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-000002");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .metadata()
+                .index("test-000002");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
     }
@@ -513,7 +517,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("No rollover with a large max_primary_shard_size condition", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
@@ -527,7 +531,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("Should rollover with a small max_primary_shard_size condition", response.isRolledOver(), equalTo(true));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(metConditions.get(0).toString(), equalTo(new MaxPrimaryShardSizeCondition(maxPrimaryShardSizeCondition).toString()));
@@ -549,7 +553,11 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));
             assertThat("No rollover with an empty index", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-000002");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .metadata()
+                .index("test-000002");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
     }
@@ -573,7 +581,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("No rollover with a large max_primary_shard_docs condition", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
@@ -587,7 +595,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("Should rollover with a small max_primary_shard_docs condition", response.isRolledOver(), equalTo(true));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(
@@ -610,7 +618,11 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));
             assertThat("No rollover with an empty index", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-000002");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .metadata()
+                .index("test-000002");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
     }
@@ -698,7 +710,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index(firstIndexName);
         assertTrue(oldIndex.getAliases().containsKey(aliasName));
         assertTrue(oldIndex.getAliases().get(aliasName).isHidden());
@@ -732,7 +744,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexMetadata oldIndex = state.metadata().index(firstIndexName);
         assertFalse(oldIndex.getAliases().containsKey(aliasName));
         final IndexMetadata newIndex = state.metadata().index(secondIndexName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -88,10 +88,10 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         logger.info("--> disable allocation");
         disableAllocation(index);
         logger.info("--> stop random node");
-        int num = clusterAdmin().prepareState().get().getState().nodes().getSize();
+        int num = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getSize();
         internalCluster().stopNode(internalCluster().getNodeNameThat(new IndexNodePredicate(index)));
-        assertNoTimeout(clusterAdmin().prepareHealth().setWaitForNodes("" + (num - 1)));
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        assertNoTimeout(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("" + (num - 1)));
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> unassignedShards = clusterState.routingTable().index(index).shardsWithState(ShardRoutingState.UNASSIGNED);
         response = execute(new IndicesShardStoresRequest(index));
         assertThat(response.getStoreStatuses().containsKey(index), equalTo(true));
@@ -227,7 +227,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         }
 
         private Set<String> findNodesWithShard(String index) {
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             IndexRoutingTable indexRoutingTable = state.routingTable().index(index);
             List<ShardRouting> startedShards = indexRoutingTable.shardsWithState(ShardRoutingState.STARTED);
             Set<String> nodesNamesWithShard = new HashSet<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
@@ -28,7 +28,7 @@ public class BulkProcessorClusterSettingsIT extends ESIntegTestCase {
         internalCluster().startNode(settings);
 
         createIndex("willwork");
-        clusterAdmin().prepareHealth("willwork").setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "willwork").setWaitForGreenStatus().get();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
         bulkRequestBuilder.add(prepareIndex("willwork").setId("1").setSource("{\"foo\":1}", XContentType.JSON));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/TransportSimulateBulkActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/TransportSimulateBulkActionIT.java
@@ -80,7 +80,7 @@ public class TransportSimulateBulkActionIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().search(new SearchRequest(indexName)).actionGet();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
         searchResponse.decRef();
-        ClusterStateResponse clusterStateResponse = admin().cluster().state(new ClusterStateRequest()).actionGet();
+        ClusterStateResponse clusterStateResponse = admin().cluster().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet();
         Map<String, Object> indexMapping = clusterStateResponse.getState().metadata().index(indexName).mapping().sourceAsMap();
         Map<String, Object> fields = (Map<String, Object>) indexMapping.get("properties");
         assertThat(fields.size(), equalTo(1));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
@@ -134,7 +134,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
             .execute();
 
         logger.info("--> wait until the cluster state contains the new index");
-        assertBusy(() -> assertTrue(clusterAdmin().prepareState().get().getState().metadata().hasIndex(indexName)));
+        assertBusy(() -> assertTrue(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().hasIndex(indexName)));
 
         logger.info("--> delete the index");
         assertAcked(indicesAdmin().prepareDelete(indexName));
@@ -148,7 +148,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
     // only after the test cleanup does the index creation manifest in the cluster state. To take care of this problem
     // and its potential ramifications, we wait here for the index creation cluster state update task to finish
     private void waitForIndexCreationToComplete(final String indexName) {
-        clusterAdmin().prepareHealth(indexName).setWaitForEvents(Priority.URGENT).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).setWaitForEvents(Priority.URGENT).get();
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/WaitActiveShardCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/WaitActiveShardCountIT.java
@@ -53,7 +53,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
 
         allowNodes("test", 2);
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForActiveShards(2)
             .setWaitForYellowStatus()
@@ -90,7 +90,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
         }
 
         allowNodes("test", 3);
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForActiveShards(3)
             .setWaitForGreenStatus()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/master/TransportMasterNodeActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/master/TransportMasterNodeActionIT.java
@@ -79,7 +79,13 @@ public class TransportMasterNodeActionIT extends ESIntegTestCase {
 
         try {
             final var newMaster = ensureSufficientMasterEligibleNodes();
-            final long originalTerm = internalCluster().masterClient().admin().cluster().prepareState().get().getState().term();
+            final long originalTerm = internalCluster().masterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .term();
             final var previousMasterKnowsNewMasterIsElectedLatch = configureElectionLatch(newMaster, cleanupTasks);
 
             final var newMasterReceivedReroutedMessageFuture = new PlainActionFuture<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -202,7 +202,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         // For now just making sure that filter was stored with the alias
         logger.info("--> making sure that filter was stored with alias [alias1] and filter [user:kimchy]");
-        ClusterState clusterState = admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         IndexMetadata indexMd = clusterState.metadata().index("test");
         assertThat(indexMd.getAliases().get("alias1").filter().string(), equalTo("""
             {"term":{"user":{"value":"kimchy"}}}"""));
@@ -1416,21 +1416,33 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
     private void assertAliasesVersionIncreases(final String[] indices, final Runnable runnable) {
         final var beforeAliasesVersions = new HashMap<String, Long>(indices.length);
-        final var beforeMetadata = admin().cluster().prepareState().get().getState().metadata();
+        final var beforeMetadata = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         for (final var index : indices) {
             beforeAliasesVersions.put(index, beforeMetadata.index(index).getAliasesVersion());
         }
         runnable.run();
-        final var afterMetadata = admin().cluster().prepareState().get().getState().metadata();
+        final var afterMetadata = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         for (final String index : indices) {
             assertThat(afterMetadata.index(index).getAliasesVersion(), equalTo(1 + beforeAliasesVersions.get(index)));
         }
     }
 
     private void assertAliasesVersionUnchanged(final String index, final Runnable runnable) {
-        final long beforeAliasesVersion = admin().cluster().prepareState().get().getState().metadata().index(index).getAliasesVersion();
+        final long beforeAliasesVersion = admin().cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index(index)
+            .getAliasesVersion();
         runnable.run();
-        final long afterAliasesVersion = admin().cluster().prepareState().get().getState().metadata().index(index).getAliasesVersion();
+        final long afterAliasesVersion = admin().cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index(index)
+            .getAliasesVersion();
         assertThat(afterAliasesVersion, equalTo(beforeAliasesVersion));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -298,7 +298,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("index.routing.allocation.include._name", "nothing").build())
         );
 
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().indices().get(indexName).getState(), is(IndexMetadata.State.OPEN));
         assertThat(clusterState.routingTable().allShards().allMatch(ShardRouting::unassigned), is(true));
 
@@ -393,7 +393,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
             }
             indices[i] = indexName;
         }
-        assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
+        assertThat(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().indices().size(), equalTo(indices.length));
 
         final List<Thread> threads = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -434,7 +434,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
     }
 
     static void assertIndexHasBlock(APIBlock block, final String... indices) {
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (String index : indices) {
             final IndexMetadata indexMetadata = clusterState.metadata().indices().get(index);
             final Settings indexSettings = indexMetadata.getSettings();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -43,7 +43,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             logger.info("--> getting cluster health on [{}]", node);
             final ClusterHealthResponse health = client(node).admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setLocal(true)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueSeconds(30))
@@ -56,7 +56,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealth() {
         logger.info("--> running cluster health on an index that does not exists");
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test1")
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test1")
             .setWaitForYellowStatus()
             .setTimeout(TimeValue.timeValueSeconds(1))
             .get();
@@ -65,7 +65,10 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
 
         logger.info("--> running cluster wide health");
-        healthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().setTimeout(TimeValue.timeValueSeconds(10)).get();
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForGreenStatus()
+            .setTimeout(TimeValue.timeValueSeconds(10))
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
@@ -74,13 +77,16 @@ public class ClusterHealthIT extends ESIntegTestCase {
         createIndex("test1");
 
         logger.info("--> running cluster health on an index that does exists");
-        healthResponse = clusterAdmin().prepareHealth("test1").setWaitForGreenStatus().setTimeout(TimeValue.timeValueSeconds(10)).get();
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test1")
+            .setWaitForGreenStatus()
+            .setTimeout(TimeValue.timeValueSeconds(10))
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("--> running cluster health on an index that does exists and an index that doesn't exists");
-        healthResponse = clusterAdmin().prepareHealth("test1", "test2")
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test1", "test2")
             .setWaitForYellowStatus()
             .setTimeout(TimeValue.timeValueSeconds(1))
             .get();
@@ -93,7 +99,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
     public void testHealthWithClosedIndices() {
         createIndex("index-1");
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().get("index-1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -103,7 +109,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertAcked(indicesAdmin().prepareClose("index-2"));
 
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(2));
@@ -111,21 +117,21 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-1").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-1").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-2").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-2").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-*").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(2));
@@ -133,7 +139,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-*")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -143,7 +149,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-2"), nullValue());
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-*")
                 .setIndicesOptions(IndicesOptions.fromOptions(true, true, false, true))
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -157,7 +163,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertAcked(indicesAdmin().prepareClose("index-3"));
 
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth()
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForNoInitializingShards(true)
                 .setWaitForYellowStatus()
@@ -170,28 +176,28 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-3").getStatus(), equalTo(ClusterHealthStatus.YELLOW));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-1").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-1").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-2").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-2").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-3").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-3").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-3").getStatus(), equalTo(ClusterHealthStatus.YELLOW));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-*").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(3));
@@ -200,7 +206,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-3").getStatus(), equalTo(ClusterHealthStatus.YELLOW));
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-*")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -211,7 +217,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-3"), nullValue());
         }
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index-*")
                 .setIndicesOptions(IndicesOptions.fromOptions(true, true, false, true))
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
@@ -224,7 +230,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
         setReplicaCount(numberOfReplicas(), "index-3");
         {
-            ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(3));
@@ -240,7 +246,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             @Override
             public void run() {
                 while (finished.get() == false) {
-                    ClusterHealthResponse health = clusterAdmin().prepareHealth().get();
+                    ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get();
                     assertThat(health.getStatus(), not(equalTo(ClusterHealthStatus.RED)));
                 }
             }
@@ -254,7 +260,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
     }
 
     public void testWaitForEventsRetriesIfOtherConditionsNotMet() {
-        final ActionFuture<ClusterHealthResponse> healthResponseFuture = clusterAdmin().prepareHealth("index")
+        final ActionFuture<ClusterHealthResponse> healthResponseFuture = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .execute();
@@ -286,7 +292,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
         try {
             createIndex("index");
-            assertFalse(clusterAdmin().prepareHealth("index").setWaitForGreenStatus().get().isTimedOut());
+            assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index").setWaitForGreenStatus().get().isTimedOut());
 
             // at this point the original health response should not have returned: there was never a point where the index was green AND
             // the master had processed all pending tasks above LANGUID priority.
@@ -326,7 +332,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             responseFutures.add(
                 client(node).admin()
                     .cluster()
-                    .prepareHealth()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForGreenStatus()
                     .setMasterNodeTimeout(TimeValue.timeValueMinutes(timeoutMinutes))
@@ -369,7 +375,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         });
 
         try {
-            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueSeconds(1))
                 .get(TimeValue.timeValueSeconds(30));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -206,7 +206,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)).get();
         ensureGreen("test");
 
-        final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
+        final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setRoutingTable(true)
             .get()
@@ -320,7 +320,12 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             assertThat("size for shard " + shardRouting + " found", originalInfo.getShardSize(shardRouting), notNullValue());
         }
 
-        RoutingTable routingTable = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState().routingTable();
+        RoutingTable routingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setRoutingTable(true)
+            .get()
+            .getState()
+            .routingTable();
         for (ShardRouting shard : routingTable.allShardsIterator()) {
             assertTrue(
                 infoAfterRecovery.getReservedSpace(shard.currentNodeId(), infoAfterRecovery.getDataPath(shard))

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesSnapshotsIT.java
@@ -55,11 +55,15 @@ public class DesiredNodesSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     private DesiredNodes getLatestDesiredNodes() {
-        return client().execute(GetDesiredNodesAction.INSTANCE, new GetDesiredNodesAction.Request()).actionGet().getDesiredNodes();
+        return client().execute(GetDesiredNodesAction.INSTANCE, new GetDesiredNodesAction.Request(TEST_REQUEST_TIMEOUT))
+            .actionGet()
+            .getDesiredNodes();
     }
 
     private UpdateDesiredNodesRequest randomUpdateDesiredNodesRequest() {
         return new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(10),
             randomIntBetween(1, 10),
             randomList(

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesStatusIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesStatusIT.java
@@ -35,6 +35,8 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         final var pendingDesiredNodes = randomList(0, 5, DesiredNodesTestCase::randomDesiredNode);
 
         final var updateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(10),
             1,
             concatLists(actualizedDesiredNodes, pendingDesiredNodes),
@@ -43,11 +45,13 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         updateDesiredNodes(updateDesiredNodesRequest);
 
         {
-            final var clusterState = clusterAdmin().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
 
         final var newVersionUpdateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             updateDesiredNodesRequest.getHistoryID(),
             updateDesiredNodesRequest.getVersion() + 1,
             updateDesiredNodesRequest.getNodes(),
@@ -56,7 +60,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         updateDesiredNodes(newVersionUpdateDesiredNodesRequest);
 
         {
-            final var clusterState = clusterAdmin().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
     }
@@ -70,6 +74,8 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         final var pendingDesiredNodes = randomList(0, 5, DesiredNodesTestCase::randomDesiredNode);
 
         final var updateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(10),
             1,
             concatLists(actualizedDesiredNodes, pendingDesiredNodes),
@@ -78,14 +84,14 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         updateDesiredNodes(updateDesiredNodesRequest);
 
         {
-            final var clusterState = clusterAdmin().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
 
         updateDesiredNodes(updateDesiredNodesRequest);
 
         {
-            final var clusterState = clusterAdmin().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
     }
@@ -99,6 +105,8 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         final var pendingDesiredNodes = randomList(0, 5, DesiredNodesTestCase::randomDesiredNode);
 
         final var updateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(10),
             1,
             concatLists(actualizedDesiredNodes, pendingDesiredNodes),
@@ -106,7 +114,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         );
         updateDesiredNodes(updateDesiredNodesRequest);
 
-        final var clusterState = clusterAdmin().prepareState().get().getState();
+        final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
 
         final var leavingNodeNames = randomSubsetOf(nodeNames);
@@ -114,7 +122,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
             internalCluster().stopNode(leavingNodeName);
         }
 
-        final var newClusterState = clusterAdmin().prepareState().get().getState();
+        final var newClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final var latestDesiredNodes = DesiredNodes.latestFromClusterState(newClusterState);
 
         for (String leavingNodeName : leavingNodeNames) {
@@ -132,6 +140,8 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         final var pendingDesiredNodes = randomList(0, 5, DesiredNodesTestCase::randomDesiredNode);
 
         final var updateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(10),
             1,
             concatLists(actualizedDesiredNodes, pendingDesiredNodes),
@@ -139,7 +149,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         );
         updateDesiredNodes(updateDesiredNodesRequest);
 
-        final var clusterState = clusterAdmin().prepareState().get().getState();
+        final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
 
         // Stop some nodes, these shouldn't be actualized within the new desired node's history until they join back
@@ -149,6 +159,8 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         }
 
         final var updateDesiredNodesWithNewHistoryRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(10),
             1,
             updateDesiredNodesRequest.getNodes(),
@@ -157,7 +169,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         final var response = updateDesiredNodes(updateDesiredNodesWithNewHistoryRequest);
         assertThat(response.hasReplacedExistingHistoryId(), is(equalTo(true)));
 
-        final var updatedClusterState = clusterAdmin().prepareState().get().getState();
+        final var updatedClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final var latestDesiredNodes = DesiredNodes.latestFromClusterState(updatedClusterState);
 
         for (String clusterNodeName : clusterNodeNames) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -67,25 +67,25 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         String node1Name = internalCluster().startNode(settings);
 
         logger.info("--> should be blocked, no master...");
-        ClusterState state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().getSize(), equalTo(1)); // verify that we still see the local node in the cluster state
 
         logger.info("--> start second node, cluster should be formed");
         String node2Name = internalCluster().startNode(settings);
 
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(false));
 
@@ -97,7 +97,10 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         }
         // make sure that all shards recovered before trying to flush
         assertThat(
-            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).get().getActiveShards(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test")
+                .setWaitForActiveShards(numShards.totalNumShards)
+                .get()
+                .getActiveShards(),
             equalTo(numShards.totalNumShards)
         );
         // flush for simpler debugging
@@ -111,17 +114,20 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         String masterNode = internalCluster().getMasterName();
         String otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for non-master node, to be sure it's not elected");
-        client().execute(TransportAddVotingConfigExclusionsAction.TYPE, new AddVotingConfigExclusionsRequest(otherNode)).get();
+        client().execute(
+            TransportAddVotingConfigExclusionsAction.TYPE,
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, otherNode)
+        ).get();
         logger.info("--> stop master node, no master block should appear");
         Settings masterDataPathSettings = internalCluster().dataPathSettings(masterNode);
         internalCluster().stopNode(masterNode);
 
         assertBusy(() -> {
-            ClusterState clusterState = clusterAdmin().prepareState().setLocal(true).get().getState();
+            ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
             assertTrue(clusterState.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         // verify that both nodes are still in the cluster state but there is no master
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -130,19 +136,19 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.info("--> starting the previous master node again...");
         node2Name = internalCluster().startNode(Settings.builder().put(settings).put(masterDataPathSettings).build());
 
-        clusterHealthResponse = clusterAdmin().prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForNodes("2")
             .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(true));
 
@@ -154,20 +160,23 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         }
 
         logger.info("--> clearing voting config exclusions");
-        ClearVotingConfigExclusionsRequest clearRequest = new ClearVotingConfigExclusionsRequest();
+        ClearVotingConfigExclusionsRequest clearRequest = new ClearVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT);
         clearRequest.setWaitForRemoval(false);
         client().execute(TransportClearVotingConfigExclusionsAction.TYPE, clearRequest).get();
 
         masterNode = internalCluster().getMasterName();
         otherNode = node1Name.equals(masterNode) ? node2Name : node1Name;
         logger.info("--> add voting config exclusion for master node, to be sure it's not elected");
-        client().execute(TransportAddVotingConfigExclusionsAction.TYPE, new AddVotingConfigExclusionsRequest(masterNode)).get();
+        client().execute(
+            TransportAddVotingConfigExclusionsAction.TYPE,
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, masterNode)
+        ).get();
         logger.info("--> stop non-master node, no master block should appear");
         Settings otherNodeDataPathSettings = internalCluster().dataPathSettings(otherNode);
         internalCluster().stopNode(otherNode);
 
         assertBusy(() -> {
-            ClusterState state1 = clusterAdmin().prepareState().setLocal(true).get().getState();
+            ClusterState state1 = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
             assertThat(state1.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         });
 
@@ -175,19 +184,19 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().startNode(Settings.builder().put(settings).put(otherNodeDataPathSettings).build());
 
         ensureGreen();
-        clusterHealthResponse = clusterAdmin().prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .setWaitForGreenStatus()
             .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = clusterAdmin().prepareState().setLocal(true).get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(true));
 
@@ -212,7 +221,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             for (Client client : clients()) {
-                ClusterState state1 = client.admin().cluster().prepareState().setLocal(true).get().getState();
+                ClusterState state1 = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
                 assertThat(state1.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
             }
         });
@@ -221,13 +230,13 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().startNode(settings);
 
         ensureGreen();
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("3")
             .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.nodes().getSize(), equalTo(3));
 
         createIndex("test");
@@ -239,7 +248,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         ensureGreen();
         // make sure that all shards recovered before trying to flush
         assertThat(
-            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).get().isTimedOut(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").setWaitForActiveShards(numShards.totalNumShards).get().isTimedOut(),
             equalTo(false)
         );
         // flush for simpler debugging
@@ -262,7 +271,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.info("--> verify that there is no master anymore on remaining node");
         // spin here to wait till the state is set
         assertBusy(() -> {
-            ClusterState st = clusterAdmin().prepareState().setLocal(true).get().getState();
+            ClusterState st = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
             assertThat(st.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         });
 
@@ -272,7 +281,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().validateClusterFormed();
         ensureGreen();
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.nodes().getSize(), equalTo(3));
 
         logger.info("--> verify we the data back");
@@ -338,7 +347,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             DiscoveryNode masterNode = internalCluster().client(randomFrom(otherNodes))
                 .admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .nodes()
@@ -350,7 +359,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         partition.stopDisrupting();
 
         logger.debug("--> waiting for cluster to heal");
-        assertNoTimeout(clusterAdmin().prepareHealth().setWaitForNodes("3").setWaitForEvents(Priority.LANGUID));
+        assertNoTimeout(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("3").setWaitForEvents(Priority.LANGUID));
 
         for (String node : internalCluster().getNodeNames()) {
             Settings nodeSetting = internalCluster().clusterService(node).state().metadata().settings();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -72,7 +72,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         final List<String> nodes = internalCluster().startNodes(3, settings);
 
         createIndex("test");
-        clusterAdmin().prepareHealth("test").setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").setWaitForGreenStatus().get();
 
         final NetworkDisruption disruptionScheme = new NetworkDisruption(
             new IsolateAllNodes(new HashSet<>(nodes)),
@@ -84,7 +84,12 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         final Client clientToMasterlessNode = client();
 
         assertBusy(() -> {
-            ClusterState state = clientToMasterlessNode.admin().cluster().prepareState().setLocal(true).get().getState();
+            ClusterState state = clientToMasterlessNode.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -223,14 +228,14 @@ public class NoMasterNodeIT extends ESIntegTestCase {
 
         prepareCreate("test1").setSettings(indexSettings(1, 2)).get();
         prepareCreate("test2").setSettings(indexSettings(3, 0)).get();
-        clusterAdmin().prepareHealth("_all").setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "_all").setWaitForGreenStatus().get();
         prepareIndex("test1").setId("1").setSource("field", "value1").get();
         prepareIndex("test2").setId("1").setSource("field", "value1").get();
         refresh();
 
         ensureSearchable("test1", "test2");
 
-        ClusterStateResponse clusterState = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         logger.info("Cluster state:\n{}", clusterState.getState());
 
         final NetworkDisruption disruptionScheme = new NetworkDisruption(
@@ -243,7 +248,12 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         final Client clientToMasterlessNode = client();
 
         assertBusy(() -> {
-            ClusterState state = clientToMasterlessNode.admin().cluster().prepareState().setLocal(true).get().getState();
+            ClusterState state = clientToMasterlessNode.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -299,13 +309,13 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         final List<String> nodes = internalCluster().startNodes(3, settings);
 
         prepareCreate("test1").setSettings(indexSettings(1, 1)).get();
-        clusterAdmin().prepareHealth("_all").setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "_all").setWaitForGreenStatus().get();
         prepareIndex("test1").setId("1").setSource("field", "value1").get();
         refresh();
 
         ensureGreen("test1");
 
-        ClusterStateResponse clusterState = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         logger.info("Cluster state:\n{}", clusterState.getState());
 
         final List<String> nodesWithShards = clusterState.getState()
@@ -321,7 +331,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
 
         client().execute(
             TransportAddVotingConfigExclusionsAction.TYPE,
-            new AddVotingConfigExclusionsRequest(nodesWithShards.toArray(new String[0]))
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, nodesWithShards.toArray(new String[0]))
         ).get();
         ensureGreen("test1");
 
@@ -336,7 +346,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             for (String node : nodesWithShards) {
-                ClusterState state = client(node).admin().cluster().prepareState().setLocal(true).get().getState();
+                ClusterState state = client(node).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
                 assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
             }
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -76,13 +76,16 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
     }
 
     public void testRoutingTable() throws Exception {
-        ClusterStateResponse clusterStateResponseUnfiltered = clusterAdmin().prepareState().clear().setRoutingTable(true).get();
+        ClusterStateResponse clusterStateResponseUnfiltered = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setRoutingTable(true)
+            .get();
         assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("foo"), is(true));
         assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("fuu"), is(true));
         assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("baz"), is(true));
         assertThat(clusterStateResponseUnfiltered.getState().routingTable().hasIndex("non-existent"), is(false));
 
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().get();
         assertThat(clusterStateResponse.getState().routingTable().hasIndex("foo"), is(false));
         assertThat(clusterStateResponse.getState().routingTable().hasIndex("fuu"), is(false));
         assertThat(clusterStateResponse.getState().routingTable().hasIndex("baz"), is(false));
@@ -90,43 +93,49 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
     }
 
     public void testNodes() throws Exception {
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().setNodes(true).get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setNodes(true).get();
         assertThat(clusterStateResponse.getState().nodes().getNodes().size(), is(cluster().size()));
 
-        ClusterStateResponse clusterStateResponseFiltered = clusterAdmin().prepareState().clear().get();
+        ClusterStateResponse clusterStateResponseFiltered = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().get();
         assertThat(clusterStateResponseFiltered.getState().nodes().getNodes().size(), is(0));
     }
 
     public void testMetadata() throws Exception {
-        ClusterStateResponse clusterStateResponseUnfiltered = clusterAdmin().prepareState().clear().setMetadata(true).get();
+        ClusterStateResponse clusterStateResponseUnfiltered = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setMetadata(true)
+            .get();
         assertThat(clusterStateResponseUnfiltered.getState().metadata().indices().size(), is(3));
 
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().get();
         assertThat(clusterStateResponse.getState().metadata().indices().size(), is(0));
     }
 
     public void testMetadataVersion() {
         createIndex("index-1");
         createIndex("index-2");
-        long baselineVersion = clusterAdmin().prepareState().get().getState().metadata().version();
+        long baselineVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().version();
         assertThat(baselineVersion, greaterThan(0L));
         assertThat(
-            clusterAdmin().prepareState().setIndices("index-1").get().getState().metadata().version(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices("index-1").get().getState().metadata().version(),
             greaterThanOrEqualTo(baselineVersion)
         );
         assertThat(
-            clusterAdmin().prepareState().setIndices("index-2").get().getState().metadata().version(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices("index-2").get().getState().metadata().version(),
             greaterThanOrEqualTo(baselineVersion)
         );
         assertThat(
-            clusterAdmin().prepareState().setIndices("*").get().getState().metadata().version(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices("*").get().getState().metadata().version(),
             greaterThanOrEqualTo(baselineVersion)
         );
         assertThat(
-            clusterAdmin().prepareState().setIndices("not-found").get().getState().metadata().version(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices("not-found").get().getState().metadata().version(),
             greaterThanOrEqualTo(baselineVersion)
         );
-        assertThat(clusterAdmin().prepareState().clear().setMetadata(false).get().getState().metadata().version(), equalTo(0L));
+        assertThat(
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setMetadata(false).get().getState().metadata().version(),
+            equalTo(0L)
+        );
     }
 
     public void testIndexTemplates() throws Exception {
@@ -170,7 +179,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
             )
             .get();
 
-        ClusterStateResponse clusterStateResponseUnfiltered = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterStateResponseUnfiltered = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(clusterStateResponseUnfiltered.getState().metadata().templates().size(), is(greaterThanOrEqualTo(2)));
 
         GetIndexTemplatesResponse getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates("foo_template").get();
@@ -198,7 +207,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
      * that the cluster state returns coherent data for both routing table and metadata.
      */
     private void testFilteringByIndexWorks(String[] indices, String[] expected) {
-        ClusterStateResponse clusterState = clusterAdmin().prepareState()
+        ClusterStateResponse clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setRoutingTable(true)
@@ -262,19 +271,23 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
     }
 
     public void testIndicesOptions() throws Exception {
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().setMetadata(true).setIndices("f*").get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setMetadata(true)
+            .setIndices("f*")
+            .get();
         assertThat(clusterStateResponse.getState().metadata().indices().size(), is(2));
         ensureGreen("fuu");
 
         // close one index
         assertAcked(indicesAdmin().close(new CloseIndexRequest("fuu")).get());
-        clusterStateResponse = clusterAdmin().prepareState().clear().setMetadata(true).setIndices("f*").get();
+        clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setMetadata(true).setIndices("f*").get();
         assertThat(clusterStateResponse.getState().metadata().indices().size(), is(1));
         assertThat(clusterStateResponse.getState().metadata().index("foo").getState(), equalTo(IndexMetadata.State.OPEN));
 
         // expand_wildcards_closed should toggle return only closed index fuu
         IndicesOptions expandCloseOptions = IndicesOptions.fromOptions(false, true, false, true);
-        clusterStateResponse = clusterAdmin().prepareState()
+        clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices("f*")
@@ -285,7 +298,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
 
         // ignore_unavailable set to true should not raise exception on fzzbzz
         IndicesOptions ignoreUnavailabe = IndicesOptions.fromOptions(true, true, true, false);
-        clusterStateResponse = clusterAdmin().prepareState()
+        clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices("fzzbzz")
@@ -296,7 +309,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         // empty wildcard expansion result should work when allowNoIndices is
         // turned on
         IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, true, true, false);
-        clusterStateResponse = clusterAdmin().prepareState()
+        clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices("a*")
@@ -309,7 +322,12 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         // empty wildcard expansion throws exception when allowNoIndices is turned off
         IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, false, true, false);
         try {
-            clusterAdmin().prepareState().clear().setMetadata(true).setIndices("a*").setIndicesOptions(allowNoIndices).get();
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .clear()
+                .setMetadata(true)
+                .setIndices("a*")
+                .setIndicesOptions(allowNoIndices)
+                .get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
             assertThat(e.getMessage(), is("no such index [a*]"));
@@ -320,7 +338,12 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         // ignore_unavailable set to false throws exception when allowNoIndices is turned off
         IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, true, true, false);
         try {
-            clusterAdmin().prepareState().clear().setMetadata(true).setIndices("fzzbzz").setIndicesOptions(allowNoIndices).get();
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .clear()
+                .setMetadata(true)
+                .setIndices("fzzbzz")
+                .setIndicesOptions(allowNoIndices)
+                .get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
             assertThat(e.getMessage(), is("no such index [fzzbzz]"));
@@ -330,7 +353,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
     public void testPrivateCustomsAreExcluded() throws Exception {
         // ensure that the custom is injected into the cluster state
         assertBusy(() -> assertTrue(clusterService().state().customs().containsKey("test")));
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setCustoms(true).get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setCustoms(true).get();
         assertFalse(clusterStateResponse.getState().customs().containsKey("test"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
@@ -47,7 +47,12 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
 
         internalCluster().startNode(nonDataNode());
         assertThat(
-            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("2").setLocal(true).get().isTimedOut(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForNodes("2")
+                .setLocal(true)
+                .get()
+                .isTimedOut(),
             equalTo(false)
         );
 
@@ -62,7 +67,12 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         // now, start a node data, and see that it gets with shards
         internalCluster().startNode(dataNode());
         assertThat(
-            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("3").setLocal(true).get().isTimedOut(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+                .setWaitForEvents(Priority.LANGUID)
+                .setWaitForNodes("3")
+                .setLocal(true)
+                .get()
+                .isTimedOut(),
             equalTo(false)
         );
 
@@ -76,7 +86,9 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
             new CreateIndexRequest("test").settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
                 .waitForActiveShards(ActiveShardCount.NONE)
         ).actionGet();
-        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
+        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForEvents(Priority.LANGUID)
+            .get();
         assertThat(healthResponse1.isTimedOut(), equalTo(false));
         assertThat(healthResponse1.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse1.getActiveShards(), equalTo(0));
@@ -84,7 +96,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         internalCluster().startNode(dataNode());
 
         assertThat(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes("2")
                 .setWaitForGreenStatus()
@@ -100,7 +112,9 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
             new CreateIndexRequest("test").settings(Settings.builder().put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all"))
                 .waitForActiveShards(ActiveShardCount.NONE)
         ).actionGet();
-        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
+        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForEvents(Priority.LANGUID)
+            .get();
         assertThat(healthResponse1.isTimedOut(), equalTo(false));
         assertThat(healthResponse1.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse1.getActiveShards(), equalTo(0));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
@@ -37,7 +37,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
             assertThat(
-                clusterAdmin().prepareState()
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                     .get()
                     .getState()
@@ -52,11 +52,27 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start master node");
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().nonMasterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().masterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(masterNodeName)
         );
 
@@ -66,7 +82,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
 
         try {
             assertThat(
-                clusterAdmin().prepareState()
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                     .get()
                     .getState()
@@ -84,11 +100,27 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
             Settings.builder().put(nonDataNode(masterNode())).put(masterDataPathSettings)
         );
         assertThat(
-            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().nonMasterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(nextMasterEligibleNodeName)
         );
         assertThat(
-            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().masterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(nextMasterEligibleNodeName)
         );
     }
@@ -99,7 +131,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
             assertThat(
-                clusterAdmin().prepareState()
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                     .get()
                     .getState()
@@ -114,45 +146,112 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start master node (1)");
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().nonMasterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().masterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(masterNodeName)
         );
 
         logger.info("--> start master node (2)");
         final String nextMasterEligableNodeName = internalCluster().startMasterOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().nonMasterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().masterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(masterNodeName)
         );
 
         logger.info("--> closing master node (1)");
-        client().execute(TransportAddVotingConfigExclusionsAction.TYPE, new AddVotingConfigExclusionsRequest(masterNodeName)).get();
+        client().execute(
+            TransportAddVotingConfigExclusionsAction.TYPE,
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, masterNodeName)
+        ).get();
         // removing the master from the voting configuration immediately triggers the master to step down
         assertBusy(() -> {
             assertThat(
-                internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+                internalCluster().nonMasterClient()
+                    .admin()
+                    .cluster()
+                    .prepareState(TEST_REQUEST_TIMEOUT)
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNode()
+                    .getName(),
                 equalTo(nextMasterEligableNodeName)
             );
             assertThat(
-                internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+                internalCluster().masterClient()
+                    .admin()
+                    .cluster()
+                    .prepareState(TEST_REQUEST_TIMEOUT)
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNode()
+                    .getName(),
                 equalTo(nextMasterEligableNodeName)
             );
         });
         internalCluster().stopNode(masterNodeName);
         assertThat(
-            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().nonMasterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(nextMasterEligableNodeName)
         );
         assertThat(
-            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
+            internalCluster().masterClient()
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNode()
+                .getName(),
             equalTo(nextMasterEligableNodeName)
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
@@ -27,7 +27,7 @@ public class UpdateSettingsValidationIT extends ESIntegTestCase {
         createIndex("test");
         NumShards test = getNumShards("test");
 
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test")
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("3")
             .setWaitForGreenStatus()
@@ -36,7 +36,10 @@ public class UpdateSettingsValidationIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.totalNumShards));
 
         setReplicaCount(0, "test");
-        healthResponse = clusterAdmin().prepareHealth("test").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test")
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForGreenStatus()
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.numPrimaries));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -71,7 +71,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         // On slow machines the initial relocation might be delayed
         assertBusy(() -> {
             logger.info("--> waiting for no relocation");
-            ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+            ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setIndices("test1", "test2")
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForGreenStatus()
@@ -82,7 +82,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertThat("Cluster health request timed out", clusterHealth.isTimedOut(), equalTo(false));
 
             logger.info("--> checking current state");
-            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+            ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
             // check that closed indices are effectively closed
             final List<String> notClosedIndices = indicesToClose.stream()
@@ -115,7 +115,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         String A_1 = nodes.get(3);
 
         logger.info("--> waiting for nodes to form a cluster");
-        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForNodes("4").get();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("4").get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         createIndex("test", 5, 1);
@@ -125,7 +125,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         }
 
         logger.info("--> waiting for shards to be allocated");
-        health = clusterAdmin().prepareHealth()
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -133,7 +133,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .get();
         assertThat(health.isTimedOut(), equalTo(false));
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         Map<String, Integer> counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_1), anyOf(equalTo(2), equalTo(3)));
@@ -162,7 +162,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertAcked(indicesAdmin().prepareClose("test"));
         }
 
-        ClusterHealthResponse health = clusterAdmin().prepareHealth()
+        ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -170,7 +170,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForNoRelocatingShards(true)
             .get();
         assertThat(health.isTimedOut(), equalTo(false));
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         Map<String, Integer> counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -178,7 +178,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         logger.info("--> starting another node in zone 'b'");
 
         String B_1 = internalCluster().startNode(Settings.builder().put(commonSettings).put("node.attr.zone", "b").build());
-        health = clusterAdmin().prepareHealth()
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -186,7 +186,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .get();
         assertThat(health.isTimedOut(), equalTo(false));
         ClusterRerouteUtils.reroute(client());
-        health = clusterAdmin().prepareHealth()
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -196,7 +196,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .get();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -204,7 +204,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(counts.get(B_1), equalTo(2));
 
         String noZoneNode = internalCluster().startNode();
-        health = clusterAdmin().prepareHealth()
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -212,7 +212,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .get();
         assertThat(health.isTimedOut(), equalTo(false));
         ClusterRerouteUtils.reroute(client());
-        health = clusterAdmin().prepareHealth()
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -222,7 +222,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .get();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -230,7 +230,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(counts.get(B_1), equalTo(2));
         assertThat(counts.containsKey(noZoneNode), equalTo(false));
         updateClusterSettings(Settings.builder().put("cluster.routing.allocation.awareness.attributes", ""));
-        health = clusterAdmin().prepareHealth()
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -240,7 +240,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .get();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(3));
@@ -254,7 +254,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
         final IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put(prefix + "nonsense", "foo"))
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(Settings.builder().put(prefix + "nonsense", "foo"))
         );
         assertThat(illegalArgumentException.getMessage(), containsString("[cluster.routing.allocation.awareness.force.]"));
         assertThat(illegalArgumentException.getCause(), instanceOf(SettingsException.class));
@@ -263,7 +264,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put(prefix + "attr.not_values", "foo"))
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                    .setPersistentSettings(Settings.builder().put(prefix + "attr.not_values", "foo"))
             ).getMessage(),
             containsString("[cluster.routing.allocation.awareness.force.attr.not_values]")
         );
@@ -271,7 +273,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put(prefix + "attr.values.junk", "foo"))
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                    .setPersistentSettings(Settings.builder().put(prefix + "attr.values.junk", "foo"))
             ).getMessage(),
             containsString("[cluster.routing.allocation.awareness.force.attr.values.junk]")
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -96,7 +96,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, *under dry_run*");
@@ -115,7 +115,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         );
 
         logger.info("--> get the state, verify nothing changed because of the dry run");
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, actually allocating, no dry run");
@@ -132,7 +132,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             equalTo(ShardRoutingState.INITIALIZING)
         );
 
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
@@ -140,7 +140,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary allocated");
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_1).getId()).iterator().next().state(),
@@ -165,7 +165,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             equalTo(ShardRoutingState.INITIALIZING)
         );
 
-        healthResponse = clusterAdmin().prepareHealth()
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
@@ -174,7 +174,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary moved from node1 to node2");
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_2).getId()).iterator().next().state(),
@@ -209,7 +209,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         internalCluster().startNode(commonSettings);
 
         assertThat(cluster().size(), equalTo(4));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("4").get();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("4").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create indices");
@@ -239,7 +239,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         String node_1 = internalCluster().startNode(commonSettings);
         internalCluster().startNode(commonSettings);
         assertThat(cluster().size(), equalTo(2));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").get();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("2").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create an index with 1 shard, 1 replica, nothing should allocate");
@@ -253,7 +253,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, actually allocating, no dry run");
@@ -270,7 +270,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             equalTo(ShardRoutingState.INITIALIZING)
         );
 
-        healthResponse = clusterAdmin().prepareHealth()
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
@@ -278,7 +278,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary allocated");
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_1).getId()).iterator().next().state(),
@@ -306,7 +306,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         // TODO can we get around this? the cluster is RED, so what do we wait for?
         ClusterRerouteUtils.reroute(client());
         assertThat(
-            clusterAdmin().prepareHealth().setIndices("test").setWaitForNodes("2").get().getStatus(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setIndices("test").setWaitForNodes("2").get().getStatus(),
             equalTo(ClusterHealthStatus.RED)
         );
         logger.info("--> explicitly allocate primary");
@@ -326,7 +326,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         logger.info("--> get the state, verify shard 1 primary allocated");
         final String nodeToCheck = node_1;
         assertBusy(() -> {
-            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+            ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             String nodeId = clusterState.nodes().resolveNode(nodeToCheck).getId();
             assertThat(clusterState.getRoutingNodes().node(nodeId).iterator().next().state(), equalTo(ShardRoutingState.STARTED));
         });
@@ -339,7 +339,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         String node_1 = internalCluster().startNode(commonSettings);
 
         assertThat(cluster().size(), equalTo(1));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").get();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("1").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create an index with 1 shard");
@@ -356,7 +356,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         logger.info("--> starting a second node");
         String node_2 = internalCluster().startNode(commonSettings);
         assertThat(cluster().size(), equalTo(2));
-        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").get();
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("2").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> try to move the shard from node1 to node2");
@@ -385,12 +385,12 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         final String nodeName1 = internalCluster().startNode(settings);
         assertThat(cluster().size(), equalTo(1));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").get();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("1").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         final String nodeName2 = internalCluster().startNode(settings);
         assertThat(cluster().size(), equalTo(2));
-        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").get();
+        healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("2").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         final String indexName = "test_index";
@@ -474,7 +474,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         ensureGreen("test-blocks");
 
         logger.info("--> check that the index has 1 shard");
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> shards = state.routingTable().allShards("test-blocks");
         assertThat(shards, hasSize(1));
 
@@ -504,7 +504,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                     new MoveAllocationCommand("test-blocks", 0, nodesIds.get(toggle % 2), nodesIds.get(++toggle % 2))
                 );
 
-                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setIndices("test-blocks")
                     .setWaitForYellowStatus()
                     .setWaitForNoRelocatingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -66,7 +66,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all are allocated on node1 now");
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
@@ -93,7 +93,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> creating an index with auto-expand replicas");
         createIndex("test", Settings.builder().put(AutoExpandReplicas.SETTING.getKey(), "0-all").build());
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(1));
         ensureGreen("test");
 
@@ -106,7 +106,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all are allocated on node1 now");
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(0));
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
@@ -142,7 +142,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             ensureGreen("test");
         }
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         IndexRoutingTable indexRoutingTable = clusterState.routingTable().index("test");
         int numShardsOnNode1 = 0;
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
@@ -165,7 +165,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all shards are allocated on node_1 now");
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         indexRoutingTable = clusterState.routingTable().index("test");
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
             final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
@@ -180,7 +180,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify that there are shards allocated on both nodes now");
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.routingTable().index("test").numberOfNodesShardsAreAllocatedOn(), equalTo(2));
     }
 
@@ -193,7 +193,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         );
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            clusterAdmin().prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                 .setPersistentSettings(Settings.builder().put(filterSetting.getKey() + ipKey, "192.168.1.1."))
         );
         assertEquals("invalid IP address [192.168.1.1.] for [" + filterSetting.getKey() + ipKey + "]", e.getMessage());
@@ -221,12 +221,12 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             .build();
 
         logger.info("--> updating settings");
-        clusterAdmin().prepareUpdateSettings().setTransientSettings(exclude).get();
+        clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(exclude).get();
 
         logger.info("--> waiting for relocation");
         waitForRelocation(ClusterHealthStatus.GREEN);
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         for (ShardRouting shard : RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED)) {
             String node = state.getRoutingNodes().node(shard.currentNodeId()).node().getName();
@@ -243,12 +243,15 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         Settings other = Settings.builder().put("cluster.info.update.interval", "45s").build();
 
         logger.info("--> updating settings with random persistent setting");
-        clusterAdmin().prepareUpdateSettings().setPersistentSettings(other).setTransientSettings(exclude).get();
+        clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .setPersistentSettings(other)
+            .setTransientSettings(exclude)
+            .get();
 
         logger.info("--> waiting for relocation");
         waitForRelocation(ClusterHealthStatus.GREEN);
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         // The transient settings still exist in the state
         assertThat(state.metadata().transientSettings(), equalTo(exclude));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/SimpleAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/SimpleAllocationIT.java
@@ -33,7 +33,7 @@ public class SimpleAllocationIT extends ESIntegTestCase {
         }
         ensureGreen("test");
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.getRoutingNodes()) {
             if (node.isEmpty() == false) {
@@ -42,7 +42,7 @@ public class SimpleAllocationIT extends ESIntegTestCase {
         }
         setReplicaCount(0, "test");
         ensureGreen("test");
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.getRoutingNodes()) {
@@ -60,7 +60,7 @@ public class SimpleAllocationIT extends ESIntegTestCase {
 
         setReplicaCount(1, "test");
         ensureGreen("test");
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.getRoutingNodes()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/InitialClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/InitialClusterStateIT.java
@@ -33,7 +33,13 @@ public class InitialClusterStateIT extends ESIntegTestCase {
 
     private static void assertClusterUuid(boolean expectCommitted, String expectedValue) {
         for (String nodeName : internalCluster().getNodeNames()) {
-            final Metadata metadata = client(nodeName).admin().cluster().prepareState().setLocal(true).get().getState().metadata();
+            final Metadata metadata = client(nodeName).admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .metadata();
             assertEquals(expectCommitted, metadata.clusterUUIDCommitted());
             assertEquals(expectedValue, metadata.clusterUUID());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -135,7 +135,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         final var dataNode = internalCluster().startDataOnlyNode();
         final var dataNodeClusterService = internalCluster().clusterService(dataNode);
 
-        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("2").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("2").get().isTimedOut());
         prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen("test");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveCustomsCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveCustomsCommandIT.java
@@ -46,7 +46,10 @@ public class RemoveCustomsCommandIT extends ESIntegTestCase {
         String node = internalCluster().startNode();
         createIndex("test");
         indicesAdmin().prepareDelete("test").get();
-        assertEquals(1, clusterAdmin().prepareState().get().getState().metadata().indexGraveyard().getTombstones().size());
+        assertEquals(
+            1,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().indexGraveyard().getTombstones().size()
+        );
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
         ensureStableCluster(1);
         internalCluster().stopRandomDataNode();
@@ -64,7 +67,10 @@ public class RemoveCustomsCommandIT extends ESIntegTestCase {
         assertThat(terminal.getOutput(), containsString("index-graveyard"));
 
         internalCluster().startNode(dataPathSettings);
-        assertEquals(0, clusterAdmin().prepareState().get().getState().metadata().indexGraveyard().getTombstones().size());
+        assertEquals(
+            0,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().indexGraveyard().getTombstones().size()
+        );
     }
 
     public void testCustomDoesNotMatch() throws Exception {
@@ -72,7 +78,10 @@ public class RemoveCustomsCommandIT extends ESIntegTestCase {
         String node = internalCluster().startNode();
         createIndex("test");
         indicesAdmin().prepareDelete("test").get();
-        assertEquals(1, clusterAdmin().prepareState().get().getState().metadata().indexGraveyard().getTombstones().size());
+        assertEquals(
+            1,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().indexGraveyard().getTombstones().size()
+        );
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
         ensureStableCluster(1);
         internalCluster().stopRandomDataNode();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveSettingsCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveSettingsCommandIT.java
@@ -58,7 +58,7 @@ public class RemoveSettingsCommandIT extends ESIntegTestCase {
             Settings.builder().put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), false)
         );
         assertThat(
-            clusterAdmin().prepareState().get().getState().metadata().persistentSettings().keySet(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().persistentSettings().keySet(),
             contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey())
         );
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
@@ -84,7 +84,7 @@ public class RemoveSettingsCommandIT extends ESIntegTestCase {
 
         internalCluster().startNode(dataPathSettings);
         assertThat(
-            clusterAdmin().prepareState().get().getState().metadata().persistentSettings().keySet(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().persistentSettings().keySet(),
             not(contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey()))
         );
     }
@@ -96,7 +96,7 @@ public class RemoveSettingsCommandIT extends ESIntegTestCase {
             Settings.builder().put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), false)
         );
         assertThat(
-            clusterAdmin().prepareState().get().getState().metadata().persistentSettings().keySet(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().persistentSettings().keySet(),
             contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey())
         );
         Settings dataPathSettings = internalCluster().dataPathSettings(node);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -137,7 +137,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
                 .build()
         );
         assertBusy(() -> {
-            ClusterState state = clusterAdmin().prepareState().setLocal(true).get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -242,7 +242,13 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
 
         logger.info("--> ensure NO_MASTER_BLOCK on data-only node");
         assertBusy(() -> {
-            ClusterState state = internalCluster().client(dataNode).admin().cluster().prepareState().setLocal(true).get().getState();
+            ClusterState state = internalCluster().client(dataNode)
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -288,7 +294,13 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
 
         logger.info("--> ensure there is no NO_MASTER_BLOCK and unsafe-bootstrap is reflected in cluster state");
         assertBusy(() -> {
-            ClusterState state = internalCluster().client(dataNode2).admin().cluster().prepareState().setLocal(true).get().getState();
+            ClusterState state = internalCluster().client(dataNode2)
+                .admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState();
             assertFalse(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
             assertTrue(state.metadata().persistentSettings().getAsBoolean(UnsafeBootstrapMasterCommand.UNSAFE_BOOTSTRAP.getKey(), false));
         });
@@ -333,7 +345,13 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
                 .build()
         );
 
-        ClusterState state = internalCluster().client().admin().cluster().prepareState().setLocal(true).get().getState();
+        ClusterState state = internalCluster().client()
+            .admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .setLocal(true)
+            .get()
+            .getState();
         assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
 
         internalCluster().stopNode(node);
@@ -345,7 +363,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
         Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
         updateClusterSettings(Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb"));
 
-        ClusterState state = internalCluster().client().admin().cluster().prepareState().get().getState();
+        ClusterState state = internalCluster().client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()), equalTo("1234kb"));
 
         internalCluster().stopCurrentMasterNode();
@@ -359,7 +377,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
         internalCluster().startMasterOnlyNode(masterNodeDataPathSettings);
         ensureGreen();
 
-        state = internalCluster().client().admin().cluster().prepareState().get().getState();
+        state = internalCluster().client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(state.metadata().settings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()), equalTo("1234kb"));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingConfigurationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingConfigurationIT.java
@@ -43,8 +43,11 @@ public class VotingConfigurationIT extends ESIntegTestCase {
         final String originalMaster = internalCluster().getMasterName();
 
         logger.info("--> excluding master node {}", originalMaster);
-        client().execute(TransportAddVotingConfigExclusionsAction.TYPE, new AddVotingConfigExclusionsRequest(originalMaster)).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
+        client().execute(
+            TransportAddVotingConfigExclusionsAction.TYPE,
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, originalMaster)
+        ).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get();
         assertNotEquals(originalMaster, internalCluster().getMasterName());
     }
 
@@ -60,7 +63,7 @@ public class VotingConfigurationIT extends ESIntegTestCase {
             internalCluster().client()
                 .admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForNodes("4")
                 .setWaitForEvents(Priority.LANGUID)
                 .get()
@@ -71,7 +74,7 @@ public class VotingConfigurationIT extends ESIntegTestCase {
         final ClusterState clusterState = internalCluster().client()
             .admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setNodes(true)
             .setMetadata(true)
@@ -111,7 +114,7 @@ public class VotingConfigurationIT extends ESIntegTestCase {
             internalCluster().client()
                 .admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForNodes("3")
                 .setWaitForEvents(Priority.LANGUID)
                 .get()
@@ -121,7 +124,7 @@ public class VotingConfigurationIT extends ESIntegTestCase {
         final ClusterState newClusterState = internalCluster().client()
             .admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setNodes(true)
             .setMetadata(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
@@ -35,7 +35,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         internalCluster().startNodes(2, masterNodeSettings);
         Settings dateNodeSettings = dataNode();
         internalCluster().startNodes(2, dateNodeSettings);
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("4")
             .setWaitForNoRelocatingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
@@ -111,7 +111,7 @@ public class AllocationIdIT extends ESIntegTestCase {
 
         // allocation fails due to corruption marker
         assertBusy(() -> {
-            final ClusterState state = clusterAdmin().prepareState().get().getState();
+            final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             final ShardRouting shardRouting = state.routingTable().index(indexName).shard(shardId.id()).primaryShard();
             assertThat(shardRouting.state(), equalTo(ShardRoutingState.UNASSIGNED));
             assertThat(shardRouting.unassignedInfo().reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
@@ -143,7 +143,9 @@ public class AllocationIdIT extends ESIntegTestCase {
     }
 
     public void checkHealthStatus(String indexName, ClusterHealthStatus healthStatus) {
-        final ClusterHealthStatus indexHealthStatus = clusterAdmin().health(new ClusterHealthRequest(indexName)).actionGet().getStatus();
+        final ClusterHealthStatus indexHealthStatus = clusterAdmin().health(new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, indexName))
+            .actionGet()
+            .getStatus();
         assertThat(indexHealthStatus, is(healthStatus));
     }
 
@@ -169,7 +171,7 @@ public class AllocationIdIT extends ESIntegTestCase {
     }
 
     private Set<String> getAllocationIds(String indexName) {
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         return state.metadata().index(indexName).inSyncAllocationIds(0);
     }
 
@@ -181,7 +183,14 @@ public class AllocationIdIT extends ESIntegTestCase {
 
     private String historyUUID(String node, String indexName) {
         final ShardStats[] shards = client(node).admin().indices().prepareStats(indexName).clear().get().getShards();
-        final String nodeId = client(node).admin().cluster().prepareState().get().getState().nodes().resolveNode(node).getId();
+        final String nodeId = client(node).admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .nodes()
+            .resolveNode(node)
+            .getId();
         assertThat(shards.length, greaterThan(0));
         final Set<String> historyUUIDs = Arrays.stream(shards)
             .filter(shard -> shard.getShardRouting().currentNodeId().equals(nodeId))

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/DelayedAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/DelayedAllocationIT.java
@@ -32,7 +32,7 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
         indexRandomData();
         internalCluster().stopNode(findNodeWithShard());
-        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(0));
         ensureGreen("test");
     }
 
@@ -53,9 +53,12 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         Settings nodeWithShardDataPathSettings = internalCluster().dataPathSettings(nodeWithShard);
         internalCluster().stopNode(nodeWithShard);
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0, equalTo(true))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState().getRoutingNodes().unassigned().size() > 0,
+                equalTo(true)
+            )
         );
-        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(1));
         internalCluster().startNode(nodeWithShardDataPathSettings); // this will use the same data location as the stopped node
         ensureGreen("test");
     }
@@ -97,16 +100,19 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         indexRandomData();
         internalCluster().stopNode(findNodeWithShard());
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0, equalTo(true))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState().getRoutingNodes().unassigned().size() > 0,
+                equalTo(true)
+            )
         );
-        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(1));
         logger.info("Setting shorter allocation delay");
         updateIndexSettings(
             Settings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100)),
             "test"
         );
         ensureGreen("test");
-        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(0));
     }
 
     /**
@@ -123,15 +129,18 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         indexRandomData();
         internalCluster().stopNode(findNodeWithShard());
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0, equalTo(true))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState().getRoutingNodes().unassigned().size() > 0,
+                equalTo(true)
+            )
         );
-        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(1));
         updateIndexSettings(
             Settings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0)),
             "test"
         );
         ensureGreen("test");
-        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(0));
     }
 
     private void indexRandomData() throws Exception {
@@ -147,7 +156,7 @@ public class DelayedAllocationIT extends ESIntegTestCase {
     }
 
     private String findNodeWithShard() {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
         return state.nodes().get(randomFrom(startedShards).currentNodeId()).getName();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -118,7 +118,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
     private Settings createStaleReplicaScenario(String master) throws Exception {
         prepareIndex("test").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         refresh();
-        ClusterState state = clusterAdmin().prepareState().all().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
         List<ShardRouting> shards = state.routingTable().allShards("test");
         assertThat(shards.size(), equalTo(2));
 
@@ -164,7 +164,10 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         );
         // kick reroute a second time and check that all shards are unassigned
         ClusterRerouteUtils.reroute(client(master));
-        assertThat(client(master).admin().cluster().prepareState().get().getState().getRoutingNodes().unassigned().size(), equalTo(2));
+        assertThat(
+            client(master).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getRoutingNodes().unassigned().size(),
+            equalTo(2)
+        );
         return inSyncDataPathSettings;
     }
 
@@ -197,7 +200,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         internalCluster().stopNode(dataNodeWithShardCopy);
         ensureStableCluster(1);
         assertThat(
-            clusterAdmin().prepareState()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .getRoutingTable()
@@ -223,11 +226,11 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertTrue(
-            clusterAdmin().prepareState().get().getState().toString(),
-            clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().toString(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
         );
         assertThat(
-            clusterAdmin().prepareState()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .getRoutingTable()
@@ -302,7 +305,14 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             // search can throw an "all shards failed" exception. We will wait until the shard initialization has completed before
             // verifying the search hit count.
             assertBusy(
-                () -> assertTrue(clusterAdmin().prepareState().get().getState().routingTable().index(idxName).allPrimaryShardsActive())
+                () -> assertTrue(
+                    clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                        .get()
+                        .getState()
+                        .routingTable()
+                        .index(idxName)
+                        .allPrimaryShardsActive()
+                )
             );
         }
         ShardStats[] shardStats = indicesAdmin().prepareStats("test")
@@ -313,7 +323,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             assertThat(shardStat.getCommitStats().getNumDocs(), equalTo(useStaleReplica ? 1 : 0));
         }
         // allocation id of old primary was cleaned from the in-sync set
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         assertEquals(
             Collections.singleton(state.routingTable().index(idxName).shard(0).primary.allocationId().getId()),
@@ -402,7 +412,15 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             .setSettings(indexSettings(1, 0).put("index.routing.allocation.exclude._name", node))
             .get();
 
-        assertThat(clusterAdmin().prepareState().get().getState().getRoutingTable().shardRoutingTable("test", 0).assignedShards(), empty());
+        assertThat(
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .getRoutingTable()
+                .shardRoutingTable("test", 0)
+                .assignedShards(),
+            empty()
+        );
 
         ClusterRerouteUtils.reroute(client(), new AllocateEmptyPrimaryAllocationCommand("test", 0, node, true));
         ensureGreen("test");
@@ -419,7 +437,10 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final Settings inSyncDataPathSettings = internalCluster().dataPathSettings(replicaNode);
         internalCluster().stopNode(replicaNode);
         ensureYellow("test");
-        assertEquals(2, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(
+            2,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").inSyncAllocationIds(0).size()
+        );
         internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
             @Override
             public boolean clearData(String nodeName) {
@@ -428,9 +449,19 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         });
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertBusy(
-            () -> assertTrue(clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned())
+            () -> assertTrue(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                    .get()
+                    .getState()
+                    .getRoutingTable()
+                    .index("test")
+                    .allPrimaryShardsUnassigned()
+            )
         );
-        assertEquals(2, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(
+            2,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").inSyncAllocationIds(0).size()
+        );
 
         logger.info("--> starting node that reuses data folder with the up-to-date shard");
         internalCluster().startDataOnlyNode(inSyncDataPathSettings);
@@ -448,10 +479,16 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final Settings inSyncDataPathSettings = internalCluster().dataPathSettings(replicaNode);
         internalCluster().stopNode(replicaNode);
         ensureYellow("test");
-        assertEquals(2, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(
+            2,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").inSyncAllocationIds(0).size()
+        );
         logger.info("--> indexing...");
         prepareIndex("test").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
-        assertEquals(1, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(
+            1,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").inSyncAllocationIds(0).size()
+        );
         internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
             @Override
             public boolean clearData(String nodeName) {
@@ -460,14 +497,31 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         });
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertBusy(
-            () -> assertTrue(clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned())
+            () -> assertTrue(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                    .get()
+                    .getState()
+                    .getRoutingTable()
+                    .index("test")
+                    .allPrimaryShardsUnassigned()
+            )
         );
-        assertEquals(1, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(
+            1,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").inSyncAllocationIds(0).size()
+        );
 
         logger.info("--> starting node that reuses data folder with the up-to-date shard");
         internalCluster().startDataOnlyNode(inSyncDataPathSettings);
         assertBusy(
-            () -> assertTrue(clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned())
+            () -> assertTrue(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                    .get()
+                    .getState()
+                    .getRoutingTable()
+                    .index("test")
+                    .allPrimaryShardsUnassigned()
+            )
         );
     }
 
@@ -506,7 +560,13 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         ensureGreen(indexName);
         assertEquals(
             1,
-            clusterAdmin().prepareState().get().getState().routingTable().index(indexName).shardsWithState(ShardRoutingState.STARTED).size()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                .get()
+                .getState()
+                .routingTable()
+                .index(indexName)
+                .shardsWithState(ShardRoutingState.STARTED)
+                .size()
         );
     }
 
@@ -547,7 +607,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         internalCluster().stopNode(oldPrimary);
         // Checks that we fails replicas in one side but not mark them as stale.
         assertBusy(() -> {
-            ClusterState state = client(master).admin().cluster().prepareState().get().getState();
+            ClusterState state = client(master).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             final IndexShardRoutingTable shardRoutingTable = state.routingTable().shardRoutingTable(shardId);
             final String newPrimaryNode = state.getRoutingNodes().node(shardRoutingTable.primary.currentNodeId()).node().getName();
             assertThat(newPrimaryNode, not(equalTo(oldPrimary)));
@@ -563,7 +623,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         partition.ensureHealthy(internalCluster());
         logger.info("--> stop disrupting network and re-enable allocation");
         assertBusy(() -> {
-            ClusterState state = client(master).admin().cluster().prepareState().get().getState();
+            ClusterState state = client(master).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat(state.routingTable().shardRoutingTable(shardId).activeShards(), hasSize(numberOfReplicas));
             assertThat(state.metadata().index("test").inSyncAllocationIds(shardId.id()), hasSize(numberOfReplicas + 1));
             for (String node : replicaNodes) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/RemoveReplicaPriorityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/RemoveReplicaPriorityIT.java
@@ -52,7 +52,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             });
         }
 
-        final String dataNodeIdFilter = clusterAdmin().prepareState()
+        final String dataNodeIdFilter = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setNodes(true)
             .get()
@@ -74,7 +74,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
         );
 
         assertBusy(() -> {
-            final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
+            final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setRoutingTable(true)
                 .get()
@@ -90,7 +90,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
         updateIndexSettings(Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._id"), INDEX_NAME);
 
         assertBusy(() -> {
-            final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
+            final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setRoutingTable(true)
                 .get()
@@ -107,7 +107,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             setReplicaCount(2, INDEX_NAME);
 
             assertBusy(() -> {
-                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
+                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setRoutingTable(true)
                     .get()
@@ -125,7 +125,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             setReplicaCount(1, INDEX_NAME);
 
             assertBusy(() -> {
-                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
+                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setRoutingTable(true)
                     .get()
@@ -143,7 +143,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             setReplicaCount(0, INDEX_NAME);
 
             assertBusy(() -> {
-                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
+                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setRoutingTable(true)
                     .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -296,7 +296,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
             createIndex(INDEX_NAME, routingTableWatcher.getIndexSettings());
 
-            final var clusterState = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState();
+            final var clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setRoutingTable(true).get().getState();
 
             // verify non-DEFAULT roles reported in cluster state XContent
             assertRolesInRoutingTableXContent(clusterState);
@@ -440,7 +440,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
     @Nullable
     public AllocationCommand getCancelPrimaryCommand() {
-        final var indexRoutingTable = clusterAdmin().prepareState()
+        final var indexRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setRoutingTable(true)
             .get()
@@ -488,7 +488,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
             assertEngineTypes();
 
             final var searchShardProfileKeys = new HashSet<String>();
-            final var indexRoutingTable = clusterAdmin().prepareState()
+            final var indexRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setRoutingTable(true)
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetIT.java
@@ -48,7 +48,7 @@ public class AllocationFailuresResetIT extends ESIntegTestCase {
     private void awaitShardAllocMaxRetries() throws Exception {
         var maxRetries = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.get(internalCluster().getDefaultSettings());
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             var index = state.getRoutingTable().index(INDEX);
             assertNotNull(index);
             var shard = index.shard(SHARD).primaryShard();
@@ -61,7 +61,7 @@ public class AllocationFailuresResetIT extends ESIntegTestCase {
 
     private void awaitShardAllocSucceed() throws Exception {
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             var index = state.getRoutingTable().index(INDEX);
             assertNotNull(index);
             var shard = index.shard(SHARD).primaryShard();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -86,7 +86,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         final String newDataNodeName = internalCluster().startDataOnlyNode();
         final String newDataNodeId = clusterAdmin().prepareNodesInfo(newDataNodeName).get().getNodes().get(0).getNode().getId();
         assertBusy(() -> {
-            final ShardRouting primaryShard = clusterAdmin().prepareState()
+            final ShardRouting primaryShard = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setRoutingTable(true)
                 .setNodes(true)
@@ -103,7 +103,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
         // Verify that the block is removed once the shard migration is complete
         refreshClusterInfo();
-        assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertNull(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE));
     }
 
@@ -135,7 +135,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
         // Verify that the block is removed
         refreshClusterInfo();
-        assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertNull(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE));
 
         // Re-enable and the blocks should be back!
@@ -143,7 +143,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
             Settings.builder().put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), true)
         );
         refreshClusterInfo();
-        assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertThat(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE), equalTo("true"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/ShardStateIT.java
@@ -28,7 +28,7 @@ public class ShardStateIT extends ESIntegTestCase {
         logger.info("--> disabling allocation to capture shard failure");
         disableAllocation("test");
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final int shard = randomBoolean() ? 0 : 1;
         final String nodeId = state.routingTable().index("test").shard(shard).primaryShard().currentNodeId();
         final String node = state.nodes().get(nodeId).getName();
@@ -38,7 +38,12 @@ public class ShardStateIT extends ESIntegTestCase {
 
         logger.info("--> waiting for a yellow index");
         // we can't use ensureYellow since that one is just as happy with a GREEN status.
-        assertBusy(() -> assertThat(clusterAdmin().prepareHealth("test").get().getStatus(), equalTo(ClusterHealthStatus.YELLOW)));
+        assertBusy(
+            () -> assertThat(
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").get().getStatus(),
+                equalTo(ClusterHealthStatus.YELLOW)
+            )
+        );
 
         final long term0 = shard == 0 ? 2 : 1;
         final long term1 = shard == 1 ? 2 : 1;
@@ -53,7 +58,7 @@ public class ShardStateIT extends ESIntegTestCase {
     protected void assertPrimaryTerms(long shard0Term, long shard1Term) {
         for (String node : internalCluster().getNodeNames()) {
             logger.debug("--> asserting primary terms terms on [{}]", node);
-            ClusterState state = client(node).admin().cluster().prepareState().setLocal(true).get().getState();
+            ClusterState state = client(node).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
             IndexMetadata metadata = state.metadata().index("test");
             assertThat(metadata.primaryTerm(0), equalTo(shard0Term));
             assertThat(metadata.primaryTerm(1), equalTo(shard1Term));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -231,7 +231,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
     private Set<ShardId> getShardIds(final String nodeId, final String indexName) {
         final Set<ShardId> shardIds = new HashSet<>();
-        final IndexRoutingTable indexRoutingTable = clusterAdmin().prepareState()
+        final IndexRoutingTable indexRoutingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setRoutingTable(true)
             .get()
@@ -319,7 +319,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
         }
 
         assertFalse(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForNoInitializingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -75,7 +75,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             internalCluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
         }
 
-        final List<String> nodeIds = clusterAdmin().prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .getRoutingNodes()
@@ -153,7 +153,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             internalCluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
         }
 
-        final List<String> nodeIds = clusterAdmin().prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .getRoutingNodes()
@@ -211,7 +211,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             () -> assertBlocked(prepareIndex("test").setId("1").setSource("foo", "bar"), IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK)
         );
 
-        assertFalse(clusterAdmin().prepareHealth("test").setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").setWaitForEvents(Priority.LANGUID).get().isTimedOut());
 
         // Cannot add further documents
         assertBlocked(prepareIndex("test").setId("2").setSource("foo", "bar"), IndexMetadata.INDEX_READ_ONLY_ALLOW_DELETE_BLOCK);
@@ -261,7 +261,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
                 .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms")
         );
 
-        final List<String> nodeIds = clusterAdmin().prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .getRoutingNodes()
@@ -318,7 +318,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
 
         final MockInternalClusterInfoService clusterInfoService = getMockInternalClusterInfoService();
 
-        final List<String> nodeIds = clusterAdmin().prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .getRoutingNodes()
@@ -414,7 +414,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
                 .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms")
         );
 
-        final List<String> nodeIds = clusterAdmin().prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .getRoutingNodes()
@@ -483,7 +483,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
 
     private Map<String, Integer> getShardCountByNodeId() {
         final Map<String, Integer> shardCountByNodeId = new HashMap<>();
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (final RoutingNode node : clusterState.getRoutingNodes()) {
             logger.info(
                 "----> node {} has {} shards",

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/UpdateShardAllocationSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/UpdateShardAllocationSettingsIT.java
@@ -100,7 +100,7 @@ public class UpdateShardAllocationSettingsIT extends ESIntegTestCase {
         updateClusterSettings(Settings.builder().put(CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey(), true));
         final String indexName = "idx";
         createIndex(indexName, 1, 1);
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertFalse(
             "replica should be unassigned",
             clusterState.getRoutingTable().index(indexName).shardsWithState(ShardRoutingState.UNASSIGNED).isEmpty()
@@ -109,7 +109,7 @@ public class UpdateShardAllocationSettingsIT extends ESIntegTestCase {
         // the same host - the replica should get assigned
         updateClusterSettings(Settings.builder().put(CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey(), false));
 
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertTrue(
             "all shards should be assigned",
             clusterState.getRoutingTable().index(indexName).shardsWithState(ShardRoutingState.UNASSIGNED).isEmpty()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -43,7 +43,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
     @After
     public void cleanup() throws Exception {
         assertAcked(
-            clusterAdmin().prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                 .setPersistentSettings(Settings.builder().putNull("*"))
                 .setTransientSettings(Settings.builder().putNull("*"))
         );
@@ -64,7 +64,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         String key1 = "no_idea_what_you_are_talking_about";
         int value1 = 10;
         try {
-            ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
             consumer.accept(Settings.builder().put(key1, value1), builder);
 
             builder.get();
@@ -95,7 +95,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
         final Setting<TimeValue> REROUTE_INTERVAL = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
 
-        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 7).put(REROUTE_INTERVAL.getKey(), "42s"), builder);
 
         ClusterUpdateSettingsResponse response = builder.get();
@@ -106,7 +106,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(REROUTE_INTERVAL.get(settingsFunction.apply(response)), equalTo(TimeValue.timeValueSeconds(42)));
         assertThat(clusterService().getClusterSettings().get(REROUTE_INTERVAL), equalTo(TimeValue.timeValueSeconds(42)));
 
-        ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         consumer.accept(
             Settings.builder().putNull((randomBoolean() ? "cluster.routing.*" : "*")).put(REROUTE_INTERVAL.getKey(), "43s"),
             undoBuilder
@@ -124,7 +124,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
         final Setting<TimeValue> REROUTE_INTERVAL = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
 
-        ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 7).build())
             .get();
 
@@ -132,7 +132,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(INITIAL_RECOVERIES.get(response.getTransientSettings()), equalTo(7));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(7));
 
-        response = clusterAdmin().prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(Settings.builder().putNull(INITIAL_RECOVERIES.getKey()))
             .get();
 
@@ -140,7 +140,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertNull(response.getTransientSettings().get(INITIAL_RECOVERIES.getKey()));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(INITIAL_RECOVERIES.get(Settings.EMPTY)));
 
-        response = clusterAdmin().prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 8).put(REROUTE_INTERVAL.getKey(), "43s").build())
             .get();
 
@@ -149,7 +149,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(8));
         assertThat(REROUTE_INTERVAL.get(response.getTransientSettings()), equalTo(TimeValue.timeValueSeconds(43)));
         assertThat(clusterService().getClusterSettings().get(REROUTE_INTERVAL), equalTo(TimeValue.timeValueSeconds(43)));
-        response = clusterAdmin().prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(Settings.builder().putNull((randomBoolean() ? "cluster.routing.*" : "*")))
             .get();
 
@@ -164,7 +164,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
         final Setting<TimeValue> REROUTE_INTERVAL = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
 
-        ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 9).build())
             .get();
 
@@ -172,7 +172,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(INITIAL_RECOVERIES.get(response.getPersistentSettings()), equalTo(9));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(9));
 
-        response = clusterAdmin().prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().putNull(INITIAL_RECOVERIES.getKey()))
             .get();
 
@@ -180,7 +180,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(INITIAL_RECOVERIES.get(response.getPersistentSettings()), equalTo(INITIAL_RECOVERIES.get(Settings.EMPTY)));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(INITIAL_RECOVERIES.get(Settings.EMPTY)));
 
-        response = clusterAdmin().prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 10).put(REROUTE_INTERVAL.getKey(), "44s").build())
             .get();
 
@@ -189,7 +189,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(10));
         assertThat(REROUTE_INTERVAL.get(response.getPersistentSettings()), equalTo(TimeValue.timeValueSeconds(44)));
         assertThat(clusterService().getClusterSettings().get(REROUTE_INTERVAL), equalTo(TimeValue.timeValueSeconds(44)));
-        response = clusterAdmin().prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().putNull((randomBoolean() ? "cluster.routing.*" : "*")))
             .get();
 
@@ -209,7 +209,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings transientSettings1 = Settings.builder().put(key1, value1, ByteSizeUnit.BYTES).build();
         Settings persistentSettings1 = Settings.builder().put(key2, value2).build();
 
-        ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(transientSettings1)
             .setPersistentSettings(persistentSettings1)
             .get();
@@ -223,7 +223,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings transientSettings2 = Settings.builder().put(key1, value1, ByteSizeUnit.BYTES).put(key2, value2).build();
         Settings persistentSettings2 = Settings.EMPTY;
 
-        ClusterUpdateSettingsResponse response2 = clusterAdmin().prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response2 = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(transientSettings2)
             .setPersistentSettings(persistentSettings2)
             .get();
@@ -237,7 +237,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings transientSettings3 = Settings.EMPTY;
         Settings persistentSettings3 = Settings.builder().put(key1, value1, ByteSizeUnit.BYTES).put(key2, value2).build();
 
-        ClusterUpdateSettingsResponse response3 = clusterAdmin().prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response3 = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(transientSettings3)
             .setPersistentSettings(persistentSettings3)
             .get();
@@ -267,7 +267,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final BiConsumer<Settings.Builder, ClusterUpdateSettingsRequestBuilder> consumer,
         final Function<ClusterUpdateSettingsResponse, Settings> settingsFunction
     ) {
-        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         consumer.accept(
             Settings.builder().putList("transport.tracer.include", "internal:index/shard/recovery/*", "internal:gateway/local*"),
             builder
@@ -300,7 +300,10 @@ public class ClusterSettingsIT extends ESIntegTestCase {
     ) {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
 
-        ClusterUpdateSettingsRequestBuilder initialBuilder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder initialBuilder = clusterAdmin().prepareUpdateSettings(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT
+        );
         consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 42), initialBuilder);
 
         ClusterUpdateSettingsResponse response = initialBuilder.get();
@@ -310,7 +313,10 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(42));
 
         try {
-            ClusterUpdateSettingsRequestBuilder badBuilder = clusterAdmin().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder badBuilder = clusterAdmin().prepareUpdateSettings(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), "whatever"), badBuilder);
             badBuilder.get();
             fail("bogus value");
@@ -321,7 +327,10 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(42));
 
         try {
-            ClusterUpdateSettingsRequestBuilder badBuilder = clusterAdmin().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder badBuilder = clusterAdmin().prepareUpdateSettings(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), -1), badBuilder);
             badBuilder.get();
             fail("bogus value");
@@ -346,9 +355,13 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         if (readOnlyAllowDelete) {
             settingsBuilder.put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), "true");
         }
-        assertAcked(clusterAdmin().prepareUpdateSettings().setPersistentSettings(settingsBuilder).setTransientSettings(settingsBuilder));
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(settingsBuilder)
+                .setTransientSettings(settingsBuilder)
+        );
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         if (readOnly) {
             assertTrue(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().transientSettings()));
             assertTrue(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().persistentSettings()));
@@ -365,7 +378,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             .build();
         restartNodesOnBrokenClusterState(ClusterState.builder(state).metadata(brokenMeta));
         ensureGreen(); // wait for state recovery
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertTrue(state.getMetadata().persistentSettings().getAsBoolean("archived.this.is.unknown", false));
 
         // cannot remove read only block due to archived settings
@@ -375,7 +388,9 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
             final IllegalArgumentException e1 = expectThrows(
                 IllegalArgumentException.class,
-                clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder)
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                    .setPersistentSettings(builder)
+                    .setTransientSettings(builder)
             );
             assertTrue(e1.getMessage().contains("unknown setting [archived.this.is.unknown]"));
         }
@@ -383,7 +398,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         // fail to clear archived settings with non-archived settings
         final ClusterBlockException e2 = expectThrows(
             ClusterBlockException.class,
-            clusterAdmin().prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                 .setPersistentSettings(Settings.builder().putNull("cluster.routing.allocation.enable"))
                 .setTransientSettings(Settings.builder().putNull("archived.*"))
         );
@@ -397,7 +412,8 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         // fail to clear archived settings due to cluster read only block
         final ClusterBlockException e3 = expectThrows(
             ClusterBlockException.class,
-            clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().putNull("archived.*"))
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(Settings.builder().putNull("archived.*"))
         );
         if (readOnly) {
             assertTrue(e3.getMessage().contains("cluster read-only (api)"));
@@ -419,7 +435,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             }
             final ClusterBlockException e4 = expectThrows(
                 ClusterBlockException.class,
-                clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder)
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setPersistentSettings(builder)
             );
             if (readOnly) {
                 assertTrue(e4.getMessage().contains("cluster read-only (api)"));
@@ -436,7 +452,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
             final ClusterBlockException e5 = expectThrows(
                 ClusterBlockException.class,
-                clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder)
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setPersistentSettings(builder)
             );
             if (readOnly) {
                 assertTrue(e5.getMessage().contains("cluster read-only (api)"));
@@ -450,9 +466,14 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings.Builder builder = Settings.builder().putNull("archived.*");
         clearOrSetFalse(builder, readOnly, Metadata.SETTING_READ_ONLY_SETTING);
         clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
-        assertAcked(clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder).get());
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(builder)
+                .setTransientSettings(builder)
+                .get()
+        );
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertFalse(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().transientSettings()));
         assertFalse(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.get(state.getMetadata().transientSettings()));
         assertFalse(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().persistentSettings()));
@@ -477,7 +498,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         String key2 = "cluster.routing.allocation.node_concurrent_recoveries";
         Settings persistentSettings = Settings.builder().put(key2, "5").build();
 
-        ClusterUpdateSettingsRequestBuilder request = clusterAdmin().prepareUpdateSettings()
+        ClusterUpdateSettingsRequestBuilder request = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setTransientSettings(transientSettings)
             .setPersistentSettings(persistentSettings);
 
@@ -488,7 +509,9 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
             // But it's possible to update the settings to update the "cluster.blocks.read_only" setting
             Settings settings = Settings.builder().putNull(Metadata.SETTING_READ_ONLY_SETTING.getKey()).build();
-            assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings).get());
+            assertAcked(
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(settings).get()
+            );
 
         } finally {
             setClusterReadOnly(false);
@@ -498,12 +521,14 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         try {
             // But it's possible to update the settings to update the "cluster.blocks.read_only" setting
             Settings settings = Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), true).build();
-            assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings).get());
+            assertAcked(
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(settings).get()
+            );
             assertBlocked(request, Metadata.CLUSTER_READ_ONLY_ALLOW_DELETE_BLOCK);
         } finally {
             // But it's possible to update the settings to update the "cluster.blocks.read_only" setting
             Settings s = Settings.builder().putNull(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey()).build();
-            assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(s).get());
+            assertAcked(clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(s).get());
         }
 
         // It should work now
@@ -541,7 +566,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         final Level level = LogManager.getRootLogger().getLevel();
 
-        ClusterUpdateSettingsRequestBuilder throwBuilder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder throwBuilder = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         consumer.accept(Settings.builder().put("logger._root", "BOOM"), throwBuilder);
 
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, throwBuilder);
@@ -549,14 +574,20 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         try {
             final Settings.Builder testSettings = Settings.builder().put("logger.test", "TRACE").put("logger._root", "trace");
-            ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             consumer.accept(testSettings, updateBuilder);
 
             updateBuilder.get();
             assertEquals(Level.TRACE, LogManager.getLogger("test").getLevel());
             assertEquals(Level.TRACE, LogManager.getRootLogger().getLevel());
         } finally {
-            ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
 
             if (randomBoolean()) {
                 final Settings.Builder defaultSettings = Settings.builder().putNull("logger.test").putNull("logger._root");
@@ -592,18 +623,21 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         logger.info("Using " + ((persistent) ? "persistent" : "transient") + " settings");
 
-        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         consumer.accept(settings, builder);
 
         builder.get();
-        ClusterStateResponse state = clusterAdmin().prepareState().get();
+        ClusterStateResponse state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertEquals(value, getter.apply(state.getState().getMetadata()).get(key));
 
-        ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT
+        );
         consumer.accept(updatedSettings, updateBuilder);
         updateBuilder.get();
 
-        ClusterStateResponse updatedState = clusterAdmin().prepareState().get();
+        ClusterStateResponse updatedState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertEquals(updatedValue, getter.apply(updatedState.getState().getMetadata()).get(key));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
@@ -55,7 +55,7 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
         logger.info("--> updating cluster settings");
         var future = client(masterNode).admin()
             .cluster()
-            .prepareUpdateSettings()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().put(BlockingClusterSettingTestPlugin.TEST_BLOCKING_SETTING.getKey(), true).build())
             .setMasterNodeTimeout(TimeValue.timeValueMillis(100L))
             .execute();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
@@ -88,7 +88,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
             .addAliasAction(AliasActions.add().index("test1").alias("routing_alias").routing("ABC"))
             .addAliasAction(AliasActions.add().index("test2").alias("routing_alias").routing("EFG"))
             .get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         ClusterSearchShardsResponse response = safeExecute(new ClusterSearchShardsRequest(TEST_REQUEST_TIMEOUT, "routing_alias"));
         assertThat(response.getGroups().length, equalTo(2));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
@@ -49,11 +49,11 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         int negativeShardsPerNode = between(-50_000, 0);
         try {
             if (frequently()) {
-                clusterAdmin().prepareUpdateSettings()
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, negativeShardsPerNode).build())
                     .get();
             } else {
-                clusterAdmin().prepareUpdateSettings()
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, negativeShardsPerNode).build())
                     .get();
             }
@@ -67,7 +67,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
     }
 
     public void testIndexCreationOverLimit() {
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
 
         ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
 
@@ -95,12 +95,12 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         } catch (IllegalArgumentException e) {
             verifyException(dataNodes, counts, e);
         }
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertFalse(clusterState.getMetadata().hasIndex("should-fail"));
     }
 
     public void testIndexCreationOverLimitFromTemplate() {
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
 
         final ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
 
@@ -126,12 +126,12 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
 
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, indicesAdmin().prepareCreate("should-fail"));
         verifyException(dataNodes, counts, e);
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertFalse(clusterState.getMetadata().hasIndex("should-fail"));
     }
 
     public void testIncreaseReplicasOverLimit() {
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
 
         dataNodes = ensureMultipleDataNodes(dataNodes);
 
@@ -158,12 +158,12 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 + ";";
             assertEquals(expectedError, e.getMessage());
         }
-        Metadata clusterState = clusterAdmin().prepareState().get().getState().metadata();
+        Metadata clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         assertEquals(0, clusterState.index("growing-should-fail").getNumberOfReplicas());
     }
 
     public void testChangingMultipleIndicesOverLimit() {
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
 
         dataNodes = ensureMultipleDataNodes(dataNodes);
 
@@ -219,13 +219,13 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 + ";";
             assertEquals(expectedError, e.getMessage());
         }
-        Metadata clusterState = clusterAdmin().prepareState().get().getState().metadata();
+        Metadata clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         assertEquals(firstIndexReplicas, clusterState.index("test-1-index").getNumberOfReplicas());
         assertEquals(secondIndexReplicas, clusterState.index("test-2-index").getNumberOfReplicas());
     }
 
     public void testPreserveExistingSkipsCheck() {
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
 
         dataNodes = ensureMultipleDataNodes(dataNodes);
 
@@ -245,7 +245,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 .setPreserveExisting(true)
                 .setSettings(Settings.builder().put("number_of_replicas", dataNodes))
         );
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertEquals(0, clusterState.getMetadata().index("test-index").getNumberOfReplicas());
     }
 
@@ -266,7 +266,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 .setSettings(repoSettings.build())
         );
 
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
         ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
         createIndex(
             "snapshot-index",
@@ -330,13 +330,13 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
             verifyException(dataNodes, counts, e);
         }
         ensureGreen();
-        ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertFalse(clusterState.getMetadata().hasIndex("snapshot-index"));
     }
 
     public void testOpenIndexOverLimit() {
         Client client = client();
-        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
         ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
 
         createIndex(
@@ -348,7 +348,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 .build()
         );
 
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertFalse(healthResponse.isTimedOut());
 
         AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test-index-1").get();
@@ -371,7 +371,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         } catch (IllegalArgumentException e) {
             verifyException(dataNodes, counts, e);
         }
-        ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertFalse(clusterState.getMetadata().hasIndex("snapshot-index"));
     }
 
@@ -379,17 +379,22 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         if (dataNodes == 1) {
             internalCluster().startNode(dataNode());
             assertThat(
-                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").setLocal(true).get().isTimedOut(),
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setWaitForNodes(">=2")
+                    .setLocal(true)
+                    .get()
+                    .isTimedOut(),
                 equalTo(false)
             );
-            dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
+            dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getDataNodes().size();
         }
         return dataNodes;
     }
 
     private void setShardsPerNode(int shardsPerNode) {
         try {
-            ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
+            ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                 .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, shardsPerNode).build())
                 .get();
             assertEquals(shardsPerNode, response.getPersistentSettings().getAsInt(shardsPerNodeKey, -1).intValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -293,7 +293,14 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
         NetworkDisruption scheme = addRandomDisruptionType(partitions);
         scheme.startDisrupting();
         ensureStableCluster(2, notIsolatedNode);
-        assertFalse(client(notIsolatedNode).admin().cluster().prepareHealth("test").setWaitForYellowStatus().get().isTimedOut());
+        assertFalse(
+            client(notIsolatedNode).admin()
+                .cluster()
+                .prepareHealth(TEST_REQUEST_TIMEOUT, "test")
+                .setWaitForYellowStatus()
+                .get()
+                .isTimedOut()
+        );
 
         DocWriteResponse indexResponse = internalCluster().client(notIsolatedNode).prepareIndex("test").setSource("field", "value").get();
         assertThat(indexResponse.getVersion(), equalTo(1L));
@@ -424,12 +431,12 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
         });
 
         assertBusy(() -> {
-            assertFalse(internalCluster().client(masterNode).admin().cluster().prepareHealth().get().isTimedOut());
+            assertFalse(internalCluster().client(masterNode).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get().isTimedOut());
             assertTrue(
                 internalCluster().client(masterNode)
                     .admin()
                     .cluster()
-                    .prepareHealth()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForNodes("2")
                     .setTimeout(TimeValue.timeValueSeconds(2))
                     .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -145,7 +145,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
 
         isolateAllNodes.stopDisrupting();
 
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         if (state.metadata().hasIndex("test") == false) {
             fail("index 'test' was lost. current cluster state: " + state);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -158,7 +158,13 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
     private void ensureNoMaster(String node) throws Exception {
         assertBusy(
             () -> assertNull(
-                client(node).admin().cluster().state(new ClusterStateRequest().local(true)).get().getState().nodes().getMasterNode()
+                client(node).admin()
+                    .cluster()
+                    .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).local(true))
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNode()
             )
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
@@ -113,12 +113,14 @@ public class ShardInfoIT extends ESIntegTestCase {
 
     private void ensureActiveShardCopies(final int shardId, final int copyCount) throws Exception {
         assertBusy(() -> {
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat(state.routingTable().index("idx"), not(nullValue()));
             assertThat(state.routingTable().index("idx").shard(shardId), not(nullValue()));
             assertThat(state.routingTable().index("idx").shard(shardId).activeShards().size(), equalTo(copyCount));
 
-            ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("idx").setWaitForNoRelocatingShards(true).get();
+            ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "idx")
+                .setWaitForNoRelocatingShards(true)
+                .get();
             assertThat(healthResponse.isTimedOut(), equalTo(false));
 
             RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries("idx").setActiveOnly(true).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -153,7 +153,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         String node = internalCluster().startNode();
         prepareCreate("test").get();
         indexRandom(true, prepareIndex("test").setId("1").setSource("{}", XContentType.JSON));
-        String nodeId = clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId();
+        String nodeId = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNodeId();
 
         final Settings dataPathSettings = internalCluster().dataPathSettings(node);
         internalCluster().stopRandomDataNode();
@@ -235,7 +235,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         dataPaths.forEach(path -> assertTrue(Files.isDirectory(path.resolve("nodes"))));
         internalCluster().startNode(dataPathSettings);
         dataPaths.forEach(path -> assertTrue(Files.isRegularFile(path.resolve("nodes"))));
-        assertEquals(nodeId, clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId());
+        assertEquals(nodeId, clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNodeId());
         assertTrue(indexExists("test"));
         ensureYellow("test");
         assertHitCount(prepareSearch().setQuery(matchAllQuery()), 1L);

--- a/server/src/internalClusterTest/java/org/elasticsearch/features/ClusterFeaturesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/features/ClusterFeaturesIT.java
@@ -32,7 +32,7 @@ public class ClusterFeaturesIT extends ESIntegTestCase {
         assertThat(service.getNodeFeatures(), hasKey(FeatureService.FEATURES_SUPPORTED.id()));
 
         // check the nodes all have a feature in their cluster state (there should always be features_supported)
-        var response = clusterAdmin().state(new ClusterStateRequest().clear().nodes(true)).actionGet();
+        var response = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().nodes(true)).actionGet();
         var features = response.getState().clusterFeatures().nodeFeatures();
         Set<String> missing = features.entrySet()
             .stream()

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -92,7 +92,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
             .get();
 
         logger.info("--> verify meta _routing required exists");
-        MappingMetadata mappingMd = clusterAdmin().prepareState().get().getState().metadata().index("test").mapping();
+        MappingMetadata mappingMd = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").mapping();
         assertThat(mappingMd.routingRequired(), equalTo(true));
 
         logger.info("--> restarting nodes...");
@@ -102,7 +102,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         ensureYellow();
 
         logger.info("--> verify meta _routing required exists");
-        mappingMd = clusterAdmin().prepareState().get().getState().metadata().index("test").mapping();
+        mappingMd = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").mapping();
         assertThat(mappingMd.routingRequired(), equalTo(true));
     }
 
@@ -118,7 +118,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -132,7 +132,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
 
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -158,7 +158,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> verifying that the state is green");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -172,7 +172,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -181,7 +181,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for two nodes and green status");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -199,7 +199,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -233,11 +233,14 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         });
 
         logger.info("--> waiting for test index to be created");
-        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setIndices("test").get();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForEvents(Priority.LANGUID)
+            .setIndices("test")
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify we have an index");
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setIndices("test").get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setIndices("test").get();
         assertThat(clusterStateResponse.getState().metadata().hasIndex("test"), equalTo(true));
     }
 
@@ -264,7 +267,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
 
         logger.info("--> waiting for green status");
-        ClusterHealthResponse health = clusterAdmin().prepareHealth()
+        ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
@@ -279,7 +282,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -287,7 +290,11 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         indicesAdmin().prepareOpen("test").get();
 
         logger.info("--> waiting for green status");
-        health = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().setWaitForNodes("2").get();
+        health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForGreenStatus()
+            .setWaitForNodes("2")
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify 1 doc in the index");
@@ -337,7 +344,8 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> wait until all nodes are back online");
         clusterAdmin().health(
-            new ClusterHealthRequest(new String[] {}).waitForEvents(Priority.LANGUID).waitForNodes(Integer.toString(numNodes))
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForEvents(Priority.LANGUID)
+                .waitForNodes(Integer.toString(numNodes))
         ).actionGet();
 
         logger.info("--> waiting for green status");
@@ -372,13 +380,13 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         } else {
             internalCluster().startNode();
             clusterAdmin().health(
-                new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
+                new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForGreenStatus()
                     .waitForEvents(Priority.LANGUID)
                     .waitForNoRelocatingShards(true)
                     .waitForNodes("2")
             ).actionGet();
         }
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         final IndexMetadata metadata = state.getMetadata().index("test");
         final IndexMetadata.Builder brokenMeta = IndexMetadata.builder(metadata)
@@ -395,7 +403,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         // check that the cluster does not keep reallocating shards
         assertBusy(() -> {
-            final RoutingTable routingTable = clusterAdmin().prepareState().get().getState().routingTable();
+            final RoutingTable routingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().routingTable();
             final IndexRoutingTable indexRoutingTable = routingTable.index("test");
             assertNotNull(indexRoutingTable);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
@@ -410,7 +418,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         }, 60, TimeUnit.SECONDS);
         indicesAdmin().prepareClose("test").get();
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertEquals(IndexMetadata.State.CLOSE, state.getMetadata().index(metadata.getIndex()).getState());
         assertEquals("boolean", state.getMetadata().index(metadata.getIndex()).getSettings().get("archived.index.similarity.BM25.type"));
         // try to open it with the broken setting - fail again!
@@ -449,13 +457,13 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         } else {
             internalCluster().startNode();
             clusterAdmin().health(
-                new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
+                new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForGreenStatus()
                     .waitForEvents(Priority.LANGUID)
                     .waitForNoRelocatingShards(true)
                     .waitForNodes("2")
             ).actionGet();
         }
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         final IndexMetadata metadata = state.getMetadata().index("test");
         final IndexMetadata.Builder brokenMeta = IndexMetadata.builder(metadata)
@@ -464,7 +472,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         // check that the cluster does not keep reallocating shards
         assertBusy(() -> {
-            final RoutingTable routingTable = clusterAdmin().prepareState().get().getState().routingTable();
+            final RoutingTable routingTable = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().routingTable();
             final IndexRoutingTable indexRoutingTable = routingTable.index("test");
             assertNotNull(indexRoutingTable);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
@@ -497,13 +505,13 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         } else {
             internalCluster().startNode();
             clusterAdmin().health(
-                new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
+                new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForGreenStatus()
                     .waitForEvents(Priority.LANGUID)
                     .waitForNoRelocatingShards(true)
                     .waitForNodes("2")
             ).actionGet();
         }
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         final Metadata metadata = state.getMetadata();
         final Metadata brokenMeta = Metadata.builder(metadata)
@@ -518,7 +526,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         restartNodesOnBrokenClusterState(ClusterState.builder(state).metadata(brokenMeta));
 
         ensureYellow("test"); // wait for state recovery
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertEquals("true", state.metadata().persistentSettings().get("archived.this.is.unknown"));
         assertEquals(
             "broken",
@@ -528,7 +536,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         // delete these settings
         updateClusterSettings(Settings.builder().putNull("archived.*"));
 
-        state = clusterAdmin().prepareState().get().getState();
+        state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertNull(state.metadata().persistentSettings().get("archived.this.is.unknown"));
         assertNull(
             state.metadata().persistentSettings().get("archived." + ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey())

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
@@ -69,7 +69,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
 
         logger.debug("relocating index...");
         updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "_name", node2), index);
-        clusterAdmin().prepareHealth().setWaitForNoRelocatingShards(true).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNoRelocatingShards(true).get();
         ensureGreen();
         assertIndexDirectoryDeleted(node1, resolveIndex);
         assertIndexInMetaState(node2, index);
@@ -98,7 +98,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
         logger.info("--> close index");
         indicesAdmin().prepareClose(index).get();
         // close the index
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(clusterStateResponse.getState().getMetadata().index(index).getState().name(), equalTo(IndexMetadata.State.CLOSE.name()));
 
         // update the mapping. this should cause the new meta data to be written although index is closed

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/QuorumGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/QuorumGatewayIT.java
@@ -62,7 +62,7 @@ public class QuorumGatewayIT extends ESIntegTestCase {
                         ClusterHealthResponse clusterHealth = activeClient.admin()
                             .cluster()
                             .health(
-                                new ClusterHealthRequest(new String[] {}).waitForYellowStatus()
+                                new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForYellowStatus()
                                     .waitForNodes("2")
                                     .waitForActiveShards(test.numPrimaries * 2)
                             )

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoverAfterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoverAfterNodesIT.java
@@ -35,7 +35,7 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
         do {
             blocks = nodeClient.admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .setLocal(true)
                 .get()
                 .getState()
@@ -55,33 +55,75 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
         logger.info("--> start master_node (1)");
         Client master1 = startNode(Settings.builder().put(RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2).put(masterOnlyNode()));
         assertThat(
-            master1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
+            master1.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .blocks()
+                .global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
 
         logger.info("--> start data_node (1)");
         Client data1 = startNode(Settings.builder().put(RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2).put(dataOnlyNode()));
         assertThat(
-            master1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
+            master1.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .blocks()
+                .global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
         assertThat(
-            data1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
+            data1.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .blocks()
+                .global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
 
         logger.info("--> start master_node (2)");
         Client master2 = startNode(Settings.builder().put(RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2).put(masterOnlyNode()));
         assertThat(
-            master2.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
+            master2.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .blocks()
+                .global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
         assertThat(
-            data1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
+            data1.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .blocks()
+                .global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
         assertThat(
-            master2.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
+            master2.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .setLocal(true)
+                .get()
+                .getState()
+                .blocks()
+                .global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -202,7 +202,7 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         );
         internalCluster().startDataOnlyNode(nodeWithReplicaSettings);
         // need to wait for events to ensure the reroute has happened since we perform it async when a new node joins.
-        clusterAdmin().prepareHealth(indexName).setWaitForYellowStatus().setWaitForEvents(Priority.LANGUID).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).setWaitForYellowStatus().setWaitForEvents(Priority.LANGUID).get();
         blockRecovery.countDown();
         ensureGreen(indexName);
         assertThat(internalCluster().nodesInclude(indexName), hasItem(newNode));

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
@@ -253,7 +253,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
         internalCluster.client()
             .admin()
             .cluster()
-            .updateSettings(new ClusterUpdateSettingsRequest().persistentSettings(settings))
+            .updateSettings(new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(settings))
             .actionGet();
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthServiceIT.java
@@ -88,7 +88,7 @@ public class HealthServiceIT extends ESIntegTestCase {
             ClusterState state = internalCluster().client()
                 .admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setMetadata(true)
                 .setNodes(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/UpdateHealthInfoCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/UpdateHealthInfoCacheIT.java
@@ -136,13 +136,22 @@ public class UpdateHealthInfoCacheIT extends ESIntegTestCase {
             .admin()
             .cluster()
             .updateSettings(
-                new ClusterUpdateSettingsRequest().persistentSettings(
+                new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(
                     Settings.builder().put(LocalHealthMonitor.POLL_INTERVAL_SETTING.getKey(), TimeValue.timeValueSeconds(10))
                 )
             );
     }
 
     private static Map<String, DiscoveryNode> getNodes(InternalTestCluster internalCluster) {
-        return internalCluster.client().admin().cluster().prepareState().clear().setNodes(true).get().getState().getNodes().getNodes();
+        return internalCluster.client()
+            .admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get()
+            .getState()
+            .getNodes()
+            .getNodes();
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
@@ -396,7 +396,15 @@ public class IndexingPressureIT extends ESIntegTestCase {
     }
 
     private String getCoordinatingOnlyNode() {
-        return clusterAdmin().prepareState().get().getState().nodes().getCoordinatingOnlyNodes().values().iterator().next().getName();
+        return clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .nodes()
+            .getCoordinatingOnlyNodes()
+            .values()
+            .iterator()
+            .next()
+            .getName();
     }
 
     private Tuple<String, String> getPrimaryReplicaNodeNames() {
@@ -413,7 +421,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
             .findAny()
             .get()
             .currentNodeId();
-        DiscoveryNodes nodes = clusterAdmin().prepareState().get().getState().nodes();
+        DiscoveryNodes nodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes();
         String primaryName = nodes.get(primaryId).getName();
         String replicaName = nodes.get(replicaId).getName();
         return new Tuple<>(primaryName, replicaName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -84,7 +84,7 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
     public void testBackgroundGlobalCheckpointSync() throws Exception {
         runGlobalCheckpointSyncTest(TimeValue.timeValueSeconds(randomIntBetween(1, 3)), client -> {
             // prevent global checkpoint syncs between all nodes
-            final DiscoveryNodes nodes = client.admin().cluster().prepareState().get().getState().getNodes();
+            final DiscoveryNodes nodes = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes();
             for (final DiscoveryNode node : nodes) {
                 for (final DiscoveryNode other : nodes) {
                     if (node == other) {
@@ -105,7 +105,7 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
             }
         }, client -> {
             // restore global checkpoint syncs between all nodes
-            final DiscoveryNodes nodes = client.admin().cluster().prepareState().get().getState().getNodes();
+            final DiscoveryNodes nodes = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes();
             for (final DiscoveryNode node : nodes) {
                 for (final DiscoveryNode other : nodes) {
                     if (node == other) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -558,7 +558,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             .build();
         assertAcked(prepareCreate("index").setSettings(settings));
         ensureYellowAndNoInitializingShards("index");
-        assertFalse(clusterAdmin().prepareHealth("index").setWaitForActiveShards(numDataNodes).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index").setWaitForActiveShards(numDataNodes).get().isTimedOut());
 
         final String primaryShardNodeId = clusterService().state().routingTable().index("index").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -194,7 +194,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         waitNoPendingTasksOnAll();
 
         String nodeId = null;
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final DiscoveryNodes nodes = state.nodes();
         for (Map.Entry<String, DiscoveryNode> cursor : nodes.getNodes().entrySet()) {
             final String name = cursor.getValue().getName();
@@ -350,7 +350,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         });
 
         String primaryNodeId = null;
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final DiscoveryNodes nodes = state.nodes();
         for (Map.Entry<String, DiscoveryNode> cursor : nodes.getNodes().entrySet()) {
             final String name = cursor.getValue().getName();
@@ -524,7 +524,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         ensureGreen(indexName);
 
         final Map<String, String> nodeNameToNodeId = new HashMap<>();
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final DiscoveryNodes nodes = state.nodes();
         for (Map.Entry<String, DiscoveryNode> cursor : nodes.getNodes().entrySet()) {
             nodeNameToNodeId.put(cursor.getValue().getName(), cursor.getKey());
@@ -569,7 +569,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
     }
 
     private Path getPathToShardData(String indexName, String dirSuffix) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         GroupShardsIterator<ShardIterator> shardIterators = state.getRoutingTable()
             .activePrimaryShardsGrouped(new String[] { indexName }, false);
         List<ShardIterator> iterators = iterableAsArrayList(shardIterators);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -144,7 +144,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
     }
 
     private Set<String> nodeIdsWithIndex(String... indices) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         GroupShardsIterator<ShardIterator> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         Set<String> nodes = new HashSet<>();
         for (ShardIterator shardIterator : allAssignedShardsGrouped) {
@@ -159,7 +159,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
     }
 
     protected int numAssignedShards(String... indices) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         GroupShardsIterator<?> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         return allAssignedShardsGrouped.size();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
@@ -58,7 +58,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         CreateIndexResponse createIndexResponse = indicesAdmin().create(new CreateIndexRequest("test").settings(settings)).actionGet();
         assertAcked(createIndexResponse);
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         RoutingNode routingNodeEntry1 = clusterState.getRoutingNodes().node(node1);
         assertThat(routingNodeEntry1.numberOfShardsWithState(STARTED), equalTo(11));
 
@@ -68,7 +68,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         // first wait for 2 nodes in the cluster
         logger.info("Waiting for replicas to be assigned");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -83,7 +83,9 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         ClusterRerouteUtils.reroute(client());
 
         clusterHealth = clusterAdmin().health(
-            new ClusterHealthRequest(new String[] {}).waitForGreenStatus().waitForNodes("2").waitForNoRelocatingShards(true)
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForGreenStatus()
+                .waitForNodes("2")
+                .waitForNoRelocatingShards(true)
         ).actionGet();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -94,7 +96,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         assertThat(clusterHealth.getActiveShards(), equalTo(22));
         assertThat(clusterHealth.getActivePrimaryShards(), equalTo(11));
 
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertNodesPresent(clusterState.getRoutingNodes(), node1, node2);
         routingNodeEntry1 = clusterState.getRoutingNodes().node(node1);
         assertThat(routingNodeEntry1.numberOfShardsWithState(RELOCATING), equalTo(0));
@@ -109,7 +111,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         // first wait for 3 nodes in the cluster
         logger.info("Waiting for replicas to be assigned");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForGreenStatus()
             .setWaitForNodes("3")
             .setWaitForNoRelocatingShards(true)
@@ -123,7 +125,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         // explicitly call reroute, so shards will get relocated to the new node (we delay it in ES in case other nodes join)
         ClusterRerouteUtils.reroute(client());
 
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForGreenStatus()
             .setWaitForNodes("3")
             .setWaitForNoRelocatingShards(true)
@@ -138,7 +140,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         assertThat(clusterHealth.getActiveShards(), equalTo(22));
         assertThat(clusterHealth.getActivePrimaryShards(), equalTo(11));
 
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertNodesPresent(clusterState.getRoutingNodes(), node1, node2, node3);
 
         routingNodeEntry1 = clusterState.getRoutingNodes().node(node1);
@@ -165,7 +167,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         internalCluster().stopNode(server_1);
         // verify health
         logger.info("Running Cluster Health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -177,7 +179,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         ClusterRerouteUtils.reroute(client());
 
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -189,7 +191,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         assertThat(clusterHealth.getActiveShards(), equalTo(22));
         assertThat(clusterHealth.getActivePrimaryShards(), equalTo(11));
 
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertNodesPresent(clusterState.getRoutingNodes(), node3, node2);
         routingNodeEntry2 = clusterState.getRoutingNodes().node(node2);
         routingNodeEntry3 = clusterState.getRoutingNodes().node(node3);
@@ -207,7 +209,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         AcknowledgedResponse deleteIndexResponse = indicesAdmin().prepareDelete("test").get();
         assertThat(deleteIndexResponse.isAcknowledged(), equalTo(true));
 
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertNodesPresent(clusterState.getRoutingNodes(), node3, node2);
         routingNodeEntry2 = clusterState.getRoutingNodes().node(node2);
         assertThat(routingNodeEntry2.isEmpty(), equalTo(true));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -177,7 +177,7 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
             assertEquals(dateMathExp3, response.getSetting(index3, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));
         });
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().index(index1), notNullValue());
         assertThat(clusterState.metadata().index(index2), notNullValue());
         assertThat(clusterState.metadata().index(index3), notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -97,7 +97,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
             fail("should have thrown an exception during creation");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("failing on purpose"));
-            assertFalse(clusterAdmin().prepareState().get().getState().routingTable().hasIndex("failed"));
+            assertFalse(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().routingTable().hasIndex("failed"));
         }
     }
 
@@ -120,7 +120,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
         ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand("index1", 0, node1, node2));
         ensureGreen("index1");
 
-        var state = clusterAdmin().prepareState().get().getState();
+        var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         logger.info("Final routing is {}", state.getRoutingNodes().toString());
         var shard = state.routingTable().index("index1").shard(0).primaryShard();
         assertThat(shard, notNullValue());
@@ -148,13 +148,13 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
 
         // await all relocation attempts are exhausted
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             var shard = state.routingTable().index("index1").shard(0).primaryShard();
             assertThat(shard, notNullValue());
             assertThat(shard.relocationFailureInfo().failedRelocations(), equalTo(maxAttempts));
         });
         // ensure the shard remain started
-        var state = clusterAdmin().prepareState().get().getState();
+        var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         logger.info("Final routing is {}", state.getRoutingNodes().toString());
         var shard = state.routingTable().index("index1").shard(0).primaryShard();
         assertThat(shard, notNullValue());
@@ -177,7 +177,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
             fail("should have thrown an exception");
         } catch (ElasticsearchException e) {
             assertTrue(e.getMessage().contains("failing on purpose"));
-            ClusterStateResponse resp = clusterAdmin().prepareState().get();
+            ClusterStateResponse resp = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
             assertFalse(resp.getState().routingTable().indicesRouting().keySet().contains("failed"));
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ResolveClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ResolveClusterIT.java
@@ -677,7 +677,7 @@ public class ResolveClusterIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client(REMOTE_CLUSTER_1).admin()
                 .cluster()
-                .prepareHealth(remoteIndex1)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex1)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()
@@ -715,7 +715,7 @@ public class ResolveClusterIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client(REMOTE_CLUSTER_2).admin()
                 .cluster()
-                .prepareHealth(remoteIndex2)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex2)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -106,7 +106,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
             updateIndexSettings(Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name"), indexName);
             ensureYellow(indexName);
             assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-            assertEquals(ClusterHealthStatus.YELLOW, clusterAdmin().prepareHealth(indexName).get().getStatus());
+            assertEquals(ClusterHealthStatus.YELLOW, clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).get().getStatus());
             mockLog.assertAllExpectationsMatched();
         }
 
@@ -153,7 +153,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
             updateIndexSettings(Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name"), indexName);
             assertBusy(mockLog::assertAllExpectationsMatched);
-            final var clusterHealthResponse = clusterAdmin().prepareHealth(indexName)
+            final var clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .setWaitForNoInitializingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetMappingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetMappingsIT.java
@@ -62,7 +62,7 @@ public class SimpleGetMappingsIT extends ESIntegTestCase {
         indicesAdmin().prepareCreate("indexa").setMapping(getMappingForType()).get();
         indicesAdmin().prepareCreate("indexb").setMapping(getMappingForType()).get();
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -62,7 +62,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
         indicesAdmin().prepareCreate("test")
             .setSettings(indexSettings(1, 0).put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), Long.MAX_VALUE))
             .get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
         updateClusterSettings(
             Settings.builder().put(MappingUpdatedAction.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(5))
         );
@@ -100,7 +100,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
         indicesAdmin().prepareCreate("test").setSettings(indexSettings(1, 0)).setMapping("""
             {"properties":{"body":{"type":"text"}}}
             """).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping("test").setSource("""
             {"properties":{"date":{"type":"integer"}}}
@@ -115,7 +115,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
 
     public void testUpdateMappingWithoutTypeMultiObjects() {
         createIndex("test", 1, 0);
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping("test").setSource("""
             {"properties":{"date":{"type":"integer"}}}""", XContentType.JSON).get();
@@ -131,7 +131,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
         indicesAdmin().prepareCreate("test").setSettings(indexSettings(2, 0)).setMapping("""
             {"properties":{"body":{"type":"text"}}}
             """).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         try {
             indicesAdmin().preparePutMapping("test").setSource("""
@@ -163,7 +163,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     public void testUpdateMappingNoChanges() {
         indicesAdmin().prepareCreate("test").setSettings(indexSettings(2, 0)).setMapping("""
             {"properties":{"body":{"type":"text"}}}""").get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping("test").setSource("""
             {"_doc":{"properties":{"body":{"type":"text"}}}}

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -319,7 +319,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         reset();
 
         assertThat(
-            clusterAdmin().prepareState()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .metadata()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/HierarchyCircuitBreakerTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/HierarchyCircuitBreakerTelemetryIT.java
@@ -63,7 +63,12 @@ public class HierarchyCircuitBreakerTelemetryIT extends ESIntegTestCase {
             // NOTE: we start with empty circuitBreakerSettings to allow cluster formation
             masterNodeName = internalCluster().startMasterOnlyNode(Settings.EMPTY);
             dataNodeName = internalCluster().startDataOnlyNode(Settings.EMPTY);
-            assertTrue(clusterAdmin().prepareUpdateSettings().setPersistentSettings(circuitBreakerSettings).get().isAcknowledged());
+            assertTrue(
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                    .setPersistentSettings(circuitBreakerSettings)
+                    .get()
+                    .isAcknowledged()
+            );
             assertTrue(
                 client().admin()
                     .indices()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -325,7 +325,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
             }
         }
 
-        final Metadata metadata = clusterAdmin().prepareState().clear().setMetadata(true).get().getState().metadata();
+        final Metadata metadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setMetadata(true).get().getState().metadata();
         assertTrue(metadata.indexGraveyard().toString(), metadata.indexGraveyard().containsIndex(new Index(INDEX_NAME, danglingIndexUUID)));
         assertNull(Strings.toString(metadata, true, true), metadata.index(INDEX_NAME));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -53,7 +53,7 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
         };
         indexingThread.start();
 
-        ClusterState initialState = clusterAdmin().prepareState().get().getState();
+        ClusterState initialState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         DiscoveryNode[] dataNodes = initialState.getNodes().getDataNodes().values().toArray(DiscoveryNode[]::new);
         DiscoveryNode relocationSource = initialState.getNodes()
             .getDataNodes()
@@ -65,7 +65,7 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
             }
             logger.info("--> [iteration {}] relocating from {} to {} ", i, relocationSource.getName(), relocationTarget.getName());
             ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand("test", 0, relocationSource.getId(), relocationTarget.getId()));
-            ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+            ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setTimeout(TimeValue.timeValueSeconds(60))
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNoRelocatingShards(true)
@@ -77,7 +77,7 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
                     "timed out waiting for relocation iteration [" + i + "]",
                     ReferenceDocs.LOGGING
                 );
-                final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+                final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
                 logger.info("timed out for waiting for relocation iteration [{}] \ncluster state {}", i, clusterState);
                 finished.set(true);
                 indexingThread.join();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -523,7 +523,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         transportService.clearAllRules();
 
         // make sure nodeA has primary and nodeB has replica
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
         assertThat(startedShards.size(), equalTo(2));
         for (ShardRouting shardRouting : startedShards) {
@@ -635,7 +635,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
         logger.info("--> start node C");
         String nodeC = internalCluster().startNode();
-        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("3").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("3").get().isTimedOut());
 
         logger.info("--> slowing down recoveries");
         throttleRecovery10Seconds(shardSize);
@@ -1118,7 +1118,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2).putNull("index.routing.allocation.include._name"),
                 indexName
             );
-            assertFalse(clusterAdmin().prepareHealth(indexName).setWaitForActiveShards(2).get().isTimedOut());
+            assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).setWaitForActiveShards(2).get().isTimedOut());
         } finally {
             allowToCompletePhase1Latch.countDown();
         }
@@ -1261,7 +1261,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 @Override
                 public Settings onNodeStopped(String nodeName) throws Exception {
                     assertFalse(
-                        clusterAdmin().prepareHealth()
+                        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                             .setWaitForNodes(Integer.toString(discoveryNodes.getSize() - 1))
                             .setWaitForEvents(Priority.LANGUID)
                             .get()
@@ -1325,7 +1325,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 @Override
                 public Settings onNodeStopped(String nodeName) throws Exception {
                     assertFalse(
-                        clusterAdmin().prepareHealth()
+                        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                             .setWaitForNodes(Integer.toString(discoveryNodes.getSize() - 1))
                             .setWaitForEvents(Priority.LANGUID)
                             .get()
@@ -1432,7 +1432,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 @Override
                 public Settings onNodeStopped(String nodeName) throws Exception {
                     assertFalse(
-                        clusterAdmin().prepareHealth()
+                        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                             .setWaitForNodes(Integer.toString(discoveryNodes.getSize() - 1))
                             .setWaitForEvents(Priority.LANGUID)
                             .get()
@@ -1657,7 +1657,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         String indexName = "test-index";
         createIndex(indexName, indexSettings(1, 1).put("index.routing.allocation.include._name", String.join(",", dataNodes)).build());
         ensureGreen(indexName);
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         DiscoveryNode nodeWithOldPrimary = clusterState.nodes()
             .get(clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId());
         final var transportService = MockTransportService.getInstance(nodeWithOldPrimary.getName());
@@ -1731,7 +1731,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         indexRandom(randomBoolean(), true, true, indexRequests);
         assertThat(indicesAdmin().prepareFlush(indexName).get().getFailedShards(), equalTo(0));
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         DiscoveryNode nodeWithPrimary = clusterState.nodes()
             .get(clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
@@ -55,7 +55,11 @@ public class ReplicaToPrimaryPromotionIT extends ESIntegTestCase {
         }
 
         // pick up a data node that contains a random primary shard
-        ClusterState state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
+        ClusterState state = client(internalCluster().getMasterName()).admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState();
         final int numShards = state.metadata().index(indexName).getNumberOfShards();
         final ShardRouting primaryShard = state.routingTable().index(indexName).shard(randomIntBetween(0, numShards - 1)).primaryShard();
         final DiscoveryNode randomNode = state.nodes().resolveNode(primaryShard.currentNodeId());
@@ -64,7 +68,7 @@ public class ReplicaToPrimaryPromotionIT extends ESIntegTestCase {
         internalCluster().stopNode(randomNode.getName());
         ensureYellowAndNoInitializingShards(indexName);
 
-        state = client(internalCluster().getMasterName()).admin().cluster().prepareState().get().getState();
+        state = client(internalCluster().getMasterName()).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final IndexRoutingTable indexRoutingTable = state.routingTable().index(indexName);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
             for (ShardRouting shardRouting : indexRoutingTable.shard(i).activeShards()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsServiceIT.java
@@ -284,7 +284,7 @@ public class ShardSnapshotsServiceIT extends ESIntegTestCase {
     }
 
     private ShardId getShardIdForIndex(String indexName) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         return state.routingTable().index(indexName).shard(0).shardId();
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -36,7 +36,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         logger.info("Creating index test");
         assertAcked(prepareCreate("test", 2));
         logger.info("Running Cluster Health");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .get();
@@ -62,11 +62,16 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertHitCount(prepareSearch().setSize(0).setQuery(matchAllQuery()), 10L);
         }
 
-        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index("test")
+            .getSettingsVersion();
         logger.info("Increasing the number of replicas from 1 to 2");
         setReplicaCount(2, "test");
         logger.info("Running Cluster Health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -79,7 +84,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         // only 2 copies allocated (1 replica) across 2 nodes
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
-        final long afterReplicaIncreaseSettingsVersion = clusterAdmin().prepareState()
+        final long afterReplicaIncreaseSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -90,7 +95,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         logger.info("starting another node to new replicas will be allocated to it");
         allowNodes("test", 3);
 
-        final long afterStartingAnotherNodeVersion = clusterAdmin().prepareState()
+        final long afterStartingAnotherNodeVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -98,7 +103,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .getSettingsVersion();
 
         logger.info("Running Cluster Health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
@@ -120,7 +125,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         setReplicaCount(0, "test");
 
         logger.info("Running Cluster Health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
@@ -138,7 +143,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertHitCount(prepareSearch().setQuery(matchAllQuery()), 10);
         }
 
-        final long afterReplicaDecreaseSettingsVersion = clusterAdmin().prepareState()
+        final long afterReplicaDecreaseSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -155,7 +160,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("--> running cluster health");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -170,7 +175,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         if (randomBoolean()) {
             assertAcked(indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
 
-            clusterHealth = clusterAdmin().prepareHealth()
+            clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForGreenStatus()
                 .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -183,13 +188,18 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
         }
 
-        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index("test")
+            .getSettingsVersion();
 
         logger.info("--> add another node, should increase the number of replicas");
         allowNodes("test", 3);
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
@@ -202,7 +212,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(2));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
-        final long afterAddingOneNodeSettingsVersion = clusterAdmin().prepareState()
+        final long afterAddingOneNodeSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -215,7 +225,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 2);
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -228,7 +238,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
-        final long afterClosingOneNodeSettingsVersion = clusterAdmin().prepareState()
+        final long afterClosingOneNodeSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -241,7 +251,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 1);
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes(">=1")
@@ -254,7 +264,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(0));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries));
 
-        final long afterClosingAnotherNodeSettingsVersion = clusterAdmin().prepareState()
+        final long afterClosingAnotherNodeSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -271,7 +281,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("--> running cluster health");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -286,7 +296,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         if (randomBoolean()) {
             assertAcked(indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
 
-            clusterHealth = clusterAdmin().prepareHealth()
+            clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForGreenStatus()
                 .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -299,12 +309,17 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
         }
 
-        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index("test")
+            .getSettingsVersion();
         logger.info("--> add another node, should increase the number of replicas");
         allowNodes("test", 3);
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
@@ -316,7 +331,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(2));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
-        final long afterAddingOneNodeSettingsVersion = clusterAdmin().prepareState()
+        final long afterAddingOneNodeSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -329,7 +344,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 2);
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes(">=2")
@@ -342,7 +357,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
-        final long afterClosingOneNodeSettingsVersion = clusterAdmin().prepareState()
+        final long afterClosingOneNodeSettingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -355,7 +370,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 1);
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForNodes(">=1")
@@ -376,7 +391,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("--> running cluster health");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
@@ -392,12 +407,17 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 4);
         allowNodes("test", 5);
 
-        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index("test")
+            .getSettingsVersion();
         logger.info("--> update the auto expand replicas to 0-3");
         updateIndexSettings(Settings.builder().put("auto_expand_replicas", "0-3"), "test");
 
         logger.info("--> running cluster health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 4)
@@ -414,14 +434,19 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
          * time from the number of replicas changed by the allocation service.
          */
         assertThat(
-            clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").getSettingsVersion(),
             equalTo(1 + 1 + settingsVersion)
         );
     }
 
     public void testUpdateWithInvalidNumberOfReplicas() {
         createIndex("test");
-        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index("test")
+            .getSettingsVersion();
         final int value = randomIntBetween(-10, -1);
         try {
             indicesAdmin().prepareUpdateSettings("test")
@@ -431,7 +456,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         } catch (IllegalArgumentException e) {
             assertEquals("Failed to parse value [" + value + "] for setting [index.number_of_replicas] must be >= 0", e.getMessage());
             assertThat(
-                clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion(),
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").getSettingsVersion(),
                 equalTo(settingsVersion)
             );
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
@@ -47,7 +47,7 @@ public class CloseIndexDisableCloseAllIT extends ESIntegTestCase {
     }
 
     private void assertIndexIsClosed(String... indices) {
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         for (String index : indices) {
             IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().indices().get(index);
             assertNotNull(indexMetadata);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -162,7 +162,7 @@ public class CloseIndexIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("index.routing.allocation.include._name", "nothing").build())
         );
 
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().indices().get(indexName).getState(), is(IndexMetadata.State.OPEN));
         assertThat(clusterState.routingTable().allShards().allMatch(ShardRouting::unassigned), is(true));
 
@@ -182,7 +182,7 @@ public class CloseIndexIT extends ESIntegTestCase {
             IntStream.range(0, nbDocs).mapToObj(i -> prepareIndex(indexName).setId(String.valueOf(i)).setSource("num", i)).collect(toList())
         );
 
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(indexName)
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName)
             .setWaitForYellowStatus()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
@@ -243,7 +243,7 @@ public class CloseIndexIT extends ESIntegTestCase {
             }
             indices[i] = indexName;
         }
-        assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
+        assertThat(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().indices().size(), equalTo(indices.length));
 
         startInParallel(indices.length * 2, i -> {
             final String index = indices[i % indices.length];
@@ -285,7 +285,7 @@ public class CloseIndexIT extends ESIntegTestCase {
 
         indexer.stopAndAwaitStopped();
 
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         if (clusterState.metadata().indices().get(indexName).getState() == IndexMetadata.State.CLOSE) {
             assertIndexIsClosed(indexName);
             assertAcked(indicesAdmin().prepareOpen(indexName));
@@ -310,7 +310,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         ensureGreen(indexName);
 
         final CloseIndexResponse closeIndexResponse = indicesAdmin().prepareClose(indexName).get();
-        assertThat(clusterAdmin().prepareHealth(indexName).get().getStatus(), is(ClusterHealthStatus.GREEN));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).get().getStatus(), is(ClusterHealthStatus.GREEN));
         assertTrue(closeIndexResponse.isAcknowledged());
         assertTrue(closeIndexResponse.isShardsAcknowledged());
         assertThat(closeIndexResponse.getIndices().get(0), notNullValue());
@@ -532,7 +532,7 @@ public class CloseIndexIT extends ESIntegTestCase {
     }
 
     static void assertIndexIsClosed(final String... indices) {
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (String index : indices) {
             final IndexMetadata indexMetadata = clusterState.metadata().indices().get(index);
             assertThat(indexMetadata.getState(), is(IndexMetadata.State.CLOSE));
@@ -555,7 +555,7 @@ public class CloseIndexIT extends ESIntegTestCase {
     }
 
     static void assertIndexIsOpened(final String... indices) {
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (String index : indices) {
             final IndexMetadata indexMetadata = clusterState.metadata().indices().get(index);
             assertThat(indexMetadata.getState(), is(IndexMetadata.State.OPEN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -49,7 +49,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testSimpleCloseOpen() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test1").get();
@@ -70,7 +70,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testOpenOneMissingIndex() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         Exception e = expectThrows(IndexNotFoundException.class, client.admin().indices().prepareOpen("test1", "test2"));
         assertThat(e.getMessage(), is("no such index [test2]"));
@@ -79,7 +79,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testOpenOneMissingIndexIgnoreMissing() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         OpenIndexResponse openIndexResponse = client.admin()
             .indices()
@@ -94,7 +94,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenMultipleIndices() {
         Client client = client();
         createIndex("test1", "test2", "test3");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse closeIndexResponse1 = client.admin().indices().prepareClose("test1").get();
@@ -116,7 +116,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenWildcard() {
         Client client = client();
         createIndex("test1", "test2", "a");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test*").get();
@@ -133,7 +133,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenAll() {
         Client client = client();
         createIndex("test1", "test2", "test3");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("_all").get();
@@ -149,7 +149,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenAllWildcard() {
         Client client = client();
         createIndex("test1", "test2", "test3");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("*").get();
@@ -175,7 +175,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testOpenAlreadyOpenedIndex() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         // no problem if we try to open an index that's already in open state
@@ -188,7 +188,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testSimpleCloseOpenAlias() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse aliasesResponse = client.admin().indices().prepareAliases().addAlias("test1", "test1-alias").get();
@@ -207,7 +207,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenAliasMultipleIndices() {
         Client client = client();
         createIndex("test1", "test2");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         AcknowledgedResponse aliasesResponse1 = client.admin().indices().prepareAliases().addAlias("test1", "test-alias").get();
@@ -240,7 +240,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertThat(response.isShardsAcknowledged(), equalTo(false));
         assertBusy(
             () -> assertThat(
-                client.admin().cluster().prepareState().get().getState().metadata().index("test").getState(),
+                client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test").getState(),
                 equalTo(IndexMetadata.State.OPEN)
             )
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
@@ -159,7 +159,7 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
     }
 
     private static void assertIndexIsBlocked(final String... indices) {
-        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (String index : indices) {
             assertThat(clusterState.metadata().indices().get(index).getState(), is(IndexMetadata.State.OPEN));
             assertThat(clusterState.routingTable().index(index), notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/SimpleIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/SimpleIndexStateIT.java
@@ -34,7 +34,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
 
         NumShards numShards = getNumShards("test");
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(numShards.numPrimaries));
         assertEquals(
@@ -48,7 +48,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
 
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -66,7 +66,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().get();
+        stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
 
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(numShards.numPrimaries));
@@ -86,7 +86,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
             .setSettings(Settings.builder().put("index.routing.allocation.include.tag", "no_such_node").build())
             .get();
 
-        ClusterHealthResponse health = clusterAdmin().prepareHealth("test").setWaitForNodes(">=2").get();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").setWaitForNodes(">=2").get();
         assertThat(health.isTimedOut(), equalTo(false));
         assertThat(health.getStatus(), equalTo(ClusterHealthStatus.RED));
 
@@ -102,7 +102,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
 
         NumShards numShards = getNumShards("test");
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(numShards.numPrimaries));
         assertEquals(

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -237,7 +237,7 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .setMapping("field", "type=text,fielddata=true")
         );
         ensureGreen();
-        clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         prepareIndex("test").setId("1").setSource("field", "value1").get();
         prepareIndex("test").setId("2").setSource("field", "value2").get();
         indicesAdmin().prepareRefresh().get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -98,7 +98,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             )
         );
         ensureGreen("test");
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         Index index = state.metadata().index("test").getIndex();
 
         logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
@@ -110,7 +110,10 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logger.info("--> starting node server3");
         final String node_3 = internalCluster().startNode(nonMasterNode());
         logger.info("--> running cluster_health");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForNodes("4").setWaitForNoRelocatingShards(true).get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForNodes("4")
+            .setWaitForNoRelocatingShards(true)
+            .get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
@@ -131,7 +134,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         } else {
             ClusterRerouteUtils.reroute(internalCluster().client(), new MoveAllocationCommand("test", 0, node_1, node_3));
         }
-        clusterHealth = clusterAdmin().prepareHealth().setWaitForNoRelocatingShards(true).get();
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNoRelocatingShards(true).get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         assertShardDeleted(node_1, index, 0);
@@ -197,13 +200,13 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             )
         );
         ensureGreen("test");
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         Index index = state.metadata().index("test").getIndex();
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
         assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
 
         final String node_2 = internalCluster().startDataOnlyNode(Settings.builder().build());
-        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("2").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("2").get().isTimedOut());
 
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
         assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
@@ -226,7 +229,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logger.info("--> move shard from {} to {}, and wait for relocation to finish", node_1, node_2);
         ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand("test", 0, node_1, node_2));
         shardActiveRequestSent.await();
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForNoRelocatingShards(true).get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNoRelocatingShards(true).get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         logClusterState();
         // delete the index. node_1 that still waits for the next cluster state update will then get the delete index next.
@@ -258,7 +261,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         );
         ensureGreen("test");
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         Index index = state.metadata().index("test").getIndex();
         logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
@@ -267,7 +270,10 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logger.info("--> starting node server3");
         String node_3 = internalCluster().startNode();
         logger.info("--> running cluster_health");
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForNodes("3").setWaitForNoRelocatingShards(true).get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForNodes("3")
+            .setWaitForNoRelocatingShards(true)
+            .get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         logger.info("--> making sure that shard is not allocated on server3");
@@ -278,7 +284,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         internalCluster().stopNode(node_2);
 
         logger.info("--> running cluster_health");
-        clusterHealth = clusterAdmin().prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -325,7 +331,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             )
         );
         assertFalse(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForGreenStatus()
                 .setWaitForNodes("5")
@@ -344,7 +350,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         internalCluster().stopNode(nodesToShutDown.get(1));
 
         logger.debug("--> verifying index is red");
-        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForNodes("3").get();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("3").get();
         if (health.getStatus() != ClusterHealthStatus.RED) {
             logClusterState();
             fail("cluster didn't become red, despite of shutting 2 of 3 nodes");
@@ -362,7 +368,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertBusy(() -> assertTrue(internalCluster().getInstance(IndicesService.class, node4).hasIndex(index)));
 
         // wait for 4 active shards - we should have lost one shard
-        assertFalse(clusterAdmin().prepareHealth().setWaitForActiveShards(4).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForActiveShards(4).get().isTimedOut());
 
         // disable allocation again to control concurrency a bit and allow shard active to kick in before allocation
         updateClusterSettings(Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none"));
@@ -371,7 +377,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
 
         internalCluster().startNodes(node1DataPathSettings, node2DataPathSettings);
 
-        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("5").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("5").get().isTimedOut());
 
         updateClusterSettings(Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "all"));
 
@@ -395,7 +401,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         waitNoPendingTasksOnAll();
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         final Index index = stateResponse.getState().metadata().index("test").getIndex();
         RoutingNode routingNode = stateResponse.getState().getRoutingNodes().node(nonMasterId);
         final int[] node2Shards = new int[routingNode.numberOfOwningShards()];

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -178,7 +178,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
     }
 
     public void testDeleteIndexTemplate() throws Exception {
-        final int existingTemplates = admin().cluster().prepareState().get().getState().metadata().templates().size();
+        final int existingTemplates = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().templates().size();
         logger.info("--> put template_1 and template_2");
         indicesAdmin().preparePutTemplate("template_1")
             .setPatterns(Collections.singletonList("te*"))
@@ -223,7 +223,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         logger.info("--> explicitly delete template_1");
         indicesAdmin().prepareDeleteTemplate("template_1").get();
 
-        ClusterState state = admin().cluster().prepareState().get().getState();
+        ClusterState state = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         assertThat(state.metadata().templates().size(), equalTo(1 + existingTemplates));
         assertThat(state.metadata().templates().containsKey("template_2"), equalTo(true));
@@ -254,11 +254,14 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
 
         logger.info("--> delete template*");
         indicesAdmin().prepareDeleteTemplate("template*").get();
-        assertThat(admin().cluster().prepareState().get().getState().metadata().templates().size(), equalTo(existingTemplates));
+        assertThat(
+            admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().templates().size(),
+            equalTo(existingTemplates)
+        );
 
         logger.info("--> delete * with no templates, make sure we don't get a failure");
         indicesAdmin().prepareDeleteTemplate("*").get();
-        assertThat(admin().cluster().prepareState().get().getState().metadata().templates().size(), equalTo(0));
+        assertThat(admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().templates().size(), equalTo(0));
     }
 
     public void testThatGetIndexTemplatesWorks() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestFileSettingsIT.java
@@ -158,7 +158,7 @@ public class IngestFileSettingsIT extends ESIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).get();
 
         ReservedStateMetadata reservedState = clusterStateResponse.getState()

--- a/server/src/internalClusterTest/java/org/elasticsearch/nodescapabilities/SimpleNodesCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/nodescapabilities/SimpleNodesCapabilitiesIT.java
@@ -24,7 +24,10 @@ public class SimpleNodesCapabilitiesIT extends ESIntegTestCase {
     public void testNodesCapabilities() throws IOException {
         internalCluster().startNodes(2);
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForGreenStatus()
+            .setWaitForNodes("2")
+            .get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         // check we support the capabilities API itself. Which we do.

--- a/server/src/internalClusterTest/java/org/elasticsearch/nodesinfo/SimpleNodesInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/nodesinfo/SimpleNodesInfoIT.java
@@ -33,7 +33,10 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         final String node_1 = nodesNames.get(0);
         final String node_2 = nodesNames.get(1);
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForGreenStatus()
+            .setWaitForNodes("2")
+            .get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = getNodeId(node_1);
@@ -72,7 +75,10 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         final String node_1 = nodesNames.get(0);
         final String node_2 = nodesNames.get(1);
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForGreenStatus()
+            .setWaitForNodes("2")
+            .get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = getNodeId(node_1);
@@ -110,7 +116,10 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         final String node_1 = nodeNames.get(0);
         final String node_2 = nodeNames.get(1);
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForGreenStatus()
+            .setWaitForNodes("2")
+            .get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = getNodeId(node_1);

--- a/server/src/internalClusterTest/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIT.java
@@ -84,7 +84,7 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
             assertAcked(indicesAdmin().prepareClose("*").get());
         }
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (Map.Entry<String, IndexMetadata> indexMetadataEntry : state.getMetadata().indices().entrySet()) {
             assertEquals(IndexMetadata.State.CLOSE, indexMetadataEntry.getValue().getState());
         }
@@ -117,7 +117,7 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
             assertAcked(indicesAdmin().prepareOpen("*").get());
         }
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         for (Map.Entry<String, IndexMetadata> indexMetadataEntry : state.getMetadata().indices().entrySet()) {
             assertEquals(IndexMetadata.State.OPEN, indexMetadataEntry.getValue().getState());
         }
@@ -150,7 +150,7 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
             assertAcked(indicesAdmin().prepareAddBlock(WRITE, "*").get());
         }
 
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertTrue("write block is set on index1", state.getBlocks().hasIndexBlock("index1", IndexMetadata.INDEX_WRITE_BLOCK));
         assertTrue("write block is set on 1index", state.getBlocks().hasIndexBlock("1index", IndexMetadata.INDEX_WRITE_BLOCK));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/decider/EnableAssignmentDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/decider/EnableAssignmentDeciderIT.java
@@ -110,7 +110,7 @@ public class EnableAssignmentDeciderIT extends ESIntegTestCase {
     }
 
     private void assertEnableAssignmentSetting(final Allocation expected) {
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().setMetadata(true).get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setMetadata(true).get();
         Settings settings = clusterStateResponse.getState().getMetadata().settings();
 
         String value = settings.get(CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING.getKey());

--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -73,7 +73,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
         final NumShards numShards = getNumShards(indexName);
         assertFalse(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setIndices(indexName)
                 .setWaitForGreenStatus()
                 .setWaitForEvents(Priority.LANGUID)
@@ -140,7 +140,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
         final NumShards numShards = getNumShards(indexName);
         assertFalse(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setIndices(indexName)
                 .setWaitForGreenStatus()
                 .setWaitForEvents(Priority.LANGUID)
@@ -206,7 +206,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
 
         final NumShards numShards = getNumShards(indexName);
         assertFalse(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setIndices(indexName)
                 .setWaitForGreenStatus()
                 .setWaitForEvents(Priority.LANGUID)

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -111,13 +111,16 @@ public class ReadinessClusterIT extends ESIntegTestCase {
     }
 
     private void assertMasterNode(Client client, String node) {
-        assertThat(client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(), equalTo(node));
+        assertThat(
+            client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode().getName(),
+            equalTo(node)
+        );
     }
 
     private void expectMasterNotFound() {
         expectThrows(
             MasterNotDiscoveredException.class,
-            clusterAdmin().prepareState().setMasterNodeTimeout(TimeValue.timeValueMillis(100))
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setMasterNodeTimeout(TimeValue.timeValueMillis(100))
         );
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -62,7 +62,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
 
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -76,7 +76,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
 
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -94,7 +94,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -105,7 +105,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -123,7 +123,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -135,7 +135,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
 
         // make sure the cluster state is yellow, and all has been recovered
         assertTimeout(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForYellowStatus()
@@ -168,7 +168,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
             prepareIndex("test").setId(Long.toString(i)).setSource(Map.<String, Object>of("test", "value" + i)).get();
         }
         ensureGreen();
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
             assertNotEquals(
@@ -186,7 +186,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         }
         internalCluster().restartRandomDataNode();
         ensureGreen();
-        clusterAdmin().prepareState().get();
+        clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
 
         recoveryResponse = indicesAdmin().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -102,7 +102,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             logger.info("--> waiting for GREEN health status ...");
             // make sure the cluster state is green, and all has been recovered
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForGreenStatus()
@@ -163,7 +163,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
             logger.info("--> waiting for GREEN health status ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForGreenStatus()
@@ -225,7 +225,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
             logger.info("--> waiting for GREEN health status ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForGreenStatus()
@@ -242,7 +242,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 3);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForNoRelocatingShards(true)
@@ -252,7 +252,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 2);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForNoRelocatingShards(true)
@@ -262,7 +262,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 1);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForNoRelocatingShards(true)
@@ -273,7 +273,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             logger.info("--> indexing threads stopped");
 
             assertNoTimeout(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForNoRelocatingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -140,7 +140,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> start another node");
         final String node_2 = internalCluster().startNode();
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .get();
@@ -149,7 +149,7 @@ public class RelocationIT extends ESIntegTestCase {
         logger.info("--> relocate the shard from node1 to node2");
         ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand("test", 0, node_1, node_2));
 
-        clusterHealthResponse = clusterAdmin().prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -184,7 +184,7 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> starting [node{}] ...", i);
             nodes[i - 1] = internalCluster().startNode();
             if (i != numberOfNodes) {
-                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(Integer.toString(i))
                     .setWaitForGreenStatus()
@@ -215,7 +215,7 @@ public class RelocationIT extends ESIntegTestCase {
                     logger.debug("--> flushing");
                     indicesAdmin().prepareFlush().get();
                 }
-                ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+                ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNoRelocatingShards(true)
                     .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -288,7 +288,7 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> starting [node_{}] ...", i);
             nodes[i] = internalCluster().startNode();
             if (i != numberOfNodes - 1) {
-                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(Integer.toString(i + 1))
                     .setWaitForGreenStatus()
@@ -349,7 +349,7 @@ public class RelocationIT extends ESIntegTestCase {
 
             // verify cluster was finished.
             assertFalse(
-                clusterAdmin().prepareHealth()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                     .setWaitForNoRelocatingShards(true)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout(TimeValue.timeValueSeconds(30))
@@ -390,7 +390,7 @@ public class RelocationIT extends ESIntegTestCase {
             requests.add(prepareIndex(indexName).setSource("{}", XContentType.JSON));
         }
         indexRandom(true, requests);
-        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("3").setWaitForGreenStatus().get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("3").setWaitForGreenStatus().get().isTimedOut());
         flush();
 
         int allowedFailures = randomIntBetween(3, 5); // the default of the `index.allocation.max_retries` is 5.
@@ -418,7 +418,7 @@ public class RelocationIT extends ESIntegTestCase {
                 if (node.equals(p_node)) {
                     continue;
                 }
-                ClusterState state = client(node).admin().cluster().prepareState().setLocal(true).get().getState();
+                ClusterState state = client(node).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
                 assertThat(
                     node + " indicates assigned replicas",
                     state.getRoutingTable().index(indexName).shardsWithState(ShardRoutingState.UNASSIGNED).size(),
@@ -551,7 +551,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> start another node");
         final String node2 = internalCluster().startNode();
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .get();
@@ -560,7 +560,7 @@ public class RelocationIT extends ESIntegTestCase {
         logger.info("--> relocate the shard from node1 to node2");
         ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand("test", 0, node1, node2));
 
-        clusterHealthResponse = clusterAdmin().prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -602,7 +602,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> start another node");
         final String node2 = internalCluster().startNode();
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .get();
@@ -623,7 +623,7 @@ public class RelocationIT extends ESIntegTestCase {
             );
         }
         safeGet(relocationListener);
-        clusterHealthResponse = clusterAdmin().prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -670,7 +670,7 @@ public class RelocationIT extends ESIntegTestCase {
 
     private void assertActiveCopiesEstablishedPeerRecoveryRetentionLeases() throws Exception {
         assertBusy(() -> {
-            for (String index : clusterAdmin().prepareState().get().getState().metadata().indices().keySet()) {
+            for (String index : clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().indices().keySet()) {
                 Map<ShardId, List<ShardStats>> byShardId = Stream.of(indicesAdmin().prepareStats(index).get().getShards())
                     .collect(Collectors.groupingBy(l -> l.getShardRouting().shardId()));
                 for (List<ShardStats> shardStats : byShardId.values()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RestartInactiveAutoExpandReplicaNotStaleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RestartInactiveAutoExpandReplicaNotStaleIT.java
@@ -28,7 +28,7 @@ public class RestartInactiveAutoExpandReplicaNotStaleIT extends ESIntegTestCase 
 
         ensureGreen();
 
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         IndexMetadata target = clusterStateResponse.getState().getMetadata().index("test");
 
         internalCluster().restartNode(replica, new InternalTestCluster.RestartCallback() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
@@ -137,7 +137,7 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             final SnapshotInfo snapshotInfo = createSnapshot(repoName, Strings.format("snap-%03d", i), snapshotIndices);
             if (snapshotInfo.indices().contains(indexName)) {
                 lastSnapshot = snapshotInfo;
-                ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().get();
+                ClusterStateResponse clusterStateResponse = admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get();
                 IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().index(indexName);
                 expectedIndexMetadataId = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetadata);
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
@@ -66,7 +66,10 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
         );
 
         logger.info("-->  ensure cleanup is still in progress");
-        final RepositoryCleanupInProgress cleanup = clusterAdmin().prepareState().get().getState().custom(RepositoryCleanupInProgress.TYPE);
+        final RepositoryCleanupInProgress cleanup = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .custom(RepositoryCleanupInProgress.TYPE);
         assertTrue(cleanup.hasCleanupInProgress());
 
         logger.info("-->  unblocking master node");

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
@@ -357,7 +357,10 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         }""";
 
     private void assertMasterNode(Client client, String node) throws ExecutionException, InterruptedException {
-        assertThat(client.admin().cluster().prepareState().execute().get().getState().nodes().getMasterNode().getName(), equalTo(node));
+        assertThat(
+            client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute().get().getState().nodes().getMasterNode().getName(),
+            equalTo(node)
+        );
     }
 
     private void writeJSONFile(String node, String json) throws Exception {
@@ -403,7 +406,7 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
 
         Map<String, ComposableIndexTemplate> allTemplates = clusterStateResponse.getState().metadata().templatesV2();

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
@@ -102,7 +102,10 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         }""";
 
     private void assertMasterNode(Client client, String node) {
-        assertThat(client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(), equalTo(node));
+        assertThat(
+            client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode().getName(),
+            equalTo(node)
+        );
     }
 
     public static void writeJSONFile(String node, String json, AtomicLong versionCounter, Logger logger) throws Exception {
@@ -169,7 +172,7 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         assertTrue(savedClusterState.await(20, TimeUnit.SECONDS));
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
 
         assertThat(
@@ -177,7 +180,7 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
             equalTo(expectedBytesPerSec)
         );
 
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest().persistentSettings(
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(
             Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb")
         );
         assertThat(
@@ -257,7 +260,7 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         logger.info("--> restart master");
         internalCluster().restartNode(masterNode);
 
-        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(new ClusterStateRequest()).actionGet();
+        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet();
         assertThat(
             clusterStateResponse.getState()
                 .metadata()
@@ -300,7 +303,7 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
 
         assertThat(clusterStateResponse.getState().metadata().persistentSettings().get("search.allow_expensive_queries"), nullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/RepositoriesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/RepositoriesFileSettingsIT.java
@@ -94,7 +94,10 @@ public class RepositoriesFileSettingsIT extends ESIntegTestCase {
         }""";
 
     private void assertMasterNode(Client client, String node) throws ExecutionException, InterruptedException {
-        assertThat(client.admin().cluster().prepareState().execute().get().getState().nodes().getMasterNode().getName(), equalTo(node));
+        assertThat(
+            client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute().get().getState().nodes().getMasterNode().getName(),
+            equalTo(node)
+        );
     }
 
     private void writeJSONFile(String node, String json) throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnapshotsAndFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnapshotsAndFileSettingsIT.java
@@ -133,7 +133,7 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
         boolean awaitSuccessful = savedClusterState.await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
-        return clusterAdmin().state(new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())).get();
+        return clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())).get();
     }
 
     public void testRestoreWithRemovedFileSettings() throws Exception {
@@ -180,14 +180,15 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
 
         ensureGreen();
 
-        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(new ClusterStateRequest().metadata(true)).actionGet();
+        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).metadata(true))
+            .actionGet();
 
         // We expect no reserved metadata state for file based settings, the operator file was deleted.
         assertNull(clusterStateResponse.getState().metadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE));
 
         final ClusterGetSettingsAction.Response getSettingsResponse = clusterAdmin().execute(
             ClusterGetSettingsAction.INSTANCE,
-            new ClusterGetSettingsAction.Request()
+            new ClusterGetSettingsAction.Request(TEST_REQUEST_TIMEOUT)
         ).actionGet();
 
         assertThat(
@@ -305,14 +306,14 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> reserved state would be restored to non-zero version");
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().metadata(true).waitForMetadataVersion(removedReservedState.v2().get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).metadata(true).waitForMetadataVersion(removedReservedState.v2().get())
         ).actionGet();
 
         assertNotNull(clusterStateResponse.getState().metadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE));
 
         final ClusterGetSettingsAction.Response getSettingsResponse = clusterAdmin().execute(
             ClusterGetSettingsAction.INSTANCE,
-            new ClusterGetSettingsAction.Request()
+            new ClusterGetSettingsAction.Request(TEST_REQUEST_TIMEOUT)
         ).actionGet();
 
         assertThat(

--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/discovery/Zen2RestApiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/discovery/Zen2RestApiIT.java
@@ -51,7 +51,12 @@ public class Zen2RestApiIT extends ESIntegTestCase {
         );
         ensureGreen("test");
 
-        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState().clear().setNodes(true).get().getState().nodes();
+        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get()
+            .getState()
+            .nodes();
         final Map<String, String> nodeIdsByName = Maps.newMapWithExpectedSize(discoveryNodes.getSize());
         discoveryNodes.forEach(n -> nodeIdsByName.put(n.getName(), n.getId()));
 
@@ -98,7 +103,7 @@ public class Zen2RestApiIT extends ESIntegTestCase {
 
                     ClusterHealthResponse clusterHealthResponse = client(viaNode).admin()
                         .cluster()
-                        .prepareHealth()
+                        .prepareHealth(TEST_REQUEST_TIMEOUT)
                         .setWaitForEvents(Priority.LANGUID)
                         .setWaitForNodes(Integer.toString(1))
                         .setTimeout(TimeValue.timeValueSeconds(30L))

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -51,7 +51,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
     public void testResolveIndexRouting() {
         createIndex("test1");
         createIndex("test2");
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         indicesAdmin().prepareAliases()
             .addAliasAction(AliasActions.add().index("test1").alias("alias"))
@@ -93,7 +93,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
         createIndex("test1");
         createIndex("test2");
         createIndex("test3");
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         indicesAdmin().prepareAliases()
             .addAliasAction(AliasActions.add().index("test1").alias("alias"))

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
@@ -93,8 +93,13 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
                 Settings.builder()
                     .put(
                         "index.routing.allocation.require._name",
-                        clusterAdmin().prepareState().get().getState().nodes().getDataNodes().values().toArray(DiscoveryNode[]::new)[0]
-                            .getName()
+                        clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+                            .get()
+                            .getState()
+                            .nodes()
+                            .getDataNodes()
+                            .values()
+                            .toArray(DiscoveryNode[]::new)[0].getName()
                     )
                     .put("index.blocks.write", true),
                 index

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -49,7 +49,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
     }
 
     public String findNonMatchingRoutingValue(String index, String id) {
-        ClusterState state = clusterAdmin().prepareState().all().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
         IndexMetadata metadata = state.metadata().index(index);
         IndexMetadata withoutRoutingRequired = IndexMetadata.builder(metadata).putMapping("{}").build();
         IndexRouting indexRouting = IndexRouting.fromIndexMetadata(withoutRoutingRequired);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
@@ -56,7 +56,7 @@ public class SearchServiceCleanupOnLostMasterIT extends ESIntegTestCase {
             assertBusy(() -> {
                 final ClusterHealthStatus indexHealthStatus = client(master).admin()
                     .cluster()
-                    .health(new ClusterHealthRequest("test"))
+                    .health(new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, "test"))
                     .actionGet()
                     .getStatus();
                 assertThat(indexHealthStatus, Matchers.is(ClusterHealthStatus.RED));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -223,7 +223,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        clusterAdmin().prepareHealth("idx_unmapped").setWaitForYellowStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "idx_unmapped").setWaitForYellowStatus().get();
 
         assertNoFailuresAndResponse(
             prepareSearch("idx_unmapped").addAggregation(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -761,7 +761,7 @@ public class RangeIT extends ESIntegTestCase {
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        clusterAdmin().prepareHealth("idx_unmapped").setWaitForYellowStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "idx_unmapped").setWaitForYellowStatus().get();
 
         assertNoFailuresAndResponse(
             prepareSearch("idx", "idx_unmapped").addAggregation(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
@@ -99,7 +99,9 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
 
         Settings persistentSettings = Settings.builder().put(key, allowPartialResults).build();
 
-        ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings().setPersistentSettings(persistentSettings).get();
+        ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .setPersistentSettings(persistentSettings)
+            .get();
 
         assertAcked(response1);
         assertEquals(response1.getPersistentSettings().getAsBoolean(key, null), allowPartialResults);
@@ -115,10 +117,10 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
 
         internalCluster().stopRandomDataNode();
 
-        clusterAdmin().prepareHealth().setWaitForStatus(ClusterHealthStatus.RED).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForStatus(ClusterHealthStatus.RED).get();
 
         assertBusy(() -> {
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<ShardRouting> unassigneds = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.UNASSIGNED);
             assertThat(unassigneds.size(), greaterThan(0));
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexIT.java
@@ -61,7 +61,7 @@ public class SearchWhileCreatingIndexIT extends ESIntegTestCase {
 
         logger.info("using preference {}", preference);
         // we want to make sure that while recovery happens, and a replica gets recovered, its properly refreshed
-        ClusterHealthStatus status = clusterAdmin().prepareHealth("test").get().getStatus();
+        ClusterHealthStatus status = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").get().getStatus();
         while (status != ClusterHealthStatus.GREEN) {
             // first, verify that search normal search works
             assertHitCount(prepareSearch("test").setQuery(QueryBuilders.termQuery("field", "test")), 1);
@@ -97,7 +97,7 @@ public class SearchWhileCreatingIndexIT extends ESIntegTestCase {
                     assertHitCount(searchResponse, 1);
                 }
             );
-            status = clusterAdmin().prepareHealth("test").get().getStatus();
+            status = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test").get().getStatus();
             internalCluster().ensureAtLeastNumDataNodes(numberOfReplicas + 1);
         }
         cluster().wipeIndices("test");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
@@ -125,7 +125,7 @@ public class SearchWhileRelocatingIT extends ESIntegTestCase {
                 threads[j].join();
             }
             // this might time out on some machines if they are really busy and you hit lots of throttling
-            ClusterHealthResponse resp = clusterAdmin().prepareHealth()
+            ClusterHealthResponse resp = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForYellowStatus()
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForEvents(Priority.LANGUID)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -102,7 +102,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealthResponse = clusterAdmin()
             // it's OK to timeout here
             .health(
-                new ClusterHealthRequest(new String[] {}).waitForYellowStatus()
+                new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, new String[] {}).waitForYellowStatus()
                     .masterNodeTimeout(TimeValue.timeValueSeconds(5))
                     .timeout(TimeValue.timeValueSeconds(5))
             )

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
@@ -74,13 +74,13 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
 
         allowNodes("test", 2);
         assertThat(
-            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").get().isTimedOut(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").get().isTimedOut(),
             equalTo(false)
         );
 
         logger.info("Running Cluster Health");
         ClusterHealthResponse clusterHealth = clusterAdmin().health(
-            new ClusterHealthRequest("test").waitForYellowStatus()
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, "test").waitForYellowStatus()
                 .waitForNoRelocatingShards(true)
                 .waitForEvents(Priority.LANGUID)
                 .waitForActiveShards(test.totalNumShards)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -670,7 +670,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
             assertFalse(
                 client(clusterAlias).admin()
                     .cluster()
-                    .prepareHealth(remoteIndex)
+                    .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex)
                     .setWaitForYellowStatus()
                     .setTimeout(TimeValue.timeValueSeconds(10))
                     .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterIT.java
@@ -224,7 +224,7 @@ public class CrossClusterIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client("cluster_a").admin()
                 .cluster()
-                .prepareHealth("prod")
+                .prepareHealth(TEST_REQUEST_TIMEOUT, "prod")
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -701,7 +701,7 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client(REMOTE_CLUSTER).admin()
                 .cluster()
-                .prepareHealth(remoteIndex)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchLeakIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchLeakIT.java
@@ -110,7 +110,7 @@ public class CrossClusterSearchLeakIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client("cluster_a").admin()
                 .cluster()
-                .prepareHealth("prod")
+                .prepareHealth(TEST_REQUEST_TIMEOUT, "prod")
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()
@@ -169,7 +169,11 @@ public class CrossClusterSearchLeakIT extends AbstractMultiClustersTestCase {
 
             settings.put("cluster.remote." + clusterAlias + ".mode", "proxy");
             settings.put("cluster.remote." + clusterAlias + ".proxy_address", seedAddress);
-            client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+            client().admin()
+                .cluster()
+                .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(settings)
+                .get();
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScorePluginIT.java
@@ -65,7 +65,7 @@ public class FunctionScorePluginIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForYellowStatus().get();
 
         client().index(
             new IndexRequest("test").id("1")

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/retriever/MinimalCompoundRetrieverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/retriever/MinimalCompoundRetrieverIT.java
@@ -106,7 +106,7 @@ public class MinimalCompoundRetrieverIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client(REMOTE_CLUSTER).admin()
                 .cluster()
-                .prepareHealth(remoteIndex)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/retriever/RetrieverRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/retriever/RetrieverRewriteIT.java
@@ -115,7 +115,7 @@ public class RetrieverRewriteIT extends ESIntegTestCase {
                 throw new IllegalStateException("node did not stop");
             }
             assertBusy(() -> {
-                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(testIndex)
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, testIndex)
                     .setWaitForStatus(ClusterHealthStatus.RED) // we are now known red because the primary shard is missing
                     .setWaitForEvents(Priority.LANGUID) // ensures that the update has occurred
                     .execute()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchPreferenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchPreferenceIT.java
@@ -59,7 +59,7 @@ public class SearchPreferenceIT extends ESIntegTestCase {
         }
         refresh();
         internalCluster().stopRandomDataNode();
-        clusterAdmin().prepareHealth().setWaitForStatus(ClusterHealthStatus.RED).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForStatus(ClusterHealthStatus.RED).get();
         String[] preferences = new String[] {
             "_local",
             "_prefer_nodes:somenode",

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchReplicaSelectionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchReplicaSelectionIT.java
@@ -68,7 +68,7 @@ public class SearchReplicaSelectionIT extends ESIntegTestCase {
             client.prepareSearch().setQuery(matchAllQuery()).get().decRef();
         }
 
-        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().get();
+        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get();
         Map<String, DiscoveryNode> coordinatingNodes = clusterStateResponse.getState().nodes().getCoordinatingOnlyNodes();
         assertEquals(1, coordinatingNodes.size());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -70,9 +70,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetch() throws Exception {
         indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             prepareIndex("test").setId(Integer.toString(i)).setSource(jsonBuilder().startObject().field("field", i).endObject()).get();
@@ -119,9 +119,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetchSmallSizeUnevenDistribution() throws Exception {
         indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             String routing = "0";
@@ -189,7 +189,7 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testScrollAndUpdateIndex() throws Exception {
         indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 5)).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 500; i++) {
             prepareIndex("test").setId(Integer.toString(i))
@@ -241,9 +241,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetch_clearScrollIds() throws Exception {
         indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             prepareIndex("test").setId(Integer.toString(i)).setSource(jsonBuilder().startObject().field("field", i).endObject()).get();
@@ -360,9 +360,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetchClearAllScrollIds() throws Exception {
         indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             prepareIndex("test").setId(Integer.toString(i)).setSource(jsonBuilder().startObject().field("field", i).endObject()).get();
@@ -553,7 +553,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     public void testScrollInvalidDefaultKeepAlive() throws IOException {
         IllegalArgumentException exc = expectThrows(
             IllegalArgumentException.class,
-            clusterAdmin().prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                 .setPersistentSettings(Settings.builder().put("search.max_keep_alive", "1m").put("search.default_keep_alive", "2m"))
         );
         assertThat(exc.getMessage(), containsString("was (2m > 1m)"));
@@ -564,7 +564,8 @@ public class SearchScrollIT extends ESIntegTestCase {
 
         exc = expectThrows(
             IllegalArgumentException.class,
-            clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put("search.default_keep_alive", "3m"))
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(Settings.builder().put("search.default_keep_alive", "3m"))
         );
         assertThat(exc.getMessage(), containsString("was (3m > 2m)"));
 
@@ -572,7 +573,8 @@ public class SearchScrollIT extends ESIntegTestCase {
 
         exc = expectThrows(
             IllegalArgumentException.class,
-            clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put("search.max_keep_alive", "30s"))
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(Settings.builder().put("search.max_keep_alive", "30s"))
         );
         assertThat(exc.getMessage(), containsString("was (1m > 30s)"));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -156,7 +156,7 @@ public class SearchStatsIT extends ESIntegTestCase {
     }
 
     private Set<String> nodeIdsWithIndex(String... indices) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         GroupShardsIterator<ShardIterator> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         Set<String> nodes = new HashSet<>();
         for (ShardIterator shardIterator : allAssignedShardsGrouped) {
@@ -239,7 +239,7 @@ public class SearchStatsIT extends ESIntegTestCase {
     }
 
     protected int numAssignedShards(String... indices) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         GroupShardsIterator<?> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         return allAssignedShardsGrouped.size();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -971,7 +971,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> wait for relocations to start");
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareHealth(testIndex).get().getRelocatingShards(), greaterThan(0)),
+            () -> assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, testIndex).get().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataContextIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataContextIT.java
@@ -106,7 +106,7 @@ public class CustomMetadataContextIT extends AbstractSnapshotIntegTestCase {
             .setWaitForCompletion(true)
             .get();
 
-        var metadata = clusterAdmin().prepareState().get().getState().getMetadata();
+        var metadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getMetadata();
         logger.info("check that custom persistent metadata [{}] is correctly restored", metadata);
         if (isSnapshotMetadataSet) {
             assertThat(metadata.<SnapshotMetadata>custom(SnapshotMetadata.TYPE).getData(), equalTo("before_snapshot_s"));
@@ -127,7 +127,7 @@ public class CustomMetadataContextIT extends AbstractSnapshotIntegTestCase {
         internalCluster().fullRestart();
         ensureYellow();
 
-        var metadata = clusterAdmin().prepareState().get().getState().getMetadata();
+        var metadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getMetadata();
         logger.info("check that gateway custom metadata [{}] survived full cluster restart", metadata);
         assertThat(metadata.<GatewayMetadata>custom(GatewayMetadata.TYPE).getData(), equalTo("before_restart_s_gw"));
         assertThat(metadata.<ApiMetadata>custom(ApiMetadata.TYPE), nullValue());
@@ -140,7 +140,7 @@ public class CustomMetadataContextIT extends AbstractSnapshotIntegTestCase {
             metadataBuilder.putCustom(NonApiMetadata.TYPE, new NonApiMetadata("before_restart_ns"));
         }));
 
-        var metadata = clusterAdmin().prepareState().get().getState().getMetadata();
+        var metadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getMetadata();
         logger.info("check that api custom metadata [{}] is visible via api", metadata);
         assertThat(metadata.<ApiMetadata>custom(ApiMetadata.TYPE).getData(), equalTo("before_restart_s_gw"));
         assertThat(metadata.<NonApiMetadata>custom(NonApiMetadata.TYPE), nullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -245,7 +245,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> shutdown one of the nodes");
         internalCluster().stopRandomDataNode();
         assertThat(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueMinutes(1))
                 .setWaitForNodes("<2")
@@ -432,7 +432,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         });
 
         assertThat(
-            clusterAdmin().prepareHealth()
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueMinutes(1))
                 .setWaitForNodes("2")
@@ -666,7 +666,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         assertAcked(indicesAdmin().prepareDelete(sourceIdx).get());
         assertAcked(indicesAdmin().prepareDelete(shrunkIdx).get());
         internalCluster().stopRandomDataNode();
-        clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("1");
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("1");
 
         logger.info("--> start a new data node");
         final Settings dataSettings = Settings.builder()
@@ -674,7 +674,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()) // to get a new node id
             .build();
         internalCluster().startDataOnlyNode(dataSettings);
-        clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("2");
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("2");
 
         logger.info("--> restore the shrunk index and ensure all shards are allocated");
         RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, repo, snapshot)
@@ -1127,7 +1127,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> wait for relocations to start");
 
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareHealth(indexName).get().getRelocatingShards(), greaterThan(0)),
+            () -> assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).get().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
@@ -142,7 +142,7 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
                     + repoNameOnFirstCluster
                     + "] concurrent modification of the index-N file, expected current generation [2] but it was not found in "
                     + "the repository. The last cluster to write to this repository was ["
-                    + secondCluster.client().admin().cluster().prepareState().get().getState().metadata().clusterUUID()
+                    + secondCluster.client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().clusterUUID()
                     + "] at generation [4]."
             )
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoriesIT.java
@@ -75,7 +75,12 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         assertThat(FileSystemUtils.files(location).length, equalTo(numberOfFiles));
 
         logger.info("--> check that repository is really there");
-        ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().clear().setMetadata(true).get();
+        ClusterStateResponse clusterStateResponse = client.admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setMetadata(true)
+            .get();
         Metadata metadata = clusterStateResponse.getState().getMetadata();
         RepositoriesMetadata repositoriesMetadata = metadata.custom(RepositoriesMetadata.TYPE);
         assertThat(repositoriesMetadata, notNullValue());
@@ -86,7 +91,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         createRepository("test-repo-2", "fs");
 
         logger.info("--> check that both repositories are in cluster state");
-        clusterStateResponse = client.admin().cluster().prepareState().clear().setMetadata(true).get();
+        clusterStateResponse = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).clear().setMetadata(true).get();
         metadata = clusterStateResponse.getState().getMetadata();
         repositoriesMetadata = metadata.custom(RepositoriesMetadata.TYPE);
         assertThat(repositoriesMetadata, notNullValue());
@@ -117,7 +122,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
                 .isAcknowledged(),
             equalTo(true)
         );
-        assertEquals(beforeStateUuid, client.admin().cluster().prepareState().clear().get().getState().stateUUID());
+        assertEquals(beforeStateUuid, client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).clear().get().getState().stateUUID());
 
         logger.info("--> delete repository test-repo-1");
         client.admin().cluster().prepareDeleteRepository(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "test-repo-1").get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -224,7 +224,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             }
         }
 
-        final IndexMetadata indexMetadata = clusterAdmin().prepareState()
+        final IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setIndices(indexName)
             .setMetadata(true)
@@ -251,7 +251,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards(), equalTo(numPrimaries));
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
 
-        final IndexMetadata restoredIndexMetadata = clusterAdmin().prepareState()
+        final IndexMetadata restoredIndexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setIndices(indexName)
             .setMetadata(true)
@@ -307,7 +307,13 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         logger.info("--> assert that old mapping is restored");
-        MappingMetadata mappings = clusterAdmin().prepareState().get().getState().getMetadata().getIndices().get("test-idx").mapping();
+        MappingMetadata mappings = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .getMetadata()
+            .getIndices()
+            .get("test-idx")
+            .mapping();
         assertThat(mappings.sourceAsMap().toString(), containsString("baz"));
         assertThat(mappings.sourceAsMap().toString(), not(containsString("foo")));
 
@@ -818,7 +824,14 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .get();
             assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
-            ClusterBlocks blocks = client.admin().cluster().prepareState().clear().setBlocks(true).get().getState().blocks();
+            ClusterBlocks blocks = client.admin()
+                .cluster()
+                .prepareState(TEST_REQUEST_TIMEOUT)
+                .clear()
+                .setBlocks(true)
+                .get()
+                .getState()
+                .blocks();
             // compute current index settings (as we cannot query them if they contain SETTING_BLOCKS_METADATA)
             Settings mergedSettings = Settings.builder().put(initialSettings).put(changedSettings).build();
             logger.info("--> merged block settings {}", mergedSettings);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -228,7 +228,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         ensureGreen();
         assertDocCount("test-idx-1", 100);
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.getMetadata().hasIndex("test-idx-1"), equalTo(true));
         assertThat(clusterState.getMetadata().hasIndex("test-idx-2"), equalTo(false));
 
@@ -511,7 +511,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             // same node again during the same reroute operation. Then another reroute
             // operation is scheduled, but the RestoreInProgressAllocationDecider will
             // block the shard to be assigned again because it failed during restore.
-            final ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().get();
+            final ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get();
             assertEquals(1, clusterStateResponse.getState().getNodes().getDataNodes().size());
             assertEquals(
                 restoreInfo.failedShards(),
@@ -663,7 +663,10 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(restoreResponse.getRestoreInfo().totalShards(), equalTo(numShards.numPrimaries));
         assertThat(restoreResponse.getRestoreInfo().successfulShards(), equalTo(0));
 
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setCustoms(true).setRoutingTable(true).get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .setCustoms(true)
+            .setRoutingTable(true)
+            .get();
 
         // check that there is no restore in progress
         RestoreInProgress restoreInProgress = clusterStateResponse.getState().custom(RestoreInProgress.TYPE);
@@ -867,7 +870,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         ensureGreen();
         logger.info("-->  closing index test-idx-closed");
         assertAcked(client.admin().indices().prepareClose("test-idx-closed"));
-        ClusterStateResponse stateResponse = client.admin().cluster().prepareState().get();
+        ClusterStateResponse stateResponse = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertThat(stateResponse.getState().metadata().index("test-idx-closed").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test-idx-closed"), notNullValue());
 
@@ -1261,7 +1264,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> wait for relocations to start");
 
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareHealth("test-idx").get().getRelocatingShards(), greaterThan(0)),
+            () -> assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "test-idx").get().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );
@@ -2185,7 +2188,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 equalTo(restoreSnapshotResponse.getRestoreInfo().totalShards())
             );
             assertThat(restoreSnapshotResponse.getRestoreInfo().indices(), containsInAnyOrder(normalIndex, hiddenIndex, dottedHiddenIndex));
-            ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+            ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat(clusterState.getMetadata().hasIndex(normalIndex), equalTo(true));
             assertThat(clusterState.getMetadata().hasIndex(hiddenIndex), equalTo(true));
             assertThat(clusterState.getMetadata().hasIndex(dottedHiddenIndex), equalTo(true));
@@ -2205,7 +2208,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 equalTo(restoreSnapshotResponse.getRestoreInfo().totalShards())
             );
             assertThat(restoreSnapshotResponse.getRestoreInfo().indices(), containsInAnyOrder(normalIndex, hiddenIndex));
-            ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+            ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat(clusterState.getMetadata().hasIndex(normalIndex), equalTo(true));
             assertThat(clusterState.getMetadata().hasIndex(hiddenIndex), equalTo(true));
             assertThat(clusterState.getMetadata().hasIndex(dottedHiddenIndex), equalTo(false));
@@ -2225,7 +2228,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 equalTo(restoreSnapshotResponse.getRestoreInfo().totalShards())
             );
             assertThat(restoreSnapshotResponse.getRestoreInfo().indices(), containsInAnyOrder(hiddenIndex));
-            ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+            ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat(clusterState.getMetadata().hasIndex(normalIndex), equalTo(false));
             assertThat(clusterState.getMetadata().hasIndex(hiddenIndex), equalTo(true));
             assertThat(clusterState.getMetadata().hasIndex(dottedHiddenIndex), equalTo(false));
@@ -2245,7 +2248,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 equalTo(restoreSnapshotResponse.getRestoreInfo().totalShards())
             );
             assertThat(restoreSnapshotResponse.getRestoreInfo().indices(), containsInAnyOrder(dottedHiddenIndex));
-            ClusterState clusterState = client.admin().cluster().prepareState().get().getState();
+            ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertThat(clusterState.getMetadata().hasIndex(normalIndex), equalTo(false));
             assertThat(clusterState.getMetadata().hasIndex(hiddenIndex), equalTo(false));
             assertThat(clusterState.getMetadata().hasIndex(dottedHiddenIndex), equalTo(true));

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotBrokenSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotBrokenSettingsIT.java
@@ -36,14 +36,14 @@ public class SnapshotBrokenSettingsIT extends AbstractSnapshotIntegTestCase {
         Client client = client();
         Consumer<String> setSettingValue = value -> client.admin()
             .cluster()
-            .prepareUpdateSettings()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().put(BrokenSettingPlugin.BROKEN_SETTING.getKey(), value))
             .get();
 
         Consumer<String> assertSettingValue = value -> assertThat(
             client.admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .setRoutingTable(false)
                 .setNodes(false)
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
@@ -177,7 +177,12 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
             SubscribableListener.<ActionResponse.Empty>newForked(
                 l -> client().execute(
                     TransportAddVotingConfigExclusionsAction.TYPE,
-                    new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[] { masterName }, TimeValue.timeValueSeconds(10)),
+                    new AddVotingConfigExclusionsRequest(
+                        TEST_REQUEST_TIMEOUT,
+                        Strings.EMPTY_ARRAY,
+                        new String[] { masterName },
+                        TimeValue.timeValueSeconds(10)
+                    ),
                     l
                 )
             )
@@ -212,7 +217,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         // flush master queue to ensure the completion is applied everywhere
         safeAwait(
             SubscribableListener.<ClusterHealthResponse>newForked(
-                l -> client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).execute(l)
+                l -> client().admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).execute(l)
             )
         );
 
@@ -230,7 +235,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         }
 
         safeAwait(SubscribableListener.<ActionResponse.Empty>newForked(l -> {
-            final var clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
+            final var clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT);
             clearVotingConfigExclusionsRequest.setWaitForRemoval(false);
             client().execute(TransportClearVotingConfigExclusionsAction.TYPE, clearVotingConfigExclusionsRequest, l);
         }));

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -738,7 +738,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         try {
             waitForBlockOnAnyDataNode("test-repo");
             // Make sure that the create-snapshot task completes on master
-            assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+            assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get().isTimedOut());
             final List<SnapshotStatus> snapshotStatus = clusterAdmin().prepareSnapshotStatus(TEST_REQUEST_TIMEOUT, "test-repo")
                 .setMasterNodeTimeout(TimeValue.MINUS_ONE)
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -89,7 +89,12 @@ import static org.hamcrest.Matchers.notNullValue;
 public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
     public void testRandomActivities() throws InterruptedException {
-        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState().clear().setNodes(true).get().getState().nodes();
+        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get()
+            .getState()
+            .nodes();
         new TrackedCluster(internalCluster(), nodeNames(discoveryNodes.getMasterNodes()), nodeNames(discoveryNodes.getDataNodes())).run();
         disableRepoConsistencyCheck("have not necessarily written to all repositories");
     }
@@ -354,14 +359,20 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
             if (failedPermitAcquisitions.isEmpty() == false) {
                 logger.warn("--> failed to acquire all permits: {}", failedPermitAcquisitions);
-                logger.info("--> current cluster state:\n{}", Strings.toString(clusterAdmin().prepareState().get().getState(), true, true));
+                logger.info(
+                    "--> current cluster state:\n{}",
+                    Strings.toString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
+                );
                 fail("failed to acquire all permits: " + failedPermitAcquisitions);
             }
             logger.info("--> acquired all permits");
 
             if (ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS) == false) {
                 logger.warn("--> threadpool termination timed out");
-                logger.info("--> current cluster state:\n{}", Strings.toString(clusterAdmin().prepareState().get().getState(), true, true));
+                logger.info(
+                    "--> current cluster state:\n{}",
+                    Strings.toString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
+                );
             }
         }
 
@@ -381,7 +392,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         logger.warn("--> failed to acquire permit [{}]", label);
                         logger.info(
                             "--> current cluster state:\n{}",
-                            Strings.toString(clusterAdmin().prepareState().get().getState(), true, true)
+                            Strings.toString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
                         );
                         HotThreads.logLocalHotThreads(
                             logger,
@@ -1604,7 +1615,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
     // Prepares a health request with twice the default (30s) timeout that waits for all cluster tasks to finish as well as all cluster
     // nodes before returning
     private static ClusterHealthRequestBuilder prepareClusterHealthRequest(String... targetIndexNames) {
-        return clusterAdmin().prepareHealth(targetIndexNames)
+        return clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, targetIndexNames)
             .setTimeout(TimeValue.timeValueSeconds(60))
             .setWaitForNodes(Integer.toString(internalCluster().getNodeNames().length))
             .setWaitForEvents(Priority.LANGUID);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -704,7 +704,11 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // Stop a random data node so we lose a shard from the partial index
         internalCluster().stopRandomDataNode();
-        assertBusy(() -> assertEquals(ClusterHealthStatus.RED, clusterAdmin().prepareHealth().get().getStatus()), 30, TimeUnit.SECONDS);
+        assertBusy(
+            () -> assertEquals(ClusterHealthStatus.RED, clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getStatus()),
+            30,
+            TimeUnit.SECONDS
+        );
 
         // Get ready to block
         blockMasterFromFinalizingSnapshotOnIndexFile(REPO_NAME);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -40,24 +40,28 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
      * Construct a request to add voting config exclusions for master-eligible nodes matching the given node names, and wait for a
      * default 30 seconds for these exclusions to take effect, removing the nodes from the voting configuration.
      *
+     * @param masterNodeTimeout Specifies how long to wait when the master has not been discovered yet, or is disconnected, or is busy
+     *                          processing other tasks.
      * @param nodeNames Names of the nodes to add - see {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}
      */
-    public AddVotingConfigExclusionsRequest(String... nodeNames) {
-        this(Strings.EMPTY_ARRAY, nodeNames, TimeValue.timeValueSeconds(30));
+    public AddVotingConfigExclusionsRequest(TimeValue masterNodeTimeout, String... nodeNames) {
+        this(masterNodeTimeout, Strings.EMPTY_ARRAY, nodeNames, TimeValue.timeValueSeconds(30));
     }
 
     /**
      * Construct a request to add voting config exclusions for master-eligible nodes matching the given descriptions, and wait for these
      * nodes to be removed from the voting configuration.
      *
-     * @param nodeIds   Ids of the nodes whose exclusions to add - see
-     *                  {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}.
-     * @param nodeNames Names of the nodes whose exclusions to add - see
-     *                  {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}.
-     * @param timeout   How long to wait for the added exclusions to take effect and be removed from the voting configuration.
+     * @param masterNodeTimeout Specifies how long to wait when the master has not been discovered yet, or is disconnected, or is busy
+     *                          processing other tasks.
+     * @param nodeIds           Ids of the nodes whose exclusions to add - see
+     *                          {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}.
+     * @param nodeNames         Names of the nodes whose exclusions to add - see
+     *                          {@link AddVotingConfigExclusionsRequest#resolveVotingConfigExclusions(ClusterState)}.
+     * @param timeout           How long to wait for the added exclusions to take effect and be removed from the voting configuration.
      */
-    public AddVotingConfigExclusionsRequest(String[] nodeIds, String[] nodeNames, TimeValue timeout) {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public AddVotingConfigExclusionsRequest(TimeValue masterNodeTimeout, String[] nodeIds, String[] nodeNames, TimeValue timeout) {
+        super(masterNodeTimeout);
         if (timeout.compareTo(TimeValue.ZERO) < 0) {
             throw new IllegalArgumentException("timeout [" + timeout + "] must be non-negative");
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/ClearVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/ClearVotingConfigExclusionsRequest.java
@@ -26,8 +26,8 @@ public class ClearVotingConfigExclusionsRequest extends MasterNodeRequest<ClearV
     /**
      * Construct a request to remove all the voting config exclusions from the cluster state.
      */
-    public ClearVotingConfigExclusionsRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public ClearVotingConfigExclusionsRequest(TimeValue masterNodeTimeout) {
+        super(masterNodeTimeout);
     }
 
     public ClearVotingConfigExclusionsRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/GetDesiredNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/GetDesiredNodesAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.metadata.DesiredNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -33,8 +34,8 @@ public class GetDesiredNodesAction extends ActionType<GetDesiredNodesAction.Resp
     }
 
     public static class Request extends MasterNodeReadRequest<Request> {
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+        public Request(TimeValue masterNodeTimeout) {
+            super(masterNodeTimeout);
         }
 
         public Request(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDeleteDesiredNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDeleteDesiredNodesAction.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.admin.cluster.desirednodes;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
@@ -27,6 +26,7 @@ import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -102,17 +102,12 @@ public class TransportDeleteDesiredNodesAction extends TransportMasterNodeAction
     }
 
     public static class Request extends AcknowledgedRequest<Request> {
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, DEFAULT_ACK_TIMEOUT);
+        public Request(TimeValue masterNodeTimeout, TimeValue ackTimeout) {
+            super(masterNodeTimeout, ackTimeout);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-        }
-
-        @Override
-        public ActionRequestValidationException validate() {
-            return null;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequest.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.DesiredNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -47,8 +48,15 @@ public class UpdateDesiredNodesRequest extends AcknowledgedRequest<UpdateDesired
         PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> DesiredNode.fromXContent(p), NODES_FIELD);
     }
 
-    public UpdateDesiredNodesRequest(String historyID, long version, List<DesiredNode> nodes, boolean dryRun) {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, DEFAULT_ACK_TIMEOUT);
+    public UpdateDesiredNodesRequest(
+        TimeValue masterNodeTimeout,
+        TimeValue ackTimeout,
+        String historyID,
+        long version,
+        List<DesiredNode> nodes,
+        boolean dryRun
+    ) {
+        super(masterNodeTimeout, ackTimeout);
         assert historyID != null;
         assert nodes != null;
         this.historyID = historyID;
@@ -80,10 +88,16 @@ public class UpdateDesiredNodesRequest extends AcknowledgedRequest<UpdateDesired
         }
     }
 
-    public static UpdateDesiredNodesRequest fromXContent(String historyID, long version, boolean dryRun, XContentParser parser)
-        throws IOException {
+    public static UpdateDesiredNodesRequest fromXContent(
+        TimeValue masterNodeTimeout,
+        TimeValue ackTimeout,
+        String historyID,
+        long version,
+        boolean dryRun,
+        XContentParser parser
+    ) throws IOException {
         List<DesiredNode> nodes = PARSER.parse(parser, null);
-        return new UpdateDesiredNodesRequest(historyID, version, nodes, dryRun);
+        return new UpdateDesiredNodesRequest(masterNodeTimeout, ackTimeout, historyID, version, nodes, dryRun);
     }
 
     public String getHistoryID() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -37,12 +37,12 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
     private String waitForNodes = "";
     private Priority waitForEvents = null;
 
-    public ClusterHealthRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public ClusterHealthRequest(TimeValue masterNodeTimeout) {
+        super(masterNodeTimeout);
     }
 
-    public ClusterHealthRequest(String... indices) {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public ClusterHealthRequest(TimeValue masterNodeTimeout, String... indices) {
+        super(masterNodeTimeout);
         this.indices = indices;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -21,8 +21,8 @@ public class ClusterHealthRequestBuilder extends MasterNodeReadOperationRequestB
     ClusterHealthResponse,
     ClusterHealthRequestBuilder> {
 
-    public ClusterHealthRequestBuilder(ElasticsearchClient client) {
-        super(client, TransportClusterHealthAction.TYPE, new ClusterHealthRequest());
+    public ClusterHealthRequestBuilder(ElasticsearchClient client, TimeValue masterNodeTimeout) {
+        super(client, TransportClusterHealthAction.TYPE, new ClusterHealthRequest(masterNodeTimeout));
     }
 
     public ClusterHealthRequestBuilder setIndices(String... indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusRequest.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.migration;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 
@@ -19,8 +20,8 @@ import java.io.IOException;
  */
 public class GetFeatureUpgradeStatusRequest extends MasterNodeRequest<GetFeatureUpgradeStatusRequest> {
 
-    public GetFeatureUpgradeStatusRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public GetFeatureUpgradeStatusRequest(TimeValue masterNodeTimeout) {
+        super(masterNodeTimeout);
     }
 
     public GetFeatureUpgradeStatusRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeRequest.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.migration;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 
@@ -19,8 +20,8 @@ import java.io.IOException;
  */
 public class PostFeatureUpgradeRequest extends MasterNodeRequest<PostFeatureUpgradeRequest> {
 
-    public PostFeatureUpgradeRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public PostFeatureUpgradeRequest(TimeValue masterNodeTimeout) {
+        super(masterNodeTimeout);
     }
 
     public PostFeatureUpgradeRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateNodeRemovalRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateNodeRemovalRequest.java
@@ -33,8 +33,8 @@ public class PrevalidateNodeRemovalRequest extends MasterNodeReadRequest<Prevali
     private final String[] externalIds;
     private TimeValue timeout = TimeValue.timeValueSeconds(30);
 
-    private PrevalidateNodeRemovalRequest(Builder builder) {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    private PrevalidateNodeRemovalRequest(TimeValue masterNodeTimeout, Builder builder) {
+        super(masterNodeTimeout);
         this.names = builder.names;
         this.ids = builder.ids;
         this.externalIds = builder.externalIds;
@@ -139,8 +139,8 @@ public class PrevalidateNodeRemovalRequest extends MasterNodeReadRequest<Prevali
             return this;
         }
 
-        public PrevalidateNodeRemovalRequest build() {
-            return new PrevalidateNodeRemovalRequest(this);
+        public PrevalidateNodeRemovalRequest build(TimeValue masterNodeTimeout) {
+            return new PrevalidateNodeRemovalRequest(masterNodeTimeout, this);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterGetSettingsAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -33,8 +34,8 @@ public class ClusterGetSettingsAction extends ActionType<ClusterGetSettingsActio
      * Request to retrieve the cluster settings
      */
     public static class Request extends MasterNodeReadRequest<Request> {
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+        public Request(TimeValue masterNodeTimeout) {
+            super(masterNodeTimeout);
         }
 
         public Request(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -35,10 +36,13 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
     private static final ParseField PERSISTENT = new ParseField("persistent");
     private static final ParseField TRANSIENT = new ParseField("transient");
 
-    private static final ObjectParser<ClusterUpdateSettingsRequest, Void> PARSER = new ObjectParser<>(
+    public interface Factory {
+        ClusterUpdateSettingsRequest create();
+    }
+
+    private static final ObjectParser<ClusterUpdateSettingsRequest, Factory> PARSER = ObjectParser.fromBuilder(
         "cluster_update_settings_request",
-        false,
-        ClusterUpdateSettingsRequest::new
+        Factory::create
     );
 
     static {
@@ -55,8 +59,8 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         persistentSettings = readSettingsFromStream(in);
     }
 
-    public ClusterUpdateSettingsRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, DEFAULT_ACK_TIMEOUT);
+    public ClusterUpdateSettingsRequest(TimeValue masterNodeTimeout, TimeValue ackTimeout) {
+        super(masterNodeTimeout, ackTimeout);
     }
 
     @Override
@@ -188,7 +192,7 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
         return builder;
     }
 
-    public static ClusterUpdateSettingsRequest fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+    public static ClusterUpdateSettingsRequest fromXContent(Factory factory, XContentParser parser) {
+        return PARSER.apply(parser, factory);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestBuilder.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.settings;
 import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Map;
@@ -23,8 +24,8 @@ public class ClusterUpdateSettingsRequestBuilder extends AcknowledgedRequestBuil
     ClusterUpdateSettingsResponse,
     ClusterUpdateSettingsRequestBuilder> {
 
-    public ClusterUpdateSettingsRequestBuilder(ElasticsearchClient client) {
-        super(client, ClusterUpdateSettingsAction.INSTANCE, new ClusterUpdateSettingsRequest());
+    public ClusterUpdateSettingsRequestBuilder(ElasticsearchClient client, TimeValue masterNodeTimeout, TimeValue ackTimeout) {
+        super(client, ClusterUpdateSettingsAction.INSTANCE, new ClusterUpdateSettingsRequest(masterNodeTimeout, ackTimeout));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -38,8 +38,8 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.lenientExpandOpen();
 
-    public ClusterStateRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public ClusterStateRequest(TimeValue masterNodeTimeout) {
+        super(masterNodeTimeout);
     }
 
     public ClusterStateRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -19,8 +19,8 @@ public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBu
     ClusterStateResponse,
     ClusterStateRequestBuilder> {
 
-    public ClusterStateRequestBuilder(ElasticsearchClient client) {
-        super(client, ClusterStateAction.INSTANCE, new ClusterStateRequest());
+    public ClusterStateRequestBuilder(ElasticsearchClient client, TimeValue masterNodeTimeout) {
+        super(client, ClusterStateAction.INSTANCE, new ClusterStateRequest(masterNodeTimeout));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequest.java
@@ -11,13 +11,14 @@ package org.elasticsearch.action.admin.cluster.tasks;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 
 public class PendingClusterTasksRequest extends MasterNodeReadRequest<PendingClusterTasksRequest> {
 
-    public PendingClusterTasksRequest() {
-        super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
+    public PendingClusterTasksRequest(TimeValue masterNodeTimeout) {
+        super(masterNodeTimeout);
     }
 
     public PendingClusterTasksRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
@@ -158,8 +158,8 @@ public class ClusterAdminClient implements ElasticsearchClient {
         execute(TransportClusterHealthAction.TYPE, request, listener);
     }
 
-    public ClusterHealthRequestBuilder prepareHealth(String... indices) {
-        return new ClusterHealthRequestBuilder(this).setIndices(indices);
+    public ClusterHealthRequestBuilder prepareHealth(TimeValue masterNodeTimeout, String... indices) {
+        return new ClusterHealthRequestBuilder(this, masterNodeTimeout).setIndices(indices);
     }
 
     public ActionFuture<ClusterStateResponse> state(final ClusterStateRequest request) {
@@ -170,8 +170,8 @@ public class ClusterAdminClient implements ElasticsearchClient {
         execute(ClusterStateAction.INSTANCE, request, listener);
     }
 
-    public ClusterStateRequestBuilder prepareState() {
-        return new ClusterStateRequestBuilder(this);
+    public ClusterStateRequestBuilder prepareState(TimeValue masterNodeTimeout) {
+        return new ClusterStateRequestBuilder(this, masterNodeTimeout);
     }
 
     public ActionFuture<ClusterUpdateSettingsResponse> updateSettings(final ClusterUpdateSettingsRequest request) {
@@ -182,8 +182,8 @@ public class ClusterAdminClient implements ElasticsearchClient {
         execute(ClusterUpdateSettingsAction.INSTANCE, request, listener);
     }
 
-    public ClusterUpdateSettingsRequestBuilder prepareUpdateSettings() {
-        return new ClusterUpdateSettingsRequestBuilder(this);
+    public ClusterUpdateSettingsRequestBuilder prepareUpdateSettings(TimeValue masterNodeTimeout, TimeValue ackTimeout) {
+        return new ClusterUpdateSettingsRequestBuilder(this, masterNodeTimeout, ackTimeout);
     }
 
     public ActionFuture<NodesInfoResponse> nodesInfo(final NodesInfoRequest request) {

--- a/server/src/main/java/org/elasticsearch/reservedstate/action/ReservedClusterSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/action/ReservedClusterSettingsAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequ
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsUpdater;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
 import org.elasticsearch.reservedstate.TransformState;
 import org.elasticsearch.xcontent.XContentParser;
@@ -58,7 +59,11 @@ public class ReservedClusterSettingsAction implements ReservedClusterStateHandle
         toDelete.removeAll(newSettings.keys());
         toDelete.forEach(k -> newSettings.put(k, (String) null));
 
-        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest();
+        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest(
+            // timeouts are unused, any value will do
+            TimeValue.THIRTY_SECONDS,
+            TimeValue.THIRTY_SECONDS
+        );
         clusterUpdateSettingsRequest.persistentSettings(newSettings);
         return clusterUpdateSettingsRequest;
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -77,13 +77,12 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
             nodeNames = request.param("node_names");
         }
 
-        final var resolvedRequest = new AddVotingConfigExclusionsRequest(
+        return new AddVotingConfigExclusionsRequest(
+            getMasterNodeTimeout(request),
             Strings.splitStringByCommaToArray(nodeIds),
             Strings.splitStringByCommaToArray(nodeNames),
             request.paramAsTime("timeout", DEFAULT_TIMEOUT)
         );
-
-        return resolvedRequest.masterNodeTimeout(getMasterNodeTimeout(request));
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearVotingConfigExclusionsAction.java
@@ -45,8 +45,7 @@ public class RestClearVotingConfigExclusionsAction extends BaseRestHandler {
     }
 
     static ClearVotingConfigExclusionsRequest resolveVotingConfigExclusionsRequest(final RestRequest request) {
-        final var resolvedRequest = new ClearVotingConfigExclusionsRequest();
-        resolvedRequest.masterNodeTimeout(getMasterNodeTimeout(request));
+        final var resolvedRequest = new ClearVotingConfigExclusionsRequest(getMasterNodeTimeout(request));
         resolvedRequest.setTimeout(resolvedRequest.masterNodeTimeout());
         resolvedRequest.setWaitForRemoval(request.paramAsBoolean("wait_for_removal", resolvedRequest.getWaitForRemoval()));
         return resolvedRequest;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterGetSettingsAction.java
@@ -65,7 +65,6 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
 
     private static void setUpRequestParams(MasterNodeReadRequest<?> clusterRequest, RestRequest request) {
         clusterRequest.local(request.paramAsBoolean("local", clusterRequest.local()));
-        clusterRequest.masterNodeTimeout(getMasterNodeTimeout(request));
     }
 
     @Override
@@ -76,7 +75,7 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
             return prepareLegacyRequest(request, client, renderDefaults);
         }
 
-        ClusterGetSettingsAction.Request clusterSettingsRequest = new ClusterGetSettingsAction.Request();
+        ClusterGetSettingsAction.Request clusterSettingsRequest = new ClusterGetSettingsAction.Request(getMasterNodeTimeout(request));
 
         setUpRequestParams(clusterSettingsRequest, request);
 
@@ -90,7 +89,7 @@ public class RestClusterGetSettingsAction extends BaseRestHandler {
     }
 
     private RestChannelConsumer prepareLegacyRequest(final RestRequest request, final NodeClient client, final boolean renderDefaults) {
-        ClusterStateRequest clusterStateRequest = new ClusterStateRequest().routingTable(false).nodes(false);
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request)).routingTable(false).nodes(false);
         setUpRequestParams(clusterStateRequest, request);
         return channel -> client.admin()
             .cluster()

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
@@ -32,7 +33,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 
 @ServerlessScope(Scope.INTERNAL)
 public class RestClusterHealthAction extends BaseRestHandler {
@@ -62,15 +62,15 @@ public class RestClusterHealthAction extends BaseRestHandler {
 
     public static ClusterHealthRequest fromRequest(final RestRequest request) {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
-        final ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest(indices);
+
+        final var masterNodeTimeout = request.hasParam(RestUtils.REST_MASTER_TIMEOUT_PARAM)
+            ? RestUtils.getMasterNodeTimeout(request)
+            : request.paramAsTime("timeout", RestUtils.REST_MASTER_TIMEOUT_DEFAULT);
+
+        final ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest(masterNodeTimeout, indices);
         clusterHealthRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterHealthRequest.indicesOptions()));
         clusterHealthRequest.local(request.paramAsBoolean("local", clusterHealthRequest.local()));
         clusterHealthRequest.timeout(request.paramAsTime("timeout", clusterHealthRequest.timeout()));
-        if (request.hasParam("master_timeout")) {
-            clusterHealthRequest.masterNodeTimeout(getMasterNodeTimeout(request));
-        } else {
-            clusterHealthRequest.masterNodeTimeout(clusterHealthRequest.timeout());
-        }
         String waitForStatus = request.param("wait_for_status");
         if (waitForStatus != null) {
             clusterHealthRequest.waitForStatus(ClusterHealthStatus.valueOf(waitForStatus.toUpperCase(Locale.ROOT)));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -79,10 +79,9 @@ public class RestClusterStateAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterStateRequest.indicesOptions()));
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
         if (request.hasParam("wait_for_metadata_version")) {
             clusterStateRequest.waitForMetadataVersion(request.paramAsLong("wait_for_metadata_version", 0));
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
@@ -45,9 +45,10 @@ public class RestClusterUpdateSettingsAction extends BaseRestHandler {
     @Override
     @SuppressWarnings("unchecked")
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest();
-        clusterUpdateSettingsRequest.ackTimeout(getAckTimeout(request));
-        clusterUpdateSettingsRequest.masterNodeTimeout(getMasterNodeTimeout(request));
+        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest(
+            getMasterNodeTimeout(request),
+            getAckTimeout(request)
+        );
         Map<String, Object> source;
         try (XContentParser parser = request.contentParser()) {
             source = parser.map();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetDesiredNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetDesiredNodesAction.java
@@ -32,8 +32,7 @@ public class RestGetDesiredNodesAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        final GetDesiredNodesAction.Request getDesiredNodesRequest = new GetDesiredNodesAction.Request();
-        getDesiredNodesRequest.masterNodeTimeout(getMasterNodeTimeout(request));
+        final GetDesiredNodesAction.Request getDesiredNodesRequest = new GetDesiredNodesAction.Request(getMasterNodeTimeout(request));
         return restChannel -> client.execute(
             GetDesiredNodesAction.INSTANCE,
             getDesiredNodesRequest,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetFeatureUpgradeStatusAction.java
@@ -41,10 +41,7 @@ public class RestGetFeatureUpgradeStatusAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-
-        final GetFeatureUpgradeStatusRequest req = new GetFeatureUpgradeStatusRequest();
-        req.masterNodeTimeout(getMasterNodeTimeout(request));
-
-        return restChannel -> { client.execute(GetFeatureUpgradeStatusAction.INSTANCE, req, new RestToXContentListener<>(restChannel)); };
+        final GetFeatureUpgradeStatusRequest req = new GetFeatureUpgradeStatusRequest(getMasterNodeTimeout(request));
+        return restChannel -> client.execute(GetFeatureUpgradeStatusAction.INSTANCE, req, new RestToXContentListener<>(restChannel));
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPendingClusterTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPendingClusterTasksAction.java
@@ -38,8 +38,7 @@ public class RestPendingClusterTasksAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
-        pendingClusterTasksRequest.masterNodeTimeout(getMasterNodeTimeout(request));
+        PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest(getMasterNodeTimeout(request));
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         return channel -> client.execute(
             TransportPendingClusterTasksAction.TYPE,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPostFeatureUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPostFeatureUpgradeAction.java
@@ -41,10 +41,7 @@ public class RestPostFeatureUpgradeAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-
-        final PostFeatureUpgradeRequest req = new PostFeatureUpgradeRequest();
-        req.masterNodeTimeout(getMasterNodeTimeout(request));
-
-        return restChannel -> { client.execute(PostFeatureUpgradeAction.INSTANCE, req, new RestToXContentListener<>(restChannel)); };
+        final PostFeatureUpgradeRequest req = new PostFeatureUpgradeRequest(getMasterNodeTimeout(request));
+        return restChannel -> client.execute(PostFeatureUpgradeAction.INSTANCE, req, new RestToXContentListener<>(restChannel));
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestUpdateDesiredNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestUpdateDesiredNodesAction.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.rest.RestUtils.getAckTimeout;
 import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 
 public class RestUpdateDesiredNodesAction extends BaseRestHandler {
@@ -55,7 +56,14 @@ public class RestUpdateDesiredNodesAction extends BaseRestHandler {
 
         final UpdateDesiredNodesRequest updateDesiredNodesRequest;
         try (XContentParser parser = request.contentParser()) {
-            updateDesiredNodesRequest = UpdateDesiredNodesRequest.fromXContent(historyId, version, dryRun, parser);
+            updateDesiredNodesRequest = UpdateDesiredNodesRequest.fromXContent(
+                getMasterNodeTimeout(request),
+                getAckTimeout(request),
+                historyId,
+                version,
+                dryRun,
+                parser
+            );
         }
 
         if (clusterSupportsFeature.test(DesiredNode.DESIRED_NODE_VERSION_DEPRECATED)) {
@@ -68,7 +76,6 @@ public class RestUpdateDesiredNodesAction extends BaseRestHandler {
             }
         }
 
-        updateDesiredNodesRequest.masterNodeTimeout(getMasterNodeTimeout(request));
         return restChannel -> client.execute(
             UpdateDesiredNodesAction.INSTANCE,
             updateDesiredNodesRequest,

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -59,10 +59,9 @@ public class RestAllocationAction extends AbstractCatAction {
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
         final String[] nodes = Strings.splitStringByCommaToArray(request.param("nodes", "data:true"));
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().routingTable(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateAction.java
@@ -74,10 +74,9 @@ public class RestCatComponentTemplateAction extends AbstractCatAction {
     @Override
     protected BaseRestHandler.RestChannelConsumer doCatRequest(RestRequest request, NodeClient client) {
         final String matchPattern = request.hasParam("name") ? request.param("name") : null;
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().metadata(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(ClusterStateResponse clusterStateResponse) throws Exception {

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestHealthAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.Table;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestResponseListener;
@@ -50,9 +51,9 @@ public class RestHealthAction extends AbstractCatAction {
 
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
-        ClusterHealthRequest clusterHealthRequest = new ClusterHealthRequest();
+        final var clusterHealthRequest = new ClusterHealthRequest(RestUtils.getMasterNodeTimeout(request));
 
-        return channel -> client.admin().cluster().health(clusterHealthRequest, new RestResponseListener<ClusterHealthResponse>(channel) {
+        return channel -> client.admin().cluster().health(clusterHealthRequest, new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(final ClusterHealthResponse health) throws Exception {
                 return RestTable.buildResponse(buildTable(health, request), channel);

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -127,13 +127,12 @@ public class RestIndicesAction extends AbstractCatAction {
 
                 client.admin()
                     .cluster()
-                    .prepareState()
+                    .prepareState(masterNodeTimeout)
                     .clear()
                     .setMetadata(true)
                     .setRoutingTable(true)
                     .setIndices(indices)
                     .setIndicesOptions(subRequestIndicesOptions)
-                    .setMasterNodeTimeout(masterNodeTimeout)
                     .execute(listeners.acquire(clusterStateRef::set));
 
                 client.admin()

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestMasterAction.java
@@ -45,10 +45,9 @@ public class RestMasterAction extends AbstractCatAction {
 
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestResponseListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodeAttrsAction.java
@@ -53,10 +53,9 @@ public class RestNodeAttrsAction extends AbstractCatAction {
 
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -85,9 +85,8 @@ public class RestNodesAction extends AbstractCatAction {
 
         final boolean fullId = request.paramAsBoolean("full_id", false);
 
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true);
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
 
         final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
         nodesInfoRequest.clear()

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestPendingClusterTasksAction.java
@@ -45,8 +45,7 @@ public class RestPendingClusterTasksAction extends AbstractCatAction {
 
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
-        PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest();
-        pendingClusterTasksRequest.masterNodeTimeout(getMasterNodeTimeout(request));
+        PendingClusterTasksRequest pendingClusterTasksRequest = new PendingClusterTasksRequest(getMasterNodeTimeout(request));
         pendingClusterTasksRequest.local(request.paramAsBoolean("local", pendingClusterTasksRequest.local()));
         return channel -> client.execute(
             TransportPendingClusterTasksAction.TYPE,

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -54,10 +54,9 @@ public class RestPluginsAction extends AbstractCatAction {
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
         final boolean includeBootstrapPlugins = request.paramAsBoolean("include_bootstrap", false);
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestSegmentsAction.java
@@ -57,9 +57,8 @@ public class RestSegmentsAction extends AbstractCatAction {
     protected RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices);
 
         final RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -84,8 +84,7 @@ public class RestShardsAction extends AbstractCatAction {
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
         final String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
 
-        final var clusterStateRequest = new ClusterStateRequest();
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
+        final var clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true).routingTable(true).indices(indices).indicesOptions(IndicesOptions.strictExpandHidden());
 
         return channel -> {

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -70,10 +70,9 @@ public class RestThreadPoolAction extends AbstractCatAction {
 
     @Override
     public RestChannelConsumer doCatRequest(final RestRequest request, final NodeClient client) {
-        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(getMasterNodeTimeout(request));
         clusterStateRequest.clear().nodes(true);
         clusterStateRequest.local(request.paramAsBoolean("local", clusterStateRequest.local()));
-        clusterStateRequest.masterNodeTimeout(getMasterNodeTimeout(request));
 
         return channel -> client.admin().cluster().state(clusterStateRequest, new RestActionListener<ClusterStateResponse>(channel) {
             @Override

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -148,7 +148,10 @@ final class RemoteClusterConnection implements Closeable {
                         }), RemoteClusterNodesAction.Response::new, TransportResponseHandler.TRANSPORT_WORKER)
                     );
                 } else {
-                    final ClusterStateRequest request = new ClusterStateRequest();
+                    final ClusterStateRequest request = new ClusterStateRequest(
+                        /* Timeout doesn't really matter with .local(true) */
+                        TimeValue.THIRTY_SECONDS
+                    );
                     request.clear();
                     request.nodes(true);
                     request.local(true); // run this on the node that gets the request it's as good as any other

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -115,6 +116,8 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
     );
 
     static final int CHANNELS_PER_CONNECTION = 6;
+
+    private static final TimeValue SNIFF_REQUEST_TIMEOUT = TimeValue.THIRTY_SECONDS; // TODO make configurable?
 
     private static final Predicate<DiscoveryNode> DEFAULT_NODE_PREDICATE = (node) -> Version.CURRENT.isCompatible(node.getVersion())
         && (node.isMasterNode() == false || node.canContainData() || node.isIngestNode());
@@ -317,7 +320,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                     sniffResponseHandler = new RemoteClusterNodesSniffResponseHandler(connection, listener, seedNodesSuppliers);
                 } else {
                     action = ClusterStateAction.NAME;
-                    final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+                    final ClusterStateRequest clusterStateRequest = new ClusterStateRequest(SNIFF_REQUEST_TIMEOUT);
                     clusterStateRequest.clear();
                     clusterStateRequest.nodes(true);
                     request = clusterStateRequest;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
@@ -35,6 +35,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
 
     public void testSerializationForNodeIdOrNodeName() throws IOException {
         AddVotingConfigExclusionsRequest originalRequest = new AddVotingConfigExclusionsRequest(
+            TEST_REQUEST_TIMEOUT,
             new String[] { "nodeId1", "nodeId2" },
             Strings.EMPTY_ARRAY,
             TimeValue.ZERO
@@ -49,7 +50,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
         assertThat(deserialized.getNodeNames(), equalTo(originalRequest.getNodeNames()));
         assertThat(deserialized.getTimeout(), equalTo(originalRequest.getTimeout()));
 
-        originalRequest = new AddVotingConfigExclusionsRequest("nodeName1", "nodeName2");
+        originalRequest = new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "nodeName1", "nodeName2");
         deserialized = copyWriteable(originalRequest, writableRegistry(), AddVotingConfigExclusionsRequest::new);
 
         assertThat(deserialized.getNodeIds(), equalTo(originalRequest.getNodeIds()));
@@ -80,17 +81,26 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
             .build();
 
         assertThat(
-            new AddVotingConfigExclusionsRequest("local", "other1", "other2").resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "local", "other1", "other2").resolveVotingConfigExclusions(
+                clusterState
+            ),
             containsInAnyOrder(localNodeExclusion, otherNode1Exclusion, otherNode2Exclusion)
         );
-        assertThat(new AddVotingConfigExclusionsRequest("local").resolveVotingConfigExclusions(clusterState), contains(localNodeExclusion));
         assertThat(
-            new AddVotingConfigExclusionsRequest("other1", "other2").resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "local").resolveVotingConfigExclusions(clusterState),
+            contains(localNodeExclusion)
+        );
+        assertThat(
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1", "other2").resolveVotingConfigExclusions(clusterState),
             containsInAnyOrder(otherNode1Exclusion, otherNode2Exclusion)
         );
         assertThat(
-            new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[] { "other1", "other2" }, TimeValue.ZERO)
-                .resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                Strings.EMPTY_ARRAY,
+                new String[] { "other1", "other2" },
+                TimeValue.ZERO
+            ).resolveVotingConfigExclusions(clusterState),
             containsInAnyOrder(otherNode1Exclusion, otherNode2Exclusion)
         );
     }
@@ -99,7 +109,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                () -> new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY, TimeValue.ZERO)
+                () -> new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY, TimeValue.ZERO)
             ).getMessage(),
             equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG)
         );
@@ -109,7 +119,12 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                () -> new AddVotingConfigExclusionsRequest(new String[] { "nodeId" }, new String[] { "nodeName" }, TimeValue.ZERO)
+                () -> new AddVotingConfigExclusionsRequest(
+                    TEST_REQUEST_TIMEOUT,
+                    new String[] { "nodeId" },
+                    new String[] { "nodeName" },
+                    TimeValue.ZERO
+                )
             ).getMessage(),
             equalTo(NODE_IDENTIFIERS_INCORRECTLY_SET_MSG)
         );
@@ -143,14 +158,22 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
             .build();
 
         assertThat(
-            new AddVotingConfigExclusionsRequest(new String[] { "nodeId1", "nodeId2" }, Strings.EMPTY_ARRAY, TimeValue.ZERO)
-                .resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { "nodeId1", "nodeId2" },
+                Strings.EMPTY_ARRAY,
+                TimeValue.ZERO
+            ).resolveVotingConfigExclusions(clusterState),
             containsInAnyOrder(node1Exclusion, node2Exclusion)
         );
 
         assertThat(
-            new AddVotingConfigExclusionsRequest(new String[] { "nodeId1", "unresolvableNodeId" }, Strings.EMPTY_ARRAY, TimeValue.ZERO)
-                .resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { "nodeId1", "unresolvableNodeId" },
+                Strings.EMPTY_ARRAY,
+                TimeValue.ZERO
+            ).resolveVotingConfigExclusions(clusterState),
             containsInAnyOrder(node1Exclusion, unresolvableVotingConfigExclusion)
         );
     }
@@ -183,12 +206,16 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
             .build();
 
         assertThat(
-            new AddVotingConfigExclusionsRequest("nodeName1", "nodeName2").resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "nodeName1", "nodeName2").resolveVotingConfigExclusions(
+                clusterState
+            ),
             containsInAnyOrder(node1Exclusion, node2Exclusion)
         );
 
         assertThat(
-            new AddVotingConfigExclusionsRequest("nodeName1", "unresolvableNodeName").resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "nodeName1", "unresolvableNodeName").resolveVotingConfigExclusions(
+                clusterState
+            ),
             containsInAnyOrder(node1Exclusion, unresolvableVotingConfigExclusion)
         );
     }
@@ -208,7 +235,7 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
             .nodes(new Builder().add(node1).add(node2).localNodeId(node1.getId()))
             .build();
 
-        final var request = new AddVotingConfigExclusionsRequest("ambiguous-name");
+        final var request = new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "ambiguous-name");
         assertThat(
             expectThrows(IllegalArgumentException.class, () -> request.resolveVotingConfigExclusions(clusterState)).getMessage(),
             allOf(
@@ -248,8 +275,12 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
             .build();
 
         assertThat(
-            new AddVotingConfigExclusionsRequest(new String[] { "nodeId1", "nodeId2" }, Strings.EMPTY_ARRAY, TimeValue.ZERO)
-                .resolveVotingConfigExclusions(clusterState),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { "nodeId1", "nodeId2" },
+                Strings.EMPTY_ARRAY,
+                TimeValue.ZERO
+            ).resolveVotingConfigExclusions(clusterState),
             contains(node2Exclusion)
         );
     }
@@ -278,13 +309,17 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
         final ClusterState clusterState = builder.build();
 
         assertThat(
-            new AddVotingConfigExclusionsRequest("local").resolveVotingConfigExclusionsAndCheckMaximum(clusterState, 2, "setting.name"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "local").resolveVotingConfigExclusionsAndCheckMaximum(
+                clusterState,
+                2,
+                "setting.name"
+            ),
             contains(localNodeExclusion)
         );
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                () -> new AddVotingConfigExclusionsRequest("local").resolveVotingConfigExclusionsAndCheckMaximum(
+                () -> new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "local").resolveVotingConfigExclusionsAndCheckMaximum(
                     clusterState,
                     1,
                     "setting.name"

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/ClearVotingConfigExclusionsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/ClearVotingConfigExclusionsRequestTests.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ClearVotingConfigExclusionsRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
-        final ClearVotingConfigExclusionsRequest originalRequest = new ClearVotingConfigExclusionsRequest();
+        final ClearVotingConfigExclusionsRequest originalRequest = new ClearVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT);
         if (randomBoolean()) {
             originalRequest.setWaitForRemoval(randomBoolean());
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -180,7 +180,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("other1"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1"),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var state = clusterService.getClusterApplierService().state();
@@ -198,7 +198,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("other1", "other2"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1", "other2"),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var state = clusterService.getClusterApplierService().state();
@@ -231,7 +231,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("other1"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1"),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var finalState = clusterService.getClusterApplierService().state();
@@ -248,7 +248,12 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest(new String[] { "absent_id" }, Strings.EMPTY_ARRAY, TimeValue.timeValueSeconds(30)),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { "absent_id" },
+                Strings.EMPTY_ARRAY,
+                TimeValue.timeValueSeconds(30)
+            ),
             expectSuccess(r -> {
                 final var state = clusterService.getClusterApplierService().state();
                 assertEquals(
@@ -268,7 +273,12 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest(new String[] { "other1", "other2" }, Strings.EMPTY_ARRAY, TimeValue.timeValueSeconds(30)),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { "other1", "other2" },
+                Strings.EMPTY_ARRAY,
+                TimeValue.timeValueSeconds(30)
+            ),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var state = clusterService.getClusterApplierService().state();
@@ -285,7 +295,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("absent_node"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "absent_node"),
             expectSuccess(r -> {
                 final var state = clusterService.getClusterApplierService().state();
                 assertEquals(
@@ -305,7 +315,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("other1", "other2"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1", "other2"),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var state = clusterService.getClusterApplierService().state();
@@ -334,8 +344,13 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
             randomFrom(
-                new AddVotingConfigExclusionsRequest("other1"),
-                new AddVotingConfigExclusionsRequest(new String[] { "other1" }, Strings.EMPTY_ARRAY, TimeValue.timeValueSeconds(30))
+                new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1"),
+                new AddVotingConfigExclusionsRequest(
+                    TEST_REQUEST_TIMEOUT,
+                    new String[] { "other1" },
+                    Strings.EMPTY_ARRAY,
+                    TimeValue.timeValueSeconds(30)
+                )
             ),
             expectSuccess(r -> {
                 assertNotNull(r);
@@ -368,7 +383,12 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest(new String[] { "other1" }, Strings.EMPTY_ARRAY, TimeValue.timeValueSeconds(30)),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                new String[] { "other1" },
+                Strings.EMPTY_ARRAY,
+                TimeValue.timeValueSeconds(30)
+            ),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var finalState = clusterService.getClusterApplierService().state();
@@ -400,7 +420,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("other1"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1"),
             expectSuccess(r -> {
                 assertNotNull(r);
                 final var finalState = clusterService.getClusterApplierService().state();
@@ -457,7 +477,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest("other1", "other2"),
+            new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, "other1", "other2"),
             expectError(e -> {
                 final Throwable rootCause = e.getRootCause();
                 assertThat(rootCause, instanceOf(IllegalArgumentException.class));
@@ -485,7 +505,12 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[] { "other1" }, TimeValue.timeValueMillis(100)),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                Strings.EMPTY_ARRAY,
+                new String[] { "other1" },
+                TimeValue.timeValueMillis(100)
+            ),
             expectError(e -> {
                 final Throwable rootCause = e.getRootCause();
                 assertThat(rootCause, instanceOf(ElasticsearchTimeoutException.class));
@@ -504,7 +529,12 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
         transportService.sendRequest(
             localNode,
             TransportAddVotingConfigExclusionsAction.TYPE.name(),
-            new AddVotingConfigExclusionsRequest(Strings.EMPTY_ARRAY, new String[] { "other1" }, TimeValue.timeValueMillis(100)),
+            new AddVotingConfigExclusionsRequest(
+                TEST_REQUEST_TIMEOUT,
+                Strings.EMPTY_ARRAY,
+                new String[] { "other1" },
+                TimeValue.timeValueMillis(100)
+            ),
             expectError(e -> {
                 final Throwable rootCause = e.getRootCause();
                 assertThat(rootCause, instanceOf(IllegalStateException.class));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -118,7 +118,9 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
     public void testClearsVotingConfigExclusions() {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
 
-        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
+        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest(
+            TEST_REQUEST_TIMEOUT
+        );
         clearVotingConfigExclusionsRequest.setWaitForRemoval(false);
         transportService.sendRequest(
             localNode,
@@ -136,7 +138,9 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
     public void testTimesOutIfWaitingForNodesThatAreNotRemoved() {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
 
-        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
+        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest(
+            TEST_REQUEST_TIMEOUT
+        );
         clearVotingConfigExclusionsRequest.setTimeout(TimeValue.timeValueMillis(100));
         transportService.sendRequest(
             localNode,
@@ -165,7 +169,7 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
         transportService.sendRequest(
             localNode,
             TransportClearVotingConfigExclusionsAction.TYPE.name(),
-            new ClearVotingConfigExclusionsRequest(),
+            new ClearVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT),
             expectSuccess(r -> {
                 assertThat(clusterService.getClusterApplierService().state().getVotingConfigExclusions(), empty());
                 countDownLatch.countDown();
@@ -187,7 +191,7 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
         transportService.sendRequest(
             localNode,
             TransportClearVotingConfigExclusionsAction.TYPE.name(),
-            new ClearVotingConfigExclusionsRequest(),
+            new ClearVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT),
             expectError(e -> {
                 final Throwable rootCause = e.getRootCause();
                 assertThat(rootCause, instanceOf(IllegalStateException.class));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportUpdateDesiredNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportUpdateDesiredNodesActionTests.java
@@ -117,7 +117,14 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
                 .stream()
                 .map(DesiredNodeWithStatus::desiredNode)
                 .toList();
-            request = new UpdateDesiredNodesRequest(desiredNodes.historyID(), desiredNodes.version() + 1, updatedNodes, false);
+            request = new UpdateDesiredNodesRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT,
+                desiredNodes.historyID(),
+                desiredNodes.version() + 1,
+                updatedNodes,
+                false
+            );
         } else {
             request = randomUpdateDesiredNodesRequest();
         }
@@ -148,6 +155,8 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
             Collections.shuffle(equivalentDesiredNodesList, random());
         }
         final UpdateDesiredNodesRequest equivalentDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             updateDesiredNodesRequest.getHistoryID(),
             updateDesiredNodesRequest.getVersion(),
             equivalentDesiredNodesList,
@@ -165,6 +174,8 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
         final var latestDesiredNodes = TransportUpdateDesiredNodesAction.updateDesiredNodes(null, updateDesiredNodesRequest);
 
         final UpdateDesiredNodesRequest request = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             latestDesiredNodes.historyID(),
             latestDesiredNodes.version(),
             randomList(1, 10, DesiredNodesTestCase::randomDesiredNode),
@@ -182,6 +193,8 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
         final var updateDesiredNodesRequest = randomUpdateDesiredNodesRequest();
         final var latestDesiredNodes = TransportUpdateDesiredNodesAction.updateDesiredNodes(null, updateDesiredNodesRequest);
         final UpdateDesiredNodesRequest request = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             latestDesiredNodes.historyID(),
             latestDesiredNodes.version() - 1,
             List.copyOf(latestDesiredNodes.nodes().stream().map(DesiredNodeWithStatus::desiredNode).toList()),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequestSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequestSerializationTests.java
@@ -20,7 +20,14 @@ public class UpdateDesiredNodesRequestSerializationTests extends AbstractWireSer
 
     @Override
     protected UpdateDesiredNodesRequest mutateInstance(UpdateDesiredNodesRequest request) {
-        return new UpdateDesiredNodesRequest(request.getHistoryID(), request.getVersion() + 1, request.getNodes(), request.isDryRun());
+        return new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            request.getHistoryID(),
+            request.getVersion() + 1,
+            request.getNodes(),
+            request.isDryRun()
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesRequestTests.java
@@ -26,6 +26,8 @@ import static org.hamcrest.Matchers.notNullValue;
 public class UpdateDesiredNodesRequestTests extends ESTestCase {
     public void testValidation() {
         final UpdateDesiredNodesRequest updateDesiredNodesRequest = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomBoolean() ? "" : "     ",
             -1,
             randomBoolean() ? Collections.emptyList() : List.of(hotDesiredNode()),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestTests.java
@@ -42,12 +42,12 @@ public class ClusterHealthRequestTests extends ESTestCase {
     }
 
     public void testRequestReturnsHiddenIndicesByDefault() {
-        final ClusterHealthRequest defaultRequest = new ClusterHealthRequest();
+        final ClusterHealthRequest defaultRequest = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT);
         assertTrue(defaultRequest.indicesOptions().expandWildcardsHidden());
     }
 
     private ClusterHealthRequest randomRequest() {
-        ClusterHealthRequest request = new ClusterHealthRequest();
+        ClusterHealthRequest request = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT);
         request.waitForStatus(randomFrom(ClusterHealthStatus.values()));
         request.waitForNodes(randomFrom("", "<", "<=", ">", ">=") + between(0, 1000));
         request.waitForNoInitializingShards(randomBoolean());

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthActionTests.java
@@ -33,7 +33,7 @@ public class TransportClusterHealthActionTests extends ESTestCase {
 
     public void testWaitForInitializingShards() throws Exception {
         final String[] indices = { "test" };
-        final ClusterHealthRequest request = new ClusterHealthRequest();
+        final ClusterHealthRequest request = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT);
         request.waitForNoInitializingShards(true);
         ClusterState clusterState = randomClusterStateWithInitializingShards("test", 0);
         ClusterHealthResponse response = new ClusterHealthResponse("", indices, clusterState);
@@ -52,7 +52,7 @@ public class TransportClusterHealthActionTests extends ESTestCase {
 
     public void testWaitForAllShards() {
         final String[] indices = { "test" };
-        final ClusterHealthRequest request = new ClusterHealthRequest();
+        final ClusterHealthRequest request = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT);
         request.waitForActiveShards(ActiveShardCount.ALL);
 
         ClusterState clusterState = randomClusterStateWithInitializingShards("test", 1);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateNodeRemovalRequestSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateNodeRemovalRequestSerializationTests.java
@@ -38,7 +38,7 @@ public class PrevalidateNodeRemovalRequestSerializationTests extends AbstractWir
                 )
                 .setIds(request.getIds())
                 .setExternalIds(request.getExternalIds())
-                .build();
+                .build(TEST_REQUEST_TIMEOUT);
 
             case 1 -> PrevalidateNodeRemovalRequest.builder()
                 .setNames(request.getNames())
@@ -49,7 +49,7 @@ public class PrevalidateNodeRemovalRequestSerializationTests extends AbstractWir
                     )
                 )
                 .setExternalIds(request.getExternalIds())
-                .build();
+                .build(TEST_REQUEST_TIMEOUT);
 
             case 2 -> PrevalidateNodeRemovalRequest.builder()
                 .setNames(request.getNames())
@@ -60,7 +60,7 @@ public class PrevalidateNodeRemovalRequestSerializationTests extends AbstractWir
                         PrevalidateNodeRemovalRequestSerializationTests::randomStringArray
                     )
                 )
-                .build();
+                .build(TEST_REQUEST_TIMEOUT);
             default -> throw new IllegalStateException("unexpected value: " + i);
         };
     }
@@ -74,6 +74,6 @@ public class PrevalidateNodeRemovalRequestSerializationTests extends AbstractWir
             .setNames(randomStringArray())
             .setIds(randomStringArray())
             .setExternalIds(randomStringArray())
-            .build();
+            .build(TEST_REQUEST_TIMEOUT);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateNodeRemovalRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/PrevalidateNodeRemovalRequestTests.java
@@ -18,24 +18,28 @@ import static org.hamcrest.Matchers.equalTo;
 public class PrevalidateNodeRemovalRequestTests extends ESTestCase {
 
     public void testValidate() {
-        ActionRequestValidationException ex1 = PrevalidateNodeRemovalRequest.builder().build().validate();
+        ActionRequestValidationException ex1 = PrevalidateNodeRemovalRequest.builder().build(TEST_REQUEST_TIMEOUT).validate();
         assertNotNull(ex1);
         assertThat(ex1.validationErrors(), equalTo(List.of(PrevalidateNodeRemovalRequest.VALIDATION_ERROR_MSG_NO_QUERY_PARAM)));
 
-        ActionRequestValidationException ex2 = PrevalidateNodeRemovalRequest.builder().setNames("name1").setIds("id1").build().validate();
+        ActionRequestValidationException ex2 = PrevalidateNodeRemovalRequest.builder()
+            .setNames("name1")
+            .setIds("id1")
+            .build(TEST_REQUEST_TIMEOUT)
+            .validate();
         assertNotNull(ex2);
         assertThat(ex2.validationErrors(), equalTo(List.of(PrevalidateNodeRemovalRequest.VALIDATION_ERROR_MSG_ONLY_ONE_QUERY_PARAM)));
 
         ActionRequestValidationException ex3 = PrevalidateNodeRemovalRequest.builder()
             .setNames("name1")
             .setExternalIds("id1")
-            .build()
+            .build(TEST_REQUEST_TIMEOUT)
             .validate();
         assertNotNull(ex3);
         assertThat(ex3.validationErrors(), equalTo(List.of(PrevalidateNodeRemovalRequest.VALIDATION_ERROR_MSG_ONLY_ONE_QUERY_PARAM)));
 
-        assertNull(PrevalidateNodeRemovalRequest.builder().setNames("name1").build().validate());
-        assertNull(PrevalidateNodeRemovalRequest.builder().setIds("id1").build().validate());
-        assertNull(PrevalidateNodeRemovalRequest.builder().setExternalIds("external_id1").build().validate());
+        assertNull(PrevalidateNodeRemovalRequest.builder().setNames("name1").build(TEST_REQUEST_TIMEOUT).validate());
+        assertNull(PrevalidateNodeRemovalRequest.builder().setIds("id1").build(TEST_REQUEST_TIMEOUT).validate());
+        assertNull(PrevalidateNodeRemovalRequest.builder().setExternalIds("external_id1").build(TEST_REQUEST_TIMEOUT).validate());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportPrevalidateNodeRemovalActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportPrevalidateNodeRemovalActionTests.java
@@ -35,24 +35,32 @@ public class TransportPrevalidateNodeRemovalActionTests extends ESTestCase {
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder().add(node1).add(node2).build();
 
         assertThat(
-            resolveNodes(PrevalidateNodeRemovalRequest.builder().setNames(node1Name).build(), discoveryNodes),
+            resolveNodes(PrevalidateNodeRemovalRequest.builder().setNames(node1Name).build(TEST_REQUEST_TIMEOUT), discoveryNodes),
             equalTo(Set.of(node1))
         );
         assertThat(
-            resolveNodes(PrevalidateNodeRemovalRequest.builder().setIds(node1Id, node2Id).build(), discoveryNodes),
+            resolveNodes(PrevalidateNodeRemovalRequest.builder().setIds(node1Id, node2Id).build(TEST_REQUEST_TIMEOUT), discoveryNodes),
             equalTo(Set.of(node1, node2))
         );
         expectThrows(
             ResourceNotFoundException.class,
-            () -> resolveNodes(PrevalidateNodeRemovalRequest.builder().setNames(node1Name, node1Id).build(), discoveryNodes)
+            () -> resolveNodes(
+                PrevalidateNodeRemovalRequest.builder().setNames(node1Name, node1Id).build(TEST_REQUEST_TIMEOUT),
+                discoveryNodes
+            )
         );
         expectThrows(
             ResourceNotFoundException.class,
-            () -> resolveNodes(PrevalidateNodeRemovalRequest.builder().setIds(node1Name, node1Id).build(), discoveryNodes)
+            () -> resolveNodes(
+                PrevalidateNodeRemovalRequest.builder().setIds(node1Name, node1Id).build(TEST_REQUEST_TIMEOUT),
+                discoveryNodes
+            )
         );
         assertThat(
             resolveNodes(
-                PrevalidateNodeRemovalRequest.builder().setExternalIds(node1.getExternalId(), node2.getExternalId()).build(),
+                PrevalidateNodeRemovalRequest.builder()
+                    .setExternalIds(node1.getExternalId(), node2.getExternalId())
+                    .build(TEST_REQUEST_TIMEOUT),
                 discoveryNodes
             ),
             equalTo(Set.of(node1, node2))

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
@@ -63,13 +63,13 @@ public class ClusterUpdateSettingsRequestTests extends ESTestCase {
             );
             XContentParseException iae = expectThrows(XContentParseException.class, () -> {
                 try (var parser = createParser(xContentType.xContent(), mutated)) {
-                    ClusterUpdateSettingsRequest.fromXContent(parser);
+                    ClusterUpdateSettingsRequest.fromXContent(ClusterUpdateSettingsRequestTests::newTestRequest, parser);
                 }
             });
             assertThat(iae.getMessage(), containsString("[cluster_update_settings_request] unknown field [" + unsupportedField + "]"));
         } else {
             try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
-                ClusterUpdateSettingsRequest parsedRequest = ClusterUpdateSettingsRequest.fromXContent(parser);
+                var parsedRequest = ClusterUpdateSettingsRequest.fromXContent(ClusterUpdateSettingsRequestTests::newTestRequest, parser);
 
                 assertNull(parser.nextToken());
                 assertThat(parsedRequest.transientSettings(), equalTo(request.transientSettings()));
@@ -79,7 +79,7 @@ public class ClusterUpdateSettingsRequestTests extends ESTestCase {
     }
 
     private static ClusterUpdateSettingsRequest createTestItem() {
-        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         request.persistentSettings(ClusterUpdateSettingsResponseTests.randomClusterSettings(0, 2));
         request.transientSettings(ClusterUpdateSettingsResponseTests.randomClusterSettings(0, 2));
         return request;
@@ -119,11 +119,15 @@ public class ClusterUpdateSettingsRequestTests extends ESTestCase {
             }""";
 
         try (XContentParser parser = createParser(XContentType.JSON.xContent(), oneSettingJSON)) {
-            ClusterUpdateSettingsRequest parsedRequest = ClusterUpdateSettingsRequest.fromXContent(parser);
+            var parsedRequest = ClusterUpdateSettingsRequest.fromXContent(ClusterUpdateSettingsRequestTests::newTestRequest, parser);
             assertThat(
                 action.modifiedKeys(parsedRequest),
                 containsInAnyOrder("indices.recovery.max_bytes_per_sec", "cluster.remote.cluster_one.seeds")
             );
         }
+    }
+
+    public static ClusterUpdateSettingsRequest newTestRequest() {
+        return new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateApiTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateApiTests.java
@@ -31,20 +31,20 @@ public class ClusterStateApiTests extends ESSingleNodeTestCase {
     }
 
     public void testWaitForMetadataVersion() throws Exception {
-        ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest(TEST_REQUEST_TIMEOUT);
         clusterStateRequest.waitForTimeout(TimeValue.timeValueHours(1));
         ClusterStateResponse response = clusterAdmin().state(clusterStateRequest).get(10L, TimeUnit.SECONDS);
         assertThat(response.isWaitForTimedOut(), is(false));
         long metadataVersion = response.getState().getMetadata().version();
 
         // Verify that cluster state api returns after the cluster settings have been updated:
-        clusterStateRequest = new ClusterStateRequest();
+        clusterStateRequest = new ClusterStateRequest(TEST_REQUEST_TIMEOUT);
         clusterStateRequest.waitForMetadataVersion(metadataVersion + 1);
 
         ActionFuture<ClusterStateResponse> future2 = clusterAdmin().state(clusterStateRequest);
         assertThat(future2.isDone(), is(false));
 
-        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         // Pick an arbitrary dynamic cluster setting and change it. Just to get metadata version incremented:
         updateSettingsRequest.transientSettings(Settings.builder().put("cluster.max_shards_per_node", 999));
         assertAcked(clusterAdmin().updateSettings(updateSettingsRequest).actionGet());
@@ -63,7 +63,7 @@ public class ClusterStateApiTests extends ESSingleNodeTestCase {
         assertThat(response.getState(), nullValue());
 
         // Remove transient setting, otherwise test fails with the reason that this test leaves state behind:
-        updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         updateSettingsRequest.transientSettings(Settings.builder().put("cluster.max_shards_per_node", (String) null));
         assertAcked(clusterAdmin().updateSettings(updateSettingsRequest).actionGet());
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -29,7 +29,7 @@ public class ClusterStateRequestTests extends ESTestCase {
         for (int i = 0; i < iterations; i++) {
 
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
-            ClusterStateRequest clusterStateRequest = new ClusterStateRequest().routingTable(randomBoolean())
+            ClusterStateRequest clusterStateRequest = new ClusterStateRequest(TEST_REQUEST_TIMEOUT).routingTable(randomBoolean())
                 .metadata(randomBoolean())
                 .nodes(randomBoolean())
                 .blocks(randomBoolean())
@@ -68,7 +68,7 @@ public class ClusterStateRequestTests extends ESTestCase {
     }
 
     public void testWaitForMetadataVersion() {
-        ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest(TEST_REQUEST_TIMEOUT);
         expectThrows(
             IllegalArgumentException.class,
             () -> clusterStateRequest.waitForMetadataVersion(randomLongBetween(Long.MIN_VALUE, 0))
@@ -84,21 +84,27 @@ public class ClusterStateRequestTests extends ESTestCase {
     }
 
     public void testDescription() {
-        assertThat(new ClusterStateRequest().clear().getDescription(), equalTo("cluster state [master timeout [30s]]"));
+        assertThat(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().getDescription(), equalTo("cluster state [master timeout [30s]]"));
         assertThat(
-            new ClusterStateRequest().masterNodeTimeout(TimeValue.timeValueMinutes(5)).getDescription(),
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).masterNodeTimeout(TimeValue.timeValueMinutes(5)).getDescription(),
             equalTo("cluster state [routing table, nodes, metadata, blocks, customs, master timeout [5m]]")
         );
-        assertThat(new ClusterStateRequest().clear().routingTable(true).getDescription(), containsString("routing table"));
-        assertThat(new ClusterStateRequest().clear().nodes(true).getDescription(), containsString("nodes"));
-        assertThat(new ClusterStateRequest().clear().metadata(true).getDescription(), containsString("metadata"));
-        assertThat(new ClusterStateRequest().clear().blocks(true).getDescription(), containsString("blocks"));
-        assertThat(new ClusterStateRequest().clear().customs(true).getDescription(), containsString("customs"));
-        assertThat(new ClusterStateRequest().local(true).getDescription(), containsString("local"));
         assertThat(
-            new ClusterStateRequest().waitForMetadataVersion(23L).getDescription(),
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().routingTable(true).getDescription(),
+            containsString("routing table")
+        );
+        assertThat(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().nodes(true).getDescription(), containsString("nodes"));
+        assertThat(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().metadata(true).getDescription(), containsString("metadata"));
+        assertThat(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().blocks(true).getDescription(), containsString("blocks"));
+        assertThat(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().customs(true).getDescription(), containsString("customs"));
+        assertThat(new ClusterStateRequest(TEST_REQUEST_TIMEOUT).local(true).getDescription(), containsString("local"));
+        assertThat(
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(23L).getDescription(),
             containsString("wait for metadata version [23] with timeout [1m]")
         );
-        assertThat(new ClusterStateRequest().indices("foo", "bar").getDescription(), containsString("indices [foo, bar]"));
+        assertThat(
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).indices("foo", "bar").getDescription(),
+            containsString("indices [foo, bar]")
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportActionTests.java
@@ -56,9 +56,9 @@ public class ReservedStateAwareHandledTransportActionTests extends ESTestCase {
         handler.doExecute(mock(Task.class), new DummyRequest(), future);
         assertNotNull(future.actionGet());
 
-        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest().persistentSettings(
-            Settings.builder().put("a", "a value").build()
-        ).transientSettings(Settings.builder().put("e", "e value").build());
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .persistentSettings(Settings.builder().put("a", "a value").build())
+            .transientSettings(Settings.builder().put("e", "e value").build());
 
         FakeReservedStateAwareAction action = new FakeReservedStateAwareAction(
             "internal:testClusterSettings",
@@ -80,9 +80,9 @@ public class ReservedStateAwareHandledTransportActionTests extends ESTestCase {
             }
         })).getMessage().contains("with errors: [[a] set as read-only by [namespace_one], " + "[e] set as read-only by [namespace_two]"));
 
-        ClusterUpdateSettingsRequest okRequest = new ClusterUpdateSettingsRequest().persistentSettings(
-            Settings.builder().put("m", "m value").build()
-        ).transientSettings(Settings.builder().put("n", "n value").build());
+        ClusterUpdateSettingsRequest okRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .persistentSettings(Settings.builder().put("m", "m value").build())
+            .transientSettings(Settings.builder().put("n", "n value").build());
 
         // this should just work, no conflicts
         action.doExecute(mock(Task.class), okRequest, new ActionListener<>() {

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -840,9 +840,9 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         // nothing should happen here, since the request doesn't touch any of the immutable state keys
         noHandler.validateForReservedState(new Request(), clusterState);
 
-        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest().persistentSettings(
-            Settings.builder().put("a", "a value").build()
-        ).transientSettings(Settings.builder().put("e", "e value").build());
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .persistentSettings(Settings.builder().put("a", "a value").build())
+            .transientSettings(Settings.builder().put("e", "e value").build());
 
         FakeClusterStateUpdateAction action = new FakeClusterStateUpdateAction(
             "internal:testClusterSettings",
@@ -859,9 +859,9 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                 .contains("with errors: [[a] set as read-only by [namespace_one], " + "[e] set as read-only by [namespace_two]")
         );
 
-        ClusterUpdateSettingsRequest okRequest = new ClusterUpdateSettingsRequest().persistentSettings(
-            Settings.builder().put("m", "m value").build()
-        ).transientSettings(Settings.builder().put("n", "n value").build());
+        ClusterUpdateSettingsRequest okRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .persistentSettings(Settings.builder().put("m", "m value").build())
+            .transientSettings(Settings.builder().put("n", "n value").build());
 
         // this should just work, no conflicts
         action.validateForReservedState(okRequest, clusterState);

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -98,7 +98,11 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
                     UnsupportedOperationException.class,
                     safeAwaitFailure(
                         ClusterStateResponse.class,
-                        listener -> remoteClusterClient.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(), listener)
+                        listener -> remoteClusterClient.execute(
+                            ClusterStateAction.REMOTE_TYPE,
+                            new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                            listener
+                        )
                     )
                 ).getMessage()
             );

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -159,7 +159,7 @@ public class ClusterStateHealthTests extends ESTestCase {
         ActionTestUtils.execute(
             action,
             new CancellableTask(1, "direct", TransportClusterHealthAction.NAME, "", TaskId.EMPTY_TASK_ID, Map.of()),
-            new ClusterHealthRequest().waitForGreenStatus(),
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT).waitForGreenStatus(),
             listener
         );
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodesTestCase.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodesTestCase.java
@@ -117,6 +117,8 @@ public abstract class DesiredNodesTestCase extends ESTestCase {
 
     public static UpdateDesiredNodesRequest randomUpdateDesiredNodesRequest() {
         return new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             UUIDs.randomBase64UUID(random()),
             randomLongBetween(0, Long.MAX_VALUE - 1000),
             randomList(1, 100, DesiredNodesTestCase::randomDesiredNode),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -248,7 +248,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         List<Throwable> errors = putTemplateDetail(request);
         assertThat(errors, is(empty()));
 
-        final Metadata metadata = clusterAdmin().prepareState().get().getState().metadata();
+        final Metadata metadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         IndexTemplateMetadata template = metadata.templates().get(templateName);
         Map<String, AliasMetadata> aliasMap = template.getAliases();
         assertThat(aliasMap.size(), equalTo(1));
@@ -266,7 +266,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
         putTemplateDetail(new PutRequest("test", "foo-1").patterns(singletonList("foo-*")).order(1));
         putTemplateDetail(new PutRequest("test", "foo-2").patterns(singletonList("foo-*")).order(2));
         putTemplateDetail(new PutRequest("test", "bar").patterns(singletonList("bar-*")).order(between(0, 100)));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(
             MetadataIndexTemplateService.findV1Templates(state.metadata(), "foo-1234", randomBoolean())
                 .stream()
@@ -296,7 +296,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             new PutRequest("testFindTemplatesWithHiddenIndices", "sneaky-hidden").patterns(singletonList("sneaky*"))
                 .settings(Settings.builder().put("index.hidden", true).build())
         );
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         // hidden
         assertThat(
@@ -380,7 +380,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
     public void testFindTemplatesWithDateMathIndex() throws Exception {
         client().admin().indices().prepareDeleteTemplate("*").get(); // Delete all existing templates
         putTemplateDetail(new PutRequest("testFindTemplatesWithDateMathIndex", "foo-1").patterns(singletonList("test-*")).order(1));
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
 
         assertThat(
             MetadataIndexTemplateService.findV1Templates(state.metadata(), "<test-{now/d}>", false)

--- a/server/src/test/java/org/elasticsearch/discovery/AbstractDisruptionTestCase.java
+++ b/server/src/test/java/org/elasticsearch/discovery/AbstractDisruptionTestCase.java
@@ -130,7 +130,7 @@ public abstract class AbstractDisruptionTestCase extends ESIntegTestCase {
     }
 
     ClusterState getNodeClusterState(String node) {
-        return client(node).admin().cluster().prepareState().setLocal(true).get().getState();
+        return client(node).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
     }
 
     void assertNoMaster(final String node) throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -449,14 +449,14 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertNotNull(indexService.getFsyncTask());
         assertTrue(indexService.getFsyncTask().mustReschedule());
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test");
         assertEquals("5s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
 
         indicesAdmin().prepareClose("test").get();
         indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), "20s"))
             .get();
-        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("test");
         assertEquals("20s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
     }
 

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -2719,7 +2719,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             try {
                 ClusterUpdateSettingsResponse response = client().admin()
                     .cluster()
-                    .prepareUpdateSettings()
+                    .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(Settings.builder().put(SEARCH_WORKER_THREADS_ENABLED.getKey(), false).build())
                     .get();
                 assertTrue(response.isAcknowledged());
@@ -2730,7 +2730,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 // reset original default setting
                 client().admin()
                     .cluster()
-                    .prepareUpdateSettings()
+                    .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(Settings.builder().putNull(SEARCH_WORKER_THREADS_ENABLED.getKey()).build())
                     .get();
                 try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.DFS, randomBoolean())) {
@@ -2868,7 +2868,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             try {
                 ClusterUpdateSettingsResponse response = client().admin()
                     .cluster()
-                    .prepareUpdateSettings()
+                    .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(Settings.builder().put(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey(), false).build())
                     .get();
                 assertTrue(response.isAcknowledged());
@@ -2891,7 +2891,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 // Reset to the original default setting and check to ensure it takes effect.
                 client().admin()
                     .cluster()
-                    .prepareUpdateSettings()
+                    .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(Settings.builder().putNull(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey()).build())
                     .get();
                 {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1036,7 +1036,9 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         continueOrDie(
             createRepoAndIndex(repoName, index, shards),
-            createIndexResponse -> client().admin().cluster().state(new ClusterStateRequest(), clusterStateResponseStepListener)
+            createIndexResponse -> client().admin()
+                .cluster()
+                .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT), clusterStateResponseStepListener)
         );
 
         continueOrDie(clusterStateResponseStepListener, clusterStateResponse -> {
@@ -1048,7 +1050,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 @Override
                 public void run() {
                     final SubscribableListener<ClusterStateResponse> updatedClusterStateResponseStepListener = new SubscribableListener<>();
-                    masterAdminClient.cluster().state(new ClusterStateRequest(), updatedClusterStateResponseStepListener);
+                    masterAdminClient.cluster()
+                        .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT), updatedClusterStateResponseStepListener);
                     continueOrDie(updatedClusterStateResponseStepListener, updatedClusterState -> {
                         final ShardRouting shardRouting = updatedClusterState.getState()
                             .routingTable()

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -104,7 +104,7 @@ public class RemoteClusterClientTests extends ESTestCase {
                 ClusterStateResponse clusterStateResponse = safeAwait(
                     listener -> client.execute(
                         ClusterStateAction.REMOTE_TYPE,
-                        new ClusterStateRequest(),
+                        new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
                         ActionListener.runBefore(
                             listener,
                             () -> assertTrue(Thread.currentThread().getName().contains('[' + TEST_THREAD_POOL_NAME + ']'))
@@ -184,7 +184,7 @@ public class RemoteClusterClientTests extends ESTestCase {
                         )
                     );
                     ClusterStateResponse clusterStateResponse = safeAwait(
-                        listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(), listener)
+                        listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(TEST_REQUEST_TIMEOUT), listener)
                     );
                     assertNotNull(clusterStateResponse);
                     assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
@@ -273,7 +273,11 @@ public class RemoteClusterClientTests extends ESTestCase {
                     ESTestCase.assertThat(
                         safeAwaitFailure(
                             ClusterStateResponse.class,
-                            listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(), listener)
+                            listener -> client.execute(
+                                ClusterStateAction.REMOTE_TYPE,
+                                new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                                listener
+                            )
                         ),
                         instanceOf(ConnectTransportException.class)
                     );
@@ -284,7 +288,7 @@ public class RemoteClusterClientTests extends ESTestCase {
 
                 assertBusy(() -> {
                     ClusterStateResponse ignored = safeAwait(
-                        listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(), listener)
+                        listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(TEST_REQUEST_TIMEOUT), listener)
                     );
                     // keep retrying on an exception, the goal is to check that we eventually reconnect
                 });

--- a/test/framework/src/integTest/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
+++ b/test/framework/src/integTest/java/org/elasticsearch/test/disruption/NetworkDisruptionIT.java
@@ -164,7 +164,7 @@ public class NetworkDisruptionIT extends ESIntegTestCase {
         source.sendRequest(
             target.getLocalNode(),
             TransportClusterHealthAction.NAME,
-            new ClusterHealthRequest(),
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT),
             new TransportResponseHandler<>() {
                 private AtomicBoolean responded = new AtomicBoolean();
 

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
@@ -103,7 +103,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         );
         final String redNodeName = internalCluster().startNode(Settings.builder().put("node.attr.color", "red").put(nodeSettings).build());
 
-        ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForNodes(">=3").get();
+        ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes(">=3").get();
         assertThat(response.isTimedOut(), is(false));
 
         indicesAdmin().prepareCreate(indexName)
@@ -128,7 +128,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         indexRandom(true, requests);
         ensureSearchable(indexName);
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         final String blueNodeId = getNodeId(blueNodeName);
 
         assertFalse(stateResponse.getState().getRoutingNodes().node(blueNodeId).isEmpty());
@@ -204,7 +204,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         );
         final String redNodeName = internalCluster().startNode(Settings.builder().put("node.attr.color", "red").put(nodeSettings).build());
 
-        ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForNodes(">=3").get();
+        ClusterHealthResponse response = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes(">=3").get();
         assertThat(response.isTimedOut(), is(false));
 
         indicesAdmin().prepareCreate(indexName)
@@ -219,7 +219,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         indexRandom(true, requests);
         ensureSearchable(indexName);
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         final String blueNodeId = getNodeId(blueNodeName);
 
         assertFalse(stateResponse.getState().getRoutingNodes().node(blueNodeId).isEmpty());
@@ -344,7 +344,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
                                 "Expected there to be some initializing shards",
                                 client(blueNodeName).admin()
                                     .cluster()
-                                    .prepareState()
+                                    .prepareState(TEST_REQUEST_TIMEOUT)
                                     .setLocal(true)
                                     .get()
                                     .getState()

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
@@ -282,7 +282,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
             .setMapping(mapping)
             .setSettings(settings(version).build());
         mappingRequest.get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         // Create a multipolygon with two polygons. The first is an rectangle of size 10x10
         // with a hole of size 5x5 equidistant from all sides. This hole in turn contains
@@ -458,7 +458,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
     protected abstract void doDistanceAndBoundingBoxTest(String key);
 
     private static String findNodeName(String index) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         IndexShardRoutingTable shard = state.getRoutingTable().index(index).shard(0);
         String nodeId = shard.assignedShards().get(0).currentNodeId();
         return state.getNodes().get(nodeId).getName();

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -510,7 +510,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
      * @param metadata     snapshot metadata to write (as returned by {@link SnapshotInfo#userMetadata()})
      */
     protected void addBwCFailedSnapshot(String repoName, String snapshotName, Map<String, Object> metadata) throws Exception {
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final RepositoriesMetadata repositoriesMetadata = state.metadata().custom(RepositoriesMetadata.TYPE);
         assertNotNull(repositoriesMetadata);
         final RepositoryMetadata initialRepoMetadata = repositoriesMetadata.repository(repoName);

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
@@ -157,7 +157,7 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
                 settings.putNull("cluster.remote." + clusterAlias + ".proxy_address");
             }
         }
-        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+        client().admin().cluster().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setPersistentSettings(settings).get();
         assertBusy(() -> {
             for (TransportService transportService : cluster(LOCAL_CLUSTER).getInstances(TransportService.class)) {
                 assertThat(transportService.getRemoteClusterService().getRegisteredRemoteClusterNames(), empty());
@@ -204,7 +204,11 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
         }
         builder.build();
 
-        ClusterUpdateSettingsResponse resp = client().admin().cluster().prepareUpdateSettings().setPersistentSettings(settings).get();
+        ClusterUpdateSettingsResponse resp = client().admin()
+            .cluster()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .setPersistentSettings(settings)
+            .get();
         if (skipUnavailable != DEFAULT_SKIP_UNAVAILABLE) {
             String key = Strings.format("cluster.remote.%s.skip_unavailable", clusterAlias);
             assertEquals(String.valueOf(skipUnavailable), resp.getPersistentSettings().get(key));

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -94,7 +94,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         // we must wait for the node to actually be up and running. otherwise the node might have started,
         // elected itself master but might not yet have removed the
         // SERVICE_UNAVAILABLE/1/state not recovered / initialized block
-        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForGreenStatus().get();
         assertFalse(clusterHealthResponse.isTimedOut());
         indicesAdmin().preparePutTemplate("one_shard_index_template")
             .setPatterns(Collections.singletonList("*"))
@@ -154,7 +154,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         var deleteComponentTemplateRequest = new TransportDeleteComponentTemplateAction.Request("*");
         assertAcked(client().execute(TransportDeleteComponentTemplateAction.TYPE, deleteComponentTemplateRequest).actionGet());
         assertAcked(indicesAdmin().prepareDelete("*").setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN).get());
-        Metadata metadata = clusterAdmin().prepareState().get().getState().getMetadata();
+        Metadata metadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getMetadata();
         assertThat(
             "test leaves persistent cluster metadata behind: " + metadata.persistentSettings().keySet(),
             metadata.persistentSettings().size(),
@@ -384,7 +384,9 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         // Wait for the index to be allocated so that cluster state updates don't override
         // changes that would have been done locally
         ClusterHealthResponse health = clusterAdmin().health(
-            new ClusterHealthRequest(index).waitForYellowStatus().waitForEvents(Priority.LANGUID).waitForNoRelocatingShards(true)
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, index).waitForYellowStatus()
+                .waitForEvents(Priority.LANGUID)
+                .waitForNoRelocatingShards(true)
         ).actionGet();
         assertThat(health.getStatus(), lessThanOrEqualTo(ClusterHealthStatus.YELLOW));
         assertThat("Cluster must be a single node cluster", health.getNumberOfDataNodes(), equalTo(1));
@@ -428,7 +430,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
      */
     public ClusterHealthStatus ensureGreen(TimeValue timeout, String... indices) {
         ClusterHealthResponse actionGet = clusterAdmin().health(
-            new ClusterHealthRequest(indices).masterNodeTimeout(timeout)
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, indices).masterNodeTimeout(timeout)
                 .timeout(timeout)
                 .waitForGreenStatus()
                 .waitForEvents(Priority.LANGUID)
@@ -437,7 +439,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         if (actionGet.isTimedOut()) {
             logger.info(
                 "ensureGreen timed out, cluster state:\n{}\n{}",
-                clusterAdmin().prepareState().get().getState(),
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(),
                 ESIntegTestCase.getClusterPendingTasks(client())
             );
             assertThat("timed out waiting for green state", actionGet.isTimedOut(), equalTo(false));
@@ -462,8 +464,9 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
      * inspired by {@link ESRestTestCase}
      */
     protected void ensureNoInitializingShards() {
-        ClusterHealthResponse actionGet = clusterAdmin().health(new ClusterHealthRequest("_all").waitForNoInitializingShards(true))
-            .actionGet();
+        ClusterHealthResponse actionGet = clusterAdmin().health(
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, "_all").waitForNoInitializingShards(true)
+        ).actionGet();
 
         assertFalse("timed out waiting for shards to initialize", actionGet.isTimedOut());
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -142,6 +142,7 @@ import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING
 import static org.elasticsearch.discovery.DiscoveryModule.MULTI_NODE_DISCOVERY_TYPE;
 import static org.elasticsearch.discovery.FileBasedSeedHostsProvider.UNICAST_HOSTS_FILE;
 import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
+import static org.elasticsearch.test.ESTestCase.TEST_REQUEST_TIMEOUT;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.runInParallel;
@@ -1240,7 +1241,7 @@ public final class InternalTestCluster extends TestCluster {
         assertFalse(
             client().admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes(Integer.toString(expectedNodes.size()))
                 .get(TimeValue.timeValueSeconds(40))
@@ -1481,7 +1482,7 @@ public final class InternalTestCluster extends TestCluster {
      */
     public void assertSameDocIdsOnShards() throws Exception {
         assertBusy(() -> {
-            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            ClusterState state = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             for (var indexRoutingTable : state.routingTable().indicesRouting().values()) {
                 for (int i = 0; i < indexRoutingTable.size(); i++) {
                     IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(i);
@@ -1928,7 +1929,7 @@ public final class InternalTestCluster extends TestCluster {
                 try {
                     client().execute(
                         TransportAddVotingConfigExclusionsAction.TYPE,
-                        new AddVotingConfigExclusionsRequest(excludedNodeNames.toArray(Strings.EMPTY_ARRAY))
+                        new AddVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT, excludedNodeNames.toArray(Strings.EMPTY_ARRAY))
                     ).get();
                 } catch (InterruptedException | ExecutionException e) {
                     ESTestCase.fail(e);
@@ -1944,7 +1945,10 @@ public final class InternalTestCluster extends TestCluster {
             logger.info("removing voting config exclusions for {} after restart/shutdown", excludedNodeIds);
             try {
                 Client client = getRandomNodeAndClient(node -> excludedNodeIds.contains(node.name) == false).client();
-                client.execute(TransportClearVotingConfigExclusionsAction.TYPE, new ClearVotingConfigExclusionsRequest()).get();
+                client.execute(
+                    TransportClearVotingConfigExclusionsAction.TYPE,
+                    new ClearVotingConfigExclusionsRequest(TEST_REQUEST_TIMEOUT)
+                ).get();
             } catch (InterruptedException | ExecutionException e) {
                 ESTestCase.fail(e);
             }
@@ -2000,7 +2004,7 @@ public final class InternalTestCluster extends TestCluster {
     public String getMasterName(@Nullable String viaNode) {
         try {
             Client client = viaNode != null ? client(viaNode) : client();
-            return client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName();
+            return client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode().getName();
         } catch (Exception e) {
             logger.warn("Can't fetch cluster state", e);
             throw new RuntimeException("Can't get master node " + e.getMessage(), e);

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.Set;
 
+import static org.elasticsearch.test.ESTestCase.TEST_REQUEST_TIMEOUT;
 import static org.elasticsearch.test.ESTestCase.safeAwait;
 
 /**
@@ -84,7 +85,7 @@ public abstract class TestCluster {
                     .<AcknowledgedResponse>newForked(
                         l -> client().execute(
                             DeleteDataStreamAction.INSTANCE,
-                            new DeleteDataStreamAction.Request(ESTestCase.TEST_REQUEST_TIMEOUT, "*").indicesOptions(
+                            new DeleteDataStreamAction.Request(TEST_REQUEST_TIMEOUT, "*").indicesOptions(
                                 IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN
                             ),
                             l.delegateResponse((ll, e) -> {
@@ -255,7 +256,7 @@ public abstract class TestCluster {
             if (wipingAllIndices) {
                 SubscribableListener
 
-                    .<ClusterStateResponse>newForked(l -> client().admin().cluster().prepareState().execute(l))
+                    .<ClusterStateResponse>newForked(l -> client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).execute(l))
                     .<AcknowledgedResponse>andThen((l, clusterStateResponse) -> {
                         ArrayList<String> concreteIndices = new ArrayList<>();
                         for (IndexMetadata indexMetadata : clusterStateResponse.getState().metadata()) {
@@ -336,7 +337,7 @@ public abstract class TestCluster {
             .<AcknowledgedResponse>newForked(
                 l -> client().admin()
                     .cluster()
-                    .prepareDeleteRepository(ESTestCase.TEST_REQUEST_TIMEOUT, ESTestCase.TEST_REQUEST_TIMEOUT, "*")
+                    .prepareDeleteRepository(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "*")
                     .execute(l.delegateResponse((ll, e) -> {
                         if (e instanceof RepositoryMissingException) {
                             // ignore

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/SingleNodeDisruption.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.Random;
 
+import static org.elasticsearch.test.ESTestCase.TEST_REQUEST_TIMEOUT;
 import static org.junit.Assert.assertFalse;
 
 public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
@@ -71,7 +72,7 @@ public abstract class SingleNodeDisruption implements ServiceDisruptionScheme {
             testCluster.client()
                 .admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .setWaitForNodes(String.valueOf(testCluster.size()))
                 .setWaitForNoRelocatingShards(true)
                 .get()

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -146,7 +146,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
      */
     protected void restartTaskNode(String id, String indexName) throws Exception {
         AsyncExecutionId searchId = AsyncExecutionId.decode(id);
-        final ClusterStateResponse clusterState = clusterAdmin().prepareState().clear().setNodes(true).get();
+        final ClusterStateResponse clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setNodes(true).get();
         DiscoveryNode node = clusterState.getState().nodes().get(searchId.getTaskId().getNodeId());
 
         // Temporarily stop garbage collection, making sure to wait for any in-flight tasks to complete

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CCSUsageTelemetryAsyncSearchIT.java
@@ -349,7 +349,7 @@ public class CCSUsageTelemetryAsyncSearchIT extends AbstractMultiClustersTestCas
             assertFalse(
                 client(clusterAlias).admin()
                     .cluster()
-                    .prepareHealth(remoteIndex)
+                    .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex)
                     .setWaitForYellowStatus()
                     .setTimeout(TimeValue.timeValueSeconds(10))
                     .get()

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -1742,7 +1742,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         assertFalse(
             client(REMOTE_CLUSTER).admin()
                 .cluster()
-                .prepareHealth(remoteIndex)
+                .prepareHealth(TEST_REQUEST_TIMEOUT, remoteIndex)
                 .setWaitForYellowStatus()
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .get()

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingFileSettingsIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingFileSettingsIT.java
@@ -134,7 +134,7 @@ public class AutoscalingFileSettingsIT extends AutoscalingIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
 
         ReservedStateMetadata reservedState = clusterStateResponse.getState()

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
@@ -41,7 +41,7 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
         );
         assertAcked(client().execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());
         // now verify that the policy is not in the cluster state
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final AutoscalingMetadata metadata = state.metadata().custom(AutoscalingMetadata.NAME);
         assertNotNull(metadata);
         assertThat(metadata.policies(), not(hasKey(policy.name())));

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
@@ -32,7 +32,7 @@ public class TransportPutAutoscalingPolicyActionIT extends AutoscalingIntegTestC
 
     public void testAddPolicy() {
         final AutoscalingPolicy policy = putRandomAutoscalingPolicy();
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final AutoscalingMetadata metadata = state.metadata().custom(AutoscalingMetadata.NAME);
         assertNotNull(metadata);
         assertThat(metadata.policies(), hasKey(policy.name()));
@@ -47,7 +47,7 @@ public class TransportPutAutoscalingPolicyActionIT extends AutoscalingIntegTestC
             mutateAutoscalingDeciders(policy.deciders())
         );
         putAutoscalingPolicy(updatedPolicy);
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final AutoscalingMetadata metadata = state.metadata().custom(AutoscalingMetadata.NAME);
         assertNotNull(metadata);
         assertThat(metadata.policies(), hasKey(policy.name()));

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
@@ -116,7 +116,7 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
         assertMinimumCapacity(capacity().results().get("frozen").requiredCapacity().node());
 
         assertThat(
-            clusterAdmin().prepareHealth().get().getStatus(),
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getStatus(),
             anyOf(equalTo(ClusterHealthStatus.YELLOW), equalTo(ClusterHealthStatus.GREEN))
         );
 

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -378,7 +378,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
             equalTo(requiredSpaceForShrink + ReactiveStorageDeciderService.NODE_DISK_OVERHEAD)
         );
 
-        assertThat(clusterAdmin().prepareHealth(shrinkName).get().getUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, shrinkName).get().getUnassignedShards(), equalTo(1));
 
         // test that the required amount is enough.
         // Adjust the amount since autoscaling calculates a node size to stay below low watermark though the shard can be
@@ -387,7 +387,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         assert tooLittleSpaceForShrink <= requiredSpaceForShrink;
         setTotalSpace(dataNode1Name, tooLittleSpaceForShrink);
         ClusterRerouteUtils.reroute(client());
-        assertThat(clusterAdmin().prepareHealth(shrinkName).get().getUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, shrinkName).get().getUnassignedShards(), equalTo(1));
         setTotalSpace(dataNode1Name, tooLittleSpaceForShrink + 1);
         ClusterRerouteUtils.reroute(client());
         ensureGreen();
@@ -488,7 +488,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
             equalTo(requiredSpaceForClone + ReactiveStorageDeciderService.NODE_DISK_OVERHEAD)
         );
 
-        assertThat(clusterAdmin().prepareHealth(cloneName).get().getUnassignedShards(), equalTo(resizedShardCount));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, cloneName).get().getUnassignedShards(), equalTo(resizedShardCount));
 
         // test that the required amount is enough.
         // Adjust the amount since autoscaling calculates a node size to stay below low watermark though the shard can be
@@ -497,7 +497,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         assert tooLittleSpaceForClone <= requiredSpaceForClone;
         setTotalSpace(dataNode1Name, tooLittleSpaceForClone);
         ClusterRerouteUtils.reroute(client());
-        assertThat(clusterAdmin().prepareHealth(cloneName).get().getUnassignedShards(), equalTo(resizedShardCount));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, cloneName).get().getUnassignedShards(), equalTo(resizedShardCount));
         setTotalSpace(dataNode1Name, requiredSpaceForClone);
         ClusterRerouteUtils.reroute(client());
         ensureGreen();

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -465,7 +465,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
             assertThat(
                 client.admin()
                     .cluster()
-                    .prepareState()
+                    .prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setIndices("copy-*")
                     .setMetadata(true)
@@ -564,7 +564,12 @@ public class AutoFollowIT extends CcrIntegTestCase {
 
         // check that all leader indices have been correctly auto followed
         List<String> matchingPrefixes = Arrays.stream(prefixes).map(prefix -> prefix + "*").collect(Collectors.toList());
-        for (IndexMetadata leaderIndexMetadata : leaderClient().admin().cluster().prepareState().get().getState().metadata()) {
+        for (IndexMetadata leaderIndexMetadata : leaderClient().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()) {
             final String leaderIndex = leaderIndexMetadata.getIndex().getName();
             if (Regex.simpleMatch(matchingPrefixes, leaderIndex)) {
                 String followingIndex = "copy-" + leaderIndex;
@@ -690,7 +695,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
             assertThat(autoFollowStats.getNumberOfSuccessfulFollowIndices(), equalTo(3L));
         });
 
-        final Metadata metadata = followerClient().admin().cluster().prepareState().get().getState().metadata();
+        final Metadata metadata = followerClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata();
         final DataStream dataStream = metadata.dataStreams().get(datastream);
         assertTrue(dataStream.getIndices().stream().anyMatch(i -> i.getName().equals(indexInDatastream)));
         assertEquals(IndexMetadata.State.OPEN, metadata.index(indexInDatastream).getState());

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrAliasesIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrAliasesIT.java
@@ -396,7 +396,7 @@ public class CcrAliasesIT extends CcrIntegTestCase {
 
     private CheckedRunnable<Exception> assertShardFollowTask(final int numberOfPrimaryShards) {
         return () -> {
-            final ClusterState clusterState = followerClient().admin().cluster().prepareState().get().getState();
+            final ClusterState clusterState = followerClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             final PersistentTasksCustomMetadata taskMetadata = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
             assertNotNull("task metadata for follower should exist", taskMetadata);
 

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -173,14 +173,14 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
 
         ClusterStateResponse leaderState = leaderClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(leaderIndex)
             .get();
         ClusterStateResponse followerState = followerClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(followerIndex)
@@ -402,7 +402,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
                 transportService.clearAllRules();
             }
 
-            settingsRequest = new ClusterUpdateSettingsRequest();
+            settingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
             TimeValue defaultValue = CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.getDefault(Settings.EMPTY);
             settingsRequest.persistentSettings(
                 Settings.builder().put(CcrSettings.INDICES_RECOVERY_ACTION_TIMEOUT_SETTING.getKey(), defaultValue)
@@ -417,7 +417,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
     }
 
     private ClusterUpdateSettingsRequest newSettingsRequest() {
-        return new ClusterUpdateSettingsRequest().masterNodeTimeout(TimeValue.MAX_VALUE);
+        return new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).masterNodeTimeout(TimeValue.MAX_VALUE);
     }
 
     public void testFollowerMappingIsUpdated() throws IOException {
@@ -482,7 +482,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
             assertEquals(restoreInfo.totalShards(), restoreInfo.successfulShards());
             assertEquals(0, restoreInfo.failedShards());
 
-            ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+            ClusterStateRequest clusterStateRequest = new ClusterStateRequest(TEST_REQUEST_TIMEOUT);
             clusterStateRequest.clear();
             clusterStateRequest.metadata(true);
             clusterStateRequest.indices(followerIndex);

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -118,7 +118,8 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
         final String followerIndex,
         final int numberOfDocuments
     ) throws IOException {
-        final ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest().masterNodeTimeout(TimeValue.MAX_VALUE);
+        final ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .masterNodeTimeout(TimeValue.MAX_VALUE);
         final String chunkSize = new ByteSizeValue(randomFrom(4, 128, 1024), ByteSizeUnit.KB).getStringRep();
         settingsRequest.persistentSettings(Settings.builder().put(CcrSettings.RECOVERY_CHUNK_SIZE.getKey(), chunkSize));
         assertAcked(followerClient().admin().cluster().updateSettings(settingsRequest).actionGet());
@@ -227,7 +228,12 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
         final CountDownLatch latch = new CountDownLatch(1);
 
         // block the recovery from completing; this ensures the background sync is still running
-        final ClusterStateResponse followerClusterState = followerClient().admin().cluster().prepareState().clear().setNodes(true).get();
+        final ClusterStateResponse followerClusterState = followerClient().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get();
         for (final DiscoveryNode senderNode : followerClusterState.getState().nodes()) {
             final MockTransportService senderTransportService = (MockTransportService) getFollowerCluster().getInstance(
                 TransportService.class,
@@ -303,7 +309,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
         final ClusterStateResponse leaderIndexClusterState = leaderClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(leaderIndex)
@@ -335,7 +341,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                     assertThat(Strings.toString(shardsStats.get(i)), currentRetentionLeases.values(), hasSize(1));
                     final ClusterStateResponse followerIndexClusterState = followerClient().admin()
                         .cluster()
-                        .prepareState()
+                        .prepareState(TEST_REQUEST_TIMEOUT)
                         .clear()
                         .setMetadata(true)
                         .setIndices(followerIndex)
@@ -378,7 +384,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 assertThat(Strings.toString(shardsStats.get(i)), currentRetentionLeases.values(), hasSize(1));
                 final ClusterStateResponse followerIndexClusterState = followerClient().admin()
                     .cluster()
-                    .prepareState()
+                    .prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setMetadata(true)
                     .setIndices(followerIndex)
@@ -430,7 +436,12 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
             randomSubsetOf(randomIntBetween(0, numberOfShards), IntStream.range(0, numberOfShards).boxed().collect(Collectors.toSet()))
         );
 
-        final ClusterStateResponse followerClusterState = followerClient().admin().cluster().prepareState().clear().setNodes(true).get();
+        final ClusterStateResponse followerClusterState = followerClient().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get();
         try {
             for (final DiscoveryNode senderNode : followerClusterState.getState().nodes()) {
                 final MockTransportService senderTransportService = (MockTransportService) getFollowerCluster().getInstance(
@@ -523,7 +534,12 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
             randomSubsetOf(randomIntBetween(1, numberOfShards), IntStream.range(0, numberOfShards).boxed().collect(Collectors.toSet()))
         );
 
-        final ClusterStateResponse followerClusterState = followerClient().admin().cluster().prepareState().clear().setNodes(true).get();
+        final ClusterStateResponse followerClusterState = followerClient().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get();
         try {
             for (final DiscoveryNode senderNode : followerClusterState.getState().nodes()) {
                 final MockTransportService senderTransportService = (MockTransportService) getFollowerCluster().getInstance(
@@ -554,7 +570,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
             final ClusterStateResponse followerIndexClusterState = followerClient().admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setMetadata(true)
                 .setIndices(followerIndex)
@@ -563,7 +579,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
             final ClusterStateResponse leaderIndexClusterState = leaderClient().admin()
                 .cluster()
-                .prepareState()
+                .prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setMetadata(true)
                 .setIndices(leaderIndex)
@@ -712,7 +728,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
         final ClusterStateResponse leaderIndexClusterState = leaderClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(leaderIndex)
@@ -743,7 +759,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                     assertThat(Strings.toString(shardsStats.get(i)), currentRetentionLeases.values(), hasSize(1));
                     final ClusterStateResponse followerIndexClusterState = followerClient().admin()
                         .cluster()
-                        .prepareState()
+                        .prepareState(TEST_REQUEST_TIMEOUT)
                         .clear()
                         .setMetadata(true)
                         .setIndices(followerIndex)
@@ -786,7 +802,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 assertThat(Strings.toString(shardsStats.get(i)), currentRetentionLeases.values(), hasSize(1));
                 final ClusterStateResponse followerIndexClusterState = followerClient().admin()
                     .cluster()
-                    .prepareState()
+                    .prepareState(TEST_REQUEST_TIMEOUT)
                     .clear()
                     .setMetadata(true)
                     .setIndices(followerIndex)
@@ -847,7 +863,12 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
         final CountDownLatch latch = new CountDownLatch(1);
 
-        final ClusterStateResponse followerClusterState = followerClient().admin().cluster().prepareState().clear().setNodes(true).get();
+        final ClusterStateResponse followerClusterState = followerClient().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get();
         try {
             for (final DiscoveryNode senderNode : followerClusterState.getState().nodes()) {
                 final MockTransportService senderTransportService = (MockTransportService) getFollowerCluster().getInstance(
@@ -956,7 +977,12 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
         final CountDownLatch unfollowLatch = new CountDownLatch(1);
         final CountDownLatch responseLatch = new CountDownLatch(1);
 
-        final ClusterStateResponse followerClusterState = followerClient().admin().cluster().prepareState().clear().setNodes(true).get();
+        final ClusterStateResponse followerClusterState = followerClient().admin()
+            .cluster()
+            .prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get();
 
         try {
             for (final DiscoveryNode senderNode : followerClusterState.getState().nodes()) {
@@ -1054,7 +1080,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
         final ClusterStateResponse followerIndexClusterState = followerClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(followerIndex)
@@ -1166,7 +1192,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
     private String getRetentionLeaseId(final String followerIndex, final String leaderIndex) {
         final ClusterStateResponse followerIndexClusterState = followerClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(followerIndex)
@@ -1175,7 +1201,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
 
         final ClusterStateResponse leaderIndexClusterState = leaderClient().admin()
             .cluster()
-            .prepareState()
+            .prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(leaderIndex)

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
@@ -106,7 +106,7 @@ public class CloseFollowerIndexIT extends CcrIntegTestCase {
         AcknowledgedResponse response = followerClient().admin().indices().close(closeIndexRequest).get();
         assertThat(response.isAcknowledged(), is(true));
 
-        ClusterState clusterState = followerClient().admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = followerClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().index("index2").getState(), is(IndexMetadata.State.CLOSE));
         assertThat(clusterState.getBlocks().hasIndexBlock("index2", MetadataIndexStateService.INDEX_CLOSED_BLOCK), is(true));
 
@@ -117,7 +117,7 @@ public class CloseFollowerIndexIT extends CcrIntegTestCase {
 
         assertAcked(followerClient().admin().indices().open(new OpenIndexRequest("index2").masterNodeTimeout(TimeValue.MAX_VALUE)).get());
 
-        clusterState = followerClient().admin().cluster().prepareState().get().getState();
+        clusterState = followerClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().index("index2").getState(), is(IndexMetadata.State.OPEN));
         assertThat(clusterState.getBlocks().hasIndexBlockWithId("index2", MetadataIndexStateService.INDEX_CLOSED_BLOCK_ID), is(false));
         ensureFollowerGreen("index2");

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/PrimaryFollowerAllocationIT.java
@@ -121,7 +121,7 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
         }
         // Empty follower primaries must be assigned to nodes with the remote cluster client role
         assertBusy(() -> {
-            final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState().get().getState();
+            final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
@@ -143,7 +143,7 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
             )
             .get();
         assertBusy(() -> {
-            final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState().get().getState();
+            final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);
@@ -160,7 +160,7 @@ public class PrimaryFollowerAllocationIT extends CcrIntegTestCase {
         getFollowerCluster().fullRestart();
         ensureFollowerGreen(followerIndex);
         assertBusy(() -> {
-            final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState().get().getState();
+            final ClusterState state = getFollowerCluster().client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             final IndexRoutingTable indexRoutingTable = state.routingTable().index(followerIndex);
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(shardId);

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
@@ -135,7 +135,8 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
     private void setupRemoteCluster() throws Exception {
         var remoteMaxPendingConnectionListeners = getRemoteMaxPendingConnectionListeners();
 
-        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest().masterNodeTimeout(TimeValue.MAX_VALUE);
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .masterNodeTimeout(TimeValue.MAX_VALUE);
         String address = getLeaderCluster().getAnyMasterNodeInstance(TransportService.class).boundAddress().publishAddress().toString();
         updateSettingsRequest.persistentSettings(Settings.builder().put("cluster.remote.leader_cluster.seeds", address));
         assertAcked(followerClient().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
@@ -161,7 +162,8 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
     }
 
     private void cleanRemoteCluster() throws Exception {
-        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest().masterNodeTimeout(TimeValue.MAX_VALUE);
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .masterNodeTimeout(TimeValue.MAX_VALUE);
         updateSettingsRequest.persistentSettings(Settings.builder().put("cluster.remote.leader_cluster.seeds", (String) null));
         assertAcked(followerClient().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -300,7 +300,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
                     CcrLicenseChecker.checkRemoteClusterLicenseAndFetchClusterState(
                         client,
                         remoteCluster,
-                        new ClusterStateRequest().clear()
+                        new ClusterStateRequest(waitForMetadataTimeOut).clear()
                             .metadata(true)
                             .routingTable(true)
                             .local(true)

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CcrRequests.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CcrRequests.java
@@ -34,7 +34,7 @@ public final class CcrRequests {
     private CcrRequests() {}
 
     public static ClusterStateRequest metadataRequest(String leaderIndex) {
-        ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+        ClusterStateRequest clusterStateRequest = new ClusterStateRequest(TimeValue.MAX_VALUE);
         clusterStateRequest.clear();
         clusterStateRequest.metadata(true);
         clusterStateRequest.indices(leaderIndex);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -133,7 +133,7 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
         CcrLicenseChecker.checkRemoteClusterLicenseAndFetchClusterState(
             client,
             request.getRemoteCluster(),
-            new ClusterStateRequest().clear().metadata(true),
+            new ClusterStateRequest(request.masterNodeTimeout()).clear().metadata(true),
             listener::onFailure,
             consumer
         );

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -166,7 +166,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
             threadPool.getThreadContext(),
             l -> getRemoteClusterClient().execute(
                 ClusterStateAction.REMOTE_TYPE,
-                new ClusterStateRequest().clear().metadata(true).nodes(true).masterNodeTimeout(TimeValue.MAX_VALUE),
+                new ClusterStateRequest(TimeValue.MAX_VALUE).clear().metadata(true).nodes(true),
                 l.map(ClusterStateResponse::getState)
             )
         );

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -409,7 +409,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
         String color = clusterHealthStatus.name().toLowerCase(Locale.ROOT);
         String method = "ensure" + Strings.capitalize(color);
 
-        ClusterHealthRequest healthRequest = new ClusterHealthRequest(indices).masterNodeTimeout(timeout)
+        ClusterHealthRequest healthRequest = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, indices).masterNodeTimeout(timeout)
             .timeout(timeout)
             .waitForStatus(clusterHealthStatus)
             .waitForEvents(Priority.LANGUID)
@@ -431,9 +431,9 @@ public abstract class CcrIntegTestCase extends ESTestCase {
                     follower cluster tasks:
                     {}""",
                 method,
-                leaderClient().admin().cluster().prepareState().get().getState(),
+                leaderClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState(),
                 ESIntegTestCase.getClusterPendingTasks(leaderClient()),
-                followerClient().admin().cluster().prepareState().get().getState(),
+                followerClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState(),
                 ESIntegTestCase.getClusterPendingTasks(followerClient())
             );
             HotThreads.logLocalHotThreads(logger, Level.INFO, "hot threads at timeout", ReferenceDocs.LOGGING);
@@ -502,7 +502,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
                 empty()
             );
 
-            final ClusterState clusterState = followerClient().admin().cluster().prepareState().get().getState();
+            final ClusterState clusterState = followerClient().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             PersistentTasksCustomMetadata tasks = clusterState.metadata().custom(PersistentTasksCustomMetadata.TYPE);
             Collection<PersistentTasksCustomMetadata.PersistentTask<?>> ccrTasks = tasks.tasks()
                 .stream()
@@ -661,7 +661,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
     }
 
     private Map<Integer, List<DocIdSeqNoAndSource>> getDocIdAndSeqNos(InternalTestCluster cluster, String index) throws IOException {
-        final ClusterState state = cluster.client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = cluster.client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> shardRoutings = state.routingTable().allShards(index);
         Randomness.shuffle(shardRoutings);
         final Map<Integer, List<DocIdSeqNoAndSource>> docs = new HashMap<>();

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrSingleNodeTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrSingleNodeTestCase.java
@@ -61,7 +61,7 @@ public abstract class CcrSingleNodeTestCase extends ESSingleNodeTestCase {
 
     @Before
     public void setupLocalRemote() throws Exception {
-        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         String address = getInstanceFromNode(TransportService.class).boundAddress().publishAddress().toString();
         updateSettingsRequest.transientSettings(Settings.builder().put("cluster.remote.local.seeds", address));
         assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
@@ -84,7 +84,7 @@ public abstract class CcrSingleNodeTestCase extends ESSingleNodeTestCase {
 
     @After
     public void removeLocalRemote() throws Exception {
-        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         updateSettingsRequest.transientSettings(Settings.builder().put("cluster.remote.local.seeds", (String) null));
         assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
 

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/nodesinfo/ComponentVersionsNodesInfoIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/nodesinfo/ComponentVersionsNodesInfoIT.java
@@ -19,7 +19,10 @@ public class ComponentVersionsNodesInfoIT extends ESIntegTestCase {
     public void testNodesInfoComponentVersions() {
         final String node_1 = internalCluster().startNode();
 
-        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("1").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+            .setWaitForGreenStatus()
+            .setWaitForNodes("1")
+            .get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = getNodeId(node_1);

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotIT.java
@@ -349,11 +349,23 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> delete index and stop the data node");
         assertAcked(client().admin().indices().prepareDelete(sourceIdx).get());
         internalCluster().stopRandomDataNode();
-        assertFalse(clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("1").get().isTimedOut());
+        assertFalse(
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+                .setTimeout(TimeValue.timeValueSeconds(30))
+                .setWaitForNodes("1")
+                .get()
+                .isTimedOut()
+        );
 
         final String newDataNode = internalCluster().startDataOnlyNode();
         logger.info("--> start a new data node " + newDataNode);
-        assertFalse(clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("2").get().isTimedOut());
+        assertFalse(
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT)
+                .setTimeout(TimeValue.timeValueSeconds(30))
+                .setWaitForNodes("2")
+                .get()
+                .isTimedOut()
+        );
 
         logger.info("--> restore the index and ensure all shards are allocated");
         RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, repo, snapshot)

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderIT.java
@@ -76,7 +76,10 @@ public class DataTierAllocationDeciderIT extends ESIntegTestCase {
         assertThat(DataTier.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_CONTENT));
 
         // index should be red
-        assertThat(clusterAdmin().prepareHealth(index).get().getIndices().get(index).getStatus(), equalTo(ClusterHealthStatus.RED));
+        assertThat(
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, index).get().getIndices().get(index).getStatus(),
+            equalTo(ClusterHealthStatus.RED)
+        );
 
         if (randomBoolean()) {
             logger.info("--> starting content node");
@@ -518,7 +521,14 @@ public class DataTierAllocationDeciderIT extends ESIntegTestCase {
     private void updateDesiredNodes(List<DesiredNode> desiredNodes) {
         assertThat(desiredNodes.size(), is(greaterThan(0)));
 
-        final var request = new UpdateDesiredNodesRequest(randomAlphaOfLength(10), 1, desiredNodes, false);
+        final var request = new UpdateDesiredNodesRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            randomAlphaOfLength(10),
+            1,
+            desiredNodes,
+            false
+        );
         internalCluster().client().execute(UpdateDesiredNodesAction.INSTANCE, request).actionGet();
     }
 
@@ -533,7 +543,7 @@ public class DataTierAllocationDeciderIT extends ESIntegTestCase {
     }
 
     private DiscoveryNode getPrimaryShardAssignedNode(int shard) {
-        final var state = clusterAdmin().prepareState().get().getState();
+        final var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final var routingTable = state.routingTable().index(index).shard(shard);
         final var primaryShard = routingTable.primaryShard();
         final var discoveryNode = state.nodes().get(primaryShard.currentNodeId());

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierShardAvailabilityHealthIndicatorIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierShardAvailabilityHealthIndicatorIT.java
@@ -183,7 +183,7 @@ public class DataTierShardAvailabilityHealthIndicatorIT extends ESIntegTestCase 
     }
 
     private String findNodeWithShard(final String indexName, final int shard, final boolean primary) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
         startedShards = startedShards.stream()
             .filter(shardRouting -> shardRouting.getIndexName().equals(indexName))

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
@@ -72,8 +72,7 @@ public class AnnotationIndex {
     ) {
 
         final ActionListener<Boolean> annotationsIndexCreatedListener = finalListener.delegateFailureAndWrap((delegate, success) -> {
-            final ClusterHealthRequest request = new ClusterHealthRequest(READ_ALIAS_NAME).waitForYellowStatus()
-                .masterNodeTimeout(masterNodeTimeout);
+            final ClusterHealthRequest request = new ClusterHealthRequest(masterNodeTimeout, READ_ALIAS_NAME).waitForYellowStatus();
             executeAsyncWithOrigin(
                 client,
                 ML_ORIGIN,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -103,9 +103,10 @@ public final class AnomalyDetectorsIndex {
         final ActionListener<Boolean> finalListener
     ) {
         final ActionListener<Boolean> stateIndexAndAliasCreated = finalListener.delegateFailureAndWrap((delegate, success) -> {
-            final ClusterHealthRequest request = new ClusterHealthRequest(AnomalyDetectorsIndex.jobStateIndexWriteAlias())
-                .waitForYellowStatus()
-                .masterNodeTimeout(masterNodeTimeout);
+            final ClusterHealthRequest request = new ClusterHealthRequest(
+                masterNodeTimeout,
+                AnomalyDetectorsIndex.jobStateIndexWriteAlias()
+            ).waitForYellowStatus();
             executeAsyncWithOrigin(
                 client,
                 ML_ORIGIN,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -224,10 +224,9 @@ public final class MlIndexAndAlias {
     }
 
     private static void waitForShardsReady(Client client, String index, TimeValue masterNodeTimeout, ActionListener<Boolean> listener) {
-        ClusterHealthRequest healthRequest = new ClusterHealthRequest(index).waitForYellowStatus()
+        ClusterHealthRequest healthRequest = new ClusterHealthRequest(masterNodeTimeout, index).waitForYellowStatus()
             .waitForNoRelocatingShards(true)
-            .waitForNoInitializingShards(true)
-            .masterNodeTimeout(masterNodeTimeout);
+            .waitForNoInitializingShards(true);
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),
             ML_ORIGIN,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -70,7 +70,7 @@ public class ClientHelperTests extends ESTestCase {
             latch.countDown();
         });
 
-        final ClusterHealthRequest request = new ClusterHealthRequest();
+        final ClusterHealthRequest request = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT);
         threadContext.putHeader(headerName, headerValue);
 
         ClientHelper.executeAsyncWithOrigin(threadContext, origin, request, listener, (req, listener1) -> {
@@ -110,7 +110,13 @@ public class ClientHelperTests extends ESTestCase {
         }).when(client).execute(any(), any(), any());
 
         threadContext.putHeader(headerName, headerValue);
-        ClientHelper.executeAsyncWithOrigin(client, origin, TransportClusterHealthAction.TYPE, new ClusterHealthRequest(), listener);
+        ClientHelper.executeAsyncWithOrigin(
+            client,
+            origin,
+            TransportClusterHealthAction.TYPE,
+            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT),
+            listener
+        );
 
         latch.await();
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncSearchIndexServiceTests.java
@@ -360,7 +360,10 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
 
             // setting very small limit for the max size of async search response
             int limit = randomIntBetween(1, 125);
-            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             updateSettingsRequest.transientSettings(Settings.builder().put("search.max_async_search_response_size", limit + "b"));
             assertAcked(clusterAdmin().updateSettings(updateSettingsRequest).actionGet());
             String expectedErrMsg = "Can't store an async search response larger than ["
@@ -393,7 +396,10 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
             assertEquals(expectedErrMsg, e2.getMessage());
         } finally {
             // restoring limit
-            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             updateSettingsRequest.transientSettings(Settings.builder().put("search.max_async_search_response_size", (String) null));
             assertAcked(clusterAdmin().updateSettings(updateSettingsRequest).actionGet());
         }

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1176,7 +1176,11 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             .map(mappingMetadata -> mappingMetadata.getValue().sourceAsMap())
             .orElseThrow(() -> new IllegalArgumentException("No mapping found for downsample source index [" + sourceIndex + "]"));
 
-        final IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().getMetadata().index(sourceIndex);
+        final IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .getMetadata()
+            .index(sourceIndex);
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         final MapperService mapperService = indicesService.createIndexMapperServiceForValidation(indexMetadata);
         final CompressedXContent sourceIndexCompressedXContent = new CompressedXContent(sourceIndexMappings);

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -203,7 +203,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
         var getTaskRequest = new GetTaskRequest().setTaskId(executePolicyResponse.getTaskId()).setWaitForCompletion(true);
         clusterAdmin().getTask(getTaskRequest).actionGet();
 
-        var discoNodes = clusterAdmin().state(new ClusterStateRequest()).actionGet().getState().nodes();
+        var discoNodes = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState().nodes();
         assertThat(discoNodes.get(executePolicyResponse.getTaskId().getNodeId()).isMasterNode(), is(false));
     }
 
@@ -230,7 +230,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
         var getTaskRequest = new GetTaskRequest().setTaskId(executePolicyResponse.getTaskId()).setWaitForCompletion(true);
         clusterAdmin().getTask(getTaskRequest).actionGet();
 
-        var discoNodes = clusterAdmin().state(new ClusterStateRequest()).actionGet().getState().nodes();
+        var discoNodes = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState().nodes();
         assertThat(executePolicyResponse.getTaskId().getNodeId(), not(equalTo(discoNodes.getMasterNodeId())));
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -51,6 +51,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.Mapper;
@@ -684,7 +685,10 @@ public class EnrichPolicyRunner {
     }
 
     private void waitForIndexGreen(ActionListener<ClusterHealthResponse> listener) {
-        ClusterHealthRequest request = new ClusterHealthRequest(enrichIndexName).waitForGreenStatus();
+        ClusterHealthRequest request = new ClusterHealthRequest(
+            TimeValue.THIRTY_SECONDS /* TODO should this be longer/configurable? */ ,
+            enrichIndexName
+        ).waitForGreenStatus();
         enrichOriginClient().admin().cluster().health(request, listener);
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
@@ -136,7 +136,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
             Settings settings = Settings.builder()
                 .put(DestructiveOperations.REQUIRES_NAME_SETTING.getKey(), destructiveRequiresName)
                 .build();
-            assertAcked(clusterAdmin().prepareUpdateSettings().setPersistentSettings(settings));
+            assertAcked(clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setPersistentSettings(settings));
         }
 
         createIndex(EnrichPolicy.getIndexName(name, 1001));
@@ -174,7 +174,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
 
         if (destructiveRequiresName) {
             Settings settings = Settings.builder().putNull(DestructiveOperations.REQUIRES_NAME_SETTING.getKey()).build();
-            assertAcked(clusterAdmin().prepareUpdateSettings().setPersistentSettings(settings));
+            assertAcked(clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setPersistentSettings(settings));
         }
 
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -118,14 +118,14 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
     protected void setRequestCircuitBreakerLimit(ByteSizeValue limit) {
         if (limit != null) {
             assertAcked(
-                clusterAdmin().prepareUpdateSettings()
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(
                         Settings.builder().put(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), limit).build()
                     )
             );
         } else {
             assertAcked(
-                clusterAdmin().prepareUpdateSettings()
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                     .setPersistentSettings(
                         Settings.builder().putNull(HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING.getKey()).build()
                     )

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
@@ -128,7 +128,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
     void waitForNoInitializingShards(Client client, TimeValue timeout, String... indices) {
         ClusterHealthResponse resp = client.admin()
             .cluster()
-            .prepareHealth(indices)
+            .prepareHealth(TEST_REQUEST_TIMEOUT, indices)
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setWaitForNoInitializingShards(true)

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1643,7 +1643,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
 
         Settings settings = Settings.builder().put(EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getKey(), 1).build();
 
-        ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest().persistentSettings(settings);
+        ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .persistentSettings(settings);
 
         client.updateSettings(settingsRequest).actionGet();
         try (EsqlQueryResponse results = run("from test")) {
@@ -1659,7 +1660,8 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
 
         Settings settings = Settings.builder().put(EsqlPlugin.QUERY_RESULT_TRUNCATION_MAX_SIZE.getKey(), 10).build();
 
-        ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest().persistentSettings(settings);
+        ClusterUpdateSettingsRequest settingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .persistentSettings(settings);
 
         client.updateSettings(settingsRequest).actionGet();
         try (EsqlQueryResponse results = run("from test | limit 40")) {
@@ -1677,7 +1679,9 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
             clearedSettings.putNull(s.getKey());
         }
 
-        var clearSettingsRequest = new ClusterUpdateSettingsRequest().persistentSettings(clearedSettings.build());
+        var clearSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(
+            clearedSettings.build()
+        );
         admin().cluster().updateSettings(clearSettingsRequest).actionGet();
     }
 

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -96,7 +96,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
         final String excludeSetting = INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getConcreteSettingForNamespace("_name").getKey();
         updateIndexSettings(Settings.builder().put(excludeSetting, nodeNames.get(0)), "index");
         ClusterRerouteUtils.reroute(client(), new CancelAllocationCommand("index", 0, nodeNames.get(0), true));
-        assertThat(clusterAdmin().prepareHealth("index").get().getUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index").get().getUnassignedShards(), equalTo(1));
 
         assertThat(client().prepareDelete("index", indexResponse.getId()).get().status(), equalTo(RestStatus.OK));
 
@@ -108,20 +108,20 @@ public class FrozenIndexIT extends ESIntegTestCase {
         );
 
         assertThat(
-            clusterAdmin().prepareState().get().getState().metadata().index("index").getTimestampRange(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index").getTimestampRange(),
             sameInstance(IndexLongFieldRange.EMPTY)
         );
 
         internalCluster().stopNode(nodeNames.get(1));
-        assertThat(clusterAdmin().prepareHealth("index").get().getUnassignedShards(), equalTo(2));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index").get().getUnassignedShards(), equalTo(2));
         updateIndexSettings(Settings.builder().putNull(excludeSetting), "index");
-        assertThat(clusterAdmin().prepareHealth("index").get().getUnassignedShards(), equalTo(2));
+        assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "index").get().getUnassignedShards(), equalTo(2));
 
         ClusterRerouteUtils.reroute(client(), new AllocateStalePrimaryAllocationCommand("index", 0, nodeNames.get(0), true));
 
         ensureYellowAndNoInitializingShards("index");
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("index");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index");
         final IndexLongFieldRange timestampFieldRange = indexMetadata.getTimestampRange();
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
@@ -129,7 +129,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
         assertThat(timestampFieldRange.getMin(), equalTo(Instant.parse(timestampVal).toEpochMilli()));
         assertThat(timestampFieldRange.getMax(), equalTo(Instant.parse(timestampVal).toEpochMilli()));
 
-        IndexLongFieldRange eventIngestedFieldRange = clusterAdmin().prepareState()
+        IndexLongFieldRange eventIngestedFieldRange = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .metadata()
@@ -188,7 +188,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
                 )
         );
 
-        final Index index = clusterAdmin().prepareState()
+        final Index index = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setIndices("index")
             .setMetadata(true)
@@ -292,7 +292,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
                 )
         );
 
-        final Index index = clusterAdmin().prepareState()
+        final Index index = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setIndices("index")
             .setMetadata(true)

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
@@ -317,7 +317,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
                     .indicesOptions(IndicesOptions.strictExpand())
             )
         );
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         assertEquals(IndexMetadata.State.CLOSE, stateResponse.getState().getMetadata().index("idx-closed").getState());
         assertEquals(IndexMetadata.State.OPEN, stateResponse.getState().getMetadata().index("idx").getState());
         assertHitCount(client().prepareSearch(), 1L);
@@ -516,7 +516,10 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             )
         );
         assertIndexFrozen("idx");
-        assertEquals(IndexMetadata.State.CLOSE, clusterAdmin().prepareState().get().getState().metadata().index("idx-close").getState());
+        assertEquals(
+            IndexMetadata.State.CLOSE,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("idx-close").getState()
+        );
     }
 
     public void testUnfreezeClosedIndex() {
@@ -525,7 +528,10 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "idx")).actionGet()
         );
         assertAcked(indicesAdmin().prepareClose("idx"));
-        assertEquals(IndexMetadata.State.CLOSE, clusterAdmin().prepareState().get().getState().metadata().index("idx").getState());
+        assertEquals(
+            IndexMetadata.State.CLOSE,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("idx").getState()
+        );
         expectThrows(
             IndexNotFoundException.class,
             client().execute(
@@ -545,7 +551,10 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
                 new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "idx").setFreeze(false)
             ).actionGet()
         );
-        assertEquals(IndexMetadata.State.OPEN, clusterAdmin().prepareState().get().getState().metadata().index("idx").getState());
+        assertEquals(
+            IndexMetadata.State.OPEN,
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("idx").getState()
+        );
     }
 
     public void testFreezeIndexIncreasesIndexSettingsVersion() {
@@ -553,14 +562,19 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         createIndex(index, indexSettings(1, 0).build());
         prepareIndex(index).setSource("field", "value").get();
 
-        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index(index).getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index(index)
+            .getSettingsVersion();
 
         assertAcked(
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, index)).actionGet()
         );
         assertIndexFrozen(index);
         assertThat(
-            clusterAdmin().prepareState().get().getState().metadata().index(index).getSettingsVersion(),
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index(index).getSettingsVersion(),
             greaterThan(settingsVersion)
         );
     }
@@ -577,7 +591,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
 
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         assertBusy(() -> {
-            final Index index = clusterAdmin().prepareState().get().getState().metadata().index(indexName).getIndex();
+            final Index index = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index(indexName).getIndex();
             final IndexService indexService = indicesService.indexService(index);
             assertThat(indexService.hasShard(0), is(true));
             assertThat(indexService.getShard(0).getLastKnownGlobalCheckpoint(), greaterThanOrEqualTo(nbNoOps - 1L));
@@ -606,7 +620,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         );
         assertIndexFrozen(indexName);
 
-        final IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index(indexName);
+        final IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index(indexName);
         final IndexService indexService = getInstanceFromNode(IndicesService.class).indexService(indexMetadata.getIndex());
         for (int i = 0; i < indexMetadata.getNumberOfShards(); i++) {
             final IndexShard indexShard = indexService.getShardOrNull(i);
@@ -674,7 +688,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "index")).actionGet()
         );
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("index");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index");
         final IndexLongFieldRange timestampFieldRange = indexMetadata.getTimestampRange();
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
@@ -706,7 +720,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "index")).actionGet()
         );
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("index");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index");
         final IndexLongFieldRange timestampFieldRange = indexMetadata.getTimestampRange();
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(timestampFieldRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
@@ -728,7 +742,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "index")).actionGet()
         );
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("index");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index");
         final IndexLongFieldRange eventIngestedRange = indexMetadata.getEventIngestedRange();
         assertThat(eventIngestedRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(eventIngestedRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
@@ -760,7 +774,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "index")).actionGet()
         );
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("index");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index");
         final IndexLongFieldRange eventIngestedRange = indexMetadata.getEventIngestedRange();
         assertThat(eventIngestedRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));
         assertThat(eventIngestedRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
@@ -784,7 +798,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "index")).actionGet()
         );
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("index");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().metadata().index("index");
 
         final IndexLongFieldRange eventIngestedRange = indexMetadata.getEventIngestedRange();
         assertThat(eventIngestedRange, not(sameInstance(IndexLongFieldRange.UNKNOWN)));

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -180,7 +180,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         logger.info("Creating index [test]");
         CreateIndexResponse createIndexResponse = indicesAdmin().create(new CreateIndexRequest("test").settings(settings)).actionGet();
         assertAcked(createIndexResponse);
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         RoutingNode routingNodeEntry1 = clusterState.getRoutingNodes().node(node1);
         assertThat(routingNodeEntry1.numberOfShardsWithState(STARTED), equalTo(1));
         assertBusy(() -> { assertTrue(indexExists("test")); });
@@ -188,7 +188,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         assertThat(indexLifecycleService.getScheduler().jobCount(), equalTo(1));
         assertNotNull(indexLifecycleService.getScheduledJob());
         assertBusy(() -> {
-            LifecycleExecutionState lifecycleState = clusterAdmin().prepareState()
+            LifecycleExecutionState lifecycleState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .getMetadata()
@@ -425,13 +425,13 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         CreateIndexResponse createIndexResponse = indicesAdmin().create(new CreateIndexRequest("test").settings(settings)).actionGet();
         assertAcked(createIndexResponse);
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         RoutingNode routingNodeEntry1 = clusterState.getRoutingNodes().node(node2);
         assertThat(routingNodeEntry1.numberOfShardsWithState(STARTED), equalTo(1));
 
         assertBusy(() -> assertTrue(indexExists("test")));
         assertBusy(() -> {
-            LifecycleExecutionState lifecycleState = clusterAdmin().prepareState()
+            LifecycleExecutionState lifecycleState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .get()
                 .getState()
                 .getMetadata()

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -91,7 +91,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         indexDocs(logger, "data-1", numDocs, twoWeeksAgo, oneWeekAgo);
 
         client().admin().indices().prepareCreate("data-2").setMapping("time", "type=date").get();
-        clusterAdmin().prepareHealth("data-1", "data-2").setWaitForYellowStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "data-1", "data-2").setWaitForYellowStatus().get();
         long numDocs2 = randomIntBetween(32, 2048);
         indexDocs(logger, "data-2", numDocs2, oneWeekAgo, now);
 
@@ -137,7 +137,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
         long twoWeeksAgo = oneWeekAgo - 604800000;
         indexDocs(logger, "datafeed_data_stream", numDocs, twoWeeksAgo, oneWeekAgo);
 
-        clusterAdmin().prepareHealth("datafeed_data_stream").setWaitForYellowStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, "datafeed_data_stream").setWaitForYellowStatus().get();
 
         Job.Builder job = createScheduledJob("lookback-data-stream-job");
         PutJobAction.Response putJobResponse = putJob(job);
@@ -320,7 +320,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
             Intervals.alignToCeil(oneWeekAgo, intervalMillis),
             Intervals.alignToFloor(now, intervalMillis)
         );
-        clusterAdmin().prepareHealth(indexName).setWaitForYellowStatus().get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).setWaitForYellowStatus().get();
 
         String scrollJobId = "stop-restart-scroll";
         Job.Builder scrollJob = createScheduledJob(scrollJobId);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -281,7 +281,7 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
     }
 
     protected Collection<PersistentTasksCustomMetadata.PersistentTask<?>> analyticsTaskList() {
-        ClusterState masterClusterState = clusterAdmin().prepareState().all().get().getState();
+        ClusterState masterClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
         PersistentTasksCustomMetadata persistentTasks = masterClusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         return persistentTasks != null
             ? persistentTasks.findTasks(MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME, task -> true)

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -279,7 +279,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
     }
 
     protected boolean upgradeMode() {
-        ClusterState masterClusterState = clusterAdmin().prepareState().all().get().getState();
+        ClusterState masterClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
         MlMetadata mlMetadata = MlMetadata.getMlMetadata(masterClusterState);
         return mlMetadata.isUpgradeMode();
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
@@ -62,7 +62,7 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
             hasSize(2)
         );
 
-        ClusterState masterClusterState = clusterAdmin().prepareState().all().get().getState();
+        ClusterState masterClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
 
         PersistentTasksCustomMetadata persistentTasks = masterClusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         assertThat(persistentTasks.findTasks(MlTasks.DATAFEED_TASK_NAME, task -> true), hasSize(1));
@@ -71,7 +71,7 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
         // Set the upgrade mode setting
         setUpgradeModeTo(true);
 
-        masterClusterState = clusterAdmin().prepareState().all().get().getState();
+        masterClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
 
         // Assert state for tasks still exists and that the upgrade setting is set
         persistentTasks = masterClusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
@@ -99,7 +99,7 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
         // Disable the setting
         setUpgradeModeTo(false);
 
-        masterClusterState = clusterAdmin().prepareState().all().get().getState();
+        masterClusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).all().get().getState();
 
         persistentTasks = masterClusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         assertThat(persistentTasks.findTasks(MlTasks.DATAFEED_TASK_NAME, task -> true), hasSize(1));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -133,7 +133,9 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
         client().execute(DeletePipelineTransportAction.TYPE, new DeletePipelineRequest("feature_reset_inference_pipeline")).actionGet();
         createdPipelines.remove("feature_reset_inference_pipeline");
 
-        assertBusy(() -> assertThat(countInferenceProcessors(clusterAdmin().prepareState().get().getState()), equalTo(0)));
+        assertBusy(
+            () -> assertThat(countInferenceProcessors(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState()), equalTo(0))
+        );
         client().execute(ResetFeatureStateAction.INSTANCE, new ResetFeatureStateRequest(TEST_REQUEST_TIMEOUT)).actionGet();
         assertBusy(() -> {
             List<String> indices = Arrays.asList(client().admin().indices().prepareGetIndex().addIndices(".ml*").get().indices());
@@ -224,7 +226,7 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
     }
 
     private boolean isResetMode() {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         return MlMetadata.getMlMetadata(state).isResetMode();
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -251,7 +251,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
             DatafeedState datafeedState = getDatafeedStats(datafeedId).getDatafeedState();
             assertEquals(DatafeedState.STOPPED, datafeedState);
 
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = findTasks(state, RELATED_TASKS);
             assertEquals(0, tasks.size());
         });
@@ -276,7 +276,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
             DatafeedState datafeedState = getDatafeedStats(datafeedId).getDatafeedState();
             assertEquals(DatafeedState.STARTED, datafeedState);
 
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = findTasks(state, RELATED_TASKS);
             assertEquals(2, tasks.size());
         });
@@ -296,7 +296,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
             DatafeedState datafeedState = getDatafeedStats(datafeedId).getDatafeedState();
             assertEquals(DatafeedState.STOPPED, datafeedState);
 
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = findTasks(state, RELATED_TASKS);
             assertEquals(0, tasks.size());
         });
@@ -336,7 +336,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         assertBusy(() -> {
             JobState jobState = getJobStats(jobId).getState();
             assertEquals(JobState.CLOSED, jobState);
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = findTasks(state, RELATED_TASKS);
             assertEquals(0, tasks.size());
         });

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -230,7 +230,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         OpenJobAction.Request openJobRequest = new OpenJobAction.Request(job.getId());
         client().execute(OpenJobAction.INSTANCE, openJobRequest).actionGet();
         assertBusy(() -> {
-            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+            ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             PersistentTasksCustomMetadata tasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
             PersistentTask<?> task = tasks.getTask(MlTasks.jobTaskId(jobId));
 
@@ -328,7 +328,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         }
         ensureStableCluster(1, nonMlNode);
         assertBusy(() -> {
-            ClusterState state = client(nonMlNode).admin().cluster().prepareState().get().getState();
+            ClusterState state = client(nonMlNode).admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTask<?>> tasks = findTasks(state, MlTasks.JOB_TASK_NAME);
             assertEquals(numJobs, tasks.size());
             for (PersistentTask<?> task : tasks) {
@@ -411,7 +411,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         CloseJobAction.Request closeJobRequest = new CloseJobAction.Request(jobId);
         client().execute(CloseJobAction.INSTANCE, closeJobRequest).actionGet();
         assertBusy(() -> {
-            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+            ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTask<?>> tasks = findTasks(clusterState, MlTasks.JOB_TASK_NAME);
             assertEquals(0, tasks.size());
         });
@@ -502,7 +502,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
     }
 
     private void assertJobTask(String jobId, JobState expectedState, boolean hasExecutorNode) {
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<PersistentTask<?>> tasks = findTasks(clusterState, MlTasks.JOB_TASK_NAME);
         assertEquals(1, tasks.size());
         PersistentTask<?> task = tasks.get(0);
@@ -524,7 +524,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
 
     private CheckedRunnable<Exception> checkAllJobsAreAssignedAndOpened(int numJobs) {
         return () -> {
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             List<PersistentTask<?>> tasks = findTasks(state, MlTasks.JOB_TASK_NAME);
             assertEquals(numJobs, tasks.size());
             for (PersistentTask<?> task : tasks) {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
@@ -244,7 +244,7 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
     private void setSkipUnavailable(boolean skip) {
         client(LOCAL_CLUSTER).admin()
             .cluster()
-            .prepareUpdateSettings()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().put("cluster.remote." + REMOTE_CLUSTER + ".skip_unavailable", skip).build())
             .get();
     }
@@ -252,7 +252,7 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
     private void clearSkipUnavailable() {
         client(LOCAL_CLUSTER).admin()
             .cluster()
-            .prepareUpdateSettings()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
             .setPersistentSettings(Settings.builder().putNull("cluster.remote." + REMOTE_CLUSTER + ".skip_unavailable").build())
             .get();
     }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -135,7 +135,12 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
             Settings masterDataPathSettings = internalCluster().dataPathSettings(internalCluster().getMasterName());
             internalCluster().stopCurrentMasterNode();
             assertBusy(() -> {
-                ClusterState state = client(mlAndDataNode).admin().cluster().prepareState().setLocal(true).get().getState();
+                ClusterState state = client(mlAndDataNode).admin()
+                    .cluster()
+                    .prepareState(TEST_REQUEST_TIMEOUT)
+                    .setLocal(true)
+                    .get()
+                    .getState();
                 assertNull(state.nodes().getMasterNodeId());
             });
             logger.info("Restarting dedicated master node");

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -63,7 +63,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
             new GetJobsStatsAction.Request("close-failed-job-2")
         ).actionGet();
         assertEquals(statsResponse.getResponse().results().get(0).getState(), JobState.CLOSED);
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<PersistentTasksCustomMetadata.PersistentTask<?>> tasks = findTasks(state, MlTasks.JOB_TASK_NAME);
         assertEquals(1, tasks.size());
         // now just double check that the first job is still opened:
@@ -147,7 +147,10 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         boolean expectMemoryLimitBeforeCountLimit = maxJobsPerNodeDueToMemoryLimit < maxNumberOfJobsPerNode;
         for (int i = 1; i <= (clusterWideMaxNumberOfJobs + 1); i++) {
             if (i == 2 && testDynamicChange) {
-                ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest().persistentSettings(
+                ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest(
+                    TEST_REQUEST_TIMEOUT,
+                    TEST_REQUEST_TIMEOUT
+                ).persistentSettings(
                     Settings.builder().put(MachineLearning.MAX_OPEN_JOBS_PER_NODE.getKey(), maxNumberOfJobsPerNode).build()
                 );
                 client().execute(ClusterUpdateSettingsAction.INSTANCE, clusterUpdateSettingsRequest).actionGet();
@@ -215,7 +218,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
                     for (Client client : clients()) {
                         PersistentTasksCustomMetadata tasks = client.admin()
                             .cluster()
-                            .prepareState()
+                            .prepareState(TEST_REQUEST_TIMEOUT)
                             .get()
                             .getState()
                             .getMetadata()

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -74,7 +74,7 @@ public class MockClientBuilder {
         PlainActionFuture<ClusterHealthResponse> actionFuture = mock(PlainActionFuture.class);
         ClusterHealthRequestBuilder clusterHealthRequestBuilder = mock(ClusterHealthRequestBuilder.class);
 
-        when(clusterAdminClient.prepareHealth()).thenReturn(clusterHealthRequestBuilder);
+        when(clusterAdminClient.prepareHealth(any())).thenReturn(clusterHealthRequestBuilder);
         when(clusterHealthRequestBuilder.setWaitForYellowStatus()).thenReturn(clusterHealthRequestBuilder);
         when(clusterHealthRequestBuilder.execute()).thenReturn(actionFuture);
         when(actionFuture.actionGet()).thenReturn(mock(ClusterHealthResponse.class));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -513,7 +513,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
     }
 
     protected void assertRecentLastTaskStateChangeTime(String taskId, Duration howRecent, String queryNode) {
-        ClusterStateRequest csRequest = new ClusterStateRequest().clear().metadata(true);
+        ClusterStateRequest csRequest = new ClusterStateRequest(TEST_REQUEST_TIMEOUT).clear().metadata(true);
         ClusterStateResponse csResponse = client(queryNode).execute(ClusterStateAction.INSTANCE, csRequest).actionGet();
         PersistentTasksCustomMetadata tasks = csResponse.getState().getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         assertNotNull(tasks);

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterSslIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterSslIT.java
@@ -160,7 +160,7 @@ public class HttpExporterSslIT extends MonitoringIntegTestCase {
     }
 
     private ActionFuture<ClusterUpdateSettingsResponse> setVerificationMode(String name, SslVerificationMode mode) {
-        final ClusterUpdateSettingsRequest updateSettings = new ClusterUpdateSettingsRequest();
+        final ClusterUpdateSettingsRequest updateSettings = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         final String verificationModeName = randomBoolean() ? mode.name() : mode.name().toLowerCase(Locale.ROOT);
         final Settings settings = Settings.builder()
             .put("xpack.monitoring.exporters." + name + ".type", HttpExporter.TYPE)

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -207,7 +207,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         );
 
         final Settings settings = Settings.builder().put("cluster.metadata.display_name", "my cluster").build();
-        assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings));
+        assertAcked(clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(settings));
 
         whenExportersAreReady(() -> {
             assertBusy(() -> {
@@ -373,7 +373,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
             .put("xpack.monitoring.exporters._local.enabled", true)
             .build();
 
-        assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings));
+        assertAcked(clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(settings));
 
         assertBusy(() -> assertThat("[_local] exporter not enabled yet", getMonitoringUsageExportersDefined(), is(true)));
 
@@ -401,7 +401,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
             .putNull("cluster.metadata.display_name")
             .build();
 
-        assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings));
+        assertAcked(clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(settings));
 
         assertBusy(() -> assertThat("Exporters are not yet stopped", getMonitoringUsageExportersDefined(), is(false)));
         assertBusy(() -> {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsAction.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsAction.java
@@ -98,7 +98,11 @@ public class TransportMonitoringMigrateAlertsAction extends TransportMasterNodeA
             Settings.Builder decommissionAlertSetting = Settings.builder().put(Monitoring.MIGRATION_DECOMMISSION_ALERTS.getKey(), true);
             client.admin()
                 .cluster()
-                .prepareUpdateSettings()
+                .prepareUpdateSettings(
+                    request.masterNodeTimeout(),
+                    /* TODO expose separate ack timeout? use masterNodeTimeout() for now */
+                    request.masterNodeTimeout()
+                )
                 .setPersistentSettings(decommissionAlertSetting)
                 .execute(completeOnManagementThread(listener));
         } catch (Exception e) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MultiNodesStatsTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MultiNodesStatsTests.java
@@ -67,7 +67,7 @@ public class MultiNodesStatsTests extends MonitoringIntegTestCase {
         final int nbNodes = nodes;
         assertBusy(() -> {
             assertThat(cluster().size(), equalTo(nbNodes));
-            assertNoTimeout(clusterAdmin().prepareHealth().setWaitForNodes(Integer.toString(nbNodes)).get());
+            assertNoTimeout(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes(Integer.toString(nbNodes)).get());
         });
 
         enableMonitoringCollection();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTests.java
@@ -246,7 +246,7 @@ public class LocalExporterIntegTests extends LocalExporterIntegTestCase {
      * fields and belongs to the right data or timestamped index.
      */
     private void checkMonitoringDocs() {
-        ClusterStateResponse response = clusterAdmin().prepareState().get();
+        ClusterStateResponse response = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         String customTimeFormat = response.getState()
             .getMetadata()
             .persistentSettings()

--- a/x-pack/plugin/old-lucene-versions/src/internalClusterTest/java/org/elasticsearch/xpack/lucene/bwc/ArchiveLicenseIntegTests.java
+++ b/x-pack/plugin/old-lucene-versions/src/internalClusterTest/java/org/elasticsearch/xpack/lucene/bwc/ArchiveLicenseIntegTests.java
@@ -119,7 +119,7 @@ public class ArchiveLicenseIntegTests extends AbstractArchiveTestCase {
         assertBusy(
             () -> assertEquals(
                 ClusterHealthStatus.RED,
-                clusterAdmin().prepareHealth(indexName).get().getIndices().get(indexName).getStatus()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).get().getIndices().get(indexName).getStatus()
             )
         );
 

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/ProfilingTestCase.java
@@ -95,13 +95,13 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
 
     protected void waitForIndices(Collection<String> indices) throws Exception {
         assertBusy(() -> {
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             assertTrue("Timed out waiting for indices to be created", state.metadata().indices().keySet().containsAll(indices));
         });
     }
 
     protected void updateProfilingTemplatesEnabled(boolean newValue) {
-        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         request.persistentSettings(Settings.builder().put(ProfilingPlugin.PROFILING_TEMPLATES_ENABLED.getKey(), newValue).build());
         ClusterUpdateSettingsResponse response = clusterAdmin().updateSettings(request).actionGet();
         assertTrue("Update of profiling templates enabled setting is not acknowledged", response.isAcknowledged());

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -342,7 +342,7 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
     }
 
     protected DiscoveryNodes getDiscoveryNodes() {
-        return clusterAdmin().prepareState().clear().setNodes(true).get().getState().nodes();
+        return clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setNodes(true).get().getState().nodes();
     }
 
     protected void assertExecutorIsIdle(String executorName) throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -147,7 +147,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
         assertShardFolders(indexName, false);
 
         assertThat(
-            clusterAdmin().prepareState()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setMetadata(true)
                 .setIndices(indexName)
@@ -311,7 +311,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
         assertBusy(() -> assertShardFolders(restoredIndexName, true), 30, TimeUnit.SECONDS);
 
         assertThat(
-            clusterAdmin().prepareState()
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                 .clear()
                 .setMetadata(true)
                 .setIndices(restoredIndexName)
@@ -365,7 +365,9 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
 
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        final DiscoveryNode dataNode = randomFrom(clusterAdmin().prepareState().get().getState().nodes().getDataNodes().values());
+        final DiscoveryNode dataNode = randomFrom(
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getDataNodes().values()
+        );
 
         updateIndexSettings(
             Settings.builder()
@@ -378,7 +380,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
         );
 
         assertFalse(
-            clusterAdmin().prepareHealth(restoredIndexName)
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, restoredIndexName)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForEvents(Priority.LANGUID)
                 .get()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/PrevalidateNodeRemovalWithSearchableSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/PrevalidateNodeRemovalWithSearchableSnapshotIntegTests.java
@@ -52,7 +52,7 @@ public class PrevalidateNodeRemovalWithSearchableSnapshotIntegTests extends Base
         // Make sure the searchable snapshot index is red
         internalCluster().stopNode(node1);
         assertBusy(() -> {
-            ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(restoredIndexName)
+            ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, restoredIndexName)
                 .setWaitForStatus(ClusterHealthStatus.RED)
                 .setWaitForEvents(Priority.LANGUID)
                 .execute()
@@ -67,7 +67,8 @@ public class PrevalidateNodeRemovalWithSearchableSnapshotIntegTests extends Base
             case 2 -> req.setExternalIds(internalCluster().clusterService(node2).localNode().getExternalId());
             default -> throw new IllegalStateException("Unexpected value");
         }
-        PrevalidateNodeRemovalResponse resp = client().execute(PrevalidateNodeRemovalAction.INSTANCE, req.build()).get();
+        PrevalidateNodeRemovalResponse resp = client().execute(PrevalidateNodeRemovalAction.INSTANCE, req.build(TEST_REQUEST_TIMEOUT))
+            .get();
         assertTrue(resp.getPrevalidation().isSafe());
         assertThat(resp.getPrevalidation().message(), equalTo("all red indices are searchable snapshot indices"));
         assertThat(resp.getPrevalidation().nodes().size(), equalTo(1));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -1067,7 +1067,14 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
     }
 
     private IndexMetadata getIndexMetadata(String indexName) {
-        return clusterAdmin().prepareState().clear().setMetadata(true).setIndices(indexName).get().getState().metadata().index(indexName);
+        return clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setMetadata(true)
+            .setIndices(indexName)
+            .get()
+            .getState()
+            .metadata()
+            .index(indexName);
     }
 
     private void waitUntilRecoveryIsDone(String index) throws Exception {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -145,7 +145,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         assertShardFolders(indexName, false);
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState()
+        IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(indexName)
@@ -251,7 +251,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         ensureGreen(restoredIndexName);
         assertBusy(() -> assertShardFolders(restoredIndexName, true), 30, TimeUnit.SECONDS);
 
-        indexMetadata = clusterAdmin().prepareState()
+        indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(restoredIndexName)
@@ -285,7 +285,9 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        final DiscoveryNode dataNode = randomFrom(clusterAdmin().prepareState().get().getState().nodes().getDataNodes().values());
+        final DiscoveryNode dataNode = randomFrom(
+            clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getDataNodes().values()
+        );
 
         updateIndexSettings(
             Settings.builder()
@@ -298,7 +300,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         );
 
         assertFalse(
-            clusterAdmin().prepareHealth(restoredIndexName)
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, restoredIndexName)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForEvents(Priority.LANGUID)
                 .get()
@@ -630,7 +632,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
             ensureGreen(restoredIndexName);
 
-            final ClusterState state = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState();
+            final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setRoutingTable(true).get().getState();
             assertThat(
                 state.toString(),
                 state.routingTable().index(restoredIndexName).shard(0).size(),
@@ -751,7 +753,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         mountSnapshot(repositoryName, snapshotOne.getName(), indexName, indexName, Settings.EMPTY);
         ensureGreen(indexName);
 
-        final IndexMetadata indexMetadata = clusterAdmin().prepareState()
+        final IndexMetadata indexMetadata = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .setIndices(indexName)
@@ -1044,7 +1046,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         assertBusy(() -> {
             final RestoreInProgress restoreInProgress = RestoreInProgress.get(
-                clusterAdmin().prepareState().clear().setCustoms(true).get().getState()
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setCustoms(true).get().getState()
             );
             assertTrue(Strings.toString(restoreInProgress, true, true), restoreInProgress.isEmpty());
         });

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
@@ -148,7 +148,7 @@ public class SearchableSnapshotsLicenseIntegTests extends BaseFrozenSearchableSn
         assertBusy(
             () -> assertEquals(
                 ClusterHealthStatus.RED,
-                clusterAdmin().prepareHealth(indexName).get().getIndices().get(indexName).getStatus()
+                clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, indexName).get().getIndices().get(indexName).getStatus()
             )
         );
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocationIntegTests.java
@@ -50,7 +50,7 @@ public class SearchableSnapshotAllocationIntegTests extends BaseSearchableSnapsh
         setAllocation(EnableAllocationDecider.Allocation.ALL);
         ensureGreen(restoredIndex);
 
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertEquals(
             state.nodes().resolveNode(firstDataNode).getId(),
             state.routingTable().index(restoredIndex).shard(0).primaryShard().currentNodeId()
@@ -88,7 +88,7 @@ public class SearchableSnapshotAllocationIntegTests extends BaseSearchableSnapsh
         setAllocation(EnableAllocationDecider.Allocation.ALL);
         ensureGreen(restoredIndex);
 
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final Set<String> nodesWithCache = Set.of(
             state.nodes().resolveNode(firstDataNode).getId(),
             state.nodes().resolveNode(secondDataNode).getId()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDiskThresholdIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDiskThresholdIntegTests.java
@@ -241,7 +241,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
 
         // The cold/frozen data node has enough disk space to hold all the shards
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().setRoutingTable(true).get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setRoutingTable(true).get().getState();
             assertThat(
                 state.routingTable()
                     .allShards()
@@ -257,7 +257,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
         mountIndices(indicesStoresSizes.keySet(), "extra-", repositoryName, snapshot, storage);
 
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().setRoutingTable(true).get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setRoutingTable(true).get().getState();
             assertThat(
                 state.routingTable()
                     .allShards()
@@ -294,7 +294,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
         );
         ensureStableCluster(3);
 
-        String coldNodeId = clusterAdmin().prepareState().get().getState().nodes().resolveNode(coldNodeName).getId();
+        String coldNodeId = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().resolveNode(coldNodeName).getId();
         logger.info("--> reducing disk size of node [{}/{}] so that all shards except one can fit on the node", coldNodeName, coldNodeId);
         String indexToSkip = randomFrom(indicesStoresSizes.keySet());
         Map<String, Long> indicesToBeMounted = indicesStoresSizes.entrySet()
@@ -316,7 +316,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
         mountIndices(indicesToBeMounted.keySet(), prefix, repositoryName, snapshotName, FULL_COPY);
 
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().setRoutingTable(true).get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setRoutingTable(true).get().getState();
             assertThat(
                 state.routingTable()
                     .allShards()
@@ -333,7 +333,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
 
         mountIndices(List.of(indexToSkip), prefix, repositoryName, snapshotName, FULL_COPY);
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().setRoutingTable(true).get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setRoutingTable(true).get().getState();
             assertThat(state.routingTable().index(prefix + indexToSkip).shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
         });
 
@@ -343,7 +343,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
         mockRepository.unlockRestore();
 
         assertBusy(() -> {
-            var state = clusterAdmin().prepareState().setRoutingTable(true).get().getState();
+            var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setRoutingTable(true).get().getState();
             assertThat(state.routingTable().index(prefix + indexToSkip).shardsWithState(ShardRoutingState.UNASSIGNED).size(), equalTo(1));
             assertThat(
                 state.routingTable()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotEnableAllocationDeciderIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotEnableAllocationDeciderIntegTests.java
@@ -39,7 +39,8 @@ public class SearchableSnapshotEnableAllocationDeciderIntegTests extends BaseSea
             internalCluster().restartNode(indexNode);
         }
 
-        ClusterHealthResponse response = clusterAdmin().health(new ClusterHealthRequest(restoredIndexName)).actionGet();
+        ClusterHealthResponse response = clusterAdmin().health(new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, restoredIndexName))
+            .actionGet();
         assertThat(response.getUnassignedShards(), Matchers.equalTo(numPrimaries));
 
         setAllocateOnRollingRestart(true);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -58,7 +58,12 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
         final Set<String> indexNodes = restoredIndexNames.stream()
             .flatMap(index -> internalCluster().nodesInclude(index).stream())
             .collect(Collectors.toSet());
-        final ClusterState state = clusterAdmin().prepareState().clear().setRoutingTable(true).setNodes(true).get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setRoutingTable(true)
+            .setNodes(true)
+            .get()
+            .getState();
         final Map<String, String> nodeNameToId = state.getNodes()
             .stream()
             .collect(Collectors.toMap(DiscoveryNode::getName, DiscoveryNode::getId));
@@ -82,8 +87,9 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
                 @Override
                 public Settings onNodeStopped(String nodeName) throws Exception {
                     assertBusy(() -> {
-                        ClusterHealthResponse response = clusterAdmin().health(new ClusterHealthRequest(restoredIndexNamesArray))
-                            .actionGet();
+                        ClusterHealthResponse response = clusterAdmin().health(
+                            new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, restoredIndexNamesArray)
+                        ).actionGet();
                         assertThat(response.getUnassignedShards(), Matchers.equalTo(shards));
                     });
                     return super.onNodeStopped(nodeName);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotsRelocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotsRelocationIntegTests.java
@@ -75,10 +75,15 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
         });
 
         assertBusy(() -> assertSame(RecoveryState.Stage.FINALIZE, getRelocations(restoredIndex).get(0).getStage()));
-        final Index restoredIdx = clusterAdmin().prepareState().get().getState().metadata().index(restoredIndex).getIndex();
+        final Index restoredIdx = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .get()
+            .getState()
+            .metadata()
+            .index(restoredIndex)
+            .getIndex();
         final IndicesService indicesService = internalCluster().getInstance(IndicesService.class, secondDataNode);
         assertEquals(1, indicesService.indexService(restoredIdx).getShard(0).outstandingCleanFilesConditions());
-        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         final String primaryNodeId = state.routingTable().index(restoredIndex).shard(0).primaryShard().currentNodeId();
         final DiscoveryNode primaryNode = state.nodes().resolveNode(primaryNodeId);
         assertEquals(firstDataNode, primaryNode.getName());
@@ -87,7 +92,7 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
         latch.countDown();
 
         assertFalse(
-            clusterAdmin().prepareHealth(restoredIndex)
+            clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, restoredIndex)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForEvents(Priority.LANGUID)
                 .get()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -79,7 +79,12 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
         assertAcked(client().admin().indices().prepareDelete(indexName));
 
-        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState().clear().setNodes(true).get().getState().nodes();
+        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .get()
+            .getState()
+            .nodes();
         final String dataNode = randomFrom(discoveryNodes.getDataNodes().values()).getName();
 
         mountSnapshot(
@@ -94,7 +99,7 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
         assertExecutorIsIdle(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
         assertExecutorIsIdle(SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME);
 
-        final Index restoredIndex = clusterAdmin().prepareState()
+        final Index restoredIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .get()
@@ -208,7 +213,11 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
                 .allMatch(recoveryState -> recoveryState.getStage() == RecoveryState.Stage.DONE)
         );
 
-        final ClusterStateResponse state = clusterAdmin().prepareState().clear().setMetadata(true).setIndices(mountedIndexName).get();
+        final ClusterStateResponse state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setMetadata(true)
+            .setIndices(mountedIndexName)
+            .get();
         final Index mountedIndex = state.getState().metadata().index(mountedIndexName).getIndex();
 
         final Set<DiscoveryNode> dataNodes = new HashSet<>();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
@@ -124,7 +124,7 @@ public class NodesCachesStatsIntegTests extends BaseFrozenSearchableSnapshotsInt
         assertThat(clearCacheResponse.getSuccessfulShards(), greaterThan(0));
         assertThat(clearCacheResponse.getFailedShards(), equalTo(0));
 
-        final String[] dataNodesWithFrozenShards = clusterAdmin().prepareState()
+        final String[] dataNodesWithFrozenShards = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .get()
             .getState()
             .routingTable()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -107,7 +107,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         final MountSearchableSnapshotRequest req = prepareMountRequest();
         final RestoreSnapshotResponse restoreSnapshotResponse = client().execute(MountSearchableSnapshotAction.INSTANCE, req).get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards(), equalTo(0));
-        final ClusterState state = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setRoutingTable(true).get().getState();
         assertTrue(state.toString(), state.routingTable().index(req.mountedIndexName()).allPrimaryShardsUnassigned());
 
         final var explanation = getClusterAllocationExplanation(client(), req.mountedIndexName(), 0, true);
@@ -139,7 +139,12 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
         ensureGreen(req.mountedIndexName());
 
-        final ClusterState state = clusterAdmin().prepareState().clear().setNodes(true).setRoutingTable(true).get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .setRoutingTable(true)
+            .get()
+            .getState();
         final Set<String> newNodeIds = newNodeNames.stream().map(n -> state.nodes().resolveNode(n).getId()).collect(Collectors.toSet());
         for (ShardRouting shardRouting : state.routingTable().index(req.mountedIndexName()).shardsWithState(ShardRoutingState.STARTED)) {
             assertThat(state.toString(), newNodeIds, hasItem(shardRouting.currentNodeId()));
@@ -160,7 +165,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
 
         createIndex("other-index", Settings.builder().putNull(TIER_PREFERENCE).build());
         ensureGreen("other-index");
-        final RoutingNodes routingNodes = clusterAdmin().prepareState()
+        final RoutingNodes routingNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setRoutingTable(true)
             .setNodes(true)
@@ -177,7 +182,12 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
         ensureGreen(req.mountedIndexName());
 
-        final ClusterState state = clusterAdmin().prepareState().clear().setNodes(true).setRoutingTable(true).get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setNodes(true)
+            .setRoutingTable(true)
+            .get()
+            .getState();
         final Set<String> newNodeIds = newNodeNames.stream().map(n -> state.nodes().resolveNode(n).getId()).collect(Collectors.toSet());
         for (ShardRouting shardRouting : state.routingTable().index(req.mountedIndexName()).shardsWithState(ShardRoutingState.STARTED)) {
             assertThat(state.toString(), newNodeIds, hasItem(shardRouting.currentNodeId()));
@@ -272,7 +282,12 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         assertFalse("should have failed before success", failurePermits.tryAcquire());
 
         final Map<String, Integer> shardCountsByNodeName = new HashMap<>();
-        final ClusterState state = clusterAdmin().prepareState().clear().setRoutingTable(true).setNodes(true).get().getState();
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
+            .clear()
+            .setRoutingTable(true)
+            .setNodes(true)
+            .get()
+            .getState();
         for (RoutingNode routingNode : state.getRoutingNodes()) {
             shardCountsByNodeName.put(
                 routingNode.node().getName(),

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
@@ -83,7 +83,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
         mountSnapshot(fsRepoName, snapshotName, indexName, restoredIndexName, Settings.EMPTY);
         ensureGreen(restoredIndexName);
 
-        final Index restoredIndex = clusterAdmin().prepareState()
+        final Index restoredIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .get()
@@ -145,7 +145,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
         internalCluster().restartRandomDataNode();
         ensureGreen(restoredIndexName);
 
-        final Index restoredIndex = clusterAdmin().prepareState()
+        final Index restoredIndex = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
             .clear()
             .setMetadata(true)
             .get()

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
@@ -260,7 +260,7 @@ public class ClusterPrivilegeIntegrationTests extends AbstractPrivilegeTestCase 
             // The status of the snapshot in the repository can become SUCCESS before it is fully finalized in the cluster state so wait for
             // it to disappear from the cluster state as well
             SnapshotsInProgress snapshotsInProgress = SnapshotsInProgress.get(
-                clusterAdmin().state(new ClusterStateRequest()).get().getState()
+                clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).get().getState()
             );
             assertTrue(snapshotsInProgress.isEmpty());
         });

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeIntegTests.java
@@ -559,7 +559,7 @@ public class IndexPrivilegeIntegTests extends AbstractPrivilegeTestCase {
                     assertAccessIsAllowed(user, "DELETE", "/" + index);
                     assertUserIsAllowed(user, "create_index", index);
                     // wait until index ready, but as admin
-                    assertNoTimeout(clusterAdmin().prepareHealth(index).setWaitForGreenStatus().get());
+                    assertNoTimeout(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, index).setWaitForGreenStatus().get());
                     assertAccessIsAllowed(user, "POST", "/" + index + "/_refresh");
                     assertAccessIsAllowed(user, "GET", "/" + index + "/_analyze", "{ \"text\" : \"test\" }");
                     assertAccessIsAllowed(user, "POST", "/" + index + "/_flush");
@@ -569,7 +569,7 @@ public class IndexPrivilegeIntegTests extends AbstractPrivilegeTestCase {
                     assertAccessIsAllowed(user, "POST", "/" + index + "/_cache/clear");
                     // indexing a document to have the mapping available, and wait for green state to make sure index is created
                     assertAccessIsAllowed("admin", "PUT", "/" + index + "/_doc/1", jsonDoc);
-                    assertNoTimeout(clusterAdmin().prepareHealth(index).setWaitForGreenStatus().get());
+                    assertNoTimeout(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT, index).setWaitForGreenStatus().get());
                     assertAccessIsAllowed(user, "GET", "/" + index + "/_mapping/field/name");
                     assertAccessIsAllowed(user, "GET", "/" + index + "/_settings");
                     assertAccessIsAllowed(user, randomFrom("GET", "POST"), "/" + index + "/_field_caps?fields=*");

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -229,7 +229,7 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).get();
 
         ReservedStateMetadata reservedState = clusterStateResponse.getState()
@@ -251,7 +251,7 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             equalTo("50mb")
         );
 
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest().persistentSettings(
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(
             Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb")
         );
         assertEquals(
@@ -300,7 +300,7 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(savedClusterState.v2().get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(savedClusterState.v2().get())
         ).get();
 
         assertNull(
@@ -384,7 +384,7 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(savedClusterState.v2().get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(savedClusterState.v2().get())
         ).get();
 
         assertNull(
@@ -440,8 +440,9 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             assertFalse(response.hasMappings());
 
             // cluster state settings are also applied
-            var clusterStateResponse = clusterAdmin().state(new ClusterStateRequest().waitForMetadataVersion(savedClusterState.v2().get()))
-                .get();
+            var clusterStateResponse = clusterAdmin().state(
+                new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(savedClusterState.v2().get())
+            ).get();
             assertThat(
                 clusterStateResponse.getState().metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()),
                 equalTo("50mb")

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureStateIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureStateIntegTests.java
@@ -175,7 +175,7 @@ public class SecurityFeatureStateIntegTests extends AbstractPrivilegeTestCase {
             // The status of the snapshot in the repository can become SUCCESS before it is fully finalized in the cluster state so wait for
             // it to disappear from the cluster state as well
             SnapshotsInProgress snapshotsInProgress = SnapshotsInProgress.get(
-                clusterAdmin().state(new ClusterStateRequest()).get().getState()
+                clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).get().getState()
             );
             assertTrue(snapshotsInProgress.isEmpty());
         });

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ShrinkIndexWithSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ShrinkIndexWithSecurityTests.java
@@ -34,7 +34,7 @@ public class ShrinkIndexWithSecurityTests extends SecurityIntegTestCase {
             prepareIndex("bigindex").setSource("foo", "bar").get();
         }
 
-        Map<String, DiscoveryNode> dataNodes = clusterAdmin().prepareState().get().getState().nodes().getDataNodes();
+        Map<String, DiscoveryNode> dataNodes = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getDataNodes();
         DiscoveryNode[] discoveryNodes = dataNodes.values().toArray(DiscoveryNode[]::new);
         final String mergeNode = discoveryNodes[0].getName();
         ensureGreen();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
@@ -158,7 +158,7 @@ public class LicensingTests extends SecurityIntegTestCase {
 
         assertElasticsearchSecurityException(() -> client.admin().indices().prepareStats().get());
         assertElasticsearchSecurityException(() -> client.admin().cluster().prepareClusterStats().get());
-        assertElasticsearchSecurityException(() -> client.admin().cluster().prepareHealth().get());
+        assertElasticsearchSecurityException(() -> client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get());
         assertElasticsearchSecurityException(() -> client.admin().cluster().prepareNodesStats().get());
 
         enableLicensing(randomFrom(License.OperationMode.values()));
@@ -172,7 +172,7 @@ public class LicensingTests extends SecurityIntegTestCase {
         assertThat(indices, notNullValue());
         assertThat(indices.getIndexCount(), greaterThanOrEqualTo(2));
 
-        ClusterHealthResponse clusterIndexHealth = client.admin().cluster().prepareHealth().get();
+        ClusterHealthResponse clusterIndexHealth = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertThat(clusterIndexHealth, notNullValue());
 
         NodesStatsResponse nodeStats = client.admin().cluster().prepareNodesStats().get();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -88,7 +88,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
-        var clusterState = clusterAdmin().state(new ClusterStateRequest()).actionGet().getState();
+        var clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
         assertRoleMappingReservedMetadata(clusterState, "everyone_kibana_alone", "everyone_fleet_alone");
         List<ExpressionRoleMapping> roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
         assertThat(
@@ -118,7 +118,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         ensureGreen();
 
         // assert role mappings are recovered from "disk"
-        clusterState = clusterAdmin().state(new ClusterStateRequest()).actionGet().getState();
+        clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
         assertRoleMappingReservedMetadata(clusterState, "everyone_kibana_alone", "everyone_fleet_alone");
         roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
         assertThat(
@@ -151,7 +151,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
-        clusterState = clusterAdmin().state(new ClusterStateRequest()).actionGet().getState();
+        clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
         assertRoleMappingReservedMetadata(clusterState);
         roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
         assertThat(roleMappings, emptyIterable());
@@ -162,7 +162,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         ensureGreen();
 
         // assert empty role mappings are recovered from "disk"
-        clusterState = clusterAdmin().state(new ClusterStateRequest()).actionGet().getState();
+        clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
         assertRoleMappingReservedMetadata(clusterState);
         roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
         assertThat(roleMappings, emptyIterable());

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/audit/logfile/AuditTrailSettingsUpdateTests.java
@@ -103,7 +103,9 @@ public class AuditTrailSettingsUpdateTests extends SecurityIntegTestCase {
         settingsBuilder.put(randomFrom(allSettingsKeys), invalidLuceneRegex);
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(settingsBuilder.build()).get()
+            () -> clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(settingsBuilder.build())
+                .get()
         );
         assertThat(e.getMessage(), containsString("invalid pattern [/invalid]"));
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -305,7 +305,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             () -> client().filterWithHeader(authorizationHeaders)
                 .admin()
                 .cluster()
-                .prepareUpdateSettings()
+                .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
                 .setPersistentSettings(Settings.builder().put(IPFilter.IP_FILTER_ENABLED_SETTING.getKey(), true))
                 .get()
         );

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -796,7 +796,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
     }
 
     public void testMetadataIsNotSentToClient() {
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setCustoms(true).get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).setCustoms(true).get();
         assertFalse(clusterStateResponse.getState().customs().containsKey(TokenMetadata.TYPE));
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -315,7 +315,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
         assertThat(apiKey.getRealmType(), equalTo("native"));
         final Client clientWithGrantedKey = client().filterWithHeader(Map.of("Authorization", "ApiKey " + base64ApiKeyKeyValue));
         // The API key has privileges (inherited from user2) to check cluster health
-        clientWithGrantedKey.execute(TransportClusterHealthAction.TYPE, new ClusterHealthRequest()).actionGet();
+        clientWithGrantedKey.execute(TransportClusterHealthAction.TYPE, new ClusterHealthRequest(TEST_REQUEST_TIMEOUT)).actionGet();
         // If the API key is granted with limiting descriptors, it should not be able to read pipeline
         if (grantApiKeyRequest.getApiKeyRequest().getRoleDescriptors().isEmpty()) {
             clientWithGrantedKey.execute(GetPipelineAction.INSTANCE, new GetPipelineRequest()).actionGet();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
@@ -440,7 +440,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
             ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
                 .admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .get();
             assertFalse(response.isTimedOut());
             preparePutRole("test_role").cluster("none")
@@ -495,12 +495,20 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
     private void assertClusterHealthOnlyAuthorizesWhenAnonymousRoleActive(String token) {
         if (anonymousEnabled && roleExists) {
             assertNoTimeout(
-                client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get()
+                client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                    .admin()
+                    .cluster()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT)
+                    .get()
             );
         } else {
             ElasticsearchSecurityException e = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get()
+                () -> client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                    .admin()
+                    .cluster()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT)
+                    .get()
             );
             assertThat(e.status(), is(RestStatus.FORBIDDEN));
         }
@@ -607,7 +615,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
         assertFalse(response.isTimedOut());
         new DeleteRoleRequestBuilder(client()).name("test_role").get();
@@ -641,7 +649,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
         assertFalse(response.isTimedOut());
 
@@ -657,12 +665,20 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         // test that role change took effect if anonymous is disabled as anonymous grants monitoring permissions...
         if (anonymousEnabled && roleExists) {
             assertNoTimeout(
-                client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get()
+                client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                    .admin()
+                    .cluster()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT)
+                    .get()
             );
         } else {
             ElasticsearchSecurityException e = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get()
+                () -> client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                    .admin()
+                    .cluster()
+                    .prepareHealth(TEST_REQUEST_TIMEOUT)
+                    .get()
             );
             assertThat(e.status(), is(RestStatus.FORBIDDEN));
             assertThat(e.getMessage(), containsString("authorized"));
@@ -680,7 +696,11 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
 
         // validate that joe cannot auth with the old token
         try {
-            client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get();
+            client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                .admin()
+                .cluster()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
+                .get();
             fail("should not authenticate with old password");
         } catch (ElasticsearchSecurityException e) {
             assertThat(e.getMessage(), containsString("authenticate"));
@@ -689,7 +709,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         // test with new password and role
         response = client().filterWithHeader(
             Collections.singletonMap("Authorization", basicAuthHeaderValue("joe", new SecureString(secondPassword.toCharArray())))
-        ).admin().cluster().prepareHealth().get();
+        ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertFalse(response.isTimedOut());
     }
 
@@ -800,7 +820,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
         assertThat(response.isTimedOut(), is(false));
 
@@ -811,13 +831,17 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
 
         ElasticsearchSecurityException expected = expectThrows(
             ElasticsearchSecurityException.class,
-            () -> client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get()
+            () -> client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                .admin()
+                .cluster()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
+                .get()
         );
         assertThat(expected.status(), is(RestStatus.UNAUTHORIZED));
 
         response = client().filterWithHeader(
             Collections.singletonMap("Authorization", basicAuthHeaderValue("joe", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING))
-        ).admin().cluster().prepareHealth().get();
+        ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertThat(response.isTimedOut(), is(false));
     }
 
@@ -942,7 +966,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         ClusterHealthResponse response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
         assertThat(response.isTimedOut(), is(false));
 
@@ -950,13 +974,21 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
 
         ElasticsearchSecurityException expected = expectThrows(
             ElasticsearchSecurityException.class,
-            () -> client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get()
+            () -> client().filterWithHeader(Collections.singletonMap("Authorization", token))
+                .admin()
+                .cluster()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
+                .get()
         );
         assertThat(expected.status(), is(RestStatus.UNAUTHORIZED));
 
         new SetEnabledRequestBuilder(client()).username("joe").enabled(true).get();
 
-        response = client().filterWithHeader(Collections.singletonMap("Authorization", token)).admin().cluster().prepareHealth().get();
+        response = client().filterWithHeader(Collections.singletonMap("Authorization", token))
+            .admin()
+            .cluster()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
+            .get();
         assertThat(response.isTimedOut(), is(false));
 
         IllegalArgumentException e = expectThrows(
@@ -974,14 +1006,14 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
             if (anonymousEnabled && roleExists) {
                 ClusterHealthResponse response = client().filterWithHeader(
                     Collections.singletonMap("Authorization", basicAuthHeaderValue("joe", new SecureString("s3krit-password")))
-                ).admin().cluster().prepareHealth().get();
+                ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
                 assertNoTimeout(response);
             } else {
                 ElasticsearchSecurityException e = expectThrows(
                     ElasticsearchSecurityException.class,
                     () -> client().filterWithHeader(
                         Collections.singletonMap("Authorization", basicAuthHeaderValue("joe", new SecureString("s3krit-password")))
-                    ).admin().cluster().prepareHealth().get()
+                    ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get()
                 );
                 assertThat(e.status(), is(RestStatus.FORBIDDEN));
             }
@@ -990,7 +1022,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         preparePutRole("unknown_role").cluster("all").get();
         ClusterHealthResponse response = client().filterWithHeader(
             Collections.singletonMap("Authorization", basicAuthHeaderValue("joe", new SecureString("s3krit-password")))
-        ).admin().cluster().prepareHealth().get();
+        ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertNoTimeout(response);
     }
 
@@ -1017,7 +1049,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
                 try {
                     latch.await();
                     for (int j = 0; j < numberOfIterations; j++) {
-                        ClusterHealthResponse response = client.admin().cluster().prepareHealth().get();
+                        ClusterHealthResponse response = client.admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
                         assertNoTimeout(response);
                     }
                 } catch (InterruptedException e) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmElasticAutoconfigIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmElasticAutoconfigIntegTests.java
@@ -92,7 +92,10 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
     public void testAutoconfigFailedPasswordPromotion() {
         try {
             // prevents the .security index from being created automatically (after elastic user authentication)
-            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             updateSettingsRequest.transientSettings(Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), true));
             assertAcked(clusterAdmin().updateSettings(updateSettingsRequest).actionGet());
 
@@ -146,7 +149,10 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
             exception = expectThrows(ResponseException.class, () -> getRestClient().performRequest(restRequest2));
             assertThat(exception.getResponse().getStatusLine().getStatusCode(), is(RestStatus.UNAUTHORIZED.getStatus()));
         } finally {
-            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             updateSettingsRequest.transientSettings(
                 Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), (String) null)
             );
@@ -168,7 +174,10 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
             awaitSecurityMigrationRanOnce();
 
             // but then make the cluster read-only
-            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             updateSettingsRequest.transientSettings(Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), true));
             assertAcked(clusterAdmin().updateSettings(updateSettingsRequest).actionGet());
 
@@ -190,7 +199,7 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
             ResponseException exception = expectThrows(ResponseException.class, () -> getRestClient().performRequest(restRequest));
             assertThat(exception.getResponse().getStatusLine().getStatusCode(), is(RestStatus.SERVICE_UNAVAILABLE.getStatus()));
             // clear cluster-wide write block
-            updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            updateSettingsRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
             updateSettingsRequest.transientSettings(
                 Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), (String) null)
             );
@@ -232,7 +241,10 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
             restRequest3.setOptions(options);
             assertThat(getRestClient().performRequest(restRequest3).getStatusLine().getStatusCode(), is(RestStatus.OK.getStatus()));
         } finally {
-            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             updateSettingsRequest.transientSettings(
                 Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), (String) null)
             );

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmIntegTests.java
@@ -64,7 +64,7 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
         for (String username : usernames) {
             ClusterHealthResponse response = client().filterWithHeader(
                 singletonMap("Authorization", basicAuthHeaderValue(username, getReservedPassword()))
-            ).admin().cluster().prepareHealth().get();
+            ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
 
             assertThat(response.getClusterName(), is(cluster().getClusterName()));
         }
@@ -89,7 +89,7 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
 
             ClusterHealthResponse response = client().filterWithHeader(
                 singletonMap("Authorization", basicAuthHeaderValue(username, getReservedPassword()))
-            ).admin().cluster().prepareHealth().get();
+            ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
 
             assertThat(response.getClusterName(), is(cluster().getClusterName()));
         }
@@ -110,7 +110,7 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
         if (randomBoolean()) {
             ClusterHealthResponse response = client().filterWithHeader(
                 singletonMap("Authorization", basicAuthHeaderValue(username, getReservedPassword()))
-            ).admin().cluster().prepareHealth().get();
+            ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
             assertThat(response.getClusterName(), is(cluster().getClusterName()));
         }
 
@@ -121,14 +121,14 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
             () -> client().filterWithHeader(singletonMap("Authorization", basicAuthHeaderValue(username, getReservedPassword())))
                 .admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .get()
         );
         assertThat(elasticsearchSecurityException.getMessage(), containsString("authenticate"));
 
         ClusterHealthResponse healthResponse = client().filterWithHeader(
             singletonMap("Authorization", basicAuthHeaderValue(username, new SecureString(newPassword)))
-        ).admin().cluster().prepareHealth().get();
+        ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertThat(healthResponse.getClusterName(), is(cluster().getClusterName()));
     }
 
@@ -136,7 +136,7 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
         // validate the user works
         ClusterHealthResponse response = client().filterWithHeader(
             singletonMap("Authorization", basicAuthHeaderValue(ElasticUser.NAME, getReservedPassword()))
-        ).admin().cluster().prepareHealth().get();
+        ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
         assertThat(response.getClusterName(), is(cluster().getClusterName()));
 
         // disable user
@@ -146,7 +146,7 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
             () -> client().filterWithHeader(singletonMap("Authorization", basicAuthHeaderValue(ElasticUser.NAME, getReservedPassword())))
                 .admin()
                 .cluster()
-                .prepareHealth()
+                .prepareHealth(TEST_REQUEST_TIMEOUT)
                 .get()
         );
         assertThat(elasticsearchSecurityException.getMessage(), containsString("authenticate"));
@@ -156,7 +156,7 @@ public class ReservedRealmIntegTests extends NativeRealmIntegTestCase {
         response = client().filterWithHeader(singletonMap("Authorization", basicAuthHeaderValue(ElasticUser.NAME, getReservedPassword())))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
         assertThat(response.getClusterName(), is(cluster().getClusterName()));
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreSingleNodeTests.java
@@ -77,7 +77,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
 
     public void testResolvePrivilegesWorkWhenExpensiveQueriesAreDisabled() throws IOException {
         // Disable expensive query
-        new ClusterUpdateSettingsRequestBuilder(client()).setTransientSettings(
+        new ClusterUpdateSettingsRequestBuilder(client(), TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(
             Settings.builder().put(ALLOW_EXPENSIVE_QUERIES.getKey(), false)
         ).get();
 
@@ -184,7 +184,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
             assertThat(authenticateResponse.authentication().getEffectiveSubject().getUser().principal(), equalTo("app_user"));
         } finally {
             // Reset setting since test suite expects things in a clean slate
-            new ClusterUpdateSettingsRequestBuilder(client()).setTransientSettings(
+            new ClusterUpdateSettingsRequestBuilder(client(), TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setTransientSettings(
                 Settings.builder().putNull(ALLOW_EXPENSIVE_QUERIES.getKey())
             ).get();
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesSingleNodeTests.java
@@ -66,7 +66,9 @@ public class OperatorPrivilegesSingleNodeTests extends SecuritySingleNodeTestCas
     }
 
     public void testNormalSuperuserWillFailToCallOperatorOnlyAction() {
-        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
+        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest(
+            TEST_REQUEST_TIMEOUT
+        );
         final ElasticsearchSecurityException e = expectThrows(
             ElasticsearchSecurityException.class,
             () -> client().execute(TransportClearVotingConfigExclusionsAction.TYPE, clearVotingConfigExclusionsRequest).actionGet()
@@ -76,7 +78,10 @@ public class OperatorPrivilegesSingleNodeTests extends SecuritySingleNodeTestCas
 
     public void testNormalSuperuserWillFailToSetOperatorOnlySettings() {
         final Settings settings = Settings.builder().put(IPFilter.IP_FILTER_ENABLED_SETTING.getKey(), "null").build();
-        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest();
+        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT
+        );
         if (randomBoolean()) {
             clusterUpdateSettingsRequest.transientSettings(settings);
         } else {
@@ -91,13 +96,18 @@ public class OperatorPrivilegesSingleNodeTests extends SecuritySingleNodeTestCas
 
     public void testOperatorUserWillSucceedToCallOperatorOnlyAction() {
         final Client client = createOperatorClient();
-        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest();
+        final ClearVotingConfigExclusionsRequest clearVotingConfigExclusionsRequest = new ClearVotingConfigExclusionsRequest(
+            TEST_REQUEST_TIMEOUT
+        );
         client.execute(TransportClearVotingConfigExclusionsAction.TYPE, clearVotingConfigExclusionsRequest).actionGet();
     }
 
     public void testOperatorUserWillSucceedToSetOperatorOnlySettings() {
         final Client client = createOperatorClient();
-        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest();
+        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT
+        );
         final Settings settings = Settings.builder().put(IPFilter.IP_FILTER_ENABLED_SETTING.getKey(), false).build();
         final boolean useTransientSetting = randomBoolean();
         try {
@@ -108,7 +118,10 @@ public class OperatorPrivilegesSingleNodeTests extends SecuritySingleNodeTestCas
             }
             client.execute(ClusterUpdateSettingsAction.INSTANCE, clusterUpdateSettingsRequest).actionGet();
         } finally {
-            final ClusterUpdateSettingsRequest clearSettingsRequest = new ClusterUpdateSettingsRequest();
+            final ClusterUpdateSettingsRequest clearSettingsRequest = new ClusterUpdateSettingsRequest(
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT
+            );
             final Settings clearSettings = Settings.builder().putNull(IPFilter.IP_FILTER_ENABLED_SETTING.getKey()).build();
             if (useTransientSetting) {
                 clearSettingsRequest.transientSettings(clearSettings);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/SecurityDomainIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/SecurityDomainIntegTests.java
@@ -336,7 +336,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
                             (createApiKeyResponse.getId() + ":" + createApiKeyResponse.getKey()).getBytes(StandardCharsets.UTF_8)
                         )
             )
-        ).admin().cluster().prepareHealth().get();
+        ).admin().cluster().prepareHealth(TEST_REQUEST_TIMEOUT).get();
     }
 
     public void testDomainCaptureForServiceToken() throws IOException {
@@ -364,7 +364,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
         client().filterWithHeader(Map.of("Authorization", "Bearer " + createServiceTokenResponse.getValue()))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
     }
 
@@ -372,7 +372,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
         client().filterWithHeader(Map.of("Authorization", "Bearer " + createTokenResponse.getTokenString()))
             .admin()
             .cluster()
-            .prepareHealth()
+            .prepareHealth(TEST_REQUEST_TIMEOUT)
             .get();
         assertResponse(prepareSearch(SecuritySystemIndices.SECURITY_TOKENS_ALIAS), searchResponse -> {
             final String encodedAuthentication;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
@@ -87,7 +87,7 @@ public class IpFilteringUpdateTests extends SecurityIntegTestCase {
         assertConnectionRejected("client", "127.0.0.8");
 
         // check that all is in cluster state
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().settings().get("xpack.security.transport.filter.allow"), is("127.0.0.1"));
         assertThat(clusterState.metadata().settings().get("xpack.security.transport.filter.deny"), is("127.0.0.8"));
         assertEquals(Arrays.asList("127.0.0.1"), clusterState.metadata().settings().getAsList("xpack.security.http.filter.allow"));
@@ -105,7 +105,7 @@ public class IpFilteringUpdateTests extends SecurityIntegTestCase {
         assertConnectionAccepted("client", "127.0.0.8");
 
         // disabling should not have any effect on the cluster state settings
-        clusterState = clusterAdmin().prepareState().get().getState();
+        clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         assertThat(clusterState.metadata().settings().get("xpack.security.transport.filter.allow"), is("127.0.0.1"));
         assertThat(clusterState.metadata().settings().get("xpack.security.transport.filter.deny"), is("127.0.0.8"));
         assertEquals(Arrays.asList("127.0.0.1"), clusterState.metadata().settings().getAsList("xpack.security.http.filter.allow"));
@@ -148,7 +148,9 @@ public class IpFilteringUpdateTests extends SecurityIntegTestCase {
                     expectThrows(
                         IllegalArgumentException.class,
                         settingName,
-                        () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(settings).get()
+                        () -> clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                            .setPersistentSettings(settings)
+                            .get()
                     ).getMessage(),
                     allOf(containsString("invalid IP filter"), containsString(invalidValue))
                 );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -387,7 +387,7 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
     public void assertSecurityIndexActive(TestCluster testCluster) throws Exception {
         for (Client client : testCluster.getClients()) {
             assertBusy(() -> {
-                ClusterState clusterState = client.admin().cluster().prepareState().setLocal(true).get().getState();
+                ClusterState clusterState = client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).setLocal(true).get().getState();
                 assertFalse(clusterState.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK));
                 Index securityIndex = resolveSecurityIndex(clusterState.metadata());
                 if (securityIndex != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -1612,7 +1612,7 @@ public class AuthorizationServiceTests extends ESTestCase {
 
         AuditUtil.getOrGenerateRequestId(threadContext);
 
-        TransportRequest request = new ClusterHealthRequest();
+        TransportRequest request = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT);
 
         ElasticsearchSecurityException securityException = expectThrows(
             ElasticsearchSecurityException.class,
@@ -2143,7 +2143,10 @@ public class AuthorizationServiceTests extends ESTestCase {
         }
 
         // we should allow waiting for the health of the index or any index if the user has this permission
-        ClusterHealthRequest request = new ClusterHealthRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7));
+        ClusterHealthRequest request = new ClusterHealthRequest(
+            TEST_REQUEST_TIMEOUT,
+            randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7)
+        );
         authorize(authentication, TransportClusterHealthAction.NAME, request);
         verify(auditTrail).accessGranted(
             eq(requestId),
@@ -2154,7 +2157,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         );
 
         // multiple indices
-        request = new ClusterHealthRequest(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7, "foo", "bar");
+        request = new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7, "foo", "bar");
         authorize(authentication, TransportClusterHealthAction.NAME, request);
         verify(auditTrail).accessGranted(
             eq(requestId),
@@ -2283,13 +2286,18 @@ public class AuthorizationServiceTests extends ESTestCase {
         requests.add(
             new Tuple<>(
                 TransportClusterHealthAction.NAME,
-                new ClusterHealthRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7))
+                new ClusterHealthRequest(TEST_REQUEST_TIMEOUT, randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7))
             )
         );
         requests.add(
             new Tuple<>(
                 TransportClusterHealthAction.NAME,
-                new ClusterHealthRequest(randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7), "foo", "bar")
+                new ClusterHealthRequest(
+                    TEST_REQUEST_TIMEOUT,
+                    randomFrom(SECURITY_MAIN_ALIAS, INTERNAL_SECURITY_MAIN_INDEX_7),
+                    "foo",
+                    "bar"
+                )
             )
         );
 

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownDelayedAllocationIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownDelayedAllocationIT.java
@@ -64,7 +64,9 @@ public class NodeShutdownDelayedAllocationIT extends ESIntegTestCase {
         internalCluster().restartNode(nodeToRestartName, new InternalTestCluster.RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
-                assertBusy(() -> assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1)));
+                assertBusy(
+                    () -> assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(1))
+                );
                 return super.onNodeStopped(nodeName);
             }
         });
@@ -135,7 +137,9 @@ public class NodeShutdownDelayedAllocationIT extends ESIntegTestCase {
         internalCluster().restartNode(nodeToRestartName, new InternalTestCluster.RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) throws Exception {
-                assertBusy(() -> { assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1)); });
+                assertBusy(
+                    () -> { assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(1)); }
+                );
                 return super.onNodeStopped(nodeName);
             }
         });
@@ -218,7 +222,9 @@ public class NodeShutdownDelayedAllocationIT extends ESIntegTestCase {
         internalCluster().stopNode(nodeToRestartName);
 
         // Verify that the shard's allocation is delayed
-        assertBusy(() -> { assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1)); });
+        assertBusy(
+            () -> { assertThat(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getDelayedUnassignedShards(), equalTo(1)); }
+        );
 
         return nodeToRestartId;
     }
@@ -233,13 +239,13 @@ public class NodeShutdownDelayedAllocationIT extends ESIntegTestCase {
     }
 
     private String findIdOfNodeWithShard() {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
         return randomFrom(startedShards).currentNodeId();
     }
 
     private String findNodeNameFromId(String id) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         return state.nodes().get(id).getName();
     }
 }

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -426,7 +426,7 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
     }
 
     private String findIdOfNodeWithPrimaryShard(String indexName) {
-        ClusterState state = clusterAdmin().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
         return startedShards.stream()
             .filter(ShardRouting::primary)
@@ -465,7 +465,7 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
     }
 
     private void assertIndexPrimaryShardsAreAllocatedOnNode(String indexName, String nodeId) {
-        var state = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState();
+        var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setRoutingTable(true).get().getState();
         var indexRoutingTable = state.routingTable().index(indexName);
         for (int p = 0; p < indexRoutingTable.size(); p++) {
             var primaryShard = indexRoutingTable.shard(p).primaryShard();
@@ -485,7 +485,7 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
     }
 
     private void assertIndexReplicaShardsAreNotAllocated(String indexName) {
-        var state = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState();
+        var state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setRoutingTable(true).get().getState();
         var indexRoutingTable = state.routingTable().index(indexName);
         for (int p = 0; p < indexRoutingTable.size(); p++) {
             for (ShardRouting replicaShard : indexRoutingTable.shard(p).replicaShards()) {

--- a/x-pack/plugin/slm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/slm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -432,7 +432,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         }, 60, TimeUnit.SECONDS);
 
         // Run retention every second
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         req.persistentSettings(Settings.builder().put(LifecycleSettings.SLM_RETENTION_SCHEDULE, "*/1 * * * * ?"));
         try (XContentBuilder builder = jsonBuilder()) {
             req.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -474,7 +474,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
 
         } finally {
             // Unset retention
-            ClusterUpdateSettingsRequest unsetRequest = new ClusterUpdateSettingsRequest();
+            ClusterUpdateSettingsRequest unsetRequest = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
             unsetRequest.persistentSettings(Settings.builder().put(LifecycleSettings.SLM_RETENTION_SCHEDULE, (String) null));
             try (XContentBuilder builder = jsonBuilder()) {
                 unsetRequest.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -895,7 +895,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
     }
 
     private void disableSLMMinimumIntervalValidation() throws IOException {
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest();
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT);
         req.persistentSettings(Settings.builder().put(LifecycleSettings.SLM_MINIMUM_INTERVAL, "0s"));
         try (XContentBuilder builder = jsonBuilder()) {
             req.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMFileSettingsIT.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMFileSettingsIT.java
@@ -150,7 +150,10 @@ public class SLMFileSettingsIT extends AbstractSnapshotIntegTestCase {
     }
 
     private void assertMasterNode(Client client, String node) {
-        assertThat(client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(), equalTo(node));
+        assertThat(
+            client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode().getName(),
+            equalTo(node)
+        );
     }
 
     private void writeJSONFile(String node, String json) throws Exception {
@@ -192,7 +195,7 @@ public class SLMFileSettingsIT extends AbstractSnapshotIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).get();
 
         var reservedState = clusterStateResponse.getState().metadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE);
@@ -205,7 +208,7 @@ public class SLMFileSettingsIT extends AbstractSnapshotIntegTestCase {
             equalTo("50mb")
         );
 
-        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest().persistentSettings(
+        ClusterUpdateSettingsRequest req = new ClusterUpdateSettingsRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).persistentSettings(
             Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb")
         );
         assertEquals(
@@ -306,7 +309,7 @@ public class SLMFileSettingsIT extends AbstractSnapshotIntegTestCase {
         assertTrue(awaitSuccessful);
 
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
-            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
 
         assertThat(clusterStateResponse.getState().metadata().persistentSettings().get("search.allow_expensive_queries"), nullValue());

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -355,7 +355,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
                 logger.info("-->  stopping random data node, which should cause shards to go missing");
                 internalCluster().stopRandomDataNode();
                 assertBusy(
-                    () -> assertEquals(ClusterHealthStatus.RED, clusterAdmin().prepareHealth().get().getStatus()),
+                    () -> assertEquals(ClusterHealthStatus.RED, clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).get().getStatus()),
                     30,
                     TimeUnit.SECONDS
                 );

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMStatDisruptionIT.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMStatDisruptionIT.java
@@ -578,13 +578,19 @@ public class SLMStatDisruptionIT extends AbstractSnapshotIntegTestCase {
     }
 
     private SnapshotLifecycleMetadata getSnapshotLifecycleMetadata() {
-        final ClusterStateResponse clusterStateResponse = client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        final ClusterStateResponse clusterStateResponse = client().admin()
+            .cluster()
+            .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT))
+            .actionGet();
         ClusterState state = clusterStateResponse.getState();
         return state.metadata().custom(SnapshotLifecycleMetadata.TYPE);
     }
 
     private RegisteredPolicySnapshots getRegisteredSnapshots() {
-        final ClusterStateResponse clusterStateResponse = client().admin().cluster().state(new ClusterStateRequest()).actionGet();
+        final ClusterStateResponse clusterStateResponse = client().admin()
+            .cluster()
+            .state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT))
+            .actionGet();
         ClusterState state = clusterStateResponse.getState();
         return state.metadata().custom(RegisteredPolicySnapshots.TYPE, RegisteredPolicySnapshots.EMPTY);
     }

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -566,7 +566,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             final String targetNode;
             if (seqNoRecovery) {
-                ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+                ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
                 IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index(indexName).shard(0);
                 String primaryNodeName = clusterState.nodes().resolveNode(shardRoutingTable.primaryShard().currentNodeId()).getName();
                 String replicaNodeName = clusterState.nodes()
@@ -597,7 +597,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                 );
 
             if (seqNoRecovery) {
-                ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+                ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
                 IndexShardRoutingTable shardRoutingTable = clusterState.routingTable().index(indexName).shard(0);
                 String primaryNodeName = clusterState.nodes().resolveNode(shardRoutingTable.primaryShard().currentNodeId()).getName();
 
@@ -996,7 +996,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createRepo(repoName, repoType);
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         String primaryNodeId = clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId();
         String primaryNodeName = clusterState.nodes().resolveNode(primaryNodeId).getName();
 
@@ -1006,7 +1006,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
         ensureGreen(indexName);
 
-        ClusterState clusterStateAfterPrimaryFailOver = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterStateAfterPrimaryFailOver = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         IndexShardRoutingTable shardRoutingTableAfterFailOver = clusterStateAfterPrimaryFailOver.routingTable().index(indexName).shard(0);
 
         String primaryNodeIdAfterFailOver = shardRoutingTableAfterFailOver.primaryShard().currentNodeId();
@@ -1316,7 +1316,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createRepo(repoName, TestRepositoryPlugin.FILTER_TYPE);
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         String primaryNodeId = clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId();
         String primaryNodeName = clusterState.nodes().resolveNode(primaryNodeId).getName();
         String replicaNodeId = clusterState.routingTable().index(indexName).shard(0).replicaShards().get(0).currentNodeId();
@@ -1527,7 +1527,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
     }
 
     private Store.MetadataSnapshot getMetadataSnapshot(String nodeName, String indexName) throws IOException {
-        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class, nodeName);
         IndexService indexService = indicesService.indexService(clusterState.metadata().index(indexName).getIndex());
         IndexShard shard = indexService.getShard(0);
@@ -1561,7 +1561,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
         // Ensure that the safe commit == latest commit
         assertBusy(() -> {
-            ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+            ClusterState clusterState = client().admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             var indexShardRoutingTable = clusterState.routingTable().index(indexName).shard(0);
             assertThat(indexShardRoutingTable, is(notNullValue()));
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndex.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -389,7 +390,10 @@ public final class TransformInternalIndex {
     }
 
     private static void waitForLatestVersionedIndexShardsActive(Client client, ActionListener<Void> listener) {
-        ClusterHealthRequest request = new ClusterHealthRequest(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME)
+        ClusterHealthRequest request = new ClusterHealthRequest(
+            TimeValue.THIRTY_SECONDS /* TODO should this be longer/configurable? */,
+            TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME
+        )
             // cluster health does not wait for active shards per default
             .waitForActiveShards(ActiveShardCount.ONE);
         ActionListener<ClusterHealthResponse> innerListener = ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure);

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -76,7 +76,10 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().startNodes(2);
         internalCluster().startNode(addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)));
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds(), hasSize(3))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds(),
+                hasSize(3)
+            )
         );
         assertThat(
             clusterAdmin().prepareClusterStats()
@@ -98,15 +101,20 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().startNode(addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)));
         internalCluster().startDataOnlyNodes(randomInt(2));
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(), equalTo(3))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
         );
         final String originalMaster = internalCluster().getMasterName();
 
         internalCluster().stopCurrentMasterNode();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
+        clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get();
         assertNotEquals(originalMaster, internalCluster().getMasterName());
         assertThat(
-            VotingOnlyNodePlugin.isVotingOnlyNode(clusterAdmin().prepareState().get().getState().nodes().getMasterNode()),
+            VotingOnlyNodePlugin.isVotingOnlyNode(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode()
+            ),
             equalTo(false)
         );
     }
@@ -115,10 +123,15 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)), Settings.EMPTY, Settings.EMPTY);
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(), equalTo(3))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
         );
         assertThat(
-            VotingOnlyNodePlugin.isVotingOnlyNode(clusterAdmin().prepareState().get().getState().nodes().getMasterNode()),
+            VotingOnlyNodePlugin.isVotingOnlyNode(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode()
+            ),
             equalTo(false)
         );
     }
@@ -132,9 +145,11 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
                 .build()
         );
         internalCluster().startNode();
-        assertBusy(() -> assertThat(clusterAdmin().prepareState().get().getState().getNodes().getSize(), equalTo(2)));
+        assertBusy(() -> assertThat(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getNodes().getSize(), equalTo(2)));
         assertThat(
-            VotingOnlyNodePlugin.isVotingOnlyNode(clusterAdmin().prepareState().get().getState().nodes().getMasterNode()),
+            VotingOnlyNodePlugin.isVotingOnlyNode(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode()
+            ),
             equalTo(false)
         );
     }
@@ -145,16 +160,19 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().startNodes(2, addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)));
         internalCluster().startDataOnlyNodes(randomInt(2));
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(), equalTo(3))
+            () -> assertThat(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds().size(),
+                equalTo(3)
+            )
         );
-        final String oldMasterId = clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId();
+        final String oldMasterId = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNodeId();
 
         internalCluster().stopCurrentMasterNode();
 
         expectThrows(
             MasterNotDiscoveredException.class,
             () -> assertThat(
-                clusterAdmin().prepareState()
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT)
                     .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                     .get()
                     .getState()
@@ -167,7 +185,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         // start a fresh full master node, which will be brought into the cluster as master by the voting-only nodes
         final String newMaster = internalCluster().startNode();
         assertEquals(newMaster, internalCluster().getMasterName());
-        final String newMasterId = clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId();
+        final String newMasterId = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNodeId();
         assertNotEquals(oldMasterId, newMasterId);
     }
 

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -353,7 +353,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
         final AtomicReference<SearchResponse> lastResponse = new AtomicReference<>();
         try {
             assertBusy(() -> {
-                ClusterState state = clusterAdmin().prepareState().get().getState();
+                ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
                 String[] watchHistoryIndices = indexNameExpressionResolver().concreteIndexNames(
                     state,
                     IndicesOptions.lenientExpandOpen(),
@@ -429,7 +429,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
             assertBusy(() -> {
                 // The watch_history index gets created in the background when the first watch is triggered
                 // so we to check first is this index is created and shards are started
-                ClusterState state = clusterAdmin().prepareState().get().getState();
+                ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
                 String[] watchHistoryIndices = indexNameExpressionResolver().concreteIndexNames(
                     state,
                     IndicesOptions.lenientExpandOpen(),
@@ -476,7 +476,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
     protected void assertWatchWithMinimumActionsCount(final String watchName, final ExecutionState recordState, final long recordCount)
         throws Exception {
         assertBusy(() -> {
-            ClusterState state = clusterAdmin().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
             String[] watchHistoryIndices = indexNameExpressionResolver().concreteIndexNames(
                 state,
                 IndicesOptions.lenientExpandOpen(),

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -46,7 +46,7 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
     // the watch should be executed properly, despite the index being created and the cluster state listener being reloaded
     public void testThatLoadingWithNonExistingIndexWorks() throws Exception {
         stopWatcher();
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get();
         IndexMetadata metadata = WatchStoreUtils.getConcreteIndex(Watch.INDEX, clusterStateResponse.getState().metadata());
         String watchIndexName = metadata.getIndex().getName();
         assertAcked(indicesAdmin().prepareDelete(watchIndexName));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherExecutorServiceBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherExecutorServiceBenchmark.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.watcher.test.bench;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.MockNode;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
@@ -62,7 +63,7 @@ public class WatcherExecutorServiceBenchmark {
     protected static void start() throws Exception {
         Node node = new MockNode(Settings.builder().put(SETTINGS).put("node.data", false).build(), Arrays.asList(BenchmarkWatcher.class));
         client = node.client();
-        client.admin().cluster().prepareHealth("*").setWaitForGreenStatus().get();
+        client.admin().cluster().prepareHealth(TimeValue.THIRTY_SECONDS, "*").setWaitForGreenStatus().get();
         Thread.sleep(5000);
         scheduler = node.injector().getInstance(ScheduleTriggerEngineMock.class);
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.node.InternalSettingsPreparer;
@@ -109,7 +110,7 @@ public class WatcherScheduleEngineBenchmark {
             ).start()
         ) {
             final Client client = node.client();
-            ClusterHealthResponse response = client.admin().cluster().prepareHealth().setWaitForNodes("2").get();
+            ClusterHealthResponse response = client.admin().cluster().prepareHealth(TimeValue.THIRTY_SECONDS).setWaitForNodes("2").get();
             if (response.getNumberOfNodes() != 2 && response.getNumberOfDataNodes() != 1) {
                 throw new IllegalStateException("This benchmark needs one extra data only node running outside this benchmark");
             }
@@ -161,9 +162,9 @@ public class WatcherScheduleEngineBenchmark {
                 .build();
             try (Node node = new MockNode(settings, Arrays.asList(LocalStateWatcher.class))) {
                 final Client client = node.client();
-                client.admin().cluster().prepareHealth().setWaitForNodes("2").get();
+                client.admin().cluster().prepareHealth(TimeValue.THIRTY_SECONDS).setWaitForNodes("2").get();
                 client.admin().indices().prepareDelete(HistoryStoreField.DATA_STREAM + "*").get();
-                client.admin().cluster().prepareHealth(Watch.INDEX, "test").setWaitForYellowStatus().get();
+                client.admin().cluster().prepareHealth(TimeValue.THIRTY_SECONDS, Watch.INDEX, "test").setWaitForYellowStatus().get();
 
                 Clock clock = node.injector().getInstance(Clock.class);
                 while (new WatcherStatsRequestBuilder(client).get()


### PR DESCRIPTION
Removes all usages of `TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT` in
cluster-related APIs in `:server`.

Relates #107984

<!-- Please don't remove the machine data below, even if you remove the linking label -->
<!--es-delivery-machine-data {"linkedServerlessPr":2727,"linkedStatefulPr":112674} es-delivery-machine-data-->