### PR TITLE
[8.x] ESQL: Convert some PhysicalPlans to NamedWriteable (#112764)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FilterExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FilterExec.java
@@ -6,21 +6,48 @@
  */
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 public class FilterExec extends UnaryExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "FilterExec",
+        FilterExec::new
+    );
 
     private final Expression condition;
 
     public FilterExec(Source source, PhysicalPlan child, Expression condition) {
         super(source, child);
         this.condition = condition;
+    }
+
+    private FilterExec(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readPhysicalPlanNode(), in.readNamedWriteable(Expression.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
+        out.writeNamedWriteable(condition());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
@@ -7,16 +7,28 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 public class FragmentExec extends LeafExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "FragmentExec",
+        FragmentExec::new
+    );
 
     private final LogicalPlan fragment;
     private final QueryBuilder esFilter;
@@ -38,6 +50,32 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
         this.esFilter = esFilter;
         this.estimatedRowSize = estimatedRowSize;
         this.reducer = reducer;
+    }
+
+    private FragmentExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(LogicalPlan.class),
+            in.readOptionalNamedWriteable(QueryBuilder.class),
+            in.readOptionalVInt(),
+            in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0) ? ((PlanStreamInput) in).readOptionalPhysicalPlanNode() : null
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(fragment());
+        out.writeOptionalNamedWriteable(esFilter());
+        out.writeOptionalVInt(estimatedRowSize());
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
+            ((PlanStreamOutput) out).writeOptionalPhysicalPlanNode(reducer());
+        }
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public LogicalPlan fragment() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/GrokExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/GrokExec.java
@@ -7,16 +7,27 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 public class GrokExec extends RegexExtractExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "GrokExec",
+        GrokExec::readFrom
+    );
 
     private final Grok.Parser parser;
 
@@ -29,6 +40,31 @@ public class GrokExec extends RegexExtractExec {
     ) {
         super(source, child, inputExpression, extractedAttributes);
         this.parser = parser;
+    }
+
+    private static GrokExec readFrom(StreamInput in) throws IOException {
+        Source source = Source.readFrom((PlanStreamInput) in);
+        return new GrokExec(
+            source,
+            ((PlanStreamInput) in).readPhysicalPlanNode(),
+            in.readNamedWriteable(Expression.class),
+            Grok.pattern(source, in.readString()),
+            in.readNamedWriteableCollectionAsList(Attribute.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
+        out.writeNamedWriteable(inputExpression());
+        out.writeString(pattern().pattern());
+        out.writeNamedWriteableCollection(extractedFields());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
@@ -21,6 +24,12 @@ import java.util.Objects;
 import java.util.Set;
 
 public class HashJoinExec extends UnaryExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "HashJoinExec",
+        HashJoinExec::new
+    );
+
     private final LocalSourceExec joinData;
     private final List<Attribute> matchFields;
     private final List<Attribute> leftFields;
@@ -45,8 +54,8 @@ public class HashJoinExec extends UnaryExec implements EstimatesRowSize {
         this.output = output;
     }
 
-    public HashJoinExec(PlanStreamInput in) throws IOException {
-        super(Source.readFrom(in), in.readPhysicalPlanNode());
+    private HashJoinExec(StreamInput in) throws IOException {
+        super(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readPhysicalPlanNode());
         this.joinData = new LocalSourceExec(in);
         this.matchFields = in.readNamedWriteableCollectionAsList(Attribute.class);
         this.leftFields = in.readNamedWriteableCollectionAsList(Attribute.class);
@@ -54,14 +63,20 @@ public class HashJoinExec extends UnaryExec implements EstimatesRowSize {
         this.output = in.readNamedWriteableCollectionAsList(Attribute.class);
     }
 
-    public void writeTo(PlanStreamOutput out) throws IOException {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
-        out.writePhysicalPlanNode(child());
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
         joinData.writeTo(out);
         out.writeNamedWriteableCollection(matchFields);
         out.writeNamedWriteableCollection(leftFields);
         out.writeNamedWriteableCollection(rightFields);
         out.writeNamedWriteableCollection(output);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public LocalSourceExec joinData() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LimitExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LimitExec.java
@@ -7,19 +7,46 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Objects;
 
 public class LimitExec extends UnaryExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "LimitExec",
+        LimitExec::new
+    );
 
     private final Expression limit;
 
     public LimitExec(Source source, PhysicalPlan child, Expression limit) {
         super(source, child);
         this.limit = limit;
+    }
+
+    private LimitExec(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readPhysicalPlanNode(), in.readNamedWriteable(Expression.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writePhysicalPlanNode(child());
+        out.writeNamedWriteable(limit());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LocalSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LocalSourceExec.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
-import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 
 import java.io.IOException;
@@ -19,6 +21,11 @@ import java.util.List;
 import java.util.Objects;
 
 public class LocalSourceExec extends LeafExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "LocalSourceExec",
+        LocalSourceExec::new
+    );
 
     private final List<Attribute> output;
     private final LocalSupplier supplier;
@@ -29,16 +36,22 @@ public class LocalSourceExec extends LeafExec {
         this.supplier = supplier;
     }
 
-    public LocalSourceExec(PlanStreamInput in) throws IOException {
-        super(Source.readFrom(in));
+    public LocalSourceExec(StreamInput in) throws IOException {
+        super(Source.readFrom((PlanStreamInput) in));
         this.output = in.readNamedWriteableCollectionAsList(Attribute.class);
-        this.supplier = LocalSupplier.readFrom(in);
+        this.supplier = LocalSupplier.readFrom((PlanStreamInput) in);
     }
 
-    public void writeTo(PlanStreamOutput out) throws IOException {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
         out.writeNamedWriteableCollection(output);
         supplier.writeTo(out);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/PhysicalPlan.java
@@ -33,7 +33,13 @@ public abstract class PhysicalPlan extends QueryPlan<PhysicalPlan> {
             ExchangeExec.ENTRY,
             ExchangeSinkExec.ENTRY,
             ExchangeSourceExec.ENTRY,
-            FieldExtractExec.ENTRY
+            FieldExtractExec.ENTRY,
+            FilterExec.ENTRY,
+            FragmentExec.ENTRY,
+            GrokExec.ENTRY,
+            LimitExec.ENTRY,
+            LocalSourceExec.ENTRY,
+            HashJoinExec.ENTRY
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
@@ -592,7 +592,7 @@ public class EsqlQueryRequestTests extends ESTestCase {
         }
     }
 
-    private static QueryBuilder randomQueryBuilder() {
+    public static QueryBuilder randomQueryBuilder() {
         return randomFrom(
             new TermQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 10)),
             new RangeQueryBuilder(randomAlphaOfLength(5)).gt(randomIntBetween(0, 1000))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/local/LocalSupplierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/local/LocalSupplierTests.java
@@ -47,7 +47,7 @@ public class LocalSupplierTests extends AbstractWireTestCase<LocalSupplier> {
         return randomBoolean() ? LocalSupplier.EMPTY : randomNonEmpty();
     }
 
-    private LocalSupplier randomNonEmpty() {
+    public static LocalSupplier randomNonEmpty() {
         return LocalSupplier.of(randomList(1, 10, LocalSupplierTests::randomBlock).toArray(Block[]::new));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FilterExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FilterExecSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+
+import java.io.IOException;
+
+public class FilterExecSerializationTests extends AbstractPhysicalPlanSerializationTests<FilterExec> {
+    public static FilterExec randomFilterExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        Expression condition = FieldAttributeTests.createFieldAttribute(0, false);
+        return new FilterExec(source, child, condition);
+    }
+
+    @Override
+    protected FilterExec createTestInstance() {
+        return randomFilterExec(0);
+    }
+
+    @Override
+    protected FilterExec mutateInstance(FilterExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        Expression condition = instance.condition();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            condition = randomValueOtherThan(condition, () -> FieldAttributeTests.createFieldAttribute(0, false));
+        }
+        return new FilterExec(instance.source(), child, condition);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExecSerializationTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.action.EsqlQueryRequestTests;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+public class FragmentExecSerializationTests extends AbstractPhysicalPlanSerializationTests<FragmentExec> {
+    public static FragmentExec randomFragmentExec(int depth) {
+        Source source = randomSource();
+        LogicalPlan fragment = AbstractLogicalPlanSerializationTests.randomChild(depth);
+        QueryBuilder esFilter = EsqlQueryRequestTests.randomQueryBuilder();
+        int estimatedRowSize = between(0, Integer.MAX_VALUE);
+        PhysicalPlan reducer = randomChild(depth);
+        return new FragmentExec(source, fragment, esFilter, estimatedRowSize, reducer);
+    }
+
+    @Override
+    protected FragmentExec createTestInstance() {
+        return randomFragmentExec(0);
+    }
+
+    @Override
+    protected FragmentExec mutateInstance(FragmentExec instance) throws IOException {
+        LogicalPlan fragment = instance.fragment();
+        QueryBuilder esFilter = instance.esFilter();
+        int estimatedRowSize = instance.estimatedRowSize();
+        PhysicalPlan reducer = instance.reducer();
+        switch (between(0, 3)) {
+            case 0 -> fragment = randomValueOtherThan(fragment, () -> AbstractLogicalPlanSerializationTests.randomChild(0));
+            case 1 -> esFilter = randomValueOtherThan(esFilter, EsqlQueryRequestTests::randomQueryBuilder);
+            case 2 -> estimatedRowSize = randomValueOtherThan(estimatedRowSize, () -> between(0, Integer.MAX_VALUE));
+            case 3 -> reducer = randomValueOtherThan(reducer, () -> randomChild(0));
+            default -> throw new UnsupportedEncodingException();
+        }
+        return new FragmentExec(instance.source(), fragment, esFilter, estimatedRowSize, reducer);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/GrokExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/GrokExecSerializationTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
+import org.elasticsearch.xpack.esql.plan.logical.Grok;
+import org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests;
+
+import java.io.IOException;
+
+public class GrokExecSerializationTests extends AbstractPhysicalPlanSerializationTests<GrokExec> {
+    public static GrokExec randomGrokExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        Expression inputExpression = FieldAttributeTests.createFieldAttribute(0, false);
+        Grok.Parser parser = Grok.pattern(source, EsqlNodeSubclassTests.randomGrokPattern());
+        return new GrokExec(source, child, inputExpression, parser, parser.extractedFields());
+    }
+
+    @Override
+    protected GrokExec createTestInstance() {
+        return randomGrokExec(0);
+    }
+
+    @Override
+    protected GrokExec mutateInstance(GrokExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        Expression inputExpression = instance.inputExpression();
+        Grok.Parser parser = instance.pattern();
+        switch (between(0, 2)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> inputExpression = randomValueOtherThan(inputExpression, () -> FieldAttributeTests.createFieldAttribute(0, false));
+            case 2 -> parser = Grok.pattern(
+                instance.source(),
+                randomValueOtherThan(parser.pattern(), EsqlNodeSubclassTests::randomGrokPattern)
+            );
+        }
+        return new GrokExec(instance.source(), child, inputExpression, parser, parser.extractedFields());
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExecSerializationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+
+public class HashJoinExecSerializationTests extends AbstractPhysicalPlanSerializationTests<HashJoinExec> {
+    public static HashJoinExec randomHashJoinExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        LocalSourceExec joinData = LocalSourceExecSerializationTests.randomLocalSourceExec();
+        List<Attribute> matchFields = randomFields();
+        List<Attribute> leftFields = randomFields();
+        List<Attribute> rightFields = randomFields();
+        List<Attribute> output = randomFields();
+        return new HashJoinExec(source, child, joinData, matchFields, leftFields, rightFields, output);
+    }
+
+    private static List<Attribute> randomFields() {
+        return randomFieldAttributes(1, 5, false);
+    }
+
+    @Override
+    protected HashJoinExec createTestInstance() {
+        return randomHashJoinExec(0);
+    }
+
+    @Override
+    protected HashJoinExec mutateInstance(HashJoinExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        LocalSourceExec joinData = instance.joinData();
+        List<Attribute> matchFields = randomFieldAttributes(1, 5, false);
+        List<Attribute> leftFields = randomFieldAttributes(1, 5, false);
+        List<Attribute> rightFields = randomFieldAttributes(1, 5, false);
+        List<Attribute> output = randomFieldAttributes(1, 5, false);
+        switch (between(0, 5)) {
+            case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
+            case 1 -> joinData = randomValueOtherThan(joinData, LocalSourceExecSerializationTests::randomLocalSourceExec);
+            case 2 -> matchFields = randomValueOtherThan(matchFields, HashJoinExecSerializationTests::randomFields);
+            case 3 -> leftFields = randomValueOtherThan(leftFields, HashJoinExecSerializationTests::randomFields);
+            case 4 -> rightFields = randomValueOtherThan(rightFields, HashJoinExecSerializationTests::randomFields);
+            case 5 -> output = randomValueOtherThan(output, HashJoinExecSerializationTests::randomFields);
+            default -> throw new UnsupportedOperationException();
+        }
+        return new HashJoinExec(instance.source(), child, joinData, matchFields, leftFields, rightFields, output);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/LimitExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/LimitExecSerializationTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.io.IOException;
+
+public class LimitExecSerializationTests extends AbstractPhysicalPlanSerializationTests<LimitExec> {
+    public static LimitExec randomLimitExec(int depth) {
+        Source source = randomSource();
+        PhysicalPlan child = randomChild(depth);
+        Expression limit = randomLimit();
+        return new LimitExec(source, child, limit);
+    }
+
+    private static Expression randomLimit() {
+        return new Literal(randomSource(), between(0, Integer.MAX_VALUE), DataType.INTEGER);
+    }
+
+    @Override
+    protected LimitExec createTestInstance() {
+        return randomLimitExec(0);
+    }
+
+    @Override
+    protected LimitExec mutateInstance(LimitExec instance) throws IOException {
+        PhysicalPlan child = instance.child();
+        Expression limit = randomLimit();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, () -> randomChild(0));
+        } else {
+            limit = randomValueOtherThan(limit, LimitExecSerializationTests::randomLimit);
+        }
+        return new LimitExec(instance.source(), child, limit);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/LocalSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/LocalSourceExecSerializationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplierTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class LocalSourceExecSerializationTests extends AbstractPhysicalPlanSerializationTests<LocalSourceExec> {
+    public static LocalSourceExec randomLocalSourceExec() {
+        Source source = randomSource();
+        List<Attribute> output = randomFieldAttributes(1, 9, false);
+        LocalSupplier supplier = randomBoolean() ? LocalSupplier.EMPTY : LocalSupplierTests.randomNonEmpty();
+        return new LocalSourceExec(source, output, supplier);
+    }
+
+    @Override
+    protected LocalSourceExec createTestInstance() {
+        return randomLocalSourceExec();
+    }
+
+    @Override
+    protected LocalSourceExec mutateInstance(LocalSourceExec instance) throws IOException {
+        List<Attribute> output = instance.output();
+        LocalSupplier supplier = instance.supplier();
+        if (randomBoolean()) {
+            output = randomValueOtherThan(output, () -> randomFieldAttributes(1, 9, false));
+        } else {
+            supplier = randomValueOtherThan(supplier, () -> randomBoolean() ? LocalSupplier.EMPTY : LocalSupplierTests.randomNonEmpty());
+        }
+        return new LocalSourceExec(instance.source(), output, supplier);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -659,7 +659,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
         return randomFrom(Set.of("%{a} %{b}", "%{b} %{c}", "%{a} %{b} %{c}", "%{b} %{c} %{d}", "%{x}"));
     }
 
-    static String randomGrokPattern() {
+    public static String randomGrokPattern() {
         return randomFrom(
             Set.of("%{NUMBER:b:int} %{NUMBER:c:float} %{NUMBER:d:double} %{WORD:e:boolean}", "[a-zA-Z0-9._-]+", "%{LOGLEVEL}")
         );


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Convert some PhysicalPlans to NamedWriteable (#112764)