### PR TITLE
[8.x] ESQL: Compute support for filtering ungrouped aggs (#112717)

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -240,8 +240,10 @@ public class AggregatorImplementer {
         builder.addMethod(intermediateStateDesc());
         builder.addMethod(intermediateBlockCount());
         builder.addMethod(addRawInput());
-        builder.addMethod(addRawVector());
-        builder.addMethod(addRawBlock());
+        builder.addMethod(addRawVector(false));
+        builder.addMethod(addRawVector(true));
+        builder.addMethod(addRawBlock(false));
+        builder.addMethod(addRawBlock(true));
         builder.addMethod(addIntermediateInput());
         builder.addMethod(evaluateIntermediate());
         builder.addMethod(evaluateFinal());
@@ -345,22 +347,48 @@ public class AggregatorImplementer {
 
     private MethodSpec addRawInput() {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawInput");
-        builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC).addParameter(PAGE, "page");
+        builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC).addParameter(PAGE, "page").addParameter(BOOLEAN_VECTOR, "mask");
         if (stateTypeHasFailed) {
             builder.beginControlFlow("if (state.failed())");
             builder.addStatement("return");
             builder.endControlFlow();
         }
+        builder.beginControlFlow("if (mask.isConstant())");
+        {
+            builder.beginControlFlow("if (mask.getBoolean(0) == false)");
+            {
+                builder.addComment("Entire page masked away");
+                builder.addStatement("return");
+            }
+            builder.endControlFlow();
+            builder.addComment("No masking");
+            builder.addStatement("$T block = page.getBlock(channels.get(0))", valueBlockType(init, combine));
+            builder.addStatement("$T vector = block.asVector()", valueVectorType(init, combine));
+            builder.beginControlFlow("if (vector != null)");
+            builder.addStatement("addRawVector(vector)");
+            builder.nextControlFlow("else");
+            builder.addStatement("addRawBlock(block)");
+            builder.endControlFlow();
+            builder.addStatement("return");
+        }
+        builder.endControlFlow();
+        builder.addComment("Some positions masked away, others kept");
         builder.addStatement("$T block = page.getBlock(channels.get(0))", valueBlockType(init, combine));
         builder.addStatement("$T vector = block.asVector()", valueVectorType(init, combine));
-        builder.beginControlFlow("if (vector != null)").addStatement("addRawVector(vector)");
-        builder.nextControlFlow("else").addStatement("addRawBlock(block)").endControlFlow();
+        builder.beginControlFlow("if (vector != null)");
+        builder.addStatement("addRawVector(vector, mask)");
+        builder.nextControlFlow("else");
+        builder.addStatement("addRawBlock(block, mask)");
+        builder.endControlFlow();
         return builder.build();
     }
 
-    private MethodSpec addRawVector() {
+    private MethodSpec addRawVector(boolean masked) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawVector");
         builder.addModifiers(Modifier.PRIVATE).addParameter(valueVectorType(init, combine), "vector");
+        if (masked) {
+            builder.addParameter(BOOLEAN_VECTOR, "mask");
+        }
 
         if (stateTypeHasSeen) {
             builder.addStatement("state.seen(true)");
@@ -372,6 +400,9 @@ public class AggregatorImplementer {
 
         builder.beginControlFlow("for (int i = 0; i < vector.getPositionCount(); i++)");
         {
+            if (masked) {
+                builder.beginControlFlow("if (mask.getBoolean(i) == false)").addStatement("continue").endControlFlow();
+            }
             combineRawInput(builder, "vector");
         }
         builder.endControlFlow();
@@ -381,9 +412,12 @@ public class AggregatorImplementer {
         return builder.build();
     }
 
-    private MethodSpec addRawBlock() {
+    private MethodSpec addRawBlock(boolean masked) {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addRawBlock");
         builder.addModifiers(Modifier.PRIVATE).addParameter(valueBlockType(init, combine), "block");
+        if (masked) {
+            builder.addParameter(BOOLEAN_VECTOR, "mask");
+        }
 
         if (valuesIsBytesRef) {
             // Add bytes_ref scratch var that will only be used for bytes_ref blocks/vectors
@@ -391,6 +425,9 @@ public class AggregatorImplementer {
         }
         builder.beginControlFlow("for (int p = 0; p < block.getPositionCount(); p++)");
         {
+            if (masked) {
+                builder.beginControlFlow("if (mask.getBoolean(p) == false)").addStatement("continue").endControlFlow();
+            }
             builder.beginControlFlow("if (block.isNull(p))");
             builder.addStatement("continue");
             builder.endControlFlow();

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
@@ -53,13 +53,29 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BooleanBlock block = page.getBlock(channels.get(0));
+      BooleanVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BooleanBlock block = page.getBlock(channels.get(0));
     BooleanVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -69,8 +85,33 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
     }
   }
 
+  private void addRawVector(BooleanVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      CountDistinctBooleanAggregator.combine(state, vector.getBoolean(i));
+    }
+  }
+
   private void addRawBlock(BooleanBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        CountDistinctBooleanAggregator.combine(state, block.getBoolean(i));
+      }
+    }
+  }
+
+  private void addRawBlock(BooleanBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -56,13 +57,29 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -73,9 +90,36 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      CountDistinctBytesRefAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        CountDistinctBytesRefAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -58,13 +59,29 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      DoubleBlock block = page.getBlock(channels.get(0));
+      DoubleVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     DoubleBlock block = page.getBlock(channels.get(0));
     DoubleVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
     }
   }
 
+  private void addRawVector(DoubleVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      CountDistinctDoubleAggregator.combine(state, vector.getDouble(i));
+    }
+  }
+
   private void addRawBlock(DoubleBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        CountDistinctDoubleAggregator.combine(state, block.getDouble(i));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctFloatAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -58,13 +59,29 @@ public final class CountDistinctFloatAggregatorFunction implements AggregatorFun
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class CountDistinctFloatAggregatorFunction implements AggregatorFun
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      CountDistinctFloatAggregator.combine(state, vector.getFloat(i));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        CountDistinctFloatAggregator.combine(state, block.getFloat(i));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -58,13 +59,29 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      CountDistinctIntAggregator.combine(state, vector.getInt(i));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        CountDistinctIntAggregator.combine(state, block.getInt(i));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -58,13 +59,29 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      CountDistinctLongAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        CountDistinctLongAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBooleanAggregatorFunction.java
@@ -53,13 +53,29 @@ public final class MaxBooleanAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BooleanBlock block = page.getBlock(channels.get(0));
+      BooleanVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BooleanBlock block = page.getBlock(channels.get(0));
     BooleanVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -70,8 +86,35 @@ public final class MaxBooleanAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BooleanVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.booleanValue(MaxBooleanAggregator.combine(state.booleanValue(), vector.getBoolean(i)));
+    }
+  }
+
   private void addRawBlock(BooleanBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.booleanValue(MaxBooleanAggregator.combine(state.booleanValue(), block.getBoolean(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(BooleanBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxBytesRefAggregatorFunction.java
@@ -56,13 +56,29 @@ public final class MaxBytesRefAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -73,9 +89,36 @@ public final class MaxBytesRefAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MaxBytesRefAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MaxBytesRefAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      DoubleBlock block = page.getBlock(channels.get(0));
+      DoubleVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     DoubleBlock block = page.getBlock(channels.get(0));
     DoubleVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(DoubleVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.doubleValue(MaxDoubleAggregator.combine(state.doubleValue(), vector.getDouble(i)));
+    }
+  }
+
   private void addRawBlock(DoubleBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.doubleValue(MaxDoubleAggregator.combine(state.doubleValue(), block.getDouble(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxFloatAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MaxFloatAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MaxFloatAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.floatValue(MaxFloatAggregator.combine(state.floatValue(), vector.getFloat(i)));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.floatValue(MaxFloatAggregator.combine(state.floatValue(), block.getFloat(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.intValue(MaxIntAggregator.combine(state.intValue(), vector.getInt(i)));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.intValue(MaxIntAggregator.combine(state.intValue(), block.getInt(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIpAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIpAggregatorFunction.java
@@ -56,13 +56,29 @@ public final class MaxIpAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -73,9 +89,36 @@ public final class MaxIpAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MaxIpAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MaxIpAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.longValue(MaxLongAggregator.combine(state.longValue(), vector.getLong(i)));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.longValue(MaxLongAggregator.combine(state.longValue(), block.getLong(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -55,13 +56,29 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      DoubleBlock block = page.getBlock(channels.get(0));
+      DoubleVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     DoubleBlock block = page.getBlock(channels.get(0));
     DoubleVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -71,8 +88,33 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
     }
   }
 
+  private void addRawVector(DoubleVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MedianAbsoluteDeviationDoubleAggregator.combine(state, vector.getDouble(i));
+    }
+  }
+
   private void addRawBlock(DoubleBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MedianAbsoluteDeviationDoubleAggregator.combine(state, block.getDouble(i));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationFloatAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -55,13 +56,29 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -71,8 +88,33 @@ public final class MedianAbsoluteDeviationFloatAggregatorFunction implements Agg
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MedianAbsoluteDeviationFloatAggregator.combine(state, vector.getFloat(i));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MedianAbsoluteDeviationFloatAggregator.combine(state, block.getFloat(i));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -55,13 +56,29 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -71,8 +88,33 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MedianAbsoluteDeviationIntAggregator.combine(state, vector.getInt(i));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MedianAbsoluteDeviationIntAggregator.combine(state, block.getInt(i));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -55,13 +56,29 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -71,8 +88,33 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MedianAbsoluteDeviationLongAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MedianAbsoluteDeviationLongAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBooleanAggregatorFunction.java
@@ -53,13 +53,29 @@ public final class MinBooleanAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BooleanBlock block = page.getBlock(channels.get(0));
+      BooleanVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BooleanBlock block = page.getBlock(channels.get(0));
     BooleanVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -70,8 +86,35 @@ public final class MinBooleanAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BooleanVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.booleanValue(MinBooleanAggregator.combine(state.booleanValue(), vector.getBoolean(i)));
+    }
+  }
+
   private void addRawBlock(BooleanBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.booleanValue(MinBooleanAggregator.combine(state.booleanValue(), block.getBoolean(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(BooleanBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinBytesRefAggregatorFunction.java
@@ -56,13 +56,29 @@ public final class MinBytesRefAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -73,9 +89,36 @@ public final class MinBytesRefAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MinBytesRefAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MinBytesRefAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinFloatAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MinFloatAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MinFloatAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.floatValue(MinFloatAggregator.combine(state.floatValue(), vector.getFloat(i)));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.floatValue(MinFloatAggregator.combine(state.floatValue(), block.getFloat(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.intValue(MinIntAggregator.combine(state.intValue(), vector.getInt(i)));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.intValue(MinIntAggregator.combine(state.intValue(), block.getInt(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIpAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIpAggregatorFunction.java
@@ -56,13 +56,29 @@ public final class MinIpAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -73,9 +89,36 @@ public final class MinIpAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      MinIpAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        MinIpAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.longValue(MinLongAggregator.combine(state.longValue(), vector.getLong(i)));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.longValue(MinLongAggregator.combine(state.longValue(), block.getLong(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -58,13 +59,29 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      DoubleBlock block = page.getBlock(channels.get(0));
+      DoubleVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     DoubleBlock block = page.getBlock(channels.get(0));
     DoubleVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
     }
   }
 
+  private void addRawVector(DoubleVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      PercentileDoubleAggregator.combine(state, vector.getDouble(i));
+    }
+  }
+
   private void addRawBlock(DoubleBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        PercentileDoubleAggregator.combine(state, block.getDouble(i));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileFloatAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -58,13 +59,29 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class PercentileFloatAggregatorFunction implements AggregatorFuncti
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      PercentileFloatAggregator.combine(state, vector.getFloat(i));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        PercentileFloatAggregator.combine(state, block.getFloat(i));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -58,13 +59,29 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      PercentileIntAggregator.combine(state, vector.getInt(i));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        PercentileIntAggregator.combine(state, block.getInt(i));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -58,13 +59,29 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      PercentileLongAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        PercentileLongAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
@@ -56,13 +56,29 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      DoubleBlock block = page.getBlock(channels.get(0));
+      DoubleVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     DoubleBlock block = page.getBlock(channels.get(0));
     DoubleVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -73,8 +89,35 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(DoubleVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      SumDoubleAggregator.combine(state, vector.getDouble(i));
+    }
+  }
+
   private void addRawBlock(DoubleBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        SumDoubleAggregator.combine(state, block.getDouble(i));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumFloatAggregatorFunction.java
@@ -58,13 +58,29 @@ public final class SumFloatAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -75,8 +91,35 @@ public final class SumFloatAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      SumFloatAggregator.combine(state, vector.getFloat(i));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        SumFloatAggregator.combine(state, block.getFloat(i));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
@@ -57,13 +57,29 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +90,35 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.longValue(SumIntAggregator.combine(state.longValue(), vector.getInt(i)));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.longValue(SumIntAggregator.combine(state.longValue(), block.getInt(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
@@ -55,13 +55,29 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -72,8 +88,35 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    state.seen(true);
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      state.longValue(SumLongAggregator.combine(state.longValue(), vector.getLong(i)));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      state.seen(true);
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        state.longValue(SumLongAggregator.combine(state.longValue(), block.getLong(i)));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopBooleanAggregatorFunction.java
@@ -58,13 +58,29 @@ public final class TopBooleanAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BooleanBlock block = page.getBlock(channels.get(0));
+      BooleanVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BooleanBlock block = page.getBlock(channels.get(0));
     BooleanVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +90,33 @@ public final class TopBooleanAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BooleanVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      TopBooleanAggregator.combine(state, vector.getBoolean(i));
+    }
+  }
+
   private void addRawBlock(BooleanBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        TopBooleanAggregator.combine(state, block.getBoolean(i));
+      }
+    }
+  }
+
+  private void addRawBlock(BooleanBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunction.java
@@ -10,6 +10,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.FloatVector;
@@ -58,13 +59,29 @@ public final class TopFloatAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      FloatBlock block = page.getBlock(channels.get(0));
+      FloatVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     FloatBlock block = page.getBlock(channels.get(0));
     FloatVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class TopFloatAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(FloatVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      TopFloatAggregator.combine(state, vector.getFloat(i));
+    }
+  }
+
   private void addRawBlock(FloatBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        TopFloatAggregator.combine(state, block.getFloat(i));
+      }
+    }
+  }
+
+  private void addRawBlock(FloatBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIpAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIpAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -59,13 +60,29 @@ public final class TopIpAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -76,9 +93,36 @@ public final class TopIpAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      TopIpAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        TopIpAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunction.java
@@ -10,6 +10,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -58,13 +59,29 @@ public final class TopLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -74,8 +91,33 @@ public final class TopLongAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      TopLongAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        TopLongAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBooleanAggregatorFunction.java
@@ -52,13 +52,29 @@ public final class ValuesBooleanAggregatorFunction implements AggregatorFunction
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BooleanBlock block = page.getBlock(channels.get(0));
+      BooleanVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BooleanBlock block = page.getBlock(channels.get(0));
     BooleanVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -68,8 +84,33 @@ public final class ValuesBooleanAggregatorFunction implements AggregatorFunction
     }
   }
 
+  private void addRawVector(BooleanVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ValuesBooleanAggregator.combine(state, vector.getBoolean(i));
+    }
+  }
+
   private void addRawBlock(BooleanBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ValuesBooleanAggregator.combine(state, block.getBoolean(i));
+      }
+    }
+  }
+
+  private void addRawBlock(BooleanBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregatorFunction.java
@@ -11,6 +11,7 @@ import java.lang.StringBuilder;
 import java.util.List;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -53,13 +54,29 @@ public final class ValuesBytesRefAggregatorFunction implements AggregatorFunctio
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -70,9 +87,36 @@ public final class ValuesBytesRefAggregatorFunction implements AggregatorFunctio
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ValuesBytesRefAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ValuesBytesRefAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesDoubleAggregatorFunction.java
@@ -10,6 +10,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -52,13 +53,29 @@ public final class ValuesDoubleAggregatorFunction implements AggregatorFunction 
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      DoubleBlock block = page.getBlock(channels.get(0));
+      DoubleVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     DoubleBlock block = page.getBlock(channels.get(0));
     DoubleVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -68,8 +85,33 @@ public final class ValuesDoubleAggregatorFunction implements AggregatorFunction 
     }
   }
 
+  private void addRawVector(DoubleVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ValuesDoubleAggregator.combine(state, vector.getDouble(i));
+    }
+  }
+
   private void addRawBlock(DoubleBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ValuesDoubleAggregator.combine(state, block.getDouble(i));
+      }
+    }
+  }
+
+  private void addRawBlock(DoubleBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesIntAggregatorFunction.java
@@ -10,6 +10,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
@@ -52,13 +53,29 @@ public final class ValuesIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      IntBlock block = page.getBlock(channels.get(0));
+      IntVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     IntBlock block = page.getBlock(channels.get(0));
     IntVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -68,8 +85,33 @@ public final class ValuesIntAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(IntVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ValuesIntAggregator.combine(state, vector.getInt(i));
+    }
+  }
+
   private void addRawBlock(IntBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ValuesIntAggregator.combine(state, block.getInt(i));
+      }
+    }
+  }
+
+  private void addRawBlock(IntBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/ValuesLongAggregatorFunction.java
@@ -10,6 +10,7 @@ import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -52,13 +53,29 @@ public final class ValuesLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -68,8 +85,33 @@ public final class ValuesLongAggregatorFunction implements AggregatorFunction {
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      ValuesLongAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        ValuesLongAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointDocValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointDocValuesAggregatorFunction.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.elasticsearch.compute.aggregation.AggregatorFunction;
 import org.elasticsearch.compute.aggregation.IntermediateStateDesc;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -60,13 +61,29 @@ public final class SpatialCentroidCartesianPointDocValuesAggregatorFunction impl
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -76,8 +93,33 @@ public final class SpatialCentroidCartesianPointDocValuesAggregatorFunction impl
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      SpatialCentroidCartesianPointDocValuesAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        SpatialCentroidCartesianPointDocValuesAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointSourceValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointSourceValuesAggregatorFunction.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.AggregatorFunction;
 import org.elasticsearch.compute.aggregation.IntermediateStateDesc;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -63,13 +64,29 @@ public final class SpatialCentroidCartesianPointSourceValuesAggregatorFunction i
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -80,9 +97,36 @@ public final class SpatialCentroidCartesianPointSourceValuesAggregatorFunction i
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      SpatialCentroidCartesianPointSourceValuesAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        SpatialCentroidCartesianPointSourceValuesAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointDocValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointDocValuesAggregatorFunction.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.elasticsearch.compute.aggregation.AggregatorFunction;
 import org.elasticsearch.compute.aggregation.IntermediateStateDesc;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -60,13 +61,29 @@ public final class SpatialCentroidGeoPointDocValuesAggregatorFunction implements
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      LongBlock block = page.getBlock(channels.get(0));
+      LongVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     LongBlock block = page.getBlock(channels.get(0));
     LongVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -76,8 +93,33 @@ public final class SpatialCentroidGeoPointDocValuesAggregatorFunction implements
     }
   }
 
+  private void addRawVector(LongVector vector, BooleanVector mask) {
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      SpatialCentroidGeoPointDocValuesAggregator.combine(state, vector.getLong(i));
+    }
+  }
+
   private void addRawBlock(LongBlock block) {
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        SpatialCentroidGeoPointDocValuesAggregator.combine(state, block.getLong(i));
+      }
+    }
+  }
+
+  private void addRawBlock(LongBlock block, BooleanVector mask) {
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointSourceValuesAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointSourceValuesAggregatorFunction.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.AggregatorFunction;
 import org.elasticsearch.compute.aggregation.IntermediateStateDesc;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -63,13 +64,29 @@ public final class SpatialCentroidGeoPointSourceValuesAggregatorFunction impleme
   }
 
   @Override
-  public void addRawInput(Page page) {
+  public void addRawInput(Page page, BooleanVector mask) {
+    if (mask.isConstant()) {
+      if (mask.getBoolean(0) == false) {
+        // Entire page masked away
+        return;
+      }
+      // No masking
+      BytesRefBlock block = page.getBlock(channels.get(0));
+      BytesRefVector vector = block.asVector();
+      if (vector != null) {
+        addRawVector(vector);
+      } else {
+        addRawBlock(block);
+      }
+      return;
+    }
+    // Some positions masked away, others kept
     BytesRefBlock block = page.getBlock(channels.get(0));
     BytesRefVector vector = block.asVector();
     if (vector != null) {
-      addRawVector(vector);
+      addRawVector(vector, mask);
     } else {
-      addRawBlock(block);
+      addRawBlock(block, mask);
     }
   }
 
@@ -80,9 +97,36 @@ public final class SpatialCentroidGeoPointSourceValuesAggregatorFunction impleme
     }
   }
 
+  private void addRawVector(BytesRefVector vector, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int i = 0; i < vector.getPositionCount(); i++) {
+      if (mask.getBoolean(i) == false) {
+        continue;
+      }
+      SpatialCentroidGeoPointSourceValuesAggregator.combine(state, vector.getBytesRef(i, scratch));
+    }
+  }
+
   private void addRawBlock(BytesRefBlock block) {
     BytesRef scratch = new BytesRef();
     for (int p = 0; p < block.getPositionCount(); p++) {
+      if (block.isNull(p)) {
+        continue;
+      }
+      int start = block.getFirstValueIndex(p);
+      int end = start + block.getValueCount(p);
+      for (int i = start; i < end; i++) {
+        SpatialCentroidGeoPointSourceValuesAggregator.combine(state, block.getBytesRef(i, scratch));
+      }
+    }
+  }
+
+  private void addRawBlock(BytesRefBlock block, BooleanVector mask) {
+    BytesRef scratch = new BytesRef();
+    for (int p = 0; p < block.getPositionCount(); p++) {
+      if (mask.getBoolean(p) == false) {
+        continue;
+      }
       if (block.isNull(p)) {
         continue;
       }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunction.java
@@ -8,18 +8,43 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+/**
+ * A non-grouped aggregation.
+ */
 public interface AggregatorFunction extends Releasable {
+    /**
+     * Add a page worth of data to the aggregation.
+     * @param mask a mask to apply to the positions. If the position is {@code false} then
+     *             the aggregation should skip it.
+     */
+    void addRawInput(Page page, BooleanVector mask);
 
-    void addRawInput(Page page);
-
+    /**
+     * Add a pre-aggregated page worth of "intermediate" input. This intermediate input
+     * will have been created by calling {@link #evaluateIntermediate} on this agg, though
+     * likely in a different {@link Driver} and <strong>maybe</strong> on a different
+     * physical node.
+     */
     void addIntermediateInput(Page page);
 
+    /**
+     * Build pre-aggregated "intermediate" data to pass to the {@link #addIntermediateInput}.
+     * @param blocks write the output into this array
+     * @param offset write the first {@link Block} at this offset in {@code blocks}
+     */
     void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext);
 
+    /**
+     * Build the final results from running this agg.
+     * @param blocks write the output into this array
+     * @param offset write the first {@link Block} at this offset in {@code blocks}
+     */
     void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext);
 
     /** The number of blocks used by intermediate state. */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountAggregatorFunction.java
@@ -72,11 +72,37 @@ public class CountAggregatorFunction implements AggregatorFunction {
     }
 
     @Override
-    public void addRawInput(Page page) {
+    public void addRawInput(Page page, BooleanVector mask) {
         Block block = page.getBlock(blockIndex());
         LongState state = this.state;
-        int count = countAll ? block.getPositionCount() : block.getTotalValueCount();
+        int count;
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0) == false) {
+                return;
+            }
+            count = countAll ? block.getPositionCount() : block.getTotalValueCount();
+        } else {
+            count = countMasked(block, mask);
+        }
         state.longValue(state.longValue() + count);
+    }
+
+    private int countMasked(Block block, BooleanVector mask) {
+        int count = 0;
+        if (countAll) {
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    count++;
+                }
+            }
+            return count;
+        }
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            if (mask.getBoolean(p)) {
+                count += block.getValueCount(p);
+            }
+        }
+        return count;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredAggregatorFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.ToMask;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * A {@link AggregatorFunction} that wraps another, filtering which positions
+ * are supplied to the aggregator.
+ * <p>
+ *     This works by running the filter and providing its results in the {@code mask}
+ *     parameter for {@link #addRawInput}.
+ * </p>
+ */
+record FilteredAggregatorFunction(AggregatorFunction next, EvalOperator.ExpressionEvaluator filter) implements AggregatorFunction {
+    @Override
+    public void addRawInput(Page page, BooleanVector mask) {
+        if (mask.isConstant() == false || mask.getBoolean(0) == false) {
+            throw new UnsupportedOperationException("can't filter twice");
+        }
+        try (BooleanBlock filterResult = ((BooleanBlock) filter.eval(page)); ToMask m = filterResult.toMask()) {
+            // TODO warn on mv fields
+            next.addRawInput(page, m.mask());
+        }
+    }
+
+    @Override
+    public void addIntermediateInput(Page page) {
+        next.addIntermediateInput(page);
+    }
+
+    @Override
+    public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        next.evaluateIntermediate(blocks, offset, driverContext);
+    }
+
+    @Override
+    public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+        next.evaluateFinal(blocks, offset, driverContext);
+    }
+
+    @Override
+    public int intermediateBlockCount() {
+        return next.intermediateBlockCount();
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(next, filter);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredAggregatorFunctionSupplier.java
@@ -21,7 +21,17 @@ public record FilteredAggregatorFunctionSupplier(AggregatorFunctionSupplier next
 
     @Override
     public AggregatorFunction aggregator(DriverContext driverContext) {
-        throw new UnsupportedOperationException("TODO");
+        AggregatorFunction next = this.next.aggregator(driverContext);
+        EvalOperator.ExpressionEvaluator filter = null;
+        try {
+            filter = this.filter.get(driverContext);
+            AggregatorFunction result = new FilteredAggregatorFunction(next, filter);
+            next = null;
+            filter = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(next, filter);
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunction.java
@@ -23,6 +23,11 @@ import java.util.stream.IntStream;
 /**
  * A {@link GroupingAggregatorFunction} that wraps another, filtering which positions
  * are supplied to the aggregator.
+ * <p>
+ *     This filtering works by setting all of the group ids for filtered positions to
+ *     {@code null}. {@link GroupingAggregatorFunction} will then skip collecting those
+ *     positions.
+ * </p>
  */
 record FilteredGroupingAggregatorFunction(GroupingAggregatorFunction next, EvalOperator.ExpressionEvaluator filter)
     implements

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.CompositeBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntVector;
@@ -41,7 +42,10 @@ public class FromPartialAggregatorFunction implements AggregatorFunction {
     }
 
     @Override
-    public void addRawInput(Page page) {
+    public void addRawInput(Page page, BooleanVector mask) {
+        if (mask.isConstant() == false || mask.getBoolean(0) == false) {
+            throw new IllegalStateException("can't mask partial");
+        }
         addIntermediateInput(page);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.CompositeBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
@@ -37,8 +38,8 @@ public class ToPartialAggregatorFunction implements AggregatorFunction {
     }
 
     @Override
-    public void addRawInput(Page page) {
-        delegate.addRawInput(page);
+    public void addRawInput(Page page, BooleanVector mask) {
+        delegate.addRawInput(page, mask);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.aggregation.Aggregator;
 import org.elasticsearch.compute.aggregation.Aggregator.Factory;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
@@ -93,9 +94,9 @@ public class AggregationOperator implements Operator {
         long start = System.nanoTime();
         checkState(needsInput(), "Operator is already finishing");
         requireNonNull(page, "page is null");
-        try {
+        try (BooleanVector noMasking = driverContext.blockFactory().newConstantBooleanVector(true, page.getPositionCount())) {
             for (Aggregator aggregator : aggregators) {
-                aggregator.processPage(page);
+                aggregator.processPage(page, noMasking);
             }
         } finally {
             page.releaseBlocks();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -69,8 +69,14 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
 
     @Override
     protected final Matcher<String> expectedToStringOfSimple() {
+        return equalTo(
+            "AggregationOperator[aggregators=[Aggregator[aggregatorFunction=" + expectedToStringOfSimpleAggregator() + ", mode=SINGLE]]]"
+        );
+    }
+
+    protected String expectedToStringOfSimpleAggregator() {
         String type = getClass().getSimpleName().replace("Tests", "");
-        return equalTo("AggregationOperator[aggregators=[Aggregator[aggregatorFunction=" + type + "[channels=[0]], mode=SINGLE]]]");
+        return type + "[channels=[0]]";
     }
 
     @Override
@@ -162,7 +168,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
 
     // Returns an intermediate state that is equivalent to what the local execution planner will emit
     // if it determines that certain shards have no relevant data.
-    final List<Page> nullIntermediateState(BlockFactory blockFactory) {
+    List<Page> nullIntermediateState(BlockFactory blockFactory) {
         try (var agg = aggregatorFunction(List.of()).aggregator(driverContext())) {
             var method = agg.getClass().getMethod("intermediateStateDesc");
             @SuppressWarnings("unchecked")

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FilteredAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FilteredAggregatorFunctionTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.SequenceIntBlockSourceOperator;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.junit.After;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FilteredAggregatorFunctionTests extends AggregatorFunctionTestCase {
+    private final List<Exception> unclosed = Collections.synchronizedList(new ArrayList<>());
+
+    // TODO some version of this test that applies across all aggs
+    @Override
+    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+        return new FilteredAggregatorFunctionSupplier(
+            new SumIntAggregatorFunctionSupplier(inputChannels),
+            new FilteredGroupingAggregatorFunctionTests.AnyGreaterThanFactory(unclosed, inputChannels)
+        );
+    }
+
+    @Override
+    protected String expectedDescriptionOfAggregator() {
+        return "Filtered[next=sum of ints, filter=any > 0]";
+    }
+
+    @Override
+    protected String expectedToStringOfSimpleAggregator() {
+        return "FilteredAggregatorFunction[next=SumIntAggregatorFunction[channels=[0]], filter=any > 0]";
+    }
+
+    @Override
+    protected void assertSimpleOutput(List<Block> input, Block result) {
+        long sum = 0;
+        for (Block block : input) {
+            IntBlock ints = (IntBlock) block;
+            for (int p = 0; p < ints.getPositionCount(); p++) {
+                /*
+                 * Perform the sum on the values *only* if any of the
+                 * values is > 0 to line up with the condition
+                 */
+                int start = ints.getFirstValueIndex(p);
+                int end = start + ints.getValueCount(p);
+                boolean selected = false;
+                for (int i = start; i < end; i++) {
+                    selected |= ints.getInt(i) > 0;
+                }
+                if (selected == false) {
+                    continue;
+                }
+                start = ints.getFirstValueIndex(p);
+                end = start + ints.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    sum += ints.getInt(i);
+                }
+            }
+        }
+        assertThat(((LongBlock) result).getLong(0), equalTo(sum));
+    }
+
+    @Override
+    protected List<Page> nullIntermediateState(BlockFactory blockFactory) {
+        return new SumIntAggregatorFunctionTests().nullIntermediateState(blockFactory);
+    }
+
+    @Override
+    protected SourceOperator simpleInput(BlockFactory blockFactory, int size) {
+        int max = between(1, Integer.MAX_VALUE / size / 5);
+        return new SequenceIntBlockSourceOperator(blockFactory, IntStream.range(0, size).map(l -> between(-max, max)));
+    }
+
+    @After
+    public void checkUnclosed() {
+        for (Exception tracker : unclosed) {
+            logger.error("unclosed", tracker);
+        }
+        assertThat(unclosed, empty());
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/FilteredGroupingAggregatorFunctionTests.java
@@ -116,7 +116,7 @@ public class FilteredGroupingAggregatorFunctionTests extends GroupingAggregatorF
      * This checks if *any* of the integers are > 0. If so we push the group to
      * the aggregation.
      */
-    private record AnyGreaterThanFactory(List<Exception> unclosed, List<Integer> inputChannels)
+    record AnyGreaterThanFactory(List<Exception> unclosed, List<Integer> inputChannels)
         implements
             EvalOperator.ExpressionEvaluator.Factory {
         @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -236,10 +236,10 @@ public class BlockSerializationTests extends SerializationTestCase {
     public void testSimulateAggs() {
         DriverContext driverCtx = driverContext();
         Page page = new Page(blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 10).asBlock());
-        var bigArrays = BigArrays.NON_RECYCLING_INSTANCE;
-        var params = new Object[] {};
         var function = SumLongAggregatorFunction.create(driverCtx, List.of(0));
-        function.addRawInput(page);
+        try (BooleanVector noMasking = driverContext().blockFactory().newConstantBooleanVector(true, page.getPositionCount())) {
+            function.addRawInput(page, noMasking);
+        }
         Block[] blocks = new Block[function.intermediateBlockCount()];
         try {
             function.evaluateIntermediate(blocks, 0, driverCtx);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Compute support for filtering ungrouped aggs (#112717)