### PR TITLE
[8.15] Adds details on Kibana access credentials (#112695)

### DIFF
--- a/docs/reference/quickstart/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/quickstart/run-elasticsearch-locally.asciidoc
@@ -114,6 +114,8 @@ docker run -p 127.0.0.1:5601:5601 -d --name kibana --network elastic-net \
   {kib-docker-image}
 ----
 
+When you access {kib}, use `elastic` as the username and the password you set earlier for the `ELASTIC_PASSWORD` environment variable.
+
 [NOTE]
 ====
 The service is started with a trial license. The trial license enables all features of Elasticsearch for a trial period of 30 days. After the trial period expires, the license is downgraded to a basic license, which is free forever. If you prefer to skip the trial and use the basic license, set the value of the `xpack.license.self_generated.type` variable to basic instead. For a detailed feature comparison between the different licenses, refer to our https://www.elastic.co/subscriptions[subscriptions page].


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Adds details on Kibana access credentials (#112695)