### PR TITLE
Remove unused parameter in char filter YAML test

### DIFF
--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
@@ -9,7 +9,6 @@
             char_filter:
               - type: html_strip
                 escaped_tags: ["xxx", "yyy"]
-                read_ahead: 1024
     - length: { tokens: 1 }
     - match:  { tokens.0.token: "\ntest<yyy>foo</yyy>\n" }
 


### PR DESCRIPTION
As mentioned in https://github.com/elastic/elasticsearch/issues/15543, this parameter was [removed in Elasticsearch 0.20](https://github.com/elastic/elasticsearch/commit/16cd159a381979e9d92288d6c9bada8483fea520) (!). Removing it from YAML tests will fix one error in the Elasticsearch specification.