### PR TITLE
Fix NPE in dense_vector stats

### DIFF
--- a/docs/changelog/112720.yaml
+++ b/docs/changelog/112720.yaml
@@ -1,0 +1,5 @@
+pr: 112720
+summary: Fix NPE in `dense_vector` stats
+area: Vector Search
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -258,8 +258,8 @@
 ---
 "Dense vector stats":
   - requires:
-      cluster_features: [ "gte_v8.15.0" ]
-      reason: "dense vector stats reports from primary indices in 8.15"
+      cluster_features: [ "gte_v8.16.0" ]
+      reason: "dense vector stats reports from primary indices in 8.15 and fixed in 8.16"
   - do:
       indices.create:
         index: test1
@@ -329,9 +329,17 @@
   - do:
       indices.refresh: { }
 
+  - do:
+      index:
+        index: test2
+        id: "3"
+        refresh: true
+        body:
+          not_vector_field: "not vector"
+
   - do: { cluster.stats: { } }
 
-  - match: { indices.docs.count: 4 }
+  - match: { indices.docs.count: 5 }
   - match: { indices.docs.deleted: 0 }
   - match: { indices.dense_vector.value_count: 8 }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -284,7 +284,7 @@ public abstract class Engine implements Closeable {
         long count = 0;
         for (var field : fields) {
             var info = atomicReader.getFieldInfos().fieldInfo(field);
-            if (info.getVectorDimension() > 0) {
+            if (info != null && info.getVectorDimension() > 0) {
                 switch (info.getVectorEncoding()) {
                     case FLOAT32 -> {
                         FloatVectorValues values = atomicReader.getFloatVectorValues(info.name);


### PR DESCRIPTION
If a segment doesn't contain any documents with a dense_vector field, but the mapping defines it, an NPE can occur when retrieving the dense_vector stats.

Relates #111729