### PR TITLE
[DOCS] Improves inference workflow tutorial

### DIFF
--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
@@ -2,7 +2,7 @@
 
 [source,console]
 ----
-DELETE _ingest/pipeline/*_embeddings
+DELETE _ingest/pipeline/*_embeddings_pipeline
 ----
 // TEST
 // TEARDOWN
@@ -13,7 +13,7 @@ DELETE _ingest/pipeline/*_embeddings
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/cohere_embeddings
+PUT _ingest/pipeline/cohere_embeddings_pipeline
 {
   "processors": [
     {
@@ -39,7 +39,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/elser_embeddings
+PUT _ingest/pipeline/elser_embeddings_pipeline
 {
   "processors": [
     {
@@ -65,7 +65,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/hugging_face_embeddings
+PUT _ingest/pipeline/hugging_face_embeddings_pipeline
 {
   "processors": [
     {
@@ -91,7 +91,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/openai_embeddings
+PUT _ingest/pipeline/openai_embeddings_pipeline
 {
   "processors": [
     {
@@ -117,7 +117,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/azure_openai_embeddings
+PUT _ingest/pipeline/azure_openai_embeddings_pipeline
 {
   "processors": [
     {
@@ -143,7 +143,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/azure_ai_studio_embeddings
+PUT _ingest/pipeline/azure_ai_studio_embeddings_pipeline
 {
   "processors": [
     {
@@ -169,7 +169,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/google_vertex_ai_embeddings
+PUT _ingest/pipeline/google_vertex_ai_embeddings_pipeline
 {
   "processors": [
     {
@@ -195,7 +195,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/mistral_embeddings
+PUT _ingest/pipeline/mistral_embeddings_pipeline
 {
   "processors": [
     {
@@ -221,7 +221,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/amazon_bedrock_embeddings
+PUT _ingest/pipeline/amazon_bedrock_embeddings_pipeline
 {
   "processors": [
     {
@@ -247,7 +247,7 @@ and the `output_field` that will contain the {infer} results.
 
 [source,console]
 --------------------------------------------------
-PUT _ingest/pipeline/alibabacloud_ai_search_embeddings
+PUT _ingest/pipeline/alibabacloud_ai_search_embeddings_pipeline
 {
   "processors": [
     {

--- a/docs/reference/tab-widgets/inference-api/infer-api-reindex.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-reindex.asciidoc
@@ -10,7 +10,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "cohere-embeddings",
-    "pipeline": "cohere_embeddings"
+    "pipeline": "cohere_embeddings_pipeline"
   }
 }
 ----
@@ -37,7 +37,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "elser-embeddings",
-    "pipeline": "elser_embeddings"
+    "pipeline": "elser_embeddings_pipeline"
   }
 }
 ----
@@ -60,7 +60,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "hugging-face-embeddings",
-    "pipeline": "hugging_face_embeddings"
+    "pipeline": "hugging_face_embeddings_pipeline"
   }
 }
 ----
@@ -84,7 +84,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "openai-embeddings",
-    "pipeline": "openai_embeddings"
+    "pipeline": "openai_embeddings_pipeline"
   }
 }
 ----
@@ -112,7 +112,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "azure-openai-embeddings",
-    "pipeline": "azure_openai_embeddings"
+    "pipeline": "azure_openai_embeddings_pipeline"
   }
 }
 ----
@@ -140,7 +140,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "azure-ai-studio-embeddings",
-    "pipeline": "azure_ai_studio_embeddings"
+    "pipeline": "azure_ai_studio_embeddings_pipeline"
   }
 }
 ----
@@ -167,7 +167,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "google-vertex-ai-embeddings",
-    "pipeline": "google_vertex_ai_embeddings"
+    "pipeline": "google_vertex_ai_embeddings_pipeline"
   }
 }
 ----
@@ -189,7 +189,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "mistral-embeddings",
-    "pipeline": "mistral_embeddings"
+    "pipeline": "mistral_embeddings_pipeline"
   }
 }
 ----
@@ -212,7 +212,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "amazon-bedrock-embeddings",
-    "pipeline": "amazon_bedrock_embeddings"
+    "pipeline": "amazon_bedrock_embeddings_pipeline"
   }
 }
 ----
@@ -235,7 +235,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "alibabacloud-ai-search-embeddings",
-    "pipeline": "alibabacloud_ai_search_embeddings"
+    "pipeline": "alibabacloud_ai_search_embeddings_pipeline"
   }
 }
 ----


### PR DESCRIPTION
## Overview

This PR changes the pipeline names in the inference API tutorial from `<task>_embeddings` to `<task>_embeddings_pipeline`. This naming convention refers to the related entity clearer than the previous one as the same convention is used for the inference endpoint names.