### PR TITLE
[docker] Rename -ubi8 suffix to -ubi

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DockerBase.java
@@ -15,7 +15,7 @@ public enum DockerBase {
     DEFAULT("ubuntu:20.04", "", "apt-get"),
 
     // "latest" here is intentional, since the image name specifies "8"
-    UBI("docker.elastic.co/ubi8/ubi-minimal:latest", "-ubi8", "microdnf"),
+    UBI("docker.elastic.co/ubi8/ubi-minimal:latest", "-ubi", "microdnf"),
 
     // The Iron Bank base image is UBI (albeit hardened), but we are required to parameterize the Docker build
     IRON_BANK("${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}", "-ironbank", "yum"),

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -162,7 +162,7 @@ public class DockerRun {
     public static String getImageName(Distribution distribution) {
         String suffix = switch (distribution.packaging) {
             case DOCKER -> "";
-            case DOCKER_UBI -> "-ubi8";
+            case DOCKER_UBI -> "-ubi";
             case DOCKER_IRON_BANK -> "-ironbank";
             case DOCKER_CLOUD -> "-cloud";
             case DOCKER_CLOUD_ESS -> "-cloud-ess";


### PR DESCRIPTION
We have been asked by the release team to do this just for `9.x`. Is this all that needs to happen?