### PR TITLE
Fix encoding of dynamic arrays in ignored source

### DIFF
--- a/docs/changelog/112713.yaml
+++ b/docs/changelog/112713.yaml
@@ -1,0 +1,5 @@
+pr: 112713
+summary: Fix encoding of dynamic arrays in ignored source
+area: Logs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -646,7 +646,7 @@ public final class DocumentParser {
                         context.addIgnoredField(
                             IgnoredSourceFieldMapper.NameValue.fromContext(
                                 context,
-                                currentFieldName,
+                                context.path().pathAsText(currentFieldName),
                                 XContentDataHelper.encodeToken(context.parser())
                             )
                         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -229,16 +229,8 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             b.field("a", List.of(intValue, intValue));
             b.endObject();
         });
-        assertEquals(
-            String.format(
-                Locale.ROOT,
-                """
-                    {"bar":{"a":[%s,%s]}}""",
-                intValue,
-                intValue
-            ),
-            syntheticSource
-        );
+        assertEquals(String.format(Locale.ROOT, """
+            {"bar":{"a":[%s,%s]}}""", intValue, intValue), syntheticSource);
     }
 
     public void testDisabledRootObjectSingleField() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -221,6 +221,26 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         );
     }
 
+    public void testIgnoredDynamicArrayNestedInObject() throws IOException {
+        int intValue = randomInt();
+
+        String syntheticSource = getSyntheticSourceWithFieldLimit(b -> {
+            b.startObject("bar");
+            b.field("a", List.of(intValue, intValue));
+            b.endObject();
+        });
+        assertEquals(
+            String.format(
+                Locale.ROOT,
+                """
+                    {"bar":{"a":[%s,%s]}}""",
+                intValue,
+                intValue
+            ),
+            syntheticSource
+        );
+    }
+
     public void testDisabledRootObjectSingleField() throws IOException {
         String name = randomAlphaOfLength(20);
         DocumentMapper documentMapper = createMapperService(topMapping(b -> {


### PR DESCRIPTION
This is a problem that was reported in scope of internal PoC.