### PR TITLE
[Test] Account for auto-repairing for shard gen file

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -208,9 +208,6 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cluster/stats/line_1450}
   issue: https://github.com/elastic/elasticsearch/issues/112732
-- class: org.elasticsearch.repositories.blobstore.testkit.integrity.RepositoryVerifyIntegrityIT
-  method: testCorruption
-  issue: https://github.com/elastic/elasticsearch/issues/112769
 
 # Examples:
 #

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
@@ -344,16 +344,21 @@ public class RepositoryVerifyIntegrityIT extends AbstractSnapshotIntegTestCase {
                 ? equalTo(testContext.indexNames().size())
                 : lessThan(testContext.indexNames().size())
         );
-        assertThat(anomalies, not(empty()));
+        // Missing shard generation file is automatically repaired based on the shard snapshot files.
+        // See also BlobStoreRepository#buildBlobStoreIndexShardSnapshots
+        assertThat(anomalies, corruptedFileType == RepositoryFileType.SHARD_GENERATION ? empty() : not(empty()));
         assertThat(responseObjectPath.evaluate("results.total_anomalies"), greaterThanOrEqualTo(anomalies.size()));
-        assertEquals("fail", responseObjectPath.evaluate("results.result"));
+        assertEquals(
+            corruptedFileType == RepositoryFileType.SHARD_GENERATION ? "pass" : "fail",
+            responseObjectPath.evaluate("results.result")
+        );
 
         // remove permitted/expected anomalies to verify that no unexpected ones were seen
         switch (corruptedFileType) {
             case SNAPSHOT_INFO -> anomalies.remove("failed to load snapshot info");
             case GLOBAL_METADATA -> anomalies.remove("failed to load global metadata");
             case INDEX_METADATA -> anomalies.remove("failed to load index metadata");
-            case SHARD_GENERATION -> anomalies.remove("failed to load shard generation");
+            case SHARD_GENERATION -> {}
             case SHARD_SNAPSHOT_INFO -> anomalies.remove("failed to load shard snapshot");
             case SHARD_DATA -> {
                 anomalies.remove("missing blob");

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
@@ -358,8 +358,6 @@ public class RepositoryVerifyIntegrityIT extends AbstractSnapshotIntegTestCase {
             case SNAPSHOT_INFO -> anomalies.remove("failed to load snapshot info");
             case GLOBAL_METADATA -> anomalies.remove("failed to load global metadata");
             case INDEX_METADATA -> anomalies.remove("failed to load index metadata");
-            case SHARD_GENERATION -> {
-            }
             case SHARD_SNAPSHOT_INFO -> anomalies.remove("failed to load shard snapshot");
             case SHARD_DATA -> {
                 anomalies.remove("missing blob");

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
@@ -358,7 +358,8 @@ public class RepositoryVerifyIntegrityIT extends AbstractSnapshotIntegTestCase {
             case SNAPSHOT_INFO -> anomalies.remove("failed to load snapshot info");
             case GLOBAL_METADATA -> anomalies.remove("failed to load global metadata");
             case INDEX_METADATA -> anomalies.remove("failed to load index metadata");
-            case SHARD_GENERATION -> {}
+            case SHARD_GENERATION -> {
+            }
             case SHARD_SNAPSHOT_INFO -> anomalies.remove("failed to load shard snapshot");
             case SHARD_DATA -> {
                 anomalies.remove("missing blob");

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityIT.java
@@ -346,18 +346,21 @@ public class RepositoryVerifyIntegrityIT extends AbstractSnapshotIntegTestCase {
         );
         // Missing shard generation file is automatically repaired based on the shard snapshot files.
         // See also BlobStoreRepository#buildBlobStoreIndexShardSnapshots
-        assertThat(anomalies, corruptedFileType == RepositoryFileType.SHARD_GENERATION ? empty() : not(empty()));
+        final boolean deletedShardGen = corruptedFileType == RepositoryFileType.SHARD_GENERATION && Files.exists(corruptedFile) == false;
+        assertThat(anomalies, deletedShardGen ? empty() : not(empty()));
         assertThat(responseObjectPath.evaluate("results.total_anomalies"), greaterThanOrEqualTo(anomalies.size()));
-        assertEquals(
-            corruptedFileType == RepositoryFileType.SHARD_GENERATION ? "pass" : "fail",
-            responseObjectPath.evaluate("results.result")
-        );
+        assertEquals(deletedShardGen ? "pass" : "fail", responseObjectPath.evaluate("results.result"));
 
         // remove permitted/expected anomalies to verify that no unexpected ones were seen
         switch (corruptedFileType) {
             case SNAPSHOT_INFO -> anomalies.remove("failed to load snapshot info");
             case GLOBAL_METADATA -> anomalies.remove("failed to load global metadata");
             case INDEX_METADATA -> anomalies.remove("failed to load index metadata");
+            case SHARD_GENERATION -> {
+                if (deletedShardGen == false) {
+                    anomalies.remove("failed to load shard generation");
+                }
+            }
             case SHARD_SNAPSHOT_INFO -> anomalies.remove("failed to load shard snapshot");
             case SHARD_DATA -> {
                 anomalies.remove("missing blob");


### PR DESCRIPTION
Since #112337, missing shard gen files are automatically reconstructed based on the existing shard snapshot files. If the list of shard snapshot files is complete, it means the repository is effectively not corrupted. This PR updates the test to account for this situation.

Resolves: #112769
