### PR TITLE
Fix verifyVersions task

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -223,7 +223,10 @@ public class BwcVersions {
     }
 
     private List<Version> getReleased() {
-        return versions.stream().filter(v -> unreleased.containsKey(v) == false).toList();
+        return versions.stream()
+            .filter(v -> v.getMajor() >= currentVersion.getMajor() - 1)
+            .filter(v -> unreleased.containsKey(v) == false)
+            .toList();
     }
 
     /**


### PR DESCRIPTION
Fix the `verifyVersions` task to ignore versions that are incompatible with the current version. These are just leftover version constants that are yet to be removed after the major version bump.