### PR TITLE
[DOCS] Simplifies semantic_text tutorial by removing copy_to field

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -39,14 +39,6 @@ Create an {infer} endpoint by using the <<put-inference-api>>:
 
 include::{es-ref-dir}/tab-widgets/inference-api/infer-api-task-widget.asciidoc[]
 
-[NOTE]
-====
-You might see a 502 bad gateway error in the response when using the {kib} Console.
-This error usually just reflects a timeout, while the model downloads in the background.
-You can check the download progress in the {ml-app} UI.
-If using the Python client, you can set the `timeout` parameter to a higher value.
-====
-
 
 [discrete]
 [[infer-service-mappings]]

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -39,6 +39,15 @@ Create an {infer} endpoint by using the <<put-inference-api>>:
 
 include::{es-ref-dir}/tab-widgets/inference-api/infer-api-task-widget.asciidoc[]
 
+[NOTE]
+====
+You might see a 502 bad gateway error in the response when using the {kib} Console.
+This error usually just reflects a timeout, while the model downloads in the background.
+You can check the download progress in the {ml-app} UI.
+If using the Python client, you can set the `timeout` parameter to a higher value.
+====
+
+
 [discrete]
 [[infer-service-mappings]]
 ==== Create the index mapping

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -90,7 +90,7 @@ Every time you ingest data into the related `semantic_text` field, this endpoint
 <5> The textual data stored in the `content` field will be copied to `semantic_text` and processed by the {infer} endpoint.
 The `semantic_text` field will store the embeddings generated based on the input data.
 Copying the `content` field to the `semantic_text` field is not required to use `semantic_text`.
-However, it is recommended, as it enables hybrid search, allowing for lexical search on the `content` field and semantic search on the `semantic_text` field.
+However, it is recommended because it enables hybrid search. Hybrid search combines lexical search on the `text` field with semantic search on the `semantic_text` field.
 
 
 

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -68,13 +68,9 @@ PUT semantic-embeddings
 {
   "mappings": {
     "properties": {
-      "semantic_text": { <1>
+      "content": { <1>
         "type": "semantic_text", <2>
         "inference_id": "my-elser-endpoint" <3>
-      },
-      "content": { <4>
-        "type": "text",
-        "copy_to": "semantic_text" <5>
       }
     }
   }
@@ -86,12 +82,6 @@ PUT semantic-embeddings
 <3> The `inference_id` is the inference endpoint you created in the previous step.
 It will be used to generate the embeddings based on the input text.
 Every time you ingest data into the related `semantic_text` field, this endpoint will be used for creating the vector representation of the text.
-<4> The field to store the text reindexed from a source index in the  <<semantic-text-reindex-data,Reindex the data>> step.
-<5> The textual data stored in the `content` field will be copied to `semantic_text` and processed by the {infer} endpoint.
-The `semantic_text` field will store the embeddings generated based on the input data.
-Copying the `content` field to the `semantic_text` field is not required to use `semantic_text`.
-However, it is recommended because it enables hybrid search. Hybrid search combines lexical search on the `text` field with semantic search on the `semantic_text` field.
-
 
 
 [discrete]
@@ -117,17 +107,9 @@ you can see an index named `test-data` with 182469 documents.
 [[semantic-text-reindex-data]]
 ==== Reindex the data
 
-Create the embeddings from the text by reindexing the data from the `test-data`
-index to the `semantic-embeddings` index. The data in the `content` field will
-be reindexed into the `content` field of the destination index. 
-The `content` field data will be copied to the `semantic_text` field as a result of the `copy_to`
-parameter set in the index mapping creation step. The copied data will be
-processed by the {infer} endpoint associated with the `semantic_text` semantic text
-field.
-
-IMPORTANT: Using `copy_to` fields is not required for semantic search; you can target the `semantic_text` field directly during ingestion.
-However, using the `copy_to` field enables hybrid search, which is recommended. 
-For more information, refer to <<copy-to-support,this section>> on the `semantic_text` documentation page.
+Create the embeddings from the text by reindexing the data from the `test-data` index to the `semantic-embeddings` index.
+The data in the `content` field will be reindexed into the `content` semantic text field of the destination index.
+The reindexed data will be processed by the {infer} endpoint associated with the `content` semantic text field.
 
 [source,console]
 ------------------------------------------------------------
@@ -169,10 +151,9 @@ POST _tasks/<task_id>/_cancel
 [[semantic-text-semantic-search]]
 ==== Semantic search
 
-After the data set has been enriched with the embeddings, you can query the data
-using semantic search. Provide the `semantic_text` field name and the query text
-in a `semantic` query type. The {infer} endpoint used to generate the embeddings
-for the `semantic_text` field will be used to process the query text.
+After the data set has been enriched with the embeddings, you can query the data using semantic search.
+Provide the `semantic_text` field name and the query text in a `semantic` query type.
+The {infer} endpoint used to generate the embeddings for the `semantic_text` field will be used to process the query text.
 
 [source,console]
 ------------------------------------------------------------
@@ -180,7 +161,7 @@ GET semantic-embeddings/_search
 {
   "query": {
     "semantic": { 
-      "field": "semantic_text", <1>
+      "field": "content", <1>
       "query": "How to avoid muscle soreness while running?" <2>
     }
   }
@@ -201,7 +182,7 @@ query from the `semantic-embedding` index:
     "_id": "6DdEuo8B0vYIvzmhoEtt",
     "_score": 24.972616,
     "_source": {
-      "semantic_text": {
+      "content": {
         "inference": {
           "inference_id": "my-elser-endpoint",
           "model_settings": {
@@ -226,7 +207,7 @@ query from the `semantic-embedding` index:
     "_id": "-zdEuo8B0vYIvzmhplLX",
     "_score": 22.143118,
     "_source": {
-      "semantic_text": {
+      "content": {
         "inference": {
           "inference_id": "my-elser-endpoint",
           "model_settings": {
@@ -251,7 +232,7 @@ query from the `semantic-embedding` index:
     "_id": "77JEuo8BdmhTuQdXtQWt",
     "_score": 21.506052,
     "_source": {
-      "semantic_text": {
+      "content": {
         "inference": {
           "inference_id": "my-elser-endpoint",
           "model_settings": {

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -89,8 +89,8 @@ Every time you ingest data into the related `semantic_text` field, this endpoint
 <4> The field to store the text reindexed from a source index in the  <<semantic-text-reindex-data,Reindex the data>> step.
 <5> The textual data stored in the `content` field will be copied to `semantic_text` and processed by the {infer} endpoint.
 The `semantic_text` field will store the embeddings generated based on the input data.
-Copying the `content` field content to the `semantic_text` field is not required for using `semantic_text`.
-However, it is recommended because it makes it possible to perform hybrid search during which you perform lexical search on the text field and semantic search on the semantic_text field.
+Copying the `content` field to the `semantic_text` field is not required to use `semantic_text`.
+However, it is recommended, as it enables hybrid search, allowing for lexical search on the `content` field and semantic search on the `semantic_text` field.
 
 
 
@@ -125,10 +125,9 @@ parameter set in the index mapping creation step. The copied data will be
 processed by the {infer} endpoint associated with the `semantic_text` semantic text
 field.
 
-IMPORTANT: Using `copy_to` fields is not required for performing semantic search.
-You can target the `semantic_text` field directly during ingestion.
-Using the `copy_to` field, however, makes it possible to perform hybrid search, hence it is recommended.
-To learn more about using the `copy_to` field, refer to <<copy-to-support,this section>> on the `semantic_text` documentation page.
+IMPORTANT: Using `copy_to` fields is not required for semantic search; you can target the `semantic_text` field directly during ingestion.
+However, using the `copy_to` field enables hybrid search, which is recommended. 
+For more information, refer to <<copy-to-support,this section>> on the `semantic_text` documentation page.
 
 [source,console]
 ------------------------------------------------------------

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -199,7 +199,7 @@ query from the `semantic-embedding` index:
         }
       },
       "id": 1713868,
-      "content": "There are a few foods and food groups that will help to fight inflammation and delayed onset muscle soreness (both things that are inevitable after a long, hard workout) when you incorporate them into your postworkout eats, whether immediately after your run or at a meal later in the day. Advertisement. Advertisement."
+      "text": "There are a few foods and food groups that will help to fight inflammation and delayed onset muscle soreness (both things that are inevitable after a long, hard workout) when you incorporate them into your postworkout eats, whether immediately after your run or at a meal later in the day. Advertisement. Advertisement."
     }
   },
   {
@@ -224,7 +224,7 @@ query from the `semantic-embedding` index:
         }
       },
       "id": 3389244,
-      "content": "During Your Workout. There are a few things you can do during your workout to help prevent muscle injury and soreness. According to personal trainer and writer for Iron Magazine, Marc David, doing warm-ups and cool-downs between sets can help keep muscle soreness to a minimum."
+      "text": "During Your Workout. There are a few things you can do during your workout to help prevent muscle injury and soreness. According to personal trainer and writer for Iron Magazine, Marc David, doing warm-ups and cool-downs between sets can help keep muscle soreness to a minimum."
     }
   },
   {
@@ -249,7 +249,7 @@ query from the `semantic-embedding` index:
         }
       },
       "id": 363742,
-      "content": "This is especially important if the soreness is due to a weightlifting routine. For this time period, do not exert more than around 50% of the level of effort (weight, distance and speed) that caused the muscle groups to be sore."
+      "text": "This is especially important if the soreness is due to a weightlifting routine. For this time period, do not exert more than around 50% of the level of effort (weight, distance and speed) that caused the muscle groups to be sore."
     }
   },
   (...)
@@ -257,3 +257,8 @@ query from the `semantic-embedding` index:
 ------------------------------------------------------------
 // NOTCONSOLE
 
+[discrete]
+[[semantic-text-further-examples]]
+==== Further examples
+
+If you want to use `semantic_text` in hybrid search, refer to https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/search/09-semantic-text.ipynb[this notebook] for a step-by-step guide.

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -59,10 +59,8 @@ If using the Python client, you can set the `timeout` parameter to a higher valu
 [[semantic-text-index-mapping]]
 ==== Create the index mapping
 
-The mapping of the destination index - the index that contains the embeddings
-that the inference endpoint will generate based on your input text - must be created. The
-destination index must have a field with the <<semantic-text,`semantic_text`>>
-field type to index the output of the used inference endpoint.
+The mapping of the destination index - the index that contains the embeddings that the inference endpoint will generate based on your input text - must be created.
+The destination index must have a field with the <<semantic-text,`semantic_text`>> field type to index the output of the used inference endpoint.
 
 [source,console]
 ------------------------------------------------------------
@@ -91,6 +89,9 @@ Every time you ingest data into the related `semantic_text` field, this endpoint
 <4> The field to store the text reindexed from a source index in the  <<semantic-text-reindex-data,Reindex the data>> step.
 <5> The textual data stored in the `content` field will be copied to `semantic_text` and processed by the {infer} endpoint.
 The `semantic_text` field will store the embeddings generated based on the input data.
+Copying the `content` field content to the `semantic_text` field is not required for using `semantic_text`.
+However, it is recommended because it makes it possible to perform hybrid search during which you perform lexical search on the text field and semantic search on the semantic_text field.
+
 
 
 [discrete]
@@ -123,6 +124,11 @@ The `content` field data will be copied to the `semantic_text` field as a result
 parameter set in the index mapping creation step. The copied data will be
 processed by the {infer} endpoint associated with the `semantic_text` semantic text
 field.
+
+IMPORTANT: Using `copy_to` fields is not required for performing semantic search.
+You can target the `semantic_text` field directly during ingestion.
+Using the `copy_to` field, however, makes it possible to perform hybrid search, hence it is recommended.
+To learn more about using the `copy_to` field, refer to <<copy-to-support,this section>> on the `semantic_text` documentation page.
 
 [source,console]
 ------------------------------------------------------------

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -50,6 +50,14 @@ is the unique identifier of the {infer} endpoint is `elser_embeddings`.
 You don't need to download and deploy the ELSER model upfront, the API request
 above will download the model if it's not downloaded yet and then deploy it.
 
+[NOTE]
+====
+You might see a 502 bad gateway error in the response when using the {kib} Console.
+This error usually just reflects a timeout, while the model downloads in the background.
+You can check the download progress in the {ml-app} UI.
+If using the Python client, you can set the `timeout` parameter to a higher value.
+====
+
 // end::elser[]
 
 // tag::hugging-face[]


### PR DESCRIPTION
## Overview

This PR simplifies the semantic_text tutorial by removing the `copy_to` field from the index mapping. `copy_to` is not required for semantic_text. The tutorial in its previous form might be confusing as the API request in the index mapping creation step contained it. 

As it's recommended to use `copy_to` for hybrid search, this PR also adds a link to the page that leads to a notebook demonstrating hybrid search.

It also adds a `NOTE` to the ELSER tab of the endpoint creation step in the Inference tutorial about possible timeout error messages during model download.


### Preview

[Tutorial with semantic text](https://elasticsearch_bk_112864.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-semantic-text.html#semantic-text-index-mapping)