### PR TITLE
Fix pipeline usage in incremental bulk test

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
@@ -88,9 +88,7 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
         final Response indexSuccessFul = getRestClient().performRequest(firstBulkRequest);
         assertThat(indexSuccessFul.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
 
-        clusterAdmin().prepareUpdateSettings()
-            .setPersistentSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false).build())
-            .get();
+        updateClusterSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false));
 
         internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(false));
 
@@ -98,9 +96,7 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
             sendLargeBulk();
         } finally {
             internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(true));
-            clusterAdmin().prepareUpdateSettings()
-                .setPersistentSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), (String) null).build())
-                .get();
+            updateClusterSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), (String) null));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -28,7 +28,6 @@ import org.elasticsearch.ingest.IngestClientIT;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xcontent.XContentType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -398,7 +397,8 @@ public class IncrementalBulkIT extends ESIntegTestCase {
                 .endArray()
                 .endObject()
         );
-        clusterAdmin().preparePutPipeline(pipelineId, pipelineSource, XContentType.JSON).get();
+
+        putJsonPipeline(pipelineId, pipelineSource);
 
         // By adding an ingest pipeline and sending the request to a coordinating node without the ingest role, we ensure that we are
         // testing the serialization of shard level requests over the wire. This is because the transport bulk action will be dispatched to


### PR DESCRIPTION
A recent merge issue broke compile. Transition to the new methods.