### PR TITLE
Adding skip_results, skip_model_update, and force_time_shift to ML calendar ScheduledEvent

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -209,6 +209,7 @@ public class TransportVersions {
     public static final TransportVersion CCS_TELEMETRY_STATS = def(8_739_00_0);
     public static final TransportVersion GLOBAL_RETENTION_TELEMETRY = def(8_740_00_0);
     public static final TransportVersion ROUTING_TABLE_VERSION_REMOVED = def(8_741_00_0);
+    public static final TransportVersion ML_SCHEDULED_EVENT_TIME_SHIFT_CONFIGURATION = def(8_742_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetaIndex.java
@@ -17,7 +17,7 @@ public final class MlMetaIndex {
 
     private static final String INDEX_NAME = ".ml-meta";
     private static final String MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";
-    private static final int META_INDEX_MAPPINGS_VERSION = 1;
+    private static final int META_INDEX_MAPPINGS_VERSION = 2;
 
     /**
      * Where to store the ml info in Elasticsearch - must match what's

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.calendars;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -20,6 +21,8 @@ import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
 import org.elasticsearch.xpack.core.ml.job.config.Operator;
 import org.elasticsearch.xpack.core.ml.job.config.RuleAction;
 import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
+import org.elasticsearch.xpack.core.ml.job.config.RuleParams;
+import org.elasticsearch.xpack.core.ml.job.config.RuleParamsForForceTimeShift;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.Intervals;
@@ -36,6 +39,9 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     public static final ParseField DESCRIPTION = new ParseField("description");
     public static final ParseField START_TIME = new ParseField("start_time");
     public static final ParseField END_TIME = new ParseField("end_time");
+    public static final ParseField SKIP_RESULTS = new ParseField("skip_results");
+    public static final ParseField SKIP_MODEL_UPDATE = new ParseField("skip_model_update");
+    public static final ParseField FORCE_TIME_SHIFT = new ParseField("force_time_shift");
     public static final ParseField TYPE = new ParseField("type");
     public static final ParseField EVENT_ID = new ParseField("event_id");
 
@@ -63,6 +69,9 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
             END_TIME,
             ObjectParser.ValueType.VALUE
         );
+        parser.declareBoolean(ScheduledEvent.Builder::skipResults, SKIP_RESULTS);
+        parser.declareBoolean(ScheduledEvent.Builder::skipModelUpdate, SKIP_MODEL_UPDATE);
+        parser.declareInt(ScheduledEvent.Builder::forceTimeShift, FORCE_TIME_SHIFT);
         parser.declareString(ScheduledEvent.Builder::calendarId, Calendar.ID);
         parser.declareString((builder, s) -> {}, TYPE);
 
@@ -76,13 +85,28 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     private final String description;
     private final Instant startTime;
     private final Instant endTime;
+    private final Boolean skipResults;
+    private final Boolean skipModelUpdate;
+    private final Integer forceTimeShift;
     private final String calendarId;
     private final String eventId;
 
-    ScheduledEvent(String description, Instant startTime, Instant endTime, String calendarId, @Nullable String eventId) {
+    ScheduledEvent(
+        String description,
+        Instant startTime,
+        Instant endTime,
+        Boolean skipResults,
+        Boolean skipModelUpdate,
+        @Nullable Integer forceTimeShift,
+        String calendarId,
+        @Nullable String eventId
+    ) {
         this.description = Objects.requireNonNull(description);
         this.startTime = Instant.ofEpochMilli(Objects.requireNonNull(startTime).toEpochMilli());
         this.endTime = Instant.ofEpochMilli(Objects.requireNonNull(endTime).toEpochMilli());
+        this.skipResults = Objects.requireNonNull(skipResults);
+        this.skipModelUpdate = Objects.requireNonNull(skipModelUpdate);
+        this.forceTimeShift = forceTimeShift;
         this.calendarId = Objects.requireNonNull(calendarId);
         this.eventId = eventId;
     }
@@ -91,6 +115,15 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         description = in.readString();
         startTime = in.readInstant();
         endTime = in.readInstant();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ML_SCHEDULED_EVENT_TIME_SHIFT_CONFIGURATION)) {
+            skipResults = in.readBoolean();
+            skipModelUpdate = in.readBoolean();
+            forceTimeShift = in.readOptionalInt();
+        } else {
+            skipResults = true;
+            skipModelUpdate = true;
+            forceTimeShift = null;
+        }
         calendarId = in.readString();
         eventId = in.readOptionalString();
     }
@@ -109,6 +142,18 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
     public String getCalendarId() {
         return calendarId;
+    }
+
+    public Boolean getSkipResults() {
+        return skipResults;
+    }
+
+    public Boolean getSkipModelUpdate() {
+        return skipModelUpdate;
+    }
+
+    public Integer getForceTimeShift() {
+        return forceTimeShift;
     }
 
     public String getEventId() {
@@ -138,7 +183,19 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         conditions.add(RuleCondition.createTime(Operator.LT, bucketEndTime));
 
         DetectionRule.Builder builder = new DetectionRule.Builder(conditions);
-        builder.setActions(RuleAction.SKIP_RESULT, RuleAction.SKIP_MODEL_UPDATE);
+        List<String> ruleActions = new ArrayList<>();
+        if (skipResults) {
+            ruleActions.add(RuleAction.SKIP_RESULT.toString());
+            builder.setActions(RuleAction.SKIP_RESULT);
+        }
+        if (skipModelUpdate) {
+            ruleActions.add(RuleAction.SKIP_MODEL_UPDATE.toString());
+        }
+        if (forceTimeShift != null) {
+            ruleActions.add(RuleAction.FORCE_TIME_SHIFT.toString());
+            builder.setParams(new RuleParams(new RuleParamsForForceTimeShift(forceTimeShift)));
+        }
+        builder.setActions(ruleActions);
         return builder.build();
     }
 
@@ -147,6 +204,11 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         out.writeString(description);
         out.writeInstant(startTime);
         out.writeInstant(endTime);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ML_SCHEDULED_EVENT_TIME_SHIFT_CONFIGURATION)) {
+            out.writeBoolean(skipResults);
+            out.writeBoolean(skipModelUpdate);
+            out.writeOptionalInt(forceTimeShift);
+        }
         out.writeString(calendarId);
         out.writeOptionalString(eventId);
     }
@@ -157,6 +219,12 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         builder.field(DESCRIPTION.getPreferredName(), description);
         builder.timeField(START_TIME.getPreferredName(), START_TIME.getPreferredName() + "_string", startTime.toEpochMilli());
         builder.timeField(END_TIME.getPreferredName(), END_TIME.getPreferredName() + "_string", endTime.toEpochMilli());
+        // TODO: Check if this needs to be behind a feature flag?
+        builder.field(SKIP_RESULTS.getPreferredName(), skipResults);
+        builder.field(SKIP_MODEL_UPDATE.getPreferredName(), skipModelUpdate);
+        if (forceTimeShift != null) {
+            builder.field(FORCE_TIME_SHIFT.getPreferredName(), forceTimeShift);
+        }
         builder.field(Calendar.ID.getPreferredName(), calendarId);
         if (eventId != null) {
             builder.field(EVENT_ID.getPreferredName(), eventId);
@@ -182,18 +250,24 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         return description.equals(other.description)
             && Objects.equals(startTime, other.startTime)
             && Objects.equals(endTime, other.endTime)
+            && Objects.equals(skipResults, other.skipResults)
+            && Objects.equals(skipModelUpdate, other.skipModelUpdate)
+            && Objects.equals(forceTimeShift, other.forceTimeShift)
             && calendarId.equals(other.calendarId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(description, startTime, endTime, calendarId);
+        return Objects.hash(description, startTime, endTime, skipResults, skipModelUpdate, forceTimeShift, calendarId);
     }
 
     public static class Builder {
         private String description;
         private Instant startTime;
         private Instant endTime;
+        private Boolean skipResults;
+        private Boolean skipModelUpdate;
+        private Integer forceTimeShift;
         private String calendarId;
         private String eventId;
 
@@ -209,6 +283,21 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
         public Builder endTime(Instant endTime) {
             this.endTime = Instant.ofEpochMilli(Objects.requireNonNull(endTime, END_TIME.getPreferredName()).toEpochMilli());
+            return this;
+        }
+
+        public Builder skipResults(Boolean skipResults) {
+            this.skipResults = skipResults;
+            return this;
+        }
+
+        public Builder skipModelUpdate(Boolean skipModelUpdate) {
+            this.skipModelUpdate = skipModelUpdate;
+            return this;
+        }
+
+        public Builder forceTimeShift(Integer forceTimeShift) {
+            this.forceTimeShift = forceTimeShift;
             return this;
         }
 
@@ -255,7 +344,19 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
                 );
             }
 
-            ScheduledEvent event = new ScheduledEvent(description, startTime, endTime, calendarId, eventId);
+            skipResults = skipResults == null || skipResults;
+            skipModelUpdate = skipModelUpdate == null || skipModelUpdate;
+
+            ScheduledEvent event = new ScheduledEvent(
+                description,
+                startTime,
+                endTime,
+                skipResults,
+                skipModelUpdate,
+                forceTimeShift,
+                calendarId,
+                eventId
+            );
 
             return event;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
@@ -219,7 +219,6 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         builder.field(DESCRIPTION.getPreferredName(), description);
         builder.timeField(START_TIME.getPreferredName(), START_TIME.getPreferredName() + "_string", startTime.toEpochMilli());
         builder.timeField(END_TIME.getPreferredName(), END_TIME.getPreferredName() + "_string", endTime.toEpochMilli());
-        // TODO: Check if this needs to be behind a feature flag?
         builder.field(SKIP_RESULT.getPreferredName(), skipResult);
         builder.field(SKIP_MODEL_UPDATE.getPreferredName(), skipModelUpdate);
         if (forceTimeShift != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
@@ -39,7 +39,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     public static final ParseField DESCRIPTION = new ParseField("description");
     public static final ParseField START_TIME = new ParseField("start_time");
     public static final ParseField END_TIME = new ParseField("end_time");
-    public static final ParseField SKIP_RESULTS = new ParseField("skip_results");
+    public static final ParseField SKIP_RESULT = new ParseField("skip_result");
     public static final ParseField SKIP_MODEL_UPDATE = new ParseField("skip_model_update");
     public static final ParseField FORCE_TIME_SHIFT = new ParseField("force_time_shift");
     public static final ParseField TYPE = new ParseField("type");
@@ -69,7 +69,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
             END_TIME,
             ObjectParser.ValueType.VALUE
         );
-        parser.declareBoolean(ScheduledEvent.Builder::skipResults, SKIP_RESULTS);
+        parser.declareBoolean(ScheduledEvent.Builder::skipResult, SKIP_RESULT);
         parser.declareBoolean(ScheduledEvent.Builder::skipModelUpdate, SKIP_MODEL_UPDATE);
         parser.declareInt(ScheduledEvent.Builder::forceTimeShift, FORCE_TIME_SHIFT);
         parser.declareString(ScheduledEvent.Builder::calendarId, Calendar.ID);
@@ -85,7 +85,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     private final String description;
     private final Instant startTime;
     private final Instant endTime;
-    private final Boolean skipResults;
+    private final Boolean skipResult;
     private final Boolean skipModelUpdate;
     private final Integer forceTimeShift;
     private final String calendarId;
@@ -95,7 +95,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         String description,
         Instant startTime,
         Instant endTime,
-        Boolean skipResults,
+        Boolean skipResult,
         Boolean skipModelUpdate,
         @Nullable Integer forceTimeShift,
         String calendarId,
@@ -104,7 +104,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         this.description = Objects.requireNonNull(description);
         this.startTime = Instant.ofEpochMilli(Objects.requireNonNull(startTime).toEpochMilli());
         this.endTime = Instant.ofEpochMilli(Objects.requireNonNull(endTime).toEpochMilli());
-        this.skipResults = Objects.requireNonNull(skipResults);
+        this.skipResult = Objects.requireNonNull(skipResult);
         this.skipModelUpdate = Objects.requireNonNull(skipModelUpdate);
         this.forceTimeShift = forceTimeShift;
         this.calendarId = Objects.requireNonNull(calendarId);
@@ -116,11 +116,11 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         startTime = in.readInstant();
         endTime = in.readInstant();
         if (in.getTransportVersion().onOrAfter(TransportVersions.ML_SCHEDULED_EVENT_TIME_SHIFT_CONFIGURATION)) {
-            skipResults = in.readBoolean();
+            skipResult = in.readBoolean();
             skipModelUpdate = in.readBoolean();
             forceTimeShift = in.readOptionalInt();
         } else {
-            skipResults = true;
+            skipResult = true;
             skipModelUpdate = true;
             forceTimeShift = null;
         }
@@ -144,8 +144,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         return calendarId;
     }
 
-    public Boolean getSkipResults() {
-        return skipResults;
+    public Boolean getSkipResult() {
+        return skipResult;
     }
 
     public Boolean getSkipModelUpdate() {
@@ -184,7 +184,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
         DetectionRule.Builder builder = new DetectionRule.Builder(conditions);
         List<String> ruleActions = new ArrayList<>();
-        if (skipResults) {
+        if (skipResult) {
             ruleActions.add(RuleAction.SKIP_RESULT.toString());
             builder.setActions(RuleAction.SKIP_RESULT);
         }
@@ -205,7 +205,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         out.writeInstant(startTime);
         out.writeInstant(endTime);
         if (out.getTransportVersion().onOrAfter(TransportVersions.ML_SCHEDULED_EVENT_TIME_SHIFT_CONFIGURATION)) {
-            out.writeBoolean(skipResults);
+            out.writeBoolean(skipResult);
             out.writeBoolean(skipModelUpdate);
             out.writeOptionalInt(forceTimeShift);
         }
@@ -220,7 +220,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         builder.timeField(START_TIME.getPreferredName(), START_TIME.getPreferredName() + "_string", startTime.toEpochMilli());
         builder.timeField(END_TIME.getPreferredName(), END_TIME.getPreferredName() + "_string", endTime.toEpochMilli());
         // TODO: Check if this needs to be behind a feature flag?
-        builder.field(SKIP_RESULTS.getPreferredName(), skipResults);
+        builder.field(SKIP_RESULT.getPreferredName(), skipResult);
         builder.field(SKIP_MODEL_UPDATE.getPreferredName(), skipModelUpdate);
         if (forceTimeShift != null) {
             builder.field(FORCE_TIME_SHIFT.getPreferredName(), forceTimeShift);
@@ -250,7 +250,7 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
         return description.equals(other.description)
             && Objects.equals(startTime, other.startTime)
             && Objects.equals(endTime, other.endTime)
-            && Objects.equals(skipResults, other.skipResults)
+            && Objects.equals(skipResult, other.skipResult)
             && Objects.equals(skipModelUpdate, other.skipModelUpdate)
             && Objects.equals(forceTimeShift, other.forceTimeShift)
             && calendarId.equals(other.calendarId);
@@ -258,14 +258,14 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(description, startTime, endTime, skipResults, skipModelUpdate, forceTimeShift, calendarId);
+        return Objects.hash(description, startTime, endTime, skipResult, skipModelUpdate, forceTimeShift, calendarId);
     }
 
     public static class Builder {
         private String description;
         private Instant startTime;
         private Instant endTime;
-        private Boolean skipResults;
+        private Boolean skipResult;
         private Boolean skipModelUpdate;
         private Integer forceTimeShift;
         private String calendarId;
@@ -286,8 +286,8 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
             return this;
         }
 
-        public Builder skipResults(Boolean skipResults) {
-            this.skipResults = skipResults;
+        public Builder skipResult(Boolean skipResult) {
+            this.skipResult = skipResult;
             return this;
         }
 
@@ -344,14 +344,14 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
                 );
             }
 
-            skipResults = skipResults == null || skipResults;
+            skipResult = skipResult == null || skipResult;
             skipModelUpdate = skipModelUpdate == null || skipModelUpdate;
 
             ScheduledEvent event = new ScheduledEvent(
                 description,
                 startTime,
                 endTime,
-                skipResults,
+                skipResult,
                 skipModelUpdate,
                 forceTimeShift,
                 calendarId,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -16,19 +16,51 @@ import org.elasticsearch.xpack.core.ml.job.config.DetectionRule;
 import org.elasticsearch.xpack.core.ml.job.config.Operator;
 import org.elasticsearch.xpack.core.ml.job.config.RuleAction;
 import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
+import org.elasticsearch.xpack.core.ml.job.config.RuleParams;
+import org.elasticsearch.xpack.core.ml.job.config.RuleParamsForForceTimeShift;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.containsString;
 
 public class ScheduledEventTests extends AbstractXContentSerializingTestCase<ScheduledEvent> {
 
+    private static final long BUCKET_SPAN_SECS = 300;
+
     public static ScheduledEvent createScheduledEvent(String calendarId) {
         Instant start = Instant.now();
-        return new ScheduledEvent(randomAlphaOfLength(10), start, start.plusSeconds(randomIntBetween(1, 10000)), calendarId, null);
+        return new ScheduledEvent(
+            randomAlphaOfLength(10),
+            start,
+            start.plusSeconds(randomIntBetween(1, 10000)),
+            randomBoolean(),
+            randomBoolean(),
+            randomBoolean() ? null : randomInt(),
+            calendarId,
+            null
+        );
+    }
+
+    public static ScheduledEvent createScheduledEvent(
+        String calendarId,
+        Boolean skipResult,
+        Boolean skipModelUpdate,
+        Integer forceTimeShift
+    ) {
+        Instant start = Instant.now();
+        return new ScheduledEvent(
+            randomAlphaOfLength(10),
+            start,
+            start.plusSeconds(randomIntBetween(1, 10000)),
+            skipResult,
+            skipModelUpdate,
+            forceTimeShift,
+            calendarId,
+            null
+        );
     }
 
     @Override
@@ -51,12 +83,52 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
         return ScheduledEvent.STRICT_PARSER.apply(parser, null).build();
     }
 
-    public void testToDetectionRule() {
-        long bucketSpanSecs = 300;
-        ScheduledEvent event = createTestInstance();
-        DetectionRule rule = event.toDetectionRule(TimeValue.timeValueSeconds(bucketSpanSecs));
+    public void testToDetectionRule_SetsSkipResultActionProperly() {
+        List<Boolean> validValues = List.of(true, false);
+        validValues.forEach((skipResult) -> {
+            Boolean skipModelUpdate = randomBoolean();
+            Integer forceTimeShift = randomInt();
+            ScheduledEvent event = createScheduledEvent(randomAlphaOfLength(10), skipResult, skipModelUpdate, forceTimeShift);
+            DetectionRule rule = event.toDetectionRule(TimeValue.timeValueSeconds(BUCKET_SPAN_SECS));
+            validateDetectionRule(event, rule, skipResult, skipModelUpdate, forceTimeShift);
+        });
+    }
 
-        assertEquals(rule.getActions(), EnumSet.of(RuleAction.SKIP_RESULT, RuleAction.SKIP_MODEL_UPDATE));
+    public void testToDetectionRule_SetsSkipModelUpdateActionProperly() {
+        List<Boolean> validValues = List.of(true, false);
+        validValues.forEach((skipModelUpdate) -> {
+            Boolean skipResult = randomBoolean();
+            Integer forceTimeShift = randomInt();
+            ScheduledEvent event = createScheduledEvent(randomAlphaOfLength(10), skipResult, skipModelUpdate, forceTimeShift);
+            DetectionRule rule = event.toDetectionRule(TimeValue.timeValueSeconds(BUCKET_SPAN_SECS));
+            validateDetectionRule(event, rule, skipResult, skipModelUpdate, forceTimeShift);
+        });
+    }
+
+    public void testToDetectionRule_SetsForceTimeShiftActionProperly() {
+        List<Optional<Integer>> validValues = List.of(Optional.of(randomInt()), Optional.empty());
+        validValues.forEach((forceTimeShift) -> {
+            Boolean skipResult = randomBoolean();
+            Boolean skipModelUpdate = randomBoolean();
+            ScheduledEvent event = createScheduledEvent(randomAlphaOfLength(10), skipResult, skipModelUpdate, forceTimeShift.orElse(null));
+            DetectionRule rule = event.toDetectionRule(TimeValue.timeValueSeconds(BUCKET_SPAN_SECS));
+            validateDetectionRule(event, rule, skipResult, skipModelUpdate, forceTimeShift.orElse(null));
+        });
+    }
+
+    private void validateDetectionRule(
+        ScheduledEvent event,
+        DetectionRule rule,
+        Boolean skipResult,
+        Boolean skipModelUpdate,
+        Integer forceTimeShift
+    ) {
+        assertEquals(skipResult, rule.getActions().contains(RuleAction.SKIP_RESULT));
+        assertEquals(skipModelUpdate, rule.getActions().contains(RuleAction.SKIP_MODEL_UPDATE));
+        if (forceTimeShift != null) {
+            RuleParams expectedRuleParams = new RuleParams(new RuleParamsForForceTimeShift(forceTimeShift));
+            assertEquals(expectedRuleParams, rule.getParams());
+        }
 
         List<RuleCondition> conditions = rule.getConditions();
         assertEquals(2, conditions.size());
@@ -67,16 +139,92 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
 
         // Check times are aligned with the bucket
         long conditionStartTime = (long) conditions.get(0).getValue();
-        assertEquals(0, conditionStartTime % bucketSpanSecs);
-        long bucketCount = conditionStartTime / bucketSpanSecs;
-        assertEquals(bucketSpanSecs * bucketCount, conditionStartTime);
+        assertEquals(0, conditionStartTime % BUCKET_SPAN_SECS);
+        long bucketCount = conditionStartTime / BUCKET_SPAN_SECS;
+        assertEquals(BUCKET_SPAN_SECS * bucketCount, conditionStartTime);
 
         long conditionEndTime = (long) conditions.get(1).getValue();
-        assertEquals(0, conditionEndTime % bucketSpanSecs);
+        assertEquals(0, conditionEndTime % BUCKET_SPAN_SECS);
 
         long eventTime = event.getEndTime().getEpochSecond() - conditionStartTime;
-        long numbBucketsInEvent = (eventTime + bucketSpanSecs - 1) / bucketSpanSecs;
-        assertEquals(bucketSpanSecs * (bucketCount + numbBucketsInEvent), conditionEndTime);
+        long numbBucketsInEvent = (eventTime + BUCKET_SPAN_SECS - 1) / BUCKET_SPAN_SECS;
+        assertEquals(BUCKET_SPAN_SECS * (bucketCount + numbBucketsInEvent), conditionEndTime);
+    }
+
+    public void testBuild_DescriptionNull() {
+        ScheduledEvent.Builder builder = new ScheduledEvent.Builder();
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, builder::build);
+        assertEquals("Field [description] cannot be null", e.getMessage());
+    }
+
+    public void testBuild_StartTimeNull() {
+        ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description("foo");
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, builder::build);
+        assertEquals("Field [start_time] cannot be null", e.getMessage());
+    }
+
+    public void testBuild_EndTimeNull() {
+        ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description("foo").startTime(Instant.now());
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, builder::build);
+        assertEquals("Field [end_time] cannot be null", e.getMessage());
+    }
+
+    public void testBuild_CalendarIdNull() {
+        ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description("foo")
+            .startTime(Instant.now())
+            .endTime(Instant.now().plusSeconds(1 * 60 * 60));
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, builder::build);
+        assertEquals("Field [calendar_id] cannot be null", e.getMessage());
+    }
+
+    public void testBuild_StartTimeAfterEndTime() {
+        Instant now = Instant.now();
+        ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description("f")
+            .calendarId("c")
+            .startTime(now)
+            .endTime(now.minusSeconds(2 * 60 * 60));
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, builder::build);
+        assertThat(e.getMessage(), containsString("must come before end time"));
+    }
+
+    public void testBuild_SucceedsWithDefaultSkipResultsAndSkipModelUpdatesValues() {
+        validateScheduledEventSuccessfulBuild(Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public void testBuild_SucceedsWithProvidedSkipResultsAndSkipModelUpdatesValues() {
+        Boolean skipResults = randomBoolean();
+        Boolean skipModelUpdate = randomBoolean();
+        Integer forceTimeShift = randomBoolean() ? null : randomInt();
+
+        validateScheduledEventSuccessfulBuild(Optional.of(skipResults), Optional.of(skipModelUpdate), Optional.ofNullable(forceTimeShift));
+    }
+
+    private void validateScheduledEventSuccessfulBuild(
+        Optional<Boolean> skipResults,
+        Optional<Boolean> skipModelUpdate,
+        Optional<Integer> forceTimeShift
+    ) {
+        String description = randomAlphaOfLength(10);
+        String calendarId = randomAlphaOfLength(10);
+        Instant startTime = Instant.ofEpochMilli(Instant.now().toEpochMilli());
+        Instant endTime = startTime.plusSeconds(randomInt(3600));
+
+        ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description(description)
+            .calendarId(calendarId)
+            .startTime(startTime)
+            .endTime(endTime);
+        skipResults.ifPresent(builder::skipResults);
+        skipModelUpdate.ifPresent(builder::skipModelUpdate);
+        forceTimeShift.ifPresent(builder::forceTimeShift);
+
+        ScheduledEvent event = builder.build();
+        assertEquals(description, event.getDescription());
+        assertEquals(calendarId, event.getCalendarId());
+        assertEquals(startTime, event.getStartTime());
+        assertEquals(endTime, event.getEndTime());
+        assertEquals(skipResults.orElse(true), event.getSkipResults());
+        assertEquals(skipModelUpdate.orElse(true), event.getSkipModelUpdate());
+        assertEquals(forceTimeShift.orElse(null), event.getForceTimeShift());
     }
 
     public void testBuild() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -187,20 +187,20 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
         assertThat(e.getMessage(), containsString("must come before end time"));
     }
 
-    public void testBuild_SucceedsWithDefaultSkipResultsAndSkipModelUpdatesValues() {
+    public void testBuild_SucceedsWithDefaultSkipResultAndSkipModelUpdatesValues() {
         validateScheduledEventSuccessfulBuild(Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    public void testBuild_SucceedsWithProvidedSkipResultsAndSkipModelUpdatesValues() {
-        Boolean skipResults = randomBoolean();
+    public void testBuild_SucceedsWithProvidedSkipResultAndSkipModelUpdatesValues() {
+        Boolean skipResult = randomBoolean();
         Boolean skipModelUpdate = randomBoolean();
         Integer forceTimeShift = randomBoolean() ? null : randomInt();
 
-        validateScheduledEventSuccessfulBuild(Optional.of(skipResults), Optional.of(skipModelUpdate), Optional.ofNullable(forceTimeShift));
+        validateScheduledEventSuccessfulBuild(Optional.of(skipResult), Optional.of(skipModelUpdate), Optional.ofNullable(forceTimeShift));
     }
 
     private void validateScheduledEventSuccessfulBuild(
-        Optional<Boolean> skipResults,
+        Optional<Boolean> skipResult,
         Optional<Boolean> skipModelUpdate,
         Optional<Integer> forceTimeShift
     ) {
@@ -213,7 +213,7 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
             .calendarId(calendarId)
             .startTime(startTime)
             .endTime(endTime);
-        skipResults.ifPresent(builder::skipResults);
+        skipResult.ifPresent(builder::skipResult);
         skipModelUpdate.ifPresent(builder::skipModelUpdate);
         forceTimeShift.ifPresent(builder::forceTimeShift);
 
@@ -222,7 +222,7 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
         assertEquals(calendarId, event.getCalendarId());
         assertEquals(startTime, event.getStartTime());
         assertEquals(endTime, event.getEndTime());
-        assertEquals(skipResults.orElse(true), event.getSkipResults());
+        assertEquals(skipResult.orElse(true), event.getSkipResult());
         assertEquals(skipModelUpdate.orElse(true), event.getSkipModelUpdate());
         assertEquals(forceTimeShift.orElse(null), event.getForceTimeShift());
     }

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/meta_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/meta_index_mappings.json
@@ -37,13 +37,13 @@
         "type": "date"
       },
       "skip_result": {
-        "type": "keyword"
+        "type": "boolean"
       },
       "skip_model_update": {
-        "type": "keyword"
+        "type": "boolean"
       },
       "force_time_shift": {
-        "type": "keyword"
+        "type": "integer"
       },
       "type": {
         "type": "keyword"

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/meta_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/meta_index_mappings.json
@@ -36,6 +36,15 @@
       "end_time": {
         "type": "date"
       },
+      "skip_results": {
+        "type": "keyword"
+      },
+      "skip_model_update": {
+        "type": "keyword"
+      },
+      "force_time_shift": {
+        "type": "keyword"
+      },
       "type": {
         "type": "keyword"
       }

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/meta_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/meta_index_mappings.json
@@ -36,7 +36,7 @@
       "end_time": {
         "type": "date"
       },
-      "skip_results": {
+      "skip_result": {
         "type": "keyword"
       },
       "skip_model_update": {


### PR DESCRIPTION
## Description
This change introduces:
- Logic to allow users to provide `skip_result`, `skip_model_update`, and `force_time_shift` when creating a calendar event
- Logic to add `skip_result`, `skip_model`, and `force_time_shift` to detection rules generated from scheduled calendar events

## Testing
- Ran unit tests and ensured that all succeed
- Manually tested the following API calls to create calendar events:
  - Creating a calendar event without `skip_result`, `skip_model_update`, and/or `force_time_shift` generates an event with `skip_result` and `skip_model_update` set to true and `force_time_shift` is not set.
  - Creating a calendar event with `skip_result`, `skip_model_update`, and/or `force_time_shift` generates a scheduled event with the provided values.
  - Creating a calendar with events in the Kibana UI will create events with `skip_result`, and `skip_model_update` set to true and will succeed when adding the calendar to the event.
  - Note: There is no way to check the detection rules generated from the scheduled results as they are stored in memory for an open job. Instead I have used the debugger to confirm manually that the detection rules generated when opening a job have the correct rule actions and have the force time shift set when applicable.