### PR TITLE
Unmuting simulate ingest yaml rest test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -178,9 +178,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
   method: testIndexPatternErrorMessageComparison_ESQL_SearchDSL
   issue: https://github.com/elastic/elasticsearch/issues/112630
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=simulate.ingest/10_basic/Test mapping validation from templates}
-  issue: https://github.com/elastic/elasticsearch/issues/112633
 - class: org.elasticsearch.compute.aggregation.blockhash.BlockHashTests
   method: testBytesRefLongHashHugeCombinatorialExplosion {forcePackedHash=false}
   issue: https://github.com/elastic/elasticsearch/issues/112442


### PR DESCRIPTION
It looks like @nielsbauman fixed this test in #112600, but elasticsearchmachine had muted it twice.
Closes #112633 