### PR TITLE
[8.x] Ensure that fields copied using copy_to are not present in synthetic source (#112625)

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
@@ -43,7 +43,9 @@ public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends Standa
 
     public StandardVersusLogsIndexModeRandomDataChallengeRestIT() {
         super();
-        this.subobjects = randomFrom(ObjectMapper.Subobjects.values());
+        // TODO enable subobjects: auto
+        // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using copy_to.
+        this.subobjects = randomValueOtherThan(ObjectMapper.Subobjects.AUTO, () -> randomFrom(ObjectMapper.Subobjects.values()));
         this.keepArraySource = randomBoolean();
 
         var specificationBuilder = DataGeneratorSpecification.builder().withFullyDynamicMapping(randomBoolean());
@@ -118,6 +120,14 @@ public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends Standa
                 )
             )
             .build());
+    }
+
+    @Override
+    protected final Settings restClientSettings() {
+        return Settings.builder()
+            .put(super.restClientSettings())
+            .put(org.elasticsearch.test.rest.ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "9000s")
+            .build();
     }
 
     @Override

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -974,7 +974,7 @@ subobjects auto:
 ---
 synthetic_source with copy_to:
   - requires:
-      cluster_features: ["mapper.source.synthetic_source_with_copy_to_and_doc_values_false"]
+      cluster_features: ["mapper.source.synthetic_source_copy_to_fix"]
       reason: requires copy_to support in synthetic source
 
   - do:
@@ -1068,33 +1068,43 @@ synthetic_source with copy_to:
           fields: ["number_copy", "boolean_copy", "keyword_copy", "date_copy", "text_copy", "ip_copy", "ip_range_copy", "geo_point_copy", "binary_copy", "scaled_float_copy"]
 
   - match: { hits.hits.0._source.number: 100 }
+  - match: { hits.hits.0._source.number_copy: null }
   - match: { hits.hits.0.fields.number_copy.0: "100" }
 
   - match: { hits.hits.0._source.boolean: false }
+  - match: { hits.hits.0._source.boolean_copy: null }
   - match: { hits.hits.0.fields.boolean_copy.0: "false" }
 
   - match: { hits.hits.0._source.keyword: "hello_keyword" }
+  - match: { hits.hits.0._source.keyword_copy: null }
   - match: { hits.hits.0.fields.keyword_copy.0: "hello_keyword" }
 
   - match: { hits.hits.0._source.date: "2015-01-01T12:10:30Z" }
+  - match: { hits.hits.0._source.date_copy: null }
   - match: { hits.hits.0.fields.date_copy.0: "2015-01-01T12:10:30Z" }
 
   - match: { hits.hits.0._source.text: "hello_text" }
+  - match: { hits.hits.0._source.text_copy: null }
   - match: { hits.hits.0.fields.text_copy.0: "hello_text" }
 
   - match: { hits.hits.0._source.ip: "192.168.1.1" }
+  - match: { hits.hits.0._source.ip_copy: null }
   - match: { hits.hits.0.fields.ip_copy.0: "192.168.1.1" }
 
   - match: { hits.hits.0._source.ip_range: "10.0.0.0/24" }
+  - match: { hits.hits.0._source.ip_range_copy: null }
   - match: { hits.hits.0.fields.ip_range_copy.0: "10.0.0.0/24" }
 
   - match: { hits.hits.0._source.geo_point: "POINT (-71.34 41.12)" }
+  - match: { hits.hits.0._source.geo_point_copy: null }
   - match: { hits.hits.0.fields.geo_point_copy.0: "POINT (-71.34 41.12)" }
 
   - match: { hits.hits.0._source.binary: "aGVsbG8gY3VyaW91cyBwZXJzb24=" }
+  - match: { hits.hits.0._source.binary_copy: null }
   - match: { hits.hits.0.fields.binary_copy.0: "aGVsbG8gY3VyaW91cyBwZXJzb24=" }
 
   - match: { hits.hits.0._source.scaled_float: 1.5 }
+  - match: { hits.hits.0._source.scaled_float_copy: null }
   - match: { hits.hits.0.fields.scaled_float_copy.0: "1.5" }
 
 ---
@@ -1214,3 +1224,331 @@ fallback synthetic_source for text field:
       hits.hits.0._source:
         text: [ "world", "hello", "world" ]
 
+---
+synthetic_source with copy_to and ignored values:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              name:
+                type: keyword
+              k:
+                type: keyword
+                ignore_above: 1
+                copy_to: copy
+              long:
+                type: long
+                ignore_malformed: true
+                copy_to: copy
+              copy:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          k: "hello"
+          long: "world"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          name: "B"
+          k: ["5", "6"]
+          long: ["7", "8"]
+
+  - do:
+      search:
+        index: test
+        sort: name
+        body:
+          docvalue_fields: [ "copy" ]
+
+  - match:
+      hits.hits.0._source:
+        name: "A"
+        k: "hello"
+        long: "world"
+  - match: { hits.hits.0.fields.copy: ["hello", "world"] }
+
+  - match:
+      hits.hits.1._source:
+        name: "B"
+        k: ["5", "6"]
+        long: ["7", "8"]
+  - match: { hits.hits.1.fields.copy: ["5", "6", "7", "8"] }
+
+
+---
+synthetic_source with copy_to field having values in source:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              name:
+                type: keyword
+              k:
+                type: keyword
+                copy_to: copy
+              copy:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          copy: "world"
+          k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          name: "B"
+          k: ["5", "6"]
+          copy: ["7", "8"]
+
+  - do:
+      search:
+        index: test
+        sort: name
+        body:
+          docvalue_fields: [ "copy" ]
+
+  - match:
+      hits.hits.0._source:
+        name: "A"
+        k: "hello"
+        copy: "world"
+  - match: { hits.hits.0.fields.copy: ["hello", "world"] }
+
+  - match:
+      hits.hits.1._source:
+        name: "B"
+        k: ["5", "6"]
+        copy: ["7", "8"]
+  - match: { hits.hits.1.fields.copy: ["5", "6", "7", "8"] }
+
+---
+synthetic_source with ignored source field using copy_to:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              name:
+                type: keyword
+              k:
+                type: keyword
+                doc_values: false
+                copy_to: copy
+              copy:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          copy: "world"
+          k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          name: "B"
+          k: ["5", "6"]
+          copy: ["7", "8"]
+
+  - do:
+      search:
+        index: test
+        sort: name
+        body:
+          docvalue_fields: [ "copy" ]
+
+  - match:
+      hits.hits.0._source:
+        name: "A"
+        k: "hello"
+        copy: "world"
+  - match: { hits.hits.0.fields.copy: ["hello", "world"] }
+
+  - match:
+      hits.hits.1._source:
+        name: "B"
+        k: ["5", "6"]
+        copy: ["7", "8"]
+  - match: { hits.hits.1.fields.copy: ["5", "6", "7", "8"] }
+
+---
+synthetic_source with copy_to field from dynamic template having values in source:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            dynamic_templates:
+              - copy_template:
+                  match: "k"
+                  mapping:
+                    type: keyword
+                    copy_to: copy
+            properties:
+              name:
+                type: keyword
+              copy:
+                type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          name: "B"
+          copy: "world"
+          k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 3
+        refresh: true
+        body:
+          name: "C"
+          k: ["5", "6"]
+
+  - do:
+      index:
+        index: test
+        id: 4
+        refresh: true
+        body:
+          name: "D"
+          k: ["5", "6"]
+          copy: ["7", "8"]
+
+  - do:
+      search:
+        index: test
+        sort: name
+        body:
+          docvalue_fields: [ "copy" ]
+
+  - match:
+      hits.hits.0._source:
+        name: "A"
+        k: "hello"
+  - match: { hits.hits.0.fields.copy: ["hello"] }
+
+  - match:
+      hits.hits.1._source:
+        name: "B"
+        k: "hello"
+        copy: "world"
+  - match: { hits.hits.1.fields.copy: ["hello", "world"] }
+
+  - match:
+      hits.hits.2._source:
+        name: "C"
+        k: ["5", "6"]
+  - match: { hits.hits.2.fields.copy: ["5", "6"] }
+
+  - match:
+      hits.hits.3._source:
+        name: "D"
+        k: ["5", "6"]
+        copy: ["7", "8"]
+  - match: { hits.hits.3.fields.copy: ["5", "6", "7", "8"] }
+
+---
+synthetic_source with copy_to and invalid values for copy:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_fix"]
+      reason: requires copy_to support in synthetic source
+      test_runner_features: "contains"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              name:
+                type: keyword
+              p:
+                type: long_range
+                copy_to: copy
+              copy:
+                type: keyword
+
+  - do:
+      catch: bad_request
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          p:
+            gte: 10
+
+  - match: { error.type: "document_parsing_exception" }
+  - contains: { error.reason: "Copy-to currently only works for value-type fields" }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -441,7 +441,9 @@ public final class DocumentParser {
                 parseObjectOrNested(context.createFlattenContext(currentFieldName));
                 context.path().add(currentFieldName);
             } else {
-                if (context.canAddIgnoredField() && fieldMapper.syntheticSourceMode() == FieldMapper.SyntheticSourceMode.FALLBACK) {
+                if (context.canAddIgnoredField()
+                    && (fieldMapper.syntheticSourceMode() == FieldMapper.SyntheticSourceMode.FALLBACK
+                        || (context.isWithinCopyTo() == false && context.isCopyToDestinationField(mapper.fullPath())))) {
                     Tuple<DocumentParserContext, XContentBuilder> contextWithSourceToStore = XContentDataHelper.cloneSubContext(context);
 
                     context.addIgnoredField(
@@ -685,6 +687,8 @@ public final class DocumentParser {
     ) throws IOException {
         // Check if we need to record the array source. This only applies to synthetic source.
         if (context.canAddIgnoredField()) {
+            String fullPath = context.path().pathAsText(arrayFieldName);
+
             boolean objectRequiresStoringSource = mapper instanceof ObjectMapper objectMapper
                 && (objectMapper.storeArraySource()
                     || (context.sourceKeepModeFromIndexSettings() == Mapper.SourceKeepMode.ARRAYS
@@ -692,27 +696,24 @@ public final class DocumentParser {
                     || objectMapper.dynamic == ObjectMapper.Dynamic.RUNTIME);
             boolean fieldWithFallbackSyntheticSource = mapper instanceof FieldMapper fieldMapper
                 && fieldMapper.syntheticSourceMode() == FieldMapper.SyntheticSourceMode.FALLBACK;
-            boolean fieldWithStoredArraySource = mapper instanceof FieldMapper fieldMapper
+            boolean fieldWithStoredArraySource = mapper instanceof FieldMapper
                 && context.sourceKeepModeFromIndexSettings() == Mapper.SourceKeepMode.ARRAYS;
             boolean dynamicRuntimeContext = context.dynamic() == ObjectMapper.Dynamic.RUNTIME;
-            if (objectRequiresStoringSource || fieldWithFallbackSyntheticSource || dynamicRuntimeContext || fieldWithStoredArraySource) {
+            boolean copyToFieldHasValuesInDocument = context.isWithinCopyTo() == false && context.isCopyToDestinationField(fullPath);
+            if (objectRequiresStoringSource
+                || fieldWithFallbackSyntheticSource
+                || dynamicRuntimeContext
+                || fieldWithStoredArraySource
+                || copyToFieldHasValuesInDocument) {
                 Tuple<DocumentParserContext, XContentBuilder> tuple = XContentDataHelper.cloneSubContext(context);
                 context.addIgnoredField(
-                    IgnoredSourceFieldMapper.NameValue.fromContext(
-                        context,
-                        context.path().pathAsText(arrayFieldName),
-                        XContentDataHelper.encodeXContentBuilder(tuple.v2())
-                    )
+                    IgnoredSourceFieldMapper.NameValue.fromContext(context, fullPath, XContentDataHelper.encodeXContentBuilder(tuple.v2()))
                 );
                 context = tuple.v1();
             } else if (mapper instanceof ObjectMapper objectMapper
                 && (objectMapper.isEnabled() == false || objectMapper.dynamic == ObjectMapper.Dynamic.FALSE)) {
                     context.addIgnoredField(
-                        IgnoredSourceFieldMapper.NameValue.fromContext(
-                            context,
-                            context.path().pathAsText(arrayFieldName),
-                            XContentDataHelper.encodeToken(context.parser())
-                        )
+                        IgnoredSourceFieldMapper.NameValue.fromContext(context, fullPath, XContentDataHelper.encodeToken(context.parser()))
                     );
                     return;
                 }
@@ -747,7 +748,7 @@ public final class DocumentParser {
             final List<Mapper> mappers = context.getDynamicMappers(fullFieldName);
             if (mappers == null
                 || context.isFieldAppliedFromTemplate(fullFieldName)
-                || context.isCopyToField(fullFieldName)
+                || context.isCopyToDestinationField(fullFieldName)
                 || mappers.size() < MIN_DIMS_FOR_DYNAMIC_FLOAT_MAPPING
                 || mappers.size() > MAX_DIMS_COUNT
                 // Anything that is NOT a number or anything that IS a number but not mapped to `float` should NOT be mapped to dense_vector
@@ -870,6 +871,7 @@ public final class DocumentParser {
                 // ignore copy_to that targets inference fields, values are already extracted in the coordinating node to perform inference.
                 continue;
             }
+
             // In case of a hierarchy of nested documents, we need to figure out
             // which document the field should go to
             LuceneDocument targetDoc = null;
@@ -902,14 +904,13 @@ public final class DocumentParser {
         if (fieldType != null) {
             // we haven't found a mapper with this name above, which means if a field type is found it is for sure a runtime field.
             assert fieldType.hasDocValues() == false && fieldType.isAggregatable() && fieldType.isSearchable();
-            return NO_OP_FIELDMAPPER;
+            return noopFieldMapper(fieldPath);
         }
         return null;
     }
 
-    private static final FieldMapper NO_OP_FIELDMAPPER = new FieldMapper(
-        "no-op",
-        new MappedFieldType("no-op", false, false, false, TextSearchInfo.NONE, Collections.emptyMap()) {
+    private static FieldMapper noopFieldMapper(String path) {
+        return new FieldMapper("no-op", new MappedFieldType("no-op", false, false, false, TextSearchInfo.NONE, Collections.emptyMap()) {
             @Override
             public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
                 throw new UnsupportedOperationException();
@@ -924,86 +925,84 @@ public final class DocumentParser {
             public Query termQuery(Object value, SearchExecutionContext context) {
                 throw new UnsupportedOperationException();
             }
-        },
-        FieldMapper.BuilderParams.empty()
-    ) {
+        }, FieldMapper.BuilderParams.empty()) {
 
-        @Override
-        protected void parseCreateField(DocumentParserContext context) {
-            // Run-time fields are mapped to this mapper, so it needs to handle storing values for use in synthetic source.
-            // #parseValue calls this method once the run-time field is created.
-            if (context.dynamic() == ObjectMapper.Dynamic.RUNTIME && context.canAddIgnoredField()) {
-                try {
-                    context.addIgnoredField(
-                        IgnoredSourceFieldMapper.NameValue.fromContext(
-                            context,
-                            context.path().pathAsText(context.parser().currentName()),
-                            XContentDataHelper.encodeToken(context.parser())
-                        )
-                    );
-                } catch (IOException e) {
-                    throw new IllegalArgumentException("failed to parse run-time field under [" + context.path().pathAsText("") + " ]", e);
+            @Override
+            protected void parseCreateField(DocumentParserContext context) {
+                // Run-time fields are mapped to this mapper, so it needs to handle storing values for use in synthetic source.
+                // #parseValue calls this method once the run-time field is created.
+                if (context.dynamic() == ObjectMapper.Dynamic.RUNTIME && context.canAddIgnoredField()) {
+                    try {
+                        context.addIgnoredField(
+                            IgnoredSourceFieldMapper.NameValue.fromContext(context, path, XContentDataHelper.encodeToken(context.parser()))
+                        );
+                    } catch (IOException e) {
+                        throw new IllegalArgumentException(
+                            "failed to parse run-time field under [" + context.path().pathAsText("") + " ]",
+                            e
+                        );
+                    }
                 }
             }
-        }
 
-        @Override
-        public String fullPath() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public String fullPath() {
+                return path;
+            }
 
-        @Override
-        public String typeName() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public String typeName() {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        public MappedFieldType fieldType() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public MappedFieldType fieldType() {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        public MultiFields multiFields() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public MultiFields multiFields() {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        public Iterator<Mapper> iterator() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public Iterator<Mapper> iterator() {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        protected void doValidate(MappingLookup mappers) {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            protected void doValidate(MappingLookup mappers) {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        protected void checkIncomingMergeType(FieldMapper mergeWith) {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            protected void checkIncomingMergeType(FieldMapper mergeWith) {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        public Builder getMergeBuilder() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public Builder getMergeBuilder() {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        protected String contentType() {
-            throw new UnsupportedOperationException();
-        }
+            @Override
+            protected String contentType() {
+                throw new UnsupportedOperationException();
+            }
 
-        @Override
-        protected SyntheticSourceSupport syntheticSourceSupport() {
-            // Opt out of fallback synthetic source implementation
-            // since there is custom logic in #parseCreateField().
-            return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
-        }
-    };
+            @Override
+            protected SyntheticSourceSupport syntheticSourceSupport() {
+                // Opt out of fallback synthetic source implementation
+                // since there is custom logic in #parseCreateField().
+                return new SyntheticSourceSupport.Native(SourceLoader.SyntheticFieldLoader.NOTHING);
+            }
+        };
+    }
 
     private static class NoOpObjectMapper extends ObjectMapper {
         NoOpObjectMapper(String name, String fullPath) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -36,6 +36,11 @@ final class FieldTypeLookup {
      * For convenience, the set of copied fields includes the field itself.
      */
     private final Map<String, Set<String>> fieldToCopiedFields;
+    /**
+     * Fields that are destinations of copy_to meaning fields that
+     * contain values copied from other fields.
+     */
+    private final Set<String> copyToDestinationFields;
 
     private final int maxParentPathDots;
 
@@ -54,6 +59,7 @@ final class FieldTypeLookup {
         final Map<String, String> fullSubfieldNameToParentPath = new HashMap<>();
         final Map<String, DynamicFieldType> dynamicFieldTypes = new HashMap<>();
         final Map<String, Set<String>> fieldToCopiedFields = new HashMap<>();
+        final Set<String> copiedFields = new HashSet<>();
         for (FieldMapper fieldMapper : fieldMappers) {
             String fieldName = fieldMapper.fullPath();
             MappedFieldType fieldType = fieldMapper.fieldType();
@@ -63,11 +69,13 @@ final class FieldTypeLookup {
                 dynamicFieldTypes.put(fieldType.name(), (DynamicFieldType) fieldType);
             }
             for (String targetField : fieldMapper.copyTo().copyToFields()) {
+                copiedFields.add(targetField);
+
                 Set<String> sourcePath = fieldToCopiedFields.get(targetField);
                 if (sourcePath == null) {
-                    Set<String> copiedFields = new HashSet<>();
-                    copiedFields.add(targetField);
-                    fieldToCopiedFields.put(targetField, copiedFields);
+                    Set<String> fieldCopiedFields = new HashSet<>();
+                    fieldCopiedFields.add(targetField);
+                    fieldToCopiedFields.put(targetField, fieldCopiedFields);
                 }
                 fieldToCopiedFields.get(targetField).add(fieldName);
             }
@@ -139,6 +147,7 @@ final class FieldTypeLookup {
         // make values into more compact immutable sets to save memory
         fieldToCopiedFields.entrySet().forEach(e -> e.setValue(Set.copyOf(e.getValue())));
         this.fieldToCopiedFields = Map.copyOf(fieldToCopiedFields);
+        this.copyToDestinationFields = Set.copyOf(copiedFields);
     }
 
     public static int dotCount(String path) {
@@ -259,5 +268,9 @@ final class FieldTypeLookup {
      */
     public Map<String, MappedFieldType> getFullNameToFieldType() {
         return fullNameToFieldType;
+    }
+
+    public Set<String> getCopyToDestinationFields() {
+        return copyToDestinationFields;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -36,7 +36,8 @@ public class MapperFeatures implements FeatureSpecification {
             KeywordFieldMapper.KEYWORD_NORMALIZER_SYNTHETIC_SOURCE,
             SourceFieldMapper.SYNTHETIC_SOURCE_STORED_FIELDS_ADVANCE_FIX,
             Mapper.SYNTHETIC_SOURCE_KEEP_FEATURE,
-            SourceFieldMapper.SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT
+            SourceFieldMapper.SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT,
+            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -46,6 +46,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     public static final NodeFeature SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT = new NodeFeature(
         "mapper.source.synthetic_source_with_copy_to_and_doc_values_false"
     );
+    public static final NodeFeature SYNTHETIC_SOURCE_COPY_TO_FIX = new NodeFeature("mapper.source.synthetic_source_copy_to_fix");
 
     public static final String NAME = "_source";
     public static final String RECOVERY_SOURCE_NAME = "_recovery_source";

--- a/server/src/main/java/org/elasticsearch/index/mapper/XContentDataHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/XContentDataHelper.java
@@ -71,6 +71,19 @@ public final class XContentDataHelper {
     }
 
     /**
+     * Returns a special encoded value that signals that values of this field
+     * should not be present in synthetic source.
+     *
+     * An example is a field that has values copied to it using copy_to.
+     * While that field "looks" like a regular field it should not be present in
+     * synthetic _source same as it wouldn't be present in stored source.
+     * @return
+     */
+    public static BytesRef nothing() {
+        return new BytesRef(new byte[] { VOID_ENCODING });
+    }
+
+    /**
      * Decode the value in the passed {@link BytesRef} and add it as a value to the
      * passed build. The assumption is that the passed value has encoded using the function
      * {@link #encodeToken(XContentParser)} above.
@@ -90,6 +103,7 @@ public final class XContentDataHelper {
             case DOUBLE_ENCODING -> TypeUtils.DOUBLE.decodeAndWrite(b, r);
             case FLOAT_ENCODING -> TypeUtils.FLOAT.decodeAndWrite(b, r);
             case NULL_ENCODING -> TypeUtils.NULL.decodeAndWrite(b, r);
+            case VOID_ENCODING -> TypeUtils.VOID.decodeAndWrite(b, r);
             default -> throw new IllegalArgumentException("Can't decode " + r);
         }
     }
@@ -103,19 +117,35 @@ public final class XContentDataHelper {
      * @throws IOException
      */
     static void writeMerged(XContentBuilder b, String fieldName, List<BytesRef> encodedParts) throws IOException {
-        if (encodedParts.isEmpty()) {
+        var partsWithData = 0;
+        for (BytesRef encodedPart : encodedParts) {
+            if (isDataPresent(encodedPart)) {
+                partsWithData++;
+            }
+        }
+
+        if (partsWithData == 0) {
             return;
         }
 
-        if (encodedParts.size() == 1) {
+        if (partsWithData == 1) {
             b.field(fieldName);
-            XContentDataHelper.decodeAndWrite(b, encodedParts.get(0));
+            for (BytesRef encodedPart : encodedParts) {
+                if (isDataPresent(encodedPart)) {
+                    XContentDataHelper.decodeAndWrite(b, encodedPart);
+                }
+            }
+
             return;
         }
 
         b.startArray(fieldName);
 
         for (var encodedValue : encodedParts) {
+            if (isDataPresent(encodedValue) == false) {
+                continue;
+            }
+
             Optional<XContentType> encodedXContentType = switch ((char) encodedValue.bytes[encodedValue.offset]) {
                 case CBOR_OBJECT_ENCODING, JSON_OBJECT_ENCODING, YAML_OBJECT_ENCODING, SMILE_OBJECT_ENCODING -> Optional.of(
                     getXContentType(encodedValue)
@@ -156,6 +186,10 @@ public final class XContentDataHelper {
         }
 
         b.endArray();
+    }
+
+    public static boolean isDataPresent(BytesRef encoded) {
+        return encoded.bytes[encoded.offset] != VOID_ENCODING;
     }
 
     /**
@@ -256,6 +290,7 @@ public final class XContentDataHelper {
     private static final char JSON_OBJECT_ENCODING = 'j';
     private static final char YAML_OBJECT_ENCODING = 'y';
     private static final char SMILE_OBJECT_ENCODING = 's';
+    private static final char VOID_ENCODING = 'v';
 
     private enum TypeUtils {
         STRING(STRING_ENCODING) {
@@ -482,6 +517,24 @@ public final class XContentDataHelper {
                     case YAML_OBJECT_ENCODING -> decodeAndWriteXContent(b, XContentType.YAML, r);
                     default -> throw new IllegalArgumentException("Can't decode " + r);
                 }
+            }
+        },
+        VOID(VOID_ENCODING) {
+            @Override
+            StoredField buildStoredField(String name, XContentParser parser) throws IOException {
+                return new StoredField(name, encode(parser));
+            }
+
+            @Override
+            byte[] encode(XContentParser parser) {
+                byte[] bytes = new byte[] { getEncoding() };
+                assertValidEncoding(bytes);
+                return bytes;
+            }
+
+            @Override
+            void decodeAndWrite(XContentBuilder b, BytesRef r) {
+                // NOOP
             }
         };
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/FieldType.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.logsdb.datageneration;
 
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.ByteFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.DoubleFieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.fields.leaf.FloatFieldDataGenerator;
@@ -35,18 +36,22 @@ public enum FieldType {
     HALF_FLOAT,
     SCALED_FLOAT;
 
-    public FieldDataGenerator generator(String fieldName, DataSource dataSource) {
+    public FieldDataGenerator generator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         return switch (this) {
-            case KEYWORD -> new KeywordFieldDataGenerator(fieldName, dataSource);
-            case LONG -> new LongFieldDataGenerator(fieldName, dataSource);
-            case UNSIGNED_LONG -> new UnsignedLongFieldDataGenerator(fieldName, dataSource);
-            case INTEGER -> new IntegerFieldDataGenerator(fieldName, dataSource);
-            case SHORT -> new ShortFieldDataGenerator(fieldName, dataSource);
-            case BYTE -> new ByteFieldDataGenerator(fieldName, dataSource);
-            case DOUBLE -> new DoubleFieldDataGenerator(fieldName, dataSource);
-            case FLOAT -> new FloatFieldDataGenerator(fieldName, dataSource);
-            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, dataSource);
-            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, dataSource);
+            case KEYWORD -> new KeywordFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case LONG -> new LongFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case UNSIGNED_LONG -> new UnsignedLongFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case INTEGER -> new IntegerFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case SHORT -> new ShortFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case BYTE -> new ByteFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case DOUBLE -> new DoubleFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case FLOAT -> new FloatFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case HALF_FLOAT -> new HalfFloatFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
+            case SCALED_FLOAT -> new ScaledFloatFieldDataGenerator(fieldName, dataSource, mappingParametersGenerator);
         };
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
@@ -12,6 +12,8 @@ import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.fields.DynamicMapping;
 
+import java.util.Set;
+
 public interface DataSourceRequest<TResponse extends DataSourceResponse> {
     TResponse accept(DataSourceHandler handler);
 
@@ -101,7 +103,7 @@ public interface DataSourceRequest<TResponse extends DataSourceResponse> {
         }
     }
 
-    record LeafMappingParametersGenerator(String fieldName, FieldType fieldType)
+    record LeafMappingParametersGenerator(String fieldName, FieldType fieldType, Set<String> eligibleCopyToFields)
         implements
             DataSourceRequest<DataSourceResponse.LeafMappingParametersGenerator> {
         public DataSourceResponse.LeafMappingParametersGenerator accept(DataSourceHandler handler) {

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/Context.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/Context.java
@@ -12,8 +12,10 @@ import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class Context {
@@ -21,26 +23,33 @@ class Context {
 
     private final DataSourceResponse.ChildFieldGenerator childFieldGenerator;
     private final DataSourceResponse.ObjectArrayGenerator objectArrayGenerator;
+
+    private final String path;
     private final int objectDepth;
     // We don't need atomicity, but we need to pass counter by reference to accumulate total value from sub-objects.
     private final AtomicInteger nestedFieldsCount;
+    private final Set<String> eligibleCopyToDestinations;
     private final DynamicMapping parentDynamicMapping;
 
     Context(DataGeneratorSpecification specification, DynamicMapping parentDynamicMapping) {
-        this(specification, 0, new AtomicInteger(0), parentDynamicMapping);
+        this(specification, "", 0, new AtomicInteger(0), new HashSet<>(), parentDynamicMapping);
     }
 
     private Context(
         DataGeneratorSpecification specification,
+        String path,
         int objectDepth,
         AtomicInteger nestedFieldsCount,
+        Set<String> eligibleCopyToDestinations,
         DynamicMapping parentDynamicMapping
     ) {
         this.specification = specification;
         this.childFieldGenerator = specification.dataSource().get(new DataSourceRequest.ChildFieldGenerator(specification));
         this.objectArrayGenerator = specification.dataSource().get(new DataSourceRequest.ObjectArrayGenerator());
+        this.path = path;
         this.objectDepth = objectDepth;
         this.nestedFieldsCount = nestedFieldsCount;
+        this.eligibleCopyToDestinations = eligibleCopyToDestinations;
         this.parentDynamicMapping = parentDynamicMapping;
     }
 
@@ -56,13 +65,21 @@ class Context {
         return specification.dataSource().get(new DataSourceRequest.FieldTypeGenerator(dynamicMapping));
     }
 
-    public Context subObject(DynamicMapping dynamicMapping) {
-        return new Context(specification, objectDepth + 1, nestedFieldsCount, dynamicMapping);
+    public Context subObject(String name, DynamicMapping dynamicMapping) {
+        return new Context(
+            specification,
+            pathToField(name),
+            objectDepth + 1,
+            nestedFieldsCount,
+            eligibleCopyToDestinations,
+            dynamicMapping
+        );
     }
 
-    public Context nestedObject(DynamicMapping dynamicMapping) {
+    public Context nestedObject(String name, DynamicMapping dynamicMapping) {
         nestedFieldsCount.incrementAndGet();
-        return new Context(specification, objectDepth + 1, nestedFieldsCount, dynamicMapping);
+        // copy_to can't be used across nested documents so all currently eligible fields are not eligible inside nested document.
+        return new Context(specification, pathToField(name), objectDepth + 1, nestedFieldsCount, new HashSet<>(), dynamicMapping);
     }
 
     public boolean shouldAddDynamicObjectField(DynamicMapping dynamicMapping) {
@@ -111,5 +128,17 @@ class Context {
         }
 
         return dynamicParameter.equals("strict") ? DynamicMapping.FORBIDDEN : DynamicMapping.SUPPORTED;
+    }
+
+    public Set<String> getEligibleCopyToDestinations() {
+        return eligibleCopyToDestinations;
+    }
+
+    public void markFieldAsEligibleForCopyTo(String field) {
+        eligibleCopyToDestinations.add(pathToField(field));
+    }
+
+    private String pathToField(String field) {
+        return path.isEmpty() ? field : path + "." + field;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/PredefinedField.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/PredefinedField.java
@@ -11,6 +11,9 @@ package org.elasticsearch.logsdb.datageneration.fields;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
 import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+
+import java.util.Set;
 
 public interface PredefinedField {
     String name();
@@ -25,7 +28,11 @@ public interface PredefinedField {
 
         @Override
         public FieldDataGenerator generator(DataSource dataSource) {
-            return fieldType().generator(fieldName, dataSource);
+            // copy_to currently not supported for predefined fields, use WithGenerator if needed
+            var mappingParametersGenerator = dataSource.get(
+                new DataSourceRequest.LeafMappingParametersGenerator(fieldName, fieldType, Set.of())
+            );
+            return fieldType().generator(fieldName, dataSource, mappingParametersGenerator);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ByteFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ByteFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class ByteFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public ByteFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public ByteFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var bytes = dataSource.get(new DataSourceRequest.ByteGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> bytes.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.BYTE))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/DoubleFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/DoubleFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class DoubleFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public DoubleFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public DoubleFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> doubles.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.DOUBLE))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/FloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/FloatFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class FloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public FloatFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public FloatFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var floats = dataSource.get(new DataSourceRequest.FloatGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> floats.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.FLOAT))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/HalfFloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/HalfFloatFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class HalfFloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public HalfFloatFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public HalfFloatFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var halfFloats = dataSource.get(new DataSourceRequest.HalfFloatGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> halfFloats.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.HALF_FLOAT))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/IntegerFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/IntegerFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class IntegerFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public IntegerFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public IntegerFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var ints = dataSource.get(new DataSourceRequest.IntegerGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> ints.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.INTEGER))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/KeywordFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/KeywordFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class KeywordFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public KeywordFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public KeywordFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var strings = dataSource.get(new DataSourceRequest.StringGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> strings.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.KEYWORD))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/LongFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/LongFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class LongFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public LongFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public LongFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var longs = dataSource.get(new DataSourceRequest.LongGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> longs.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.LONG))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ScaledFloatFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ScaledFloatFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class ScaledFloatFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public ScaledFloatFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public ScaledFloatFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var doubles = dataSource.get(new DataSourceRequest.DoubleGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> doubles.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.SCALED_FLOAT))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ShortFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/ShortFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class ShortFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public ShortFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public ShortFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var shorts = dataSource.get(new DataSourceRequest.ShortGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> shorts.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.SHORT))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/UnsignedLongFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/leaf/UnsignedLongFieldDataGenerator.java
@@ -10,9 +10,9 @@ package org.elasticsearch.logsdb.datageneration.fields.leaf;
 
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSource;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -23,15 +23,17 @@ public class UnsignedLongFieldDataGenerator implements FieldDataGenerator {
     private final Supplier<Object> valueGenerator;
     private final Map<String, Object> mappingParameters;
 
-    public UnsignedLongFieldDataGenerator(String fieldName, DataSource dataSource) {
+    public UnsignedLongFieldDataGenerator(
+        String fieldName,
+        DataSource dataSource,
+        DataSourceResponse.LeafMappingParametersGenerator mappingParametersGenerator
+    ) {
         var unsignedLongs = dataSource.get(new DataSourceRequest.UnsignedLongGenerator());
         var nulls = dataSource.get(new DataSourceRequest.NullWrapper());
         var arrays = dataSource.get(new DataSourceRequest.ArrayWrapper());
 
         this.valueGenerator = arrays.wrapper().compose(nulls.wrapper()).apply(() -> unsignedLongs.generator().get());
-        this.mappingParameters = dataSource.get(new DataSourceRequest.LeafMappingParametersGenerator(fieldName, FieldType.UNSIGNED_LONG))
-            .mappingGenerator()
-            .get();
+        this.mappingParameters = mappingParametersGenerator.mappingGenerator().get();
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Ensure that fields copied using copy_to are not present in synthetic source (#112625)