### PR TITLE
Validate data stream naming scheme of reroute processor

### DIFF
--- a/docs/changelog/112858.yaml
+++ b/docs/changelog/112858.yaml
@@ -1,0 +1,6 @@
+pr: 112858
+summary: Validate data stream naming scheme of reroute processor
+area: Ingest Node
+type: bug
+issues:
+  - 112543

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
@@ -70,22 +70,15 @@ public final class RerouteProcessor extends AbstractProcessor {
             return ingestDocument;
         }
         final String indexName = ingestDocument.getFieldValue(IngestDocument.Metadata.INDEX.getFieldName(), String.class);
-        final String type;
-        final String currentDataset;
-        final String currentNamespace;
 
         // parse out the <type>-<dataset>-<namespace> components from _index
-        int indexOfFirstDash = indexName.indexOf('-');
-        if (indexOfFirstDash < 0) {
+        String[] splitByDash = indexName.split("-");
+        if (splitByDash.length != 3 || splitByDash[0].isEmpty() || splitByDash[1].isEmpty() || splitByDash[2].isEmpty()) {
             throw new IllegalArgumentException(format(NAMING_SCHEME_ERROR_MESSAGE, indexName));
         }
-        int indexOfSecondDash = indexName.indexOf('-', indexOfFirstDash + 1);
-        if (indexOfSecondDash < 0) {
-            throw new IllegalArgumentException(format(NAMING_SCHEME_ERROR_MESSAGE, indexName));
-        }
-        type = parseDataStreamType(indexName, indexOfFirstDash);
-        currentDataset = parseDataStreamDataset(indexName, indexOfFirstDash, indexOfSecondDash);
-        currentNamespace = parseDataStreamNamespace(indexName, indexOfSecondDash);
+        final String type = splitByDash[0];
+        final String currentDataset = splitByDash[1];
+        final String currentNamespace = splitByDash[2];
 
         String dataset = determineDataStreamField(ingestDocument, this.dataset, currentDataset);
         String namespace = determineDataStreamField(ingestDocument, this.namespace, currentNamespace);
@@ -110,18 +103,6 @@ public final class RerouteProcessor extends AbstractProcessor {
         } else {
             doc.setFieldValue(path, value);
         }
-    }
-
-    private static String parseDataStreamType(String dataStreamName, int indexOfFirstDash) {
-        return dataStreamName.substring(0, indexOfFirstDash);
-    }
-
-    private static String parseDataStreamDataset(String dataStreamName, int indexOfFirstDash, int indexOfSecondDash) {
-        return dataStreamName.substring(indexOfFirstDash + 1, indexOfSecondDash);
-    }
-
-    private static String parseDataStreamNamespace(String dataStreamName, int indexOfSecondDash) {
-        return dataStreamName.substring(indexOfSecondDash + 1);
     }
 
     private static String determineDataStreamField(

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorTests.java
@@ -215,6 +215,16 @@ public class RerouteProcessorTests extends ESTestCase {
         }
 
         {
+            IngestDocument ingestDocument = createIngestDocument(".ds-logs-system.auth-default");
+            RerouteProcessor processor = createRerouteProcessor(List.of(), List.of());
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
+            assertThat(
+                e.getMessage(),
+                equalTo("invalid data stream name: [.ds-logs-system.auth-default]; must follow naming scheme <type>-<dataset>-<namespace>")
+            );
+        }
+
+        {
             // naturally, though, a plain destination doesn't have to match the data stream naming convention
             IngestDocument ingestDocument = createIngestDocument("foo");
             RerouteProcessor processor = createRerouteProcessor("bar");


### PR DESCRIPTION
Split the `indexName` and validate its components, ensuring the array has exactly three parts and none are empty to confirm that the `indexName` follows the expected format.

Closes #112543