### PR TITLE
Ensure partial bulks released if channel closes

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -110,9 +110,11 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
                 assertTrue(recvChunk.isLast);
                 assertEquals(0, recvChunk.chunk.length());
                 recvChunk.chunk.close();
+                assertFalse(handler.streamClosed);
 
                 // send response to process following request
                 handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+                assertBusy(() -> assertTrue(handler.streamClosed));
             }
             assertBusy(() -> assertEquals("should receive all server responses", totalRequests, ctx.clientRespQueue.size()));
         }
@@ -145,14 +147,16 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
                     }
                 }
 
+                assertFalse(handler.streamClosed);
                 assertEquals("sent and received payloads are not the same", sendData, recvData);
                 handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+                assertBusy(() -> assertTrue(handler.streamClosed));
             }
             assertBusy(() -> assertEquals("should receive all server responses", totalRequests, ctx.clientRespQueue.size()));
         }
     }
 
-    // ensures that all received chunks are released when connection closed
+    // ensures that all received chunks are released when connection closed and handler notified
     public void testClientConnectionCloseMidStream() throws Exception {
         try (var ctx = setupClientCtx()) {
             var opaqueId = opaqueId(0);
@@ -167,10 +171,14 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
 
             // enable auto-read to receive channel close event
             handler.stream.channel().config().setAutoRead(true);
+            assertFalse(handler.streamClosed);
 
             // terminate connection and wait resources are released
             ctx.clientChannel.close();
-            assertBusy(() -> assertNull(handler.stream.buf()));
+            assertBusy(() -> {
+                assertNull(handler.stream.buf());
+                assertTrue(handler.streamClosed);
+            });
         }
     }
 
@@ -186,10 +194,14 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
             // await stream handler is ready and request full content
             var handler = ctx.awaitRestChannelAccepted(opaqueId);
             assertBusy(() -> assertNotNull(handler.stream.buf()));
+            assertFalse(handler.streamClosed);
 
             // terminate connection on server and wait resources are released
             handler.channel.request().getHttpChannel().close();
-            assertBusy(() -> assertNull(handler.stream.buf()));
+            assertBusy(() -> {
+                assertNull(handler.stream.buf());
+                assertTrue(handler.streamClosed);
+            });
         }
     }
 
@@ -470,6 +482,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         final Netty4HttpRequestBodyStream stream;
         RestChannel channel;
         boolean recvLast = false;
+        volatile boolean streamClosed = false;
 
         ServerRequestHandler(String opaqueId, Netty4HttpRequestBodyStream stream) {
             this.opaqueId = opaqueId;
@@ -485,6 +498,11 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         public void accept(RestChannel channel) throws Exception {
             this.channel = channel;
             channelAccepted.onResponse(null);
+        }
+
+        @Override
+        public void streamClose() {
+            streamClosed = true;
         }
 
         void sendResponse(RestResponse response) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -127,6 +127,12 @@ public class Netty4HttpRequest implements HttpRequest {
         }
         try {
             final ByteBuf copiedContent = Unpooled.copiedBuffer(request.content());
+            HttpBody newContent;
+            if (content.isStream()) {
+                newContent = content;
+            } else {
+                newContent = Netty4Utils.fullHttpBodyFrom(copiedContent);
+            }
             return new Netty4HttpRequest(
                 sequence,
                 new DefaultFullHttpRequest(
@@ -139,7 +145,7 @@ public class Netty4HttpRequest implements HttpRequest {
                 ),
                 new AtomicBoolean(false),
                 false,
-                content
+                newContent
             );
         } finally {
             release();

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -131,6 +131,9 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private void doClose() {
         closing = true;
+        if (handler != null) {
+            handler.close();
+        }
         if (buf != null) {
             buf.release();
             buf = null;

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -185,7 +185,7 @@ public class IncrementalBulkService {
                         requestContext.restore();
                         final ArrayList<Releasable> toRelease = new ArrayList<>(releasables);
                         releasables.clear();
-                        client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
+                        client.bulk(bulkRequest, ActionListener.runBefore(new ActionListener<>() {
 
                             private final boolean isFirstRequest = incrementalRequestSubmitted == false;
 

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -99,8 +99,11 @@ public sealed interface HttpBody extends Releasable permits HttpBody.Full, HttpB
     }
 
     @FunctionalInterface
-    interface ChunkHandler {
+    interface ChunkHandler extends Releasable {
         void onNext(ReleasableBytesReference chunk, boolean isLast);
+
+        @Override
+        default void close() {}
     }
 
     record ByteRefHttpBody(BytesReference bytes) implements Full {}

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.rest.action.admin.cluster.RestNodesUsageAction;
 
@@ -126,7 +127,17 @@ public abstract class BaseRestHandler implements RestHandler {
             if (request.isStreamedContent()) {
                 assert action instanceof RequestBodyChunkConsumer;
                 var chunkConsumer = (RequestBodyChunkConsumer) action;
-                request.contentStream().setHandler((chunk, isLast) -> chunkConsumer.handleChunk(channel, chunk, isLast));
+                request.contentStream().setHandler(new HttpBody.ChunkHandler() {
+                    @Override
+                    public void onNext(ReleasableBytesReference chunk, boolean isLast) {
+                        chunkConsumer.handleChunk(channel, chunk, isLast);
+                    }
+
+                    @Override
+                    public void close() {
+                        chunkConsumer.streamClose();
+                    }
+                });
             }
 
             usageCount.increment();
@@ -192,7 +203,7 @@ public abstract class BaseRestHandler implements RestHandler {
         /**
          * Called when the stream closes. This could happen prior to the completion of the request if the underlying channel was closed.
          * Implementors should do their best to clean up resources and early terminate request processing if it is triggered before a
-         * response.
+         * response is generated.
          */
         default void streamClose() {}
     }

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -188,6 +188,13 @@ public abstract class BaseRestHandler implements RestHandler {
 
     public interface RequestBodyChunkConsumer extends RestChannelConsumer {
         void handleChunk(RestChannel channel, ReleasableBytesReference chunk, boolean isLast);
+
+        /**
+         * Called when the stream closes. This could happen prior to the completion of the request if the underlying channel was closed.
+         * Implementors should do their best to clean up resources and early terminate request processing if it is triggered before a
+         * response.
+         */
+        default void streamClose() {}
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -176,7 +176,6 @@ public class RestBulkAction extends BaseRestHandler {
 
         @Override
         public void handleChunk(RestChannel channel, ReleasableBytesReference chunk, boolean isLast) {
-            assert Transports.assertTransportThread();
             assert handler != null;
             assert channel == restChannel;
             if (shortCircuited) {

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+import org.elasticsearch.transport.Transports;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -147,7 +148,7 @@ public class RestBulkAction extends BaseRestHandler {
         private IncrementalBulkService.Handler handler;
 
         private volatile RestChannel restChannel;
-        private boolean isException;
+        private boolean shortCircuited;
         private final ArrayDeque<ReleasableBytesReference> unParsedChunks = new ArrayDeque<>(4);
         private final ArrayList<DocWriteRequest<?>> items = new ArrayList<>(4);
 
@@ -175,9 +176,10 @@ public class RestBulkAction extends BaseRestHandler {
 
         @Override
         public void handleChunk(RestChannel channel, ReleasableBytesReference chunk, boolean isLast) {
+            assert Transports.assertTransportThread();
             assert handler != null;
             assert channel == restChannel;
-            if (isException) {
+            if (shortCircuited) {
                 chunk.close();
                 return;
             }
@@ -214,12 +216,8 @@ public class RestBulkAction extends BaseRestHandler {
                 );
 
             } catch (Exception e) {
-                // TODO: This needs to be better
-                Releasables.close(handler);
-                Releasables.close(unParsedChunks);
-                unParsedChunks.clear();
+                shortCircuit();
                 new RestToXContentListener<>(channel).onFailure(e);
-                isException = true;
                 return;
             }
 
@@ -241,8 +239,16 @@ public class RestBulkAction extends BaseRestHandler {
         }
 
         @Override
-        public void close() {
-            RequestBodyChunkConsumer.super.close();
+        public void streamClose() {
+            assert Transports.assertTransportThread();
+            shortCircuit();
+        }
+
+        private void shortCircuit() {
+            shortCircuited = true;
+            Releasables.close(handler);
+            Releasables.close(unParsedChunks);
+            unParsedChunks.clear();
         }
 
         private ArrayList<Releasable> accountParsing(int bytesConsumed) {


### PR DESCRIPTION
Currently, the entire close pipeline is not hooked up in case of a
channel close while a request is being buffered or executed. This commit
resolves the issue by adding a connection to a stream closure.