### PR TITLE
(Doc+) Avoid search pile up by setting default timeout

### DIFF
--- a/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
@@ -66,6 +66,8 @@ searches, consider the following setting changes:
 <<query-dsl-allow-expensive-queries,`search.allow_expensive_queries`>> cluster
 setting.
 
+* Set a default search timeout using the <<search-timeout,`search.default_search_timeout`>> cluster setting. 
+
 [source,console]
 ----
 PUT _settings


### PR DESCRIPTION
👋! Mini doc PR to say can avoid search task pile-ups by setting [`search.default_search_timeout`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-your-data.html#search-timeout) under [High JVM > avoid expensive searches](https://www.elastic.co/guide/en/elasticsearch/reference/master/high-jvm-memory-pressure.html#reduce-jvm-memory-pressure).