### PR TITLE
Ensure http content copied for safe buffers

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -127,6 +127,12 @@ public class Netty4HttpRequest implements HttpRequest {
         }
         try {
             final ByteBuf copiedContent = Unpooled.copiedBuffer(request.content());
+            HttpBody newContent;
+            if (content.isStream()) {
+                newContent = content;
+            } else {
+                newContent = Netty4Utils.fullHttpBodyFrom(copiedContent);
+            }
             return new Netty4HttpRequest(
                 sequence,
                 new DefaultFullHttpRequest(
@@ -139,7 +145,7 @@ public class Netty4HttpRequest implements HttpRequest {
                 ),
                 new AtomicBoolean(false),
                 false,
-                content
+                newContent
             );
         } finally {
             release();


### PR DESCRIPTION
Currently, unless a rest handler specifies that it handles "unsafe"
buffers, we must copy the http buffers in releaseAndCopy. Unfortuantely,
the original content was slipping through in the initial stream PR. This
leads to memory corruption on index and update requests which depend on
buffers being copied.