### PR TITLE
Do not throw in task enqueued by CancellableRunner

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -211,9 +211,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.integrity.RepositoryVerifyIntegrityIT
   method: testCorruption
   issue: https://github.com/elastic/elasticsearch/issues/112769
-- class: org.elasticsearch.repositories.blobstore.testkit.integrity.RepositoryVerifyIntegrityIT
-  method: testTransportException
-  issue: https://github.com/elastic/elasticsearch/issues/112779
 
 # Examples:
 #

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
@@ -934,7 +934,11 @@ class RepositoryIntegrityVerifier {
                         if (cancellableThreads.isCancelled()) {
                             runnable.onFailure(new TaskCancelledException("task cancelled"));
                         } else {
-                            cancellableThreads.execute(runnable::run);
+                            try {
+                                cancellableThreads.execute(runnable::run);
+                            } catch (RuntimeException e) {
+                                runnable.onFailure(e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
CancellableThreads#excute can throw runtime exception including cancellation. This does not work with AbstractThrottledTaskRunner which expects enqueued task to _not_ throw. This PR catches any runtime exception from CancellableThreads and hand it back to the original runnable.

Resolves: #112779
