### PR TITLE
Mark data streams stats API as internal-only (again)

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestDataStreamsStatsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestDataStreamsStatsAction.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestDataStreamsStatsAction extends BaseRestHandler {
     @Override
     public String getName() {


### PR DESCRIPTION
This is a redo of https://github.com/elastic/elasticsearch/pull/108745 which was reverted. Now that https://github.com/elastic/elasticsearch/pull/112303 has been merged, there is an alternative to retrieve the `maximum_timestamp`.
