### PR TITLE
Remove duplication in settings code and some minor setting speedups

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -51,18 +51,16 @@ public class AzureRepository extends MeteredBlobStoreRepository {
 
     public static final class Repository {
         @Deprecated // Replaced by client
-        public static final Setting<String> ACCOUNT_SETTING = new Setting<>(
+        public static final Setting<String> ACCOUNT_SETTING = Setting.simpleString(
             "account",
             "default",
-            Function.identity(),
             Property.NodeScope,
             Property.DeprecatedWarning
         );
         public static final Setting<String> CLIENT_NAME = new Setting<>("client", ACCOUNT_SETTING, Function.identity());
-        public static final Setting<String> CONTAINER_SETTING = new Setting<>(
+        public static final Setting<String> CONTAINER_SETTING = Setting.simpleString(
             "container",
             "elasticsearch-snapshots",
-            Function.identity(),
             Property.NodeScope
         );
         public static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path", Property.NodeScope);

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -315,7 +315,7 @@ final class AzureStorageSettings {
 
     private static <T> T getValue(Settings settings, String groupName, Setting<T> setting) {
         final Setting.AffixKey k = (Setting.AffixKey) setting.getRawKey();
-        final String fullKey = k.toConcreteKey(groupName).toString();
+        final String fullKey = k.toConcreteKey(groupName);
         return setting.getConcreteSetting(fullKey).get(settings);
     }
 

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageClientSettings.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageClientSettings.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.elasticsearch.common.settings.Setting.timeSetting;
 
@@ -93,7 +92,7 @@ public class GoogleCloudStorageClientSettings {
     static final Setting.AffixSetting<String> APPLICATION_NAME_SETTING = Setting.affixKeySetting(
         PREFIX,
         "application_name",
-        key -> new Setting<>(key, "repository-gcs", Function.identity(), Setting.Property.NodeScope, Setting.Property.DeprecatedWarning)
+        key -> Setting.simpleString(key, "repository-gcs", Setting.Property.NodeScope, Setting.Property.DeprecatedWarning)
     );
 
     /** The type of the proxy to connect to the GCS through. Can be DIRECT (aka no proxy), HTTP or SOCKS */

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -24,7 +24,6 @@ import org.elasticsearch.repositories.blobstore.MeteredBlobStoreRepository;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.elasticsearch.common.settings.Setting.Property;
 import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
@@ -54,7 +53,7 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
         Property.NodeScope,
         Property.Dynamic
     );
-    static final Setting<String> CLIENT_NAME = new Setting<>("client", "default", Function.identity());
+    static final Setting<String> CLIENT_NAME = Setting.simpleString("client", "default");
 
     private final GoogleCloudStorageService storageService;
     private final ByteSizeValue chunkSize;

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * A container for settings used to create an S3 client.
@@ -163,14 +162,14 @@ final class S3ClientSettings {
     static final Setting.AffixSetting<String> REGION = Setting.affixKeySetting(
         PREFIX,
         "region",
-        key -> new Setting<>(key, "", Function.identity(), Property.NodeScope)
+        key -> Setting.simpleString(key, Property.NodeScope)
     );
 
     /** An override for the signer to use. */
     static final Setting.AffixSetting<String> SIGNER_OVERRIDE = Setting.affixKeySetting(
         PREFIX,
         "signer_override",
-        key -> new Setting<>(key, "", Function.identity(), Property.NodeScope)
+        key -> Setting.simpleString(key, Property.NodeScope)
     );
 
     /** Credentials to authenticate with s3. */

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -49,7 +49,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 
 /**
  * Shared file system implementation of the BlobStoreRepository
@@ -152,7 +151,7 @@ class S3Repository extends MeteredBlobStoreRepository {
      */
     static final Setting<String> CANNED_ACL_SETTING = Setting.simpleString("canned_acl");
 
-    static final Setting<String> CLIENT_NAME = new Setting<>("client", "default", Function.identity());
+    static final Setting<String> CLIENT_NAME = Setting.simpleString("client", "default");
 
     /**
      * Artificial delay to introduce after a snapshot finalization or delete has finished so long as the repository is still using the

--- a/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeService.java
+++ b/plugins/discovery-azure-classic/src/main/java/org/elasticsearch/cloud/azure/classic/management/AzureComputeService.java
@@ -19,7 +19,6 @@ import org.elasticsearch.discovery.azure.classic.AzureSeedHostsProvider.Deployme
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.function.Function;
 
 public interface AzureComputeService {
 
@@ -54,7 +53,7 @@ public interface AzureComputeService {
         );
 
         // so that it can overridden for tests
-        public static final Setting<URI> ENDPOINT_SETTING = new Setting<URI>(
+        public static final Setting<URI> ENDPOINT_SETTING = new Setting<>(
             "cloud.azure.management.endpoint",
             "https://management.core.windows.net/",
             s -> {
@@ -80,10 +79,9 @@ public interface AzureComputeService {
             AzureSeedHostsProvider.HostType::fromString,
             Property.NodeScope
         );
-        public static final Setting<String> ENDPOINT_NAME_SETTING = new Setting<>(
+        public static final Setting<String> ENDPOINT_NAME_SETTING = Setting.simpleString(
             "discovery.azure.endpoint.name",
             "elasticsearch",
-            Function.identity(),
             Property.NodeScope
         );
         public static final Setting<String> DEPLOYMENT_NAME_SETTING = Setting.simpleString(

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2Service.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2Service.java
@@ -14,7 +14,6 @@ import org.elasticsearch.core.TimeValue;
 
 import java.io.Closeable;
 import java.util.List;
-import java.util.function.Function;
 
 interface AwsEc2Service extends Closeable {
     Setting<Boolean> AUTO_ATTRIBUTE_SETTING = Setting.boolSetting("cloud.node.auto_attributes", false, Property.NodeScope);
@@ -33,12 +32,7 @@ interface AwsEc2Service extends Closeable {
      * XXXX refers to a name of a tag configured for all EC2 instances. Instances which don't
      * have this tag set will be ignored by the discovery process. Defaults to private_ip.
      */
-    Setting<String> HOST_TYPE_SETTING = new Setting<>(
-        "discovery.ec2.host_type",
-        HostType.PRIVATE_IP,
-        Function.identity(),
-        Property.NodeScope
-    );
+    Setting<String> HOST_TYPE_SETTING = Setting.simpleString("discovery.ec2.host_type", HostType.PRIVATE_IP, Property.NodeScope);
     /**
      * discovery.ec2.any_group: If set to false, will require all security groups to be present for the instance to be used for the
      * discovery. Defaults to true.

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/GceInstancesServiceImpl.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/GceInstancesServiceImpl.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 public class GceInstancesServiceImpl implements GceInstancesService {
 
@@ -52,10 +51,9 @@ public class GceInstancesServiceImpl implements GceInstancesService {
         true,
         Property.NodeScope
     );
-    public static final Setting<String> GCE_ROOT_URL = new Setting<>(
+    public static final Setting<String> GCE_ROOT_URL = Setting.simpleString(
         "cloud.gce.root_url",
         "https://www.googleapis.com",
-        Function.identity(),
         Property.NodeScope
     );
 

--- a/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/GceMetadataService.java
+++ b/plugins/discovery-gce/src/main/java/org/elasticsearch/cloud/gce/GceMetadataService.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
-import java.util.function.Function;
 
 public class GceMetadataService extends AbstractLifecycleComponent {
     private static final Logger logger = LogManager.getLogger(GceMetadataService.class);
@@ -34,10 +33,9 @@ public class GceMetadataService extends AbstractLifecycleComponent {
     // http://metadata/computeMetadata/v1/instance/service-accounts/default/token
     // See https://developers.google.com/compute/docs/metadata#metadataserver
     // all settings just used for testing - not registered by default
-    public static final Setting<String> GCE_HOST = new Setting<>(
+    public static final Setting<String> GCE_HOST = Setting.simpleString(
         "cloud.gce.host",
         "http://metadata.google.internal",
-        Function.identity(),
         Setting.Property.NodeScope
     );
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -94,7 +94,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -104,10 +103,9 @@ public class ClusterModule extends AbstractModule {
 
     public static final String BALANCED_ALLOCATOR = "balanced";
     public static final String DESIRED_BALANCE_ALLOCATOR = "desired_balance"; // default
-    public static final Setting<String> SHARDS_ALLOCATOR_TYPE_SETTING = new Setting<>(
+    public static final Setting<String> SHARDS_ALLOCATOR_TYPE_SETTING = Setting.simpleString(
         "cluster.routing.allocation.type",
         DESIRED_BALANCE_ALLOCATOR,
-        Function.identity(),
         Property.NodeScope,
         Property.Deprecated
     );

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -429,10 +429,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     public static final String SETTING_INDEX_UUID = "index.uuid";
     public static final String SETTING_HISTORY_UUID = "index.history.uuid";
     public static final String SETTING_DATA_PATH = "index.data_path";
-    public static final Setting<String> INDEX_DATA_PATH_SETTING = new Setting<>(
+    public static final Setting<String> INDEX_DATA_PATH_SETTING = Setting.simpleString(
         SETTING_DATA_PATH,
-        "",
-        Function.identity(),
         Property.IndexScope,
         Property.DeprecatedWarning
     );
@@ -1333,7 +1331,6 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static final Setting<String> INDEX_DOWNSAMPLE_INTERVAL = Setting.simpleString(
         INDEX_DOWNSAMPLE_INTERVAL_KEY,
-        "",
         Property.IndexScope,
         Property.InternalIndex
     );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
@@ -71,7 +71,7 @@ public class DataTier {
     private static final Settings NULL_TIER_PREFERENCE_SETTINGS = Settings.builder().putNull(TIER_PREFERENCE).build();
 
     public static final Setting<String> TIER_PREFERENCE_SETTING = new Setting<>(
-        new Setting.SimpleKey(TIER_PREFERENCE),
+        TIER_PREFERENCE,
         DataTierSettingValidator::getDefaultTierPreference,
         Function.identity(),
         new DataTierSettingValidator(),

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -467,10 +467,6 @@ public class Setting<T> implements ToXContentObject {
         return false;
     }
 
-    final boolean isListSetting() {
-        return this instanceof ListSetting;
-    }
-
     boolean hasComplexMatcher() {
         return isGroupSetting();
     }
@@ -1068,7 +1064,7 @@ public class Setting<T> implements ToXContentObject {
          * Get a setting with the given namespace filled in for prefix and suffix.
          */
         public Setting<T> getConcreteSettingForNamespace(String namespace) {
-            String fullKey = key.toConcreteKey(namespace).toString();
+            String fullKey = key.toConcreteKey(namespace);
             return getConcreteSetting(namespace, fullKey);
         }
 
@@ -1341,11 +1337,12 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Float> floatSetting(String key, float defaultValue, float minValue, Property... properties) {
+        final boolean isFiltered = isFiltered(properties);
         return new Setting<>(key, Float.toString(defaultValue), (s) -> {
             float value = Float.parseFloat(s);
             if (value < minValue) {
                 String err = "Failed to parse value"
-                    + (isFiltered(properties) ? "" : " [" + s + "]")
+                    + (isFiltered ? "" : " [" + s + "]")
                     + " for setting ["
                     + key
                     + "] must be >= "
@@ -1361,16 +1358,21 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, int maxValue, Property... properties) {
-        return new Setting<>(
-            key,
-            Integer.toString(defaultValue),
-            (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)),
-            properties
-        );
+        return new Setting<>(key, Integer.toString(defaultValue), intParser(key, minValue, maxValue, properties), properties);
     }
 
     public static Setting<Integer> intSetting(String key, int defaultValue, int minValue, Property... properties) {
-        return new Setting<>(key, Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key, isFiltered(properties)), properties);
+        return new Setting<>(key, Integer.toString(defaultValue), intParser(key, minValue, properties), properties);
+    }
+
+    private static Function<String, Integer> intParser(String key, int minValue, Property[] properties) {
+        final boolean isFiltered = isFiltered(properties);
+        return s -> parseInt(s, minValue, key, isFiltered);
+    }
+
+    private static Function<String, Integer> intParser(String key, int minValue, int maxValue, Property[] properties) {
+        boolean isFiltered = isFiltered(properties);
+        return s -> parseInt(s, minValue, maxValue, key, isFiltered);
     }
 
     public static Setting<Integer> intSetting(
@@ -1380,17 +1382,11 @@ public class Setting<T> implements ToXContentObject {
         Validator<Integer> validator,
         Property... properties
     ) {
-        return new Setting<>(
-            key,
-            Integer.toString(defaultValue),
-            (s) -> parseInt(s, minValue, key, isFiltered(properties)),
-            validator,
-            properties
-        );
+        return new Setting<>(key, Integer.toString(defaultValue), intParser(key, minValue, properties), validator, properties);
     }
 
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, key, isFiltered(properties)), properties);
+        return new Setting<>(key, fallbackSetting, intParser(key, minValue, properties), properties);
     }
 
     public static Setting<Integer> intSetting(
@@ -1400,7 +1396,7 @@ public class Setting<T> implements ToXContentObject {
         int maxValue,
         Property... properties
     ) {
-        return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, maxValue, key, isFiltered(properties)), properties);
+        return new Setting<>(key, fallbackSetting, intParser(key, minValue, maxValue, properties), properties);
     }
 
     public static Setting<Integer> intSetting(
@@ -1414,14 +1410,15 @@ public class Setting<T> implements ToXContentObject {
             new SimpleKey(key),
             fallbackSetting,
             fallbackSetting::getRaw,
-            (s) -> parseInt(s, minValue, key, isFiltered(properties)),
+            intParser(key, minValue, properties),
             validator,
             properties
         );
     }
 
     public static Setting<Long> longSetting(String key, long defaultValue, long minValue, Property... properties) {
-        return new Setting<>(key, Long.toString(defaultValue), (s) -> parseLong(s, minValue, key, isFiltered(properties)), properties);
+        boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Long.toString(defaultValue), s -> parseLong(s, minValue, key, isFiltered), properties);
     }
 
     public static Setting<Instant> dateSetting(String key, Instant defaultValue, Validator<Instant> validator, Property... properties) {
@@ -1449,16 +1446,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<String> simpleString(String key, Setting<String> fallback, Property... properties) {
-        return simpleString(key, fallback, Function.identity(), properties);
-    }
-
-    public static Setting<String> simpleString(
-        final String key,
-        final Setting<String> fallback,
-        final Function<String, String> parser,
-        final Property... properties
-    ) {
-        return new Setting<>(key, fallback, parser, properties);
+        return new Setting<>(key, fallback, Function.identity(), properties);
     }
 
     /**
@@ -1512,19 +1500,24 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Boolean> boolSetting(String key, boolean defaultValue, Property... properties) {
-        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)), properties);
+        return new Setting<>(key, Boolean.toString(defaultValue), booleanParser(key, properties), properties);
+    }
+
+    private static Function<String, Boolean> booleanParser(String key, Property[] properties) {
+        final boolean isFiltered = isFiltered(properties);
+        return b -> parseBoolean(b, key, isFiltered);
     }
 
     public static Setting<Boolean> boolSetting(String key, Setting<Boolean> fallbackSetting, Property... properties) {
-        return new Setting<>(key, fallbackSetting, b -> parseBoolean(b, key, isFiltered(properties)), properties);
+        return new Setting<>(key, fallbackSetting, booleanParser(key, properties), properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, boolean defaultValue, Validator<Boolean> validator, Property... properties) {
-        return new Setting<>(key, Boolean.toString(defaultValue), b -> parseBoolean(b, key, isFiltered(properties)), validator, properties);
+        return new Setting<>(key, Boolean.toString(defaultValue), booleanParser(key, properties), validator, properties);
     }
 
     public static Setting<Boolean> boolSetting(String key, Function<Settings, String> defaultValueFn, Property... properties) {
-        return new Setting<>(key, defaultValueFn, b -> parseBoolean(b, key, isFiltered(properties)), properties);
+        return new Setting<>(key, defaultValueFn, booleanParser(key, properties), properties);
     }
 
     static boolean parseBoolean(String b, String key, boolean isFiltered) {
@@ -1540,15 +1533,19 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, ByteSizeValue value, Property... properties) {
-        return new Setting<>(key, value.toString(), (s) -> ByteSizeValue.parseBytesSizeValue(s, key), properties);
+        return new Setting<>(key, value.toString(), byteSizeParser(key), properties);
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, Setting<ByteSizeValue> fallbackSetting, Property... properties) {
-        return new Setting<>(key, fallbackSetting, (s) -> ByteSizeValue.parseBytesSizeValue(s, key), properties);
+        return new Setting<>(key, fallbackSetting, byteSizeParser(key), properties);
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, Function<Settings, String> defaultValue, Property... properties) {
-        return new Setting<>(key, defaultValue, (s) -> ByteSizeValue.parseBytesSizeValue(s, key), properties);
+        return new Setting<>(key, defaultValue, byteSizeParser(key), properties);
+    }
+
+    private static Function<String, ByteSizeValue> byteSizeParser(String key) {
+        return s -> ByteSizeValue.parseBytesSizeValue(s, key);
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(
@@ -1706,7 +1703,16 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<List<String>> stringListSetting(String key, Validator<List<String>> validator, Property... properties) {
-        return listSetting(key, List.of(), Function.identity(), validator, properties);
+        return stringListSetting(key, List.of(), validator, properties);
+    }
+
+    public static Setting<List<String>> stringListSetting(
+        final String key,
+        final List<String> defaultStringValue,
+        final Validator<List<String>> validator,
+        final Property... properties
+    ) {
+        return listSetting(key, null, Function.identity(), s -> defaultStringValue, validator, properties);
     }
 
     public static <T> Setting<List<T>> listSetting(
@@ -1715,7 +1721,7 @@ public class Setting<T> implements ToXContentObject {
         final Function<String, T> singleValueParser,
         final Property... properties
     ) {
-        return listSetting(key, null, singleValueParser, (s) -> defaultStringValue, properties);
+        return listSetting(key, null, singleValueParser, s -> defaultStringValue, properties);
     }
 
     public static <T> Setting<List<T>> listSetting(
@@ -1903,9 +1909,8 @@ public class Setting<T> implements ToXContentObject {
         final TimeValue minValue,
         final Property... properties
     ) {
-        final SimpleKey simpleKey = new SimpleKey(key);
         return new Setting<>(
-            simpleKey,
+            key,
             s -> defaultValue.apply(s).getStringRep(),
             minTimeValueParser(key, minValue, isFiltered(properties)),
             properties
@@ -2054,27 +2059,18 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Property... properties) {
-        return new Setting<>(key, Double.toString(defaultValue), (s) -> parseDouble(s, minValue, maxValue, key, properties), properties);
+        final boolean isFiltered = isFiltered(properties);
+        return new Setting<>(key, Double.toString(defaultValue), (s) -> parseDouble(s, minValue, maxValue, key, isFiltered), properties);
     }
 
-    public static Double parseDouble(String s, double minValue, double maxValue, String key, Property... properties) {
+    public static Double parseDouble(String s, double minValue, double maxValue, String key, boolean isFiltered) {
         final double d = Double.parseDouble(s);
         if (d < minValue) {
-            String err = "Failed to parse value"
-                + (isFiltered(properties) ? "" : " [" + s + "]")
-                + " for setting ["
-                + key
-                + "] must be >= "
-                + minValue;
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be >= " + minValue;
             throw new IllegalArgumentException(err);
         }
         if (d > maxValue) {
-            String err = "Failed to parse value"
-                + (isFiltered(properties) ? "" : " [" + s + "]")
-                + " for setting ["
-                + key
-                + "] must be <= "
-                + maxValue;
+            String err = "Failed to parse value" + (isFiltered ? "" : " [" + s + "]") + " for setting [" + key + "] must be <= " + maxValue;
             throw new IllegalArgumentException(err);
         }
         return d;
@@ -2343,7 +2339,7 @@ public class Setting<T> implements ToXContentObject {
             return Settings.internKeyOrValue(matcher.group(3));
         }
 
-        public SimpleKey toConcreteKey(String missingPart) {
+        public String toConcreteKey(String missingPart) {
             StringBuilder key = new StringBuilder();
             if (prefix != null) {
                 key.append(prefix);
@@ -2353,7 +2349,7 @@ public class Setting<T> implements ToXContentObject {
                 key.append(".");
                 key.append(suffix);
             }
-            return new SimpleKey(key.toString());
+            return key.toString();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/elasticsearch/discovery/DiscoveryModule.java
@@ -56,7 +56,6 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
@@ -72,10 +71,9 @@ public class DiscoveryModule extends AbstractModule {
     @Deprecated
     public static final String LEGACY_MULTI_NODE_DISCOVERY_TYPE = "zen";
 
-    public static final Setting<String> DISCOVERY_TYPE_SETTING = new Setting<>(
+    public static final Setting<String> DISCOVERY_TYPE_SETTING = Setting.simpleString(
         "discovery.type",
         MULTI_NODE_DISCOVERY_TYPE,
-        Function.identity(),
         Property.NodeScope
     );
 
@@ -86,10 +84,9 @@ public class DiscoveryModule extends AbstractModule {
 
     public static final String DEFAULT_ELECTION_STRATEGY = "default";
 
-    public static final Setting<String> ELECTION_STRATEGY_SETTING = new Setting<>(
+    public static final Setting<String> ELECTION_STRATEGY_SETTING = Setting.simpleString(
         "cluster.election.strategy",
         DEFAULT_ELECTION_STRATEGY,
-        Function.identity(),
         Property.NodeScope
     );
 

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
 /**
  * The environment of where things exists.
@@ -40,7 +39,7 @@ public class Environment {
 
     public static final Setting<String> PATH_HOME_SETTING = Setting.simpleString("path.home", Property.NodeScope);
     public static final Setting<List<String>> PATH_DATA_SETTING = Setting.stringListSetting("path.data", Property.NodeScope);
-    public static final Setting<String> PATH_LOGS_SETTING = new Setting<>("path.logs", "", Function.identity(), Property.NodeScope);
+    public static final Setting<String> PATH_LOGS_SETTING = Setting.simpleString("path.logs", Property.NodeScope);
     public static final Setting<List<String>> PATH_REPO_SETTING = Setting.stringListSetting("path.repo", Property.NodeScope);
     public static final Setting<String> PATH_SHARED_DATA_SETTING = Setting.simpleString("path.shared_data", Property.NodeScope);
 

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -27,29 +27,21 @@ import static org.elasticsearch.common.settings.Setting.stringListSetting;
 public final class HttpTransportSettings {
 
     public static final Setting<Boolean> SETTING_CORS_ENABLED = Setting.boolSetting("http.cors.enabled", false, Property.NodeScope);
-    public static final Setting<String> SETTING_CORS_ALLOW_ORIGIN = new Setting<>(
-        "http.cors.allow-origin",
-        "",
-        Function.identity(),
-        Property.NodeScope
-    );
+    public static final Setting<String> SETTING_CORS_ALLOW_ORIGIN = Setting.simpleString("http.cors.allow-origin", Property.NodeScope);
     public static final Setting<Integer> SETTING_CORS_MAX_AGE = intSetting("http.cors.max-age", 1728000, Property.NodeScope);
-    public static final Setting<String> SETTING_CORS_ALLOW_METHODS = new Setting<>(
+    public static final Setting<String> SETTING_CORS_ALLOW_METHODS = Setting.simpleString(
         "http.cors.allow-methods",
         "OPTIONS,HEAD,GET,POST,PUT,DELETE",
-        Function.identity(),
         Property.NodeScope
     );
-    public static final Setting<String> SETTING_CORS_ALLOW_HEADERS = new Setting<>(
+    public static final Setting<String> SETTING_CORS_ALLOW_HEADERS = Setting.simpleString(
         "http.cors.allow-headers",
         "X-Requested-With,Content-Type,Content-Length,Authorization,Accept,User-Agent,X-Elastic-Client-Meta",
-        Function.identity(),
         Property.NodeScope
     );
-    public static final Setting<String> SETTING_CORS_EXPOSE_HEADERS = new Setting<>(
+    public static final Setting<String> SETTING_CORS_EXPOSE_HEADERS = Setting.simpleString(
         "http.cors.expose-headers",
         "X-elastic-product",
-        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<Boolean> SETTING_CORS_ALLOW_CREDENTIALS = Setting.boolSetting(

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -103,18 +103,14 @@ public final class IndexModule {
 
     private static final IndexStorePlugin.RecoveryStateFactory DEFAULT_RECOVERY_STATE_FACTORY = RecoveryState::new;
 
-    public static final Setting<String> INDEX_STORE_TYPE_SETTING = new Setting<>(
+    public static final Setting<String> INDEX_STORE_TYPE_SETTING = Setting.simpleString(
         "index.store.type",
-        "",
-        Function.identity(),
         Property.IndexScope,
         Property.NodeScope
     );
 
-    public static final Setting<String> INDEX_RECOVERY_TYPE_SETTING = new Setting<>(
+    public static final Setting<String> INDEX_RECOVERY_TYPE_SETTING = Setting.simpleString(
         "index.recovery.type",
-        "",
-        Function.identity(),
         Property.IndexScope,
         Property.NodeScope
     );

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING;
@@ -516,19 +515,17 @@ public final class IndexSettings {
         Property.IndexScope
     );
 
-    public static final Setting<String> DEFAULT_PIPELINE = new Setting<>(
+    public static final Setting<String> DEFAULT_PIPELINE = Setting.simpleString(
         "index.default_pipeline",
         IngestService.NOOP_PIPELINE_NAME,
-        Function.identity(),
         Property.Dynamic,
         Property.IndexScope,
         Property.ServerlessPublic
     );
 
-    public static final Setting<String> FINAL_PIPELINE = new Setting<>(
+    public static final Setting<String> FINAL_PIPELINE = Setting.simpleString(
         "index.final_pipeline",
         IngestService.NOOP_PIPELINE_NAME,
-        Function.identity(),
         Property.Dynamic,
         Property.IndexScope,
         Property.ServerlessPublic

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -242,7 +242,7 @@ public final class MergePolicyConfig {
     public static final Setting<ByteSizeValue> INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING = Setting.byteSizeSetting(
         "index.merge.policy.max_merged_segment",
         // We're not using DEFAULT_MAX_MERGED_SEGMENT here as we want different defaults for time-based data vs. non-time based
-        new ByteSizeValue(0, ByteSizeUnit.BYTES),
+        ByteSizeValue.ZERO,
         Property.Dynamic,
         Property.IndexScope
     );

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING;
 import static org.elasticsearch.common.settings.Setting.parseInt;
@@ -92,9 +93,13 @@ public class RecoverySettings {
     /**
      * Default factor as defined by the operator.
      */
-    public static final Setting<Double> NODE_BANDWIDTH_RECOVERY_OPERATOR_FACTOR_SETTING = operatorFactorSetting(
+    public static final Setting<Double> NODE_BANDWIDTH_RECOVERY_OPERATOR_FACTOR_SETTING = new Setting<>(
         "node.bandwidth.recovery.operator.factor",
-        DEFAULT_FACTOR_VALUE
+        Double.toString(DEFAULT_FACTOR_VALUE),
+        ratioParser("node.bandwidth.recovery.operator.factor"),
+        ratioValidator("node.bandwidth.recovery.operator.factor"),
+        Property.NodeScope,
+        Property.OperatorDynamic
     );
 
     public static final Setting<Double> NODE_BANDWIDTH_RECOVERY_OPERATOR_FACTOR_WRITE_SETTING = operatorFactorSetting(
@@ -165,34 +170,34 @@ public class RecoverySettings {
         }, Property.NodeScope);
     }
 
-    /**
-     * Operator-defined factors have a value in (0.0, 1.0]
-     */
-    private static Setting<Double> operatorFactorSetting(String key, double defaultValue) {
-        return new Setting<>(key, Double.toString(defaultValue), s -> Setting.parseDouble(s, 0d, 1d, key), v -> {
-            if (v == 0d) {
-                throw new IllegalArgumentException("Failed to validate value [" + v + "] for factor setting [" + key + "] must be > [0]");
-            }
-        }, Property.NodeScope, Property.OperatorDynamic);
-    }
-
     private static Setting<Double> operatorFactorSetting(String key) {
-        return new Setting<>(key, NODE_BANDWIDTH_RECOVERY_OPERATOR_FACTOR_SETTING, s -> Setting.parseDouble(s, 0d, 1d, key), v -> {
-            if (v == 0d) {
-                throw new IllegalArgumentException("Failed to validate value [" + v + "] for factor setting [" + key + "] must be > [0]");
-            }
-        }, Property.NodeScope, Property.OperatorDynamic);
+        return new Setting<>(
+            key,
+            NODE_BANDWIDTH_RECOVERY_OPERATOR_FACTOR_SETTING,
+            ratioParser(key),
+            ratioValidator(key),
+            Property.NodeScope,
+            Property.OperatorDynamic
+        );
     }
 
     /**
      * User-defined factors have a value in (0.0, 1.0] and fall back to a corresponding operator factor setting.
      */
     private static Setting<Double> factorSetting(String key, Setting<Double> operatorFallback) {
-        return new Setting<>(key, operatorFallback, s -> Setting.parseDouble(s, 0d, 1d, key), v -> {
+        return new Setting<>(key, operatorFallback, ratioParser(key), ratioValidator(key), Property.NodeScope, Property.Dynamic);
+    }
+
+    private static Setting.Validator<Double> ratioValidator(String key) {
+        return v -> {
             if (v == 0d) {
                 throw new IllegalArgumentException("Failed to validate value [" + v + "] for factor setting [" + key + "] must be > [0]");
             }
-        }, Property.NodeScope, Property.Dynamic);
+        };
+    }
+
+    private static Function<String, Double> ratioParser(String key) {
+        return s -> Setting.parseDouble(s, 0d, 1d, key, false);
     }
 
     static final ByteSizeValue DEFAULT_MAX_BYTES_PER_SEC = new ByteSizeValue(40L, ByteSizeUnit.MB);

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -45,7 +45,7 @@ public class FsRepository extends BlobStoreRepository {
 
     public static final String TYPE = "fs";
 
-    public static final Setting<String> LOCATION_SETTING = new Setting<>("location", "", Function.identity(), Property.NodeScope);
+    public static final Setting<String> LOCATION_SETTING = Setting.simpleString("location", Property.NodeScope);
     public static final Setting<String> REPOSITORIES_LOCATION_SETTING = new Setting<>(
         "repositories.fs.location",
         LOCATION_SETTING,

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -140,7 +140,7 @@ public class ScriptService implements Closeable, ClusterStateApplier, ScriptComp
     public static final Setting.AffixSetting<ScriptCache.CompilationRate> SCRIPT_MAX_COMPILATIONS_RATE_SETTING = Setting.affixKeySetting(
         CONTEXT_PREFIX,
         "max_compilations_rate",
-        key -> new Setting<ScriptCache.CompilationRate>(
+        key -> new Setting<>(
             key,
             "75/5m",
             (String value) -> value.equals(UNLIMITED_COMPILATION_RATE_KEY)

--- a/server/src/main/java/org/elasticsearch/transport/TransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportSettings.java
@@ -53,12 +53,7 @@ public final class TransportSettings {
         "bind_host",
         key -> listSetting(key, BIND_HOST, Function.identity(), Setting.Property.NodeScope)
     );
-    public static final Setting<String> PORT = new Setting<>(
-        "transport.port",
-        "9300-9399",
-        Function.identity(),
-        Setting.Property.NodeScope
-    );
+    public static final Setting<String> PORT = Setting.simpleString("transport.port", "9300-9399", Setting.Property.NodeScope);
     public static final Setting.AffixSetting<String> PORT_PROFILE = affixKeySetting(
         "transport.profiles.",
         "port",

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -118,7 +118,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
     }
 
     public static final Setting<RelativeByteSizeValue> SHARED_CACHE_SIZE_SETTING = new Setting<>(
-        new Setting.SimpleKey(SHARED_CACHE_SETTINGS_PREFIX + "size"),
+        SHARED_CACHE_SETTINGS_PREFIX + "size",
         (settings) -> {
             if (DiscoveryNode.isDedicatedFrozenNode(settings) || isSearchOrIndexingNode(settings)) {
                 return "90%";
@@ -184,8 +184,8 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
     }
 
     public static final Setting<ByteSizeValue> SHARED_CACHE_SIZE_MAX_HEADROOM_SETTING = new Setting<>(
-        new Setting.SimpleKey(SHARED_CACHE_SETTINGS_PREFIX + "size.max_headroom"),
-        (settings) -> {
+        SHARED_CACHE_SETTINGS_PREFIX + "size.max_headroom",
+        settings -> {
             if (SHARED_CACHE_SIZE_SETTING.exists(settings) == false
                 && (DiscoveryNode.isDedicatedFrozenNode(settings) || isSearchOrIndexingNode(settings))) {
                 return "100GB";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotRepository.java
@@ -73,12 +73,7 @@ import static org.elasticsearch.core.Strings.format;
  * match_all scroll searches in order to reindex the data.
  */
 public final class SourceOnlySnapshotRepository extends FilterRepository {
-    private static final Setting<String> DELEGATE_TYPE = new Setting<>(
-        "delegate_type",
-        "",
-        Function.identity(),
-        Setting.Property.NodeScope
-    );
+    private static final Setting<String> DELEGATE_TYPE = Setting.simpleString("delegate_type", Setting.Property.NodeScope);
     public static final Setting<Boolean> SOURCE_ONLY = Setting.boolSetting(
         "index.source_only",
         false,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -242,7 +242,7 @@ public class XPackSettings {
      * Do not allow insecure hashing algorithms to be used for password hashing
      */
     public static Setting<String> defaultStoredHashAlgorithmSetting(String key, Function<Settings, String> defaultHashingAlgorithm) {
-        return new Setting<>(new Setting.SimpleKey(key), defaultHashingAlgorithm, Function.identity(), v -> {
+        return new Setting<>(key, defaultHashingAlgorithm, Function.identity(), v -> {
             if (Hasher.getAvailableAlgoStoredHash().contains(v.toLowerCase(Locale.ROOT)) == false) {
                 throw new IllegalArgumentException(
                     "Invalid algorithm: " + v + ". Valid values for password hashing are " + Hasher.getAvailableAlgoStoredHash().toString()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/jwt/JwtRealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/jwt/JwtRealmSettings.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -232,10 +231,9 @@ public class JwtRealmSettings {
     public static final Setting.AffixSetting<List<String>> ALLOWED_SIGNATURE_ALGORITHMS = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(TYPE),
         "allowed_signature_algorithms",
-        key -> Setting.listSetting(
+        key -> Setting.stringListSetting(
             key,
             DEFAULT_ALLOWED_SIGNATURE_ALGORITHMS,
-            Function.identity(),
             values -> verifyNonNullNotEmpty(key, values, SUPPORTED_SIGNATURE_ALGORITHMS),
             Setting.Property.NodeScope
         )

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/LdapUserSearchSessionFactorySettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/LdapUserSearchSessionFactorySettings.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xpack.core.security.authc.ldap.support.SessionFactorySe
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings.LDAP_TYPE;
 
@@ -21,10 +20,9 @@ public final class LdapUserSearchSessionFactorySettings {
     public static final Setting.AffixSetting<String> SEARCH_ATTRIBUTE = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(LDAP_TYPE),
         "user_search.attribute",
-        key -> new Setting<>(
+        key -> Setting.simpleString(
             key,
             LdapUserSearchSessionFactorySettings.DEFAULT_USERNAME_ATTRIBUTE,
-            Function.identity(),
             Setting.Property.NodeScope,
             Setting.Property.DeprecatedWarning
         )

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/SearchGroupsResolverSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/SearchGroupsResolverSettings.java
@@ -20,7 +20,7 @@ public final class SearchGroupsResolverSettings {
 
     public static final Function<String, Setting.AffixSetting<String>> BASE_DN = RealmSettings.affixSetting(
         "group_search.base_dn",
-        key -> Setting.simpleString(key, new Setting.Property[] { Setting.Property.NodeScope })
+        key -> Setting.simpleString(key, Setting.Property.NodeScope)
     );
 
     public static final Function<String, Setting.AffixSetting<LdapSearchScope>> SCOPE = RealmSettings.affixSetting(
@@ -41,7 +41,7 @@ public final class SearchGroupsResolverSettings {
     public static final Setting.AffixSetting<String> FILTER = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(LDAP_TYPE),
         "group_search.filter",
-        key -> new Setting<>(key, GROUP_SEARCH_DEFAULT_FILTER, Function.identity(), Setting.Property.NodeScope)
+        key -> Setting.simpleString(key, GROUP_SEARCH_DEFAULT_FILTER, Setting.Property.NodeScope)
     );
 
     private SearchGroupsResolverSettings() {}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/UserAttributeGroupsResolverSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/UserAttributeGroupsResolverSettings.java
@@ -11,13 +11,12 @@ import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.function.Function;
 
 public final class UserAttributeGroupsResolverSettings {
     public static final Setting.AffixSetting<String> ATTRIBUTE = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(LdapRealmSettings.LDAP_TYPE),
         "user_group_attribute",
-        key -> new Setting<>(key, "memberOf", Function.identity(), Setting.Property.NodeScope)
+        key -> Setting.simpleString(key, "memberOf", Setting.Property.NodeScope)
     );
 
     private UserAttributeGroupsResolverSettings() {}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/oidc/OpenIdConnectRealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/oidc/OpenIdConnectRealmSettings.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 public class OpenIdConnectRealmSettings {
 
@@ -90,7 +89,7 @@ public class OpenIdConnectRealmSettings {
     public static final Setting.AffixSetting<String> RP_SIGNATURE_ALGORITHM = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(TYPE),
         "rp.signature_algorithm",
-        key -> new Setting<>(key, "RS256", Function.identity(), v -> {
+        key -> Setting.simpleString(key, "RS256", v -> {
             if (SUPPORTED_SIGNATURE_ALGORITHMS.contains(v) == false) {
                 throw new IllegalArgumentException(
                     "Invalid value [" + v + "] for [" + key + "]. Allowed values are " + SUPPORTED_SIGNATURE_ALGORITHMS + "}]"
@@ -106,7 +105,7 @@ public class OpenIdConnectRealmSettings {
     public static final Setting.AffixSetting<String> RP_CLIENT_AUTH_METHOD = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(TYPE),
         "rp.client_auth_method",
-        key -> new Setting<>(key, "client_secret_basic", Function.identity(), v -> {
+        key -> Setting.simpleString(key, "client_secret_basic", v -> {
             if (CLIENT_AUTH_METHODS.contains(v) == false) {
                 throw new IllegalArgumentException(
                     "Invalid value [" + v + "] for [" + key + "]. Allowed values are " + CLIENT_AUTH_METHODS + "}]"
@@ -117,7 +116,7 @@ public class OpenIdConnectRealmSettings {
     public static final Setting.AffixSetting<String> RP_CLIENT_AUTH_JWT_SIGNATURE_ALGORITHM = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(TYPE),
         "rp.client_auth_jwt_signature_algorithm",
-        key -> new Setting<>(key, "HS384", Function.identity(), v -> {
+        key -> Setting.simpleString(key, "HS384", v -> {
             if (SUPPORTED_CLIENT_AUTH_JWT_ALGORITHMS.contains(v) == false) {
                 throw new IllegalArgumentException(
                     "Invalid value [" + v + "] for [" + key + "]. Allowed values are " + SUPPORTED_CLIENT_AUTH_JWT_ALGORITHMS + "}]"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/DnRoleMapperSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/DnRoleMapperSettings.java
@@ -20,7 +20,7 @@ public final class DnRoleMapperSettings {
     public static final Function<String, Setting.AffixSetting<String>> ROLE_MAPPING_FILE_SETTING = type -> Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(type),
         FILES_ROLE_MAPPING_SUFFIX,
-        key -> new Setting<>(key, DEFAULT_FILE_NAME, Function.identity(), Setting.Property.NodeScope)
+        key -> Setting.simpleString(key, DEFAULT_FILE_NAME, Setting.Property.NodeScope)
     );
 
     public static final String UNMAPPED_GROUPS_AS_ROLES_SUFFIX = "unmapped_groups_as_roles";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Map.entry;
@@ -112,10 +111,9 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
 
     private static final Map<String, RoleDescriptor> ALL_RESERVED_ROLES = initializeReservedRoles();
 
-    public static final Setting<List<String>> INCLUDED_RESERVED_ROLES_SETTING = Setting.listSetting(
+    public static final Setting<List<String>> INCLUDED_RESERVED_ROLES_SETTING = Setting.stringListSetting(
         SecurityField.setting("reserved_roles.include"),
         List.copyOf(ALL_RESERVED_ROLES.keySet()),
-        Function.identity(),
         value -> {
             final Set<String> valueSet = Set.copyOf(value);
             if (false == valueSet.contains("superuser")) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/AnonymousUser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/AnonymousUser.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static org.elasticsearch.xpack.core.security.SecurityField.setting;
 
@@ -23,10 +22,9 @@ import static org.elasticsearch.xpack.core.security.SecurityField.setting;
 public class AnonymousUser extends ReservedUser {
 
     public static final String DEFAULT_ANONYMOUS_USERNAME = "_anonymous";
-    public static final Setting<String> USERNAME_SETTING = new Setting<>(
+    public static final Setting<String> USERNAME_SETTING = Setting.simpleString(
         setting("authc.anonymous.username"),
         DEFAULT_ANONYMOUS_USERNAME,
-        Function.identity(),
         Property.NodeScope
     );
     public static final Setting<List<String>> ROLES_SETTING = Setting.stringListSetting(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/crypto/CryptoService.java
@@ -25,7 +25,6 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-import java.util.function.Function;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -55,10 +54,9 @@ public class CryptoService {
     private static final String DEFAULT_KEY_ALGORITH = "AES";
     private static final int DEFAULT_KEY_LENGTH = 128;
 
-    private static final Setting<String> ENCRYPTION_ALGO_SETTING = new Setting<>(
+    private static final Setting<String> ENCRYPTION_ALGO_SETTING = Setting.simpleString(
         SecurityField.setting("encryption.algorithm"),
-        s -> DEFAULT_ENCRYPTION_ALGORITHM,
-        Function.identity(),
+        DEFAULT_ENCRYPTION_ALGORITHM,
         Property.NodeScope
     );
     private static final Setting<Integer> ENCRYPTION_KEY_LENGTH_SETTING = Setting.intSetting(
@@ -66,10 +64,9 @@ public class CryptoService {
         DEFAULT_KEY_LENGTH,
         Property.NodeScope
     );
-    private static final Setting<String> ENCRYPTION_KEY_ALGO_SETTING = new Setting<>(
+    private static final Setting<String> ENCRYPTION_KEY_ALGO_SETTING = Setting.simpleString(
         SecurityField.setting("encryption_key.algorithm"),
         DEFAULT_KEY_ALGORITH,
-        Function.identity(),
         Property.NodeScope
     );
     private static final Logger logger = LogManager.getLogger(CryptoService.class);

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProviderBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProviderBuilder.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -75,10 +74,9 @@ public class SamlIdentityProviderBuilder {
         value -> parseUrl("xpack.idp.slo_endpoint.post", value),
         Setting.Property.NodeScope
     );
-    public static final Setting<List<String>> IDP_ALLOWED_NAMEID_FORMATS = Setting.listSetting(
+    public static final Setting<List<String>> IDP_ALLOWED_NAMEID_FORMATS = Setting.stringListSetting(
         "xpack.idp.allowed_nameid_formats",
         List.of(TRANSIENT),
-        Function.identity(),
         SamlIdentityProviderBuilder::validateNameIDs,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporter.java
@@ -108,7 +108,7 @@ public abstract class Exporter implements AutoCloseable {
     static final Setting.AffixSetting<DateFormatter> INDEX_NAME_TIME_FORMAT_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "index.name.time_format",
-        key -> new Setting<DateFormatter>(
+        key -> new Setting<>(
             key,
             Exporter.INDEX_FORMAT,
             DateFormatter::forPattern,

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -48,7 +48,6 @@ import org.elasticsearch.xpack.monitoring.exporter.MonitoringMigrationCoordinato
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
@@ -103,7 +101,7 @@ public class HttpExporter extends Exporter {
     public static final Setting.AffixSetting<List<String>> HOST_SETTING = Setting.affixKeySetting(
         "xpack.monitoring.exporters.",
         "host",
-        key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(), new Setting.Validator<>() {
+        key -> Setting.stringListSetting(key, new Setting.Validator<>() {
 
             @Override
             public void validate(final List<String> value) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -129,7 +129,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -267,18 +266,15 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         RUN_AS_GRANTED.toString(),
         SECURITY_CONFIG_CHANGE.toString()
     );
-    public static final Setting<List<String>> INCLUDE_EVENT_SETTINGS = Setting.listSetting(
+    public static final Setting<List<String>> INCLUDE_EVENT_SETTINGS = Setting.stringListSetting(
         setting("audit.logfile.events.include"),
         DEFAULT_EVENT_INCLUDES,
-        Function.identity(),
         value -> AuditLevel.parse(value, List.of()),
         Property.NodeScope,
         Property.Dynamic
     );
-    public static final Setting<List<String>> EXCLUDE_EVENT_SETTINGS = Setting.listSetting(
+    public static final Setting<List<String>> EXCLUDE_EVENT_SETTINGS = Setting.stringListSetting(
         setting("audit.logfile.events.exclude"),
-        Collections.emptyList(),
-        Function.identity(),
         value -> AuditLevel.parse(List.of(), value),
         Property.NodeScope,
         Property.Dynamic
@@ -323,62 +319,27 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     protected static final Setting.AffixSetting<List<String>> FILTER_POLICY_IGNORE_PRINCIPALS = Setting.affixKeySetting(
         FILTER_POLICY_PREFIX,
         "users",
-        (key) -> Setting.listSetting(
-            key,
-            Collections.singletonList("*"),
-            Function.identity(),
-            EventFilterPolicy::parsePredicate,
-            Property.NodeScope,
-            Property.Dynamic
-        )
+        key -> Setting.stringListSetting(key, List.of("*"), EventFilterPolicy::parsePredicate, Property.NodeScope, Property.Dynamic)
     );
     protected static final Setting.AffixSetting<List<String>> FILTER_POLICY_IGNORE_REALMS = Setting.affixKeySetting(
         FILTER_POLICY_PREFIX,
         "realms",
-        (key) -> Setting.listSetting(
-            key,
-            Collections.singletonList("*"),
-            Function.identity(),
-            EventFilterPolicy::parsePredicate,
-            Property.NodeScope,
-            Property.Dynamic
-        )
+        key -> Setting.stringListSetting(key, List.of("*"), EventFilterPolicy::parsePredicate, Property.NodeScope, Property.Dynamic)
     );
     protected static final Setting.AffixSetting<List<String>> FILTER_POLICY_IGNORE_ROLES = Setting.affixKeySetting(
         FILTER_POLICY_PREFIX,
         "roles",
-        (key) -> Setting.listSetting(
-            key,
-            Collections.singletonList("*"),
-            Function.identity(),
-            EventFilterPolicy::parsePredicate,
-            Property.NodeScope,
-            Property.Dynamic
-        )
+        key -> Setting.stringListSetting(key, List.of("*"), EventFilterPolicy::parsePredicate, Property.NodeScope, Property.Dynamic)
     );
     protected static final Setting.AffixSetting<List<String>> FILTER_POLICY_IGNORE_INDICES = Setting.affixKeySetting(
         FILTER_POLICY_PREFIX,
         "indices",
-        (key) -> Setting.listSetting(
-            key,
-            Collections.singletonList("*"),
-            Function.identity(),
-            EventFilterPolicy::parsePredicate,
-            Property.NodeScope,
-            Property.Dynamic
-        )
+        key -> Setting.stringListSetting(key, List.of("*"), EventFilterPolicy::parsePredicate, Property.NodeScope, Property.Dynamic)
     );
     protected static final Setting.AffixSetting<List<String>> FILTER_POLICY_IGNORE_ACTIONS = Setting.affixKeySetting(
         FILTER_POLICY_PREFIX,
         "actions",
-        (key) -> Setting.listSetting(
-            key,
-            Collections.singletonList("*"),
-            Function.identity(),
-            EventFilterPolicy::parsePredicate,
-            Property.NodeScope,
-            Property.Dynamic
-        )
+        key -> Setting.stringListSetting(key, List.of("*"), EventFilterPolicy::parsePredicate, Property.NodeScope, Property.Dynamic)
     );
 
     private static final Marker AUDIT_MARKER = MarkerManager.getMarker("org.elasticsearch.xpack.security.audit");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -75,18 +75,14 @@ public class IPFilter {
     private static final IPFilterValidator ALLOW_VALIDATOR = new IPFilterValidator(true);
     private static final IPFilterValidator DENY_VALIDATOR = new IPFilterValidator(false);
 
-    public static final Setting<List<String>> TRANSPORT_FILTER_ALLOW_SETTING = Setting.listSetting(
+    public static final Setting<List<String>> TRANSPORT_FILTER_ALLOW_SETTING = Setting.stringListSetting(
         setting("transport.filter.allow"),
-        Collections.emptyList(),
-        Function.identity(),
         ALLOW_VALIDATOR,
         Property.OperatorDynamic,
         Property.NodeScope
     );
-    public static final Setting<List<String>> TRANSPORT_FILTER_DENY_SETTING = Setting.listSetting(
+    public static final Setting<List<String>> TRANSPORT_FILTER_DENY_SETTING = Setting.stringListSetting(
         setting("transport.filter.deny"),
-        Collections.emptyList(),
-        Function.identity(),
         DENY_VALIDATOR,
         Property.OperatorDynamic,
         Property.NodeScope
@@ -115,26 +111,12 @@ public class IPFilter {
     public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_DENY_SETTING = Setting.affixKeySetting(
         "transport.profiles.",
         "xpack.security.filter.deny",
-        key -> Setting.listSetting(
-            key,
-            Collections.emptyList(),
-            Function.identity(),
-            DENY_VALIDATOR,
-            Property.OperatorDynamic,
-            Property.NodeScope
-        )
+        key -> Setting.stringListSetting(key, DENY_VALIDATOR, Property.OperatorDynamic, Property.NodeScope)
     );
     public static final Setting.AffixSetting<List<String>> PROFILE_FILTER_ALLOW_SETTING = Setting.affixKeySetting(
         "transport.profiles.",
         "xpack.security.filter.allow",
-        key -> Setting.listSetting(
-            key,
-            Collections.emptyList(),
-            Function.identity(),
-            ALLOW_VALIDATOR,
-            Property.OperatorDynamic,
-            Property.NodeScope
-        )
+        key -> Setting.stringListSetting(key, ALLOW_VALIDATOR, Property.OperatorDynamic, Property.NodeScope)
     );
 
     private static final Setting<List<String>> HTTP_FILTER_ALLOW_FALLBACK = Setting.listSetting(

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -205,7 +205,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -221,10 +220,8 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
 
     // This setting is only here for backward compatibility reasons as 6.x indices made use of it. It can be removed in 8.x.
     @Deprecated
-    public static final Setting<String> INDEX_WATCHER_TEMPLATE_VERSION_SETTING = new Setting<>(
+    public static final Setting<String> INDEX_WATCHER_TEMPLATE_VERSION_SETTING = Setting.simpleString(
         "index.xpack.watcher.template.version",
-        "",
-        Function.identity(),
         Setting.Property.IndexScope
     );
     public static final Setting<Boolean> ENCRYPT_SENSITIVE_DATA_SETTING = Setting.boolSetting(


### PR DESCRIPTION
Some small speedups in here from pre-evaluating `isFiltered(properties)` in lots of spots and not creating an unused `SimpleKey` in `toConcreteKey` which runs a costly string interning at some rate. Other than that, obvious deduplication using existing utilities or adding obvious missing overloads or parser utils for them.
