### PR TITLE
Reduce heap usage for AggregatorsReducer

### DIFF
--- a/docs/changelog/112874.yaml
+++ b/docs/changelog/112874.yaml
@@ -1,0 +1,5 @@
+pr: 112874
+summary: Reduce heap usage for `AggregatorsReducer`
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -267,7 +267,7 @@ public final class InternalAggregations implements Iterable<InternalAggregation>
             return from(reduced);
         }
         // general case
-        try (AggregatorsReducer reducer = new AggregatorsReducer(context, aggregationsList.size())) {
+        try (AggregatorsReducer reducer = new AggregatorsReducer(aggregationsList.get(0), context, aggregationsList.size())) {
             for (InternalAggregations aggregations : aggregationsList) {
                 reducer.accept(aggregations);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketReducer.java
@@ -25,7 +25,7 @@ public final class BucketReducer<B extends MultiBucketsAggregation.Bucket> imple
     private long count = 0;
 
     public BucketReducer(B proto, AggregationReduceContext context, int size) {
-        this.aggregatorsReducer = new AggregatorsReducer(context, size);
+        this.aggregatorsReducer = new AggregatorsReducer(proto.getAggregations(), context, size);
         this.proto = proto;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
@@ -67,7 +67,9 @@ public final class DelayedBucketReducer<B extends MultiBucketsAggregation.Bucket
      * returns the reduced {@link InternalAggregations}.
      */
     public InternalAggregations getAggregations() {
-        try (AggregatorsReducer aggregatorsReducer = new AggregatorsReducer(context, internalAggregations.size())) {
+        try (
+            AggregatorsReducer aggregatorsReducer = new AggregatorsReducer(proto.getAggregations(), context, internalAggregations.size())
+        ) {
             for (InternalAggregations agg : internalAggregations) {
                 aggregatorsReducer.accept(agg);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -97,7 +97,7 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
             long docCount = 0L;
-            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(reduceContext, size);
+            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(getAggregations(), reduceContext, size);
 
             @Override
             public void accept(InternalAggregation aggregation) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/InternalRandomSampler.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/InternalRandomSampler.java
@@ -91,7 +91,7 @@ public class InternalRandomSampler extends InternalSingleBucketAggregation imple
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
             long docCount = 0L;
-            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(reduceContext, size);
+            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(getAggregations(), reduceContext, size);
 
             @Override
             public void accept(InternalAggregation aggregation) {


### PR DESCRIPTION
This commit reduces heap usage by sizing properly the hashmap containing the aggregations by name. 