### PR TITLE
Change default locale of date processors to ENGLISH

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -98,7 +98,7 @@ public final class DateProcessor extends AbstractProcessor {
     }
 
     private static Locale newLocale(String locale) {
-        return locale == null ? Locale.ROOT : LocaleUtils.parse(locale);
+        return locale == null ? Locale.ENGLISH : LocaleUtils.parse(locale);
     }
 
     @Override


### PR DESCRIPTION
This resolves #112692

Field mappers are covered by #112799