### PR TITLE
[8.15] #101472 Updates default index.translog.flush_threshold_size value (#112052)

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -19,7 +19,8 @@ An {es} <<indices-flush,flush>> is the process of performing a Lucene commit and
 starting a new translog generation. Flushes are performed automatically in the
 background in order to make sure the translog does not grow too large, which
 would make replaying its operations take a considerable amount of time during
-recovery. The ability to perform a flush manually is also exposed through an
+recovery.  The translog size will never exceed `1%` of the disk size.
+The ability to perform a flush manually is also exposed through an
 API, although this is rarely needed.
 
 [discrete]
@@ -71,7 +72,8 @@ update, or bulk request. This setting accepts the following parameters:
   The translog stores all operations that are not yet safely persisted in Lucene
   (i.e., are not part of a Lucene commit point). Although these operations are
   available for reads, they will need to be replayed if the shard was stopped
-  and had to be recovered. This setting controls the maximum total size of these
-  operations, to prevent recoveries from taking too long. Once the maximum size
-  has been reached a flush will happen, generating a new Lucene commit point.
-  Defaults to `512mb`.
+  and had to be recovered.
+  This setting controls the maximum total size of these operations to prevent
+  recoveries from taking too long. Once the maximum size has been reached, a flush
+  will happen, generating a new Lucene commit point. Defaults to `10 GB`.
+ 


### PR DESCRIPTION
Backports the following commits to 8.15:
 - #101472 Updates default index.translog.flush_threshold_size value (#112052)