### PR TITLE
[8.15][DOCS] Adds path params and available task types to the PUT inference page

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -32,25 +32,44 @@ use the <<ml-df-trained-models-apis>>.
 (the built-in `inference_admin` role grants this privilege)
 
 [discrete]
+[[put-inference-api-path-params]]
+==== {api-path-parms-title}
+
+`<inference_id>`::
+(Required, string)
+include::inference-shared.asciidoc[tag=inference-id]
+
+`<task_type>`::
+(Required, string)
+include::inference-shared.asciidoc[tag=task-type]
++
+--
+Refer to the service list in the <<put-inference-api-desc,API description section>> for the available task types. 
+--
+
+
+[discrete]
 [[put-inference-api-desc]]
 ==== {api-description-title}
 
 The create {infer} API enables you to create an {infer} endpoint and configure a {ml} model to perform a specific {infer} task.
 
-The following services are available through the {infer} API, click the links to review the configuration details of the services:
+The following services are available through the {infer} API.
+You can find the available task types next to the service name. 
+Click the links to review the configuration details of the services:
 
-* <<infer-service-amazon-bedrock,Amazon Bedrock>>
-* <<infer-service-anthropic,Anthropic>>
-* <<infer-service-azure-ai-studio,Azure AI Studio>>
-* <<infer-service-azure-openai,Azure OpenAI>>
-* <<infer-service-cohere,Cohere>>
-* <<infer-service-elasticsearch,Elasticsearch>> (for built-in models and models uploaded through Eland)
-* <<infer-service-elser,ELSER>>
-* <<infer-service-google-ai-studio,Google AI Studio>>
-* <<infer-service-google-vertex-ai,Google Vertex AI>>
-* <<infer-service-hugging-face,Hugging Face>>
-* <<infer-service-mistral,Mistral>>
-* <<infer-service-openai,OpenAI>>
+* <<infer-service-amazon-bedrock,Amazon Bedrock>> (`completion`, `text_embedding`)
+* <<infer-service-anthropic,Anthropic>> (`completion`)
+* <<infer-service-azure-ai-studio,Azure AI Studio>> (`completion`, `text_embedding`)
+* <<infer-service-azure-openai,Azure OpenAI>> (`completion`, `text_embedding`)
+* <<infer-service-cohere,Cohere>> (`completion`, `rerank`, `text_embedding`)
+* <<infer-service-elasticsearch,Elasticsearch>> (`rerank`, `sparse_embedding`, `text_embedding` - this service is for built-in models and models uploaded through Eland)
+* <<infer-service-elser,ELSER>> (`sparse_embedding`)
+* <<infer-service-google-ai-studio,Google AI Studio>> (`completion`, `text_embedding`)
+* <<infer-service-google-vertex-ai,Google Vertex AI>> (`rerank`, `text_embedding`) 
+* <<infer-service-hugging-face,Hugging Face>> (`text_embedding`)
+* <<infer-service-mistral,Mistral>> (`text_embedding`)
+* <<infer-service-openai,OpenAI>> (`completion`, `text_embedding`)
 
 The {es} and ELSER services run on a {ml} node in your {es} cluster. The rest of
 the services connect to external providers.


### PR DESCRIPTION
## Overview

This PR backports the following changes to the `8.15` branch:
[DOCS] Adds path params and available task types to the PUT inference page #112696