### PR TITLE
[8.x] Two empty mappings now are created equally (#107936)

### DIFF
--- a/docs/changelog/107936.yaml
+++ b/docs/changelog/107936.yaml
@@ -1,0 +1,6 @@
+pr: 107936
+summary: Two empty mappings now are created equally
+area: Mapping
+type: bug
+issues:
+ - 107031

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -85,6 +85,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search/370_profile/fetch nested source", "profile output has changed")
   task.skipTest("search/240_date_nanos/doc value fields are working as expected across date and date_nanos fields", "Fetching docvalues field multiple times is no longer allowed")
   task.skipTest("search/110_field_collapsing/field collapsing and rescore", "#107779 Field collapsing is compatible with rescore in 8.15")
+  task.skipTest("indices.create/11_basic_with_types/Create index with mappings", "Empty mapping creation has changed")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -47,6 +47,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTestsByFilePattern("**/indices.upgrade/*.yml", "upgrade api will only get a dummy endpoint returning an exception suggesting to use _reindex")
   task.skipTestsByFilePattern("**/indices.stats/60_field_usage/*/*.yml", "field usage results will be different between lucene versions")
   task.skipTestsByFilePattern("**/search.aggregation/*.yml", "run by the aggregation module")
+  task.skipTestsByFilePattern("**/indices.get_mapping/11_basic_with_types.yml", "Empty mapping creation has changed")
 
   task.skipTest("bulk/11_dynamic_templates/Dynamic templates", "Error message has changed")
   task.skipTest("index/80_date_nanos/date_nanos requires dates after 1970 and before 2262", "Error message has changed")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
@@ -1,85 +1,85 @@
 ---
 setup:
   - do:
-        indices.create:
-          index: test_1
-          body:
-            mappings: {}
+      indices.create:
+        index: test_1
+        body:
+          mappings: {}
   - do:
-        indices.create:
-          index: test_2
-          body:
-            mappings: {}
+      indices.create:
+        index: test_2
+        body:
+          mappings: {}
 ---
 "Get /{index}/_mapping with empty mappings":
 
- - do:
-     indices.create:
-       index: t
+  - do:
+      indices.create:
+        index: t
 
- - do:
-     indices.get_mapping:
-       index: t
+  - do:
+      indices.get_mapping:
+        index: t
 
- - match: { t.mappings: {}}
+  - match: { t.mappings: {}}
 
 ---
 "Get /_mapping":
 
- - do:
-    indices.get_mapping: {}
+  - do:
+      indices.get_mapping: {}
 
- - is_true: test_1.mappings
- - is_true: test_2.mappings
+  - is_true: test_1.mappings
+  - is_true: test_2.mappings
 
 ---
 "Get /{index}/_mapping":
 
- - do:
-    indices.get_mapping:
-      index: test_1
+  - do:
+      indices.get_mapping:
+        index: test_1
 
- - is_true: test_1.mappings
- - is_false: test_2
+  - is_true: test_1.mappings
+  - is_false: test_2
 
 
 
 ---
 "Get /_all/_mapping":
 
- - do:
-    indices.get_mapping:
-      index: _all
+  - do:
+      indices.get_mapping:
+        index: _all
 
- - is_true: test_1.mappings
- - is_true: test_2.mappings
+  - is_true: test_1.mappings
+  - is_true: test_2.mappings
 
 ---
 "Get /*/_mapping":
 
- - do:
-    indices.get_mapping:
-      index: '*'
+  - do:
+      indices.get_mapping:
+        index: '*'
 
- - is_true: test_1.mappings
- - is_true: test_2.mappings
+  - is_true: test_1.mappings
+  - is_true: test_2.mappings
 
 ---
 "Get /index,index/_mapping":
 
- - do:
-    indices.get_mapping:
-      index: test_1,test_2
+  - do:
+      indices.get_mapping:
+        index: test_1,test_2
 
- - is_true: test_1.mappings
- - is_true: test_2.mappings
+  - is_true: test_1.mappings
+  - is_true: test_2.mappings
 
 ---
 "Get /index*/_mapping/":
 
- - do:
-    indices.get_mapping:
-      index: '*2'
+  - do:
+      indices.get_mapping:
+        index: '*2'
 
- - is_true: test_2.mappings
- - is_false: test_1
+  - is_true: test_2.mappings
+  - is_false: test_1

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -67,8 +67,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     private boolean initializeFailureStore;
 
     private Settings settings = Settings.EMPTY;
+    public static final String EMPTY_MAPPINGS = "{}";
 
-    private String mappings = "{}";
+    private String mappings = EMPTY_MAPPINGS;
 
     private final Set<Alias> aliases = new HashSet<>();
 
@@ -284,8 +285,11 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     }
 
     private CreateIndexRequest mapping(String type, Map<String, ?> source) {
-        // wrap it in a type map if its not
-        if (source.size() != 1 || source.containsKey(type) == false) {
+        if (source.isEmpty()) {
+            // If no source is provided we return empty mappings
+            return mapping(EMPTY_MAPPINGS);
+        } else if (source.size() != 1 || source.containsKey(type) == false) {
+            // wrap it in a type map if its not
             source = Map.of(MapperService.SINGLE_MAPPING_NAME, source);
         } else if (MapperService.SINGLE_MAPPING_NAME.equals(type) == false) {
             // if it has a different type name, then unwrap and rewrap with _doc

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -660,7 +660,7 @@ public class MetadataRolloverService {
             }
             if ((request.settings().equals(Settings.EMPTY) == false)
                 || (request.aliases().size() > 0)
-                || (request.mappings().equals("{}") == false)) {
+                || (request.mappings().equals(CreateIndexRequest.EMPTY_MAPPINGS) == false)) {
                 throw new IllegalArgumentException(
                     "aliases, mappings, and index settings may not be specified when rolling over a data stream"
                 );

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
@@ -224,7 +224,7 @@ public class MetadataMigrateToDataStreamService {
         Settings nodeSettings
     ) throws IOException {
         MappingMetadata mm = im.mapping();
-        if (mm == null) {
+        if (mm == null || mm.equals(MappingMetadata.EMPTY_MAPPINGS)) {
             throw new IllegalArgumentException("backing index [" + im.getIndex().getName() + "] must have mappings for a timestamp field");
         }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -172,7 +172,7 @@ public class EnrichPolicyRunner {
     private Map<String, Object> getMappings(final GetIndexResponse getIndexResponse, final String sourceIndexName) {
         Map<String, MappingMetadata> mappings = getIndexResponse.mappings();
         MappingMetadata indexMapping = mappings.get(sourceIndexName);
-        if (indexMapping == MappingMetadata.EMPTY_MAPPINGS) {
+        if (MappingMetadata.EMPTY_MAPPINGS.equals(indexMapping)) {
             throw new ElasticsearchException(
                 "Enrich policy execution for [{}] failed. No mapping available on source [{}] included in [{}]",
                 policyName,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Two empty mappings now are created equally (#107936)](https://github.com/elastic/elasticsearch/pull/107936)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)