### PR TITLE
Replace Netty4HttpRequestBodyStream queue with composite buffer

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.http.netty4;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -16,25 +18,21 @@ import io.netty.util.concurrent.FutureListener;
 import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
-
 /**
  * Netty based implementation of {@link HttpBody.Stream}.
  * This implementation utilize {@link io.netty.channel.ChannelConfig#setAutoRead(boolean)}
  * to prevent entire payload buffering. But sometimes upstream can send few chunks of data despite
- * autoRead=off. In this case chunks will be queued until downstream calls {@link Stream#next()}
+ * autoRead=off. In this case chunks will be buffered until downstream calls {@link Stream#next()}
  */
 public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private final Channel channel;
-    private final Queue<HttpContent> chunkQueue = new ArrayDeque<>();
-    private boolean requested = false;
+    private final FutureListener<Void> closeListener = future -> doClose();
+    private ByteBuf buf;
     private boolean hasLast = false;
+    private boolean requested = false;
     private boolean closing = false;
     private HttpBody.ChunkHandler handler;
-
-    private final FutureListener<Void> closeListener = future -> doClose();
 
     public Netty4HttpRequestBodyStream(Channel channel) {
         this.channel = channel;
@@ -52,38 +50,49 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         this.handler = chunkHandler;
     }
 
-    private void sendQueuedOrRead() {
-        assert channel.eventLoop().inEventLoop();
-        requested = true;
-        var chunk = chunkQueue.poll();
-        if (chunk == null) {
-            channel.read();
-        } else {
-            sendChunk(chunk);
-        }
-    }
-
     @Override
     public void next() {
+        assert closing == false : "cannot request next chunk on closing stream";
         assert handler != null : "handler must be set before requesting next chunk";
-        if (channel.eventLoop().inEventLoop()) {
-            sendQueuedOrRead();
-        } else {
-            channel.eventLoop().submit(this::sendQueuedOrRead);
-        }
+        channel.eventLoop().submit(() -> {
+            requested = true;
+            if (buf == null) {
+                channel.read();
+            } else {
+                send();
+            }
+        });
     }
 
     public void handleNettyContent(HttpContent httpContent) {
+        assert hasLast == false : "receive http content on completed stream";
         hasLast = httpContent instanceof LastHttpContent;
         if (closing) {
             httpContent.release();
-            return;
-        }
-        assert handler != null : "handler must be set before processing http content";
-        if (requested && chunkQueue.isEmpty()) {
-            sendChunk(httpContent);
         } else {
-            chunkQueue.add(httpContent);
+            addChunk(httpContent.content());
+            if (requested) {
+                send();
+            }
+        }
+        if (hasLast) {
+            channel.config().setAutoRead(true);
+            channel.closeFuture().removeListener(closeListener);
+        }
+    }
+
+    // adds chunk to current buffer, will allocate composite buffer when need to hold more than 1 chunk
+    private void addChunk(ByteBuf chunk) {
+        assert chunk != null;
+        if (buf == null) {
+            buf = chunk;
+        } else if (buf instanceof CompositeByteBuf comp) {
+            comp.addComponent(true, chunk);
+        } else {
+            var comp = channel.alloc().compositeBuffer();
+            comp.addComponent(true, buf);
+            comp.addComponent(true, chunk);
+            buf = comp;
         }
     }
 
@@ -93,8 +102,8 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     }
 
     // visible for test
-    Queue<HttpContent> chunkQueue() {
-        return chunkQueue;
+    ByteBuf buf() {
+        return buf;
     }
 
     // visible for test
@@ -102,22 +111,13 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         return hasLast;
     }
 
-    private void sendChunk(HttpContent httpContent) {
+    private void send() {
         assert requested;
+        assert handler != null : "must set handler before receiving next chunk";
+        var bytesRef = Netty4Utils.toReleasableBytesReference(buf);
         requested = false;
-        var bytesRef = Netty4Utils.toReleasableBytesReference(httpContent.content());
-        var isLast = httpContent instanceof LastHttpContent;
-        handler.onNext(bytesRef, isLast);
-        if (isLast) {
-            channel.config().setAutoRead(true);
-            channel.closeFuture().removeListener(closeListener);
-        }
-    }
-
-    private void releaseQueuedChunks() {
-        while (chunkQueue.isEmpty() == false) {
-            chunkQueue.poll().release();
-        }
+        buf = null;
+        handler.onNext(bytesRef, hasLast);
     }
 
     @Override
@@ -131,7 +131,10 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private void doClose() {
         closing = true;
-        releaseQueuedChunks();
+        if (buf != null) {
+            buf.release();
+            buf = null;
+        }
         channel.config().setAutoRead(true);
     }
 }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
@@ -52,33 +52,31 @@ public class Netty4HttpRequestBodyStreamTests extends ESTestCase {
         for (int i = 0; i < totalChunks; i++) {
             channel.writeInbound(randomContent(1024));
         }
-        assertEquals(totalChunks, stream.chunkQueue().size());
+        assertEquals(totalChunks * 1024, stream.buf().readableBytes());
     }
 
-    // ensures all queued chunks can be flushed downstream
-    public void testFlushQueued() {
+    // ensures all received chunks can be flushed downstream
+    public void testFlushAllReceivedChunks() {
         var chunks = new ArrayList<ReleasableBytesReference>();
         var totalBytes = new AtomicInteger();
         stream.setHandler((chunk, isLast) -> {
             chunks.add(chunk);
             totalBytes.addAndGet(chunk.length());
         });
-        // enqueue chunks
+
         var chunkSize = 1024;
         var totalChunks = randomIntBetween(1, 100);
         for (int i = 0; i < totalChunks; i++) {
             channel.writeInbound(randomContent(chunkSize));
         }
-        // consume all chunks
-        for (var i = 0; i < totalChunks; i++) {
-            stream.next();
-        }
-        assertEquals(totalChunks, chunks.size());
+        stream.next();
+        channel.runPendingTasks();
+        assertEquals("should receive all chunks as single composite", 1, chunks.size());
         assertEquals(chunkSize * totalChunks, totalBytes.get());
     }
 
-    // ensures that we read from channel when chunks queue is empty
-    // and pass next chunk downstream without queuing
+    // ensures that we read from channel when no current chunks available
+    // and pass next chunk downstream without holding
     public void testReadFromChannel() {
         var gotChunks = new ArrayList<ReleasableBytesReference>();
         var gotLast = new AtomicBoolean(false);
@@ -95,8 +93,9 @@ public class Netty4HttpRequestBodyStreamTests extends ESTestCase {
         channel.writeInbound(randomLastContent(chunkSize));
 
         for (int i = 0; i < totalChunks; i++) {
-            assertEquals("should not enqueue chunks", 0, stream.chunkQueue().size());
+            assertNull("should not enqueue chunks", stream.buf());
             stream.next();
+            channel.runPendingTasks();
             assertEquals("each next() should produce single chunk", i + 1, gotChunks.size());
         }
         assertTrue("should receive last content", gotLast.get());


### PR DESCRIPTION
Replace stream chunks queue with composite buffer. On `next()` invocation downstream will receive all accumulated http parts in single chunk. Accumulation happens when more than one http-content-parts are holding by stream, in this case new composite buffer will be allocated.

Minor change. Remove recursion from `next()`, always schedule a task in channel event loop.