### PR TITLE
[8.15] Fix encoding of dynamic arrays in ignored source (#112713)

### DIFF
--- a/docs/changelog/112713.yaml
+++ b/docs/changelog/112713.yaml
@@ -1,0 +1,5 @@
+pr: 112713
+summary: Fix encoding of dynamic arrays in ignored source
+area: Logs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -639,7 +639,7 @@ public final class DocumentParser {
                         context.addIgnoredField(
                             IgnoredSourceFieldMapper.NameValue.fromContext(
                                 context,
-                                currentFieldName,
+                                context.path().pathAsText(currentFieldName),
                                 XContentDataHelper.encodeToken(context.parser())
                             )
                         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -213,6 +213,18 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         );
     }
 
+    public void testIgnoredDynamicArrayNestedInObject() throws IOException {
+        int intValue = randomInt();
+
+        String syntheticSource = getSyntheticSourceWithFieldLimit(b -> {
+            b.startObject("bar");
+            b.field("a", List.of(intValue, intValue));
+            b.endObject();
+        });
+        assertEquals(String.format(Locale.ROOT, """
+            {"bar":{"a":[%s,%s]}}""", intValue, intValue), syntheticSource);
+    }
+
     public void testDisabledRootObjectSingleField() throws IOException {
         String name = randomAlphaOfLength(20);
         DocumentMapper documentMapper = createMapperService(topMapping(b -> {


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Fix encoding of dynamic arrays in ignored source (#112713)