### PR TITLE
[8.x] Do not throw in task enqueued by CancellableRunner (#112780)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -208,9 +208,6 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cluster/stats/line_1450}
   issue: https://github.com/elastic/elasticsearch/issues/112732
-- class: org.elasticsearch.repositories.blobstore.testkit.integrity.RepositoryVerifyIntegrityIT
-  method: testCorruption
-  issue: https://github.com/elastic/elasticsearch/issues/112769
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -211,9 +211,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.integrity.RepositoryVerifyIntegrityIT
   method: testCorruption
   issue: https://github.com/elastic/elasticsearch/issues/112769
-- class: org.elasticsearch.script.StatsSummaryTests
-  method: testEqualsAndHashCode
-  issue: https://github.com/elastic/elasticsearch/issues/112439
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -208,6 +208,12 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/cluster/stats/line_1450}
   issue: https://github.com/elastic/elasticsearch/issues/112732
+- class: org.elasticsearch.repositories.blobstore.testkit.integrity.RepositoryVerifyIntegrityIT
+  method: testCorruption
+  issue: https://github.com/elastic/elasticsearch/issues/112769
+- class: org.elasticsearch.script.StatsSummaryTests
+  method: testEqualsAndHashCode
+  issue: https://github.com/elastic/elasticsearch/issues/112439
 
 # Examples:
 #

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
@@ -934,7 +934,11 @@ class RepositoryIntegrityVerifier {
                         if (cancellableThreads.isCancelled()) {
                             runnable.onFailure(new TaskCancelledException("task cancelled"));
                         } else {
-                            cancellableThreads.execute(runnable::run);
+                            try {
+                                cancellableThreads.execute(runnable::run);
+                            } catch (RuntimeException e) {
+                                runnable.onFailure(e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Do not throw in task enqueued by CancellableRunner (#112780)](https://github.com/elastic/elasticsearch/pull/112780)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)