### PR TITLE
Make "too many clauses" throw IllegalArgumentException to avoid 500s

### DIFF
--- a/docs/changelog/112678.yaml
+++ b/docs/changelog/112678.yaml
@@ -1,0 +1,6 @@
+pr: 112678
+summary: Make "too many clauses" throw IllegalArgumentException to avoid 500s
+area: Search
+type: bug
+issues:
+ - 112177

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -202,6 +202,8 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         } catch (TimeExceededException e) {
             timeExceeded = true;
             return new MatchNoDocsQuery("rewrite timed out");
+        } catch (TooManyClauses e) {
+            throw new IllegalArgumentException("Query rewrite failed: too many clauses", e);
         } finally {
             if (profiler != null) {
                 profiler.stopAndAddRewriteTime(rewriteTimer);

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.spans.SpanNearQuery;
 import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
@@ -1103,6 +1104,22 @@ public class QueryPhaseTests extends IndexShardTestCase {
             NEVER_CACHE_POLICY,
             true
         );
+    }
+
+    public void testTooManyClauses() throws Exception {
+        indexDocs();
+        var oldCount = IndexSearcher.getMaxClauseCount();
+        try {
+            var query = new BooleanQuery.Builder().add(new BooleanClause(new MatchAllDocsQuery(), Occur.SHOULD))
+                .add(new MatchAllDocsQuery(), Occur.SHOULD)
+                .build();
+            try (TestSearchContext context = createContext(newContextSearcher(reader), query)) {
+                IndexSearcher.setMaxClauseCount(1);
+                expectThrows(IllegalArgumentException.class, context::rewrittenQuery);
+            }
+        } finally {
+            IndexSearcher.setMaxClauseCount(oldCount);
+        }
     }
 
     private static ContextIndexSearcher noCollectionContextSearcher(IndexReader reader) throws IOException {


### PR DESCRIPTION
When rewriting Lucene query, if "too many clauses" exception is thrown, convert it to IllegalArgumentException, which will ultimate resolve into 4xx response. 

Fixes https://github.com/elastic/elasticsearch/issues/112177

Example response with the fix: 
```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "Query rewrite failed: too many clauses"
      }
    ],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query",
    "grouped": true,
    "failed_shards": [
      {
        "shard": 0,
        "index": "many-fields",
        "node": "srBwTgpLT1OpljGVrcTNQA",
        "reason": {
          "type": "illegal_argument_exception",
          "reason": "Query rewrite failed: too many clauses",
          "caused_by": {
            "type": "too_many_nested_clauses",
            "reason": "Query contains too many nested clauses; maxClauseCount is set to 3449"
          }
        }
      }
    ],
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "Query rewrite failed: too many clauses",
      "caused_by": {
        "type": "illegal_argument_exception",
        "reason": "Query rewrite failed: too many clauses",
        "caused_by": {
          "type": "too_many_nested_clauses",
          "reason": "Query contains too many nested clauses; maxClauseCount is set to 3449"
        }
      }
    }
  },
  "status": 400
}
```