### PR TITLE
Increase replica_unassigned_buffer_time default from 3s to 5s

### DIFF
--- a/docs/changelog/112834.yaml
+++ b/docs/changelog/112834.yaml
@@ -1,0 +1,5 @@
+pr: 112834
+summary: Increase `replica_unassigned_buffer_time` default from 3s to 5s
+area: Health
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -120,7 +120,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
      */
     public static final Setting<TimeValue> REPLICA_UNASSIGNED_BUFFER_TIME = Setting.timeSetting(
         "health.shards_availability.replica_unassigned_buffer_time",
-        TimeValue.timeValueSeconds(3),
+        TimeValue.timeValueSeconds(5),
         TimeValue.timeValueSeconds(0),
         TimeValue.timeValueSeconds(20),
         Setting.Property.NodeScope,


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/112066 changed the way we calculate if all replicas are unassigned when primary is recently created, specifically on serverless. That PR included a new setting, `health.shards_availability.replica_unassigned_buffer_time`, with a default value of 3 seconds. This PR increases the default value to 5 seconds as it will keep more shards from going red transiently, while still being low enough to go red quickly if there is an actual availability issue.