### PR TITLE
Change default S3 repository chunk_size

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -129,7 +129,8 @@ class S3Repository extends MeteredBlobStoreRepository {
      * and {@code max_number_of_parts = 10_000}
      */
     static final ByteSizeValue DEFAULT_CHUNK_SIZE = new ByteSizeValue(
-        DEFAULT_BUFFER_SIZE.getBytes() * MAX_PARTS_NUMBER_USING_MULTIPART, ByteSizeUnit.BYTES
+        DEFAULT_BUFFER_SIZE.getBytes() * MAX_PARTS_NUMBER_USING_MULTIPART,
+        ByteSizeUnit.BYTES
     );
 
     /**

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.s3.model.UploadPartResult;
 
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStoreException;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
@@ -82,6 +83,16 @@ public class S3BlobStoreContainerTests extends ESTestCase {
             )
         );
         assertEquals("Upload request size [2097152] can't be larger than buffer size", e.getMessage());
+    }
+
+    public void testDefaultChunkPartsLimit() {
+        var settings = Settings.EMPTY;
+        var blobSize = S3Repository.CHUNK_SIZE_SETTING.getDefault(settings).getBytes();
+        var partSize = S3Repository.BUFFER_SIZE_SETTING.getDefault(settings).getBytes();
+        var parts = S3BlobContainer.numberOfMultiparts(blobSize, partSize);
+        var gotParts = parts.v1();
+        var maxParts = S3Repository.MAX_PARTS_NUMBER_USING_MULTIPART;
+        assertTrue("numbers of parts should be less-or-equal " + maxParts + ", got " + gotParts, gotParts <= maxParts);
     }
 
     public void testExecuteSingleUpload() throws IOException {


### PR DESCRIPTION
Current default S3 repository settings are in conflict with S3 limit for multi-part upload. We split large files into 5TiB chunks with 100Mb part size. That means we need to send up to 50k parts, where S3 limit is 10k. https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html

This PR changes default `chunk_size` to `default_part_size * max_parts_number(10k)`, which should be in range of `[50Gb, 5Tib]`

