### PR TITLE
Use ISO week date numbering for english too

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/IsoCalendarDataProvider.java
+++ b/server/src/main/java/org/elasticsearch/common/time/IsoCalendarDataProvider.java
@@ -25,6 +25,6 @@ public class IsoCalendarDataProvider extends CalendarDataProvider {
 
     @Override
     public Locale[] getAvailableLocales() {
-        return new Locale[] { Locale.ROOT };
+        return new Locale[] { Locale.ROOT, Locale.ENGLISH };
     }
 }


### PR DESCRIPTION
TL;DR - dates are really, really complicated. Reference - https://en.wikipedia.org/wiki/ISO_week_date

With the changes to defaulting the locale to english rather than root (https://github.com/elastic/elasticsearch/pull/112796, https://github.com/elastic/elasticsearch/pull/112799), the Iso override added by https://github.com/elastic/elasticsearch/pull/48209 no longer applies to english, which results in broken tests as the week numbering changes between the two locales. This PR fixes the immediate problem.

However, this opens up a rather large can of worms - what about all the other locales people use? I don't believe we have any defined behaviour around this, so what is the correct thing to do long-term, and do we want to break week numbering too? Do we just revert to whatever CLDR does, with the corresponding break here too?

This is not a straightforward change - there may be users explicitly using `en` locale with non-iso week dates that will be broken by this PR.