### PR TITLE
Speedup DiscoveryNodes.Delta in the common case

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -527,6 +527,9 @@ public class DiscoveryNodes implements Iterable<DiscoveryNode>, SimpleDiffable<D
      * Returns the changes comparing this nodes to the provided nodes.
      */
     public Delta delta(DiscoveryNodes other) {
+        if (this == other) {
+            return new Delta(this.masterNode, this.masterNode, localNodeId, List.of(), List.of());
+        }
         final List<DiscoveryNode> removed = new ArrayList<>();
         final List<DiscoveryNode> added = new ArrayList<>();
         for (DiscoveryNode node : other) {


### PR DESCRIPTION
Found while profiling something else, we actually spend quite some time on creating these `Delta` instances.

This class is kind of weird and we could probably do without, but for now we can save lots of cycles (and in fact most cycles going into creating these) with this simple 3 line shortcut.
