### PR TITLE
[8.14] [DOCS] Collapse some content in local dev setup for readability (#112355)

### DIFF
--- a/docs/reference/quickstart/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/quickstart/run-elasticsearch-locally.asciidoc
@@ -125,6 +125,10 @@ The service is started with a trial license. The trial license enables all featu
 
 To connect to the {es} cluster from a language client, you can use basic authentication with the `elastic` username and the password you set in the environment variable.
 
+.*Expand* for details
+[%collapsible]
+==============
+
 You'll use the following connection details:
 
 * **{es} endpoint**: `http://localhost:9200`
@@ -159,6 +163,8 @@ curl -u elastic:$ELASTIC_PASSWORD \
   -H 'Content-Type: application/json'
 ----
 // NOTCONSOLE
+
+==============
 
 [discrete]
 [[local-dev-next-steps]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[DOCS] Collapse some content in local dev setup for readability (#112355)](https://github.com/elastic/elasticsearch/pull/112355)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)