### PR TITLE
Introduce constant for all production use of Base64.getUrlEncoder().withoutPadding()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.ByteUtils;
@@ -344,7 +345,7 @@ public abstract class IndexRouting {
                 byte[] idBytes = new byte[4 + suffix.length];
                 ByteUtils.writeIntLE(buildHash(onEmpty), idBytes, 0);
                 System.arraycopy(suffix, 0, idBytes, 4, suffix.length);
-                return Base64.getUrlEncoder().withoutPadding().encodeToString(idBytes);
+                return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(idBytes);
             }
 
             private void extractObject(@Nullable String path, XContentParser source) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
+++ b/server/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.CharArrays;
 
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Random;
 
 class RandomBasedUUIDGenerator implements UUIDGenerator {
@@ -36,7 +35,7 @@ class RandomBasedUUIDGenerator implements UUIDGenerator {
         byte[] encodedBytes = null;
         try {
             uuidBytes = getUUIDBytes(SecureRandomHolder.INSTANCE);
-            encodedBytes = Base64.getUrlEncoder().withoutPadding().encode(uuidBytes);
+            encodedBytes = Strings.BASE_64_NO_PADDING_URL_ENCODER.encode(uuidBytes);
             return new SecureString(CharArrays.utf8BytesToChars(encodedBytes));
         } finally {
             if (uuidBytes != null) {
@@ -54,7 +53,7 @@ class RandomBasedUUIDGenerator implements UUIDGenerator {
      * as defined here: http://www.ietf.org/rfc/rfc4122.txt
      */
     public static String getBase64UUID(Random random) {
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(getUUIDBytes(random));
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(getUUIDBytes(random));
     }
 
     static final int SIZE_IN_BYTES = 16;

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -41,6 +42,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Strings {
+
+    public static final Base64.Encoder BASE_64_NO_PADDING_URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     public static final String[] EMPTY_ARRAY = new String[0];
 

--- a/server/src/main/java/org/elasticsearch/common/TimeBasedUUIDGenerator.java
+++ b/server/src/main/java/org/elasticsearch/common/TimeBasedUUIDGenerator.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.common;
 
-import java.util.Base64;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -35,8 +34,6 @@ class TimeBasedUUIDGenerator implements UUIDGenerator {
     static {
         assert SECURE_MUNGED_ADDRESS.length == 6;
     }
-
-    private static final Base64.Encoder BASE_64_NO_PADDING = Base64.getUrlEncoder().withoutPadding();
 
     // protected for testing
     protected long currentTimeMillis() {
@@ -105,6 +102,6 @@ class TimeBasedUUIDGenerator implements UUIDGenerator {
 
         assert i == uuidBytes.length;
 
-        return BASE_64_NO_PADDING.encodeToString(uuidBytes);
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(uuidBytes);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapper.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.cluster.routing.IndexRouting;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.hash.Murmur3Hasher;
@@ -41,7 +42,6 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.time.ZoneId;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -59,7 +59,6 @@ public class TimeSeriesIdFieldMapper extends MetadataFieldMapper {
     public static final String CONTENT_TYPE = "_tsid";
     public static final TimeSeriesIdFieldType FIELD_TYPE = new TimeSeriesIdFieldType();
     public static final TimeSeriesIdFieldMapper INSTANCE = new TimeSeriesIdFieldMapper();
-    private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
@@ -381,7 +380,7 @@ public class TimeSeriesIdFieldMapper extends MetadataFieldMapper {
     private static String base64Encode(final BytesRef bytesRef) {
         byte[] bytes = new byte[bytesRef.length];
         System.arraycopy(bytesRef.bytes, bytesRef.offset, bytes, 0, bytesRef.length);
-        return BASE64_ENCODER.encodeToString(bytes);
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(bytes);
     }
 
     public static Map<String, Object> decodeTsidAsMap(BytesRef bytesRef) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.index.IndexMode;
@@ -115,9 +116,9 @@ public class TimeSeriesRoutingHashFieldMapper extends MetadataFieldMapper {
             String routingHash = context.sourceToParse().routing();
             if (routingHash == null) {
                 assert context.sourceToParse().id() != null;
-                routingHash = Base64.getUrlEncoder()
-                    .withoutPadding()
-                    .encodeToString(Arrays.copyOf(Base64.getUrlDecoder().decode(context.sourceToParse().id()), 4));
+                routingHash = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(
+                    Arrays.copyOf(Base64.getUrlDecoder().decode(context.sourceToParse().id()), 4)
+                );
             }
             var field = new SortedDocValuesField(NAME, Uid.encodeId(routingHash));
             context.rootDoc().add(field);
@@ -132,7 +133,7 @@ public class TimeSeriesRoutingHashFieldMapper extends MetadataFieldMapper {
     public static String encode(int routingId) {
         byte[] bytes = new byte[4];
         ByteUtils.writeIntLE(routingId, bytes, 0);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(bytes);
     }
 
     public static final String DUMMY_ENCODED_VALUE = encode(0);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
@@ -14,13 +14,13 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.routing.IndexRouting;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.hash.MurmurHash3.Hash128;
 import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 
-import java.util.Base64;
 import java.util.Locale;
 
 /**
@@ -105,7 +105,7 @@ public class TsidExtractingIdFieldMapper extends IdFieldMapper {
         ByteUtils.writeLongLE(hash.h1, bytes, 4);
         ByteUtils.writeLongBE(timestamp, bytes, 12);   // Big Ending shrinks the inverted index by ~37%
 
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(bytes);
     }
 
     public static String createId(

--- a/server/src/main/java/org/elasticsearch/index/mapper/Uid.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Uid.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
 import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Strings;
 
 import java.util.Arrays;
 import java.util.Base64;
@@ -169,7 +170,7 @@ public final class Uid {
         } else if ((idBytes.length == length && offset == 0) == false) { // no need to copy if it's not a slice
             idBytes = Arrays.copyOfRange(idBytes, offset, offset + length);
         }
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(idBytes);
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(idBytes);
     }
 
     /** Decode an indexed id back to its original form.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.security.authc.support;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.CharArrays;
@@ -453,14 +454,14 @@ public enum Hasher {
         public char[] hash(SecureString text) {
             MessageDigest md = MessageDigests.sha256();
             md.update(CharArrays.toUtf8Bytes(text.getChars()));
-            return Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest()).toCharArray();
+            return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(md.digest()).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
             MessageDigest md = MessageDigests.sha256();
             md.update(CharArrays.toUtf8Bytes(text.getChars()));
-            return CharArrays.constantTimeEquals(Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest()).toCharArray(), hash);
+            return CharArrays.constantTimeEquals(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(md.digest()).toCharArray(), hash);
         }
     },
 

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -28,7 +29,6 @@ import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderIndex;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.stream.Collectors;
 
 public class TransportPutSamlServiceProviderAction extends HandledTransportAction<
@@ -154,7 +154,7 @@ public class TransportPutSamlServiceProviderAction extends HandledTransportActio
 
     private static String deriveDocumentId(SamlServiceProviderDocument document) {
         final byte[] sha256 = MessageDigests.sha256().digest(document.entityId.getBytes(StandardCharsets.UTF_8));
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(sha256);
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(sha256);
     }
 
 }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIDGenerator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupIDGenerator.java
@@ -9,10 +9,10 @@ package org.elasticsearch.xpack.rollup.job;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.hash.MurmurHash3;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 /**
  * The ID Generator creates a deterministic document ID to be used for rollup docs.
@@ -101,7 +101,7 @@ public class RollupIDGenerator {
         byte[] hashedBytes = new byte[16];
         System.arraycopy(Numbers.longToBytes(hasher.h1), 0, hashedBytes, 0, 8);
         System.arraycopy(Numbers.longToBytes(hasher.h2), 0, hashedBytes, 8, 8);
-        return jobId + "$" + Base64.getUrlEncoder().withoutPadding().encodeToString(hashedBytes);
+        return jobId + "$" + Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(hashedBytes);
 
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -367,8 +367,8 @@ public class TokenService {
                     assert accessTokenBytes.length == RAW_TOKEN_BYTES_TOTAL_LENGTH;
                     MessageDigest userTokenIdDigest = sha256();
                     userTokenIdDigest.update(accessTokenBytes, RAW_TOKEN_BYTES_LENGTH, RAW_TOKEN_DOC_ID_BYTES_LENGTH);
-                    userTokenId = Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest());
-                    accessTokenToStore = Base64.getUrlEncoder().withoutPadding().encodeToString(sha256().digest(accessTokenBytes));
+                    userTokenId = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(userTokenIdDigest.digest());
+                    accessTokenToStore = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(sha256().digest(accessTokenBytes));
                     if (refreshTokenBytes != null) {
                         assert refreshTokenBytes.length == RAW_TOKEN_BYTES_TOTAL_LENGTH;
                         assert Arrays.equals(
@@ -379,31 +379,31 @@ public class TokenService {
                             RAW_TOKEN_BYTES_LENGTH,
                             RAW_TOKEN_BYTES_TOTAL_LENGTH
                         ) : "the last bytes of paired access and refresh tokens should be the same";
-                        refreshTokenToStore = Base64.getUrlEncoder().withoutPadding().encodeToString(sha256().digest(refreshTokenBytes));
+                        refreshTokenToStore = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(sha256().digest(refreshTokenBytes));
                         refreshTokenToReturn = prependVersionAndEncodeRefreshToken(tokenVersion, refreshTokenBytes);
                     } else {
                         refreshTokenToStore = refreshTokenToReturn = null;
                     }
                 } else if (tokenVersion.onOrAfter(VERSION_HASHED_TOKENS)) {
                     assert accessTokenBytes.length == RAW_TOKEN_BYTES_LENGTH;
-                    userTokenId = hashTokenString(Base64.getUrlEncoder().withoutPadding().encodeToString(accessTokenBytes));
+                    userTokenId = hashTokenString(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(accessTokenBytes));
                     accessTokenToStore = null;
                     if (refreshTokenBytes != null) {
                         assert refreshTokenBytes.length == RAW_TOKEN_BYTES_LENGTH;
-                        refreshTokenToStore = hashTokenString(Base64.getUrlEncoder().withoutPadding().encodeToString(refreshTokenBytes));
+                        refreshTokenToStore = hashTokenString(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(refreshTokenBytes));
                         refreshTokenToReturn = prependVersionAndEncodeRefreshToken(tokenVersion, refreshTokenBytes);
                     } else {
                         refreshTokenToStore = refreshTokenToReturn = null;
                     }
                 } else {
                     assert accessTokenBytes.length == RAW_TOKEN_BYTES_LENGTH;
-                    userTokenId = Base64.getUrlEncoder().withoutPadding().encodeToString(accessTokenBytes);
+                    userTokenId = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(accessTokenBytes);
                     accessTokenToStore = null;
                     if (refreshTokenBytes != null) {
                         assert refreshTokenBytes.length == RAW_TOKEN_BYTES_LENGTH;
-                        refreshTokenToStore = refreshTokenToReturn = Base64.getUrlEncoder()
-                            .withoutPadding()
-                            .encodeToString(refreshTokenBytes);
+                        refreshTokenToStore = refreshTokenToReturn = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(
+                            refreshTokenBytes
+                        );
                     } else {
                         refreshTokenToStore = refreshTokenToReturn = null;
                     }
@@ -647,8 +647,8 @@ public class TokenService {
                 }
                 MessageDigest userTokenIdDigest = sha256();
                 userTokenIdDigest.update(accessTokenBytes, RAW_TOKEN_BYTES_LENGTH, RAW_TOKEN_DOC_ID_BYTES_LENGTH);
-                final String userTokenId = Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest());
-                final String storedAccessToken = Base64.getUrlEncoder().withoutPadding().encodeToString(sha256().digest(accessTokenBytes));
+                final String userTokenId = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(userTokenIdDigest.digest());
+                final String storedAccessToken = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(sha256().digest(accessTokenBytes));
                 getAndValidateUserToken(userTokenId, version, storedAccessToken, validateUserToken, listener);
             } else if (version.onOrAfter(VERSION_ACCESS_TOKENS_AS_UUIDS)) {
                 // The token was created in a > VERSION_ACCESS_TOKENS_UUIDS cluster
@@ -1118,10 +1118,10 @@ public class TokenService {
                     } else {
                         MessageDigest userTokenIdDigest = sha256();
                         userTokenIdDigest.update(refreshTokenBytes, RAW_TOKEN_BYTES_LENGTH, RAW_TOKEN_DOC_ID_BYTES_LENGTH);
-                        final String userTokenId = Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest());
-                        final String storedRefreshToken = Base64.getUrlEncoder()
-                            .withoutPadding()
-                            .encodeToString(sha256().digest(refreshTokenBytes));
+                        final String userTokenId = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(userTokenIdDigest.digest());
+                        final String storedRefreshToken = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(
+                            sha256().digest(refreshTokenBytes)
+                        );
                         getTokenDocById(userTokenId, version, null, storedRefreshToken, listener);
                     }
                 } else if (version.onOrAfter(VERSION_HASHED_TOKENS)) {
@@ -1447,7 +1447,7 @@ public class TokenService {
                         RAW_TOKEN_BYTES_LENGTH,
                         RAW_TOKEN_DOC_ID_BYTES_LENGTH
                     );
-                    tokenDocId = getTokenDocumentId(Base64.getUrlEncoder().withoutPadding().encodeToString(userTokenIdDigest.digest()));
+                    tokenDocId = getTokenDocumentId(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(userTokenIdDigest.digest()));
                 } else {
                     tokenDocId = getTokenDocumentId(hashTokenString(decryptedTokens[0]));
                 }
@@ -1531,8 +1531,8 @@ public class TokenService {
         byte[] salt
     ) throws GeneralSecurityException {
         Cipher cipher = getEncryptionCipher(iv, refreshToken, salt);
-        final String supersedingAccessToken = Base64.getUrlEncoder().withoutPadding().encodeToString(supersedingAccessTokenBytes);
-        final String supersedingRefreshToken = Base64.getUrlEncoder().withoutPadding().encodeToString(supersedingRefreshTokenBytes);
+        final String supersedingAccessToken = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(supersedingAccessTokenBytes);
+        final String supersedingRefreshToken = Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(supersedingRefreshTokenBytes);
         final String supersedingTokens = supersedingAccessToken + "|" + supersedingRefreshToken;
         return Base64.getEncoder().encodeToString(cipher.doFinal(supersedingTokens.getBytes(StandardCharsets.UTF_8)));
     }
@@ -2026,7 +2026,7 @@ public class TokenService {
             try (BytesStreamOutput out = new BytesStreamOutput(MINIMUM_BASE64_BYTES)) {
                 out.setTransportVersion(version);
                 TransportVersion.writeVersion(version, out);
-                out.writeString(Base64.getUrlEncoder().withoutPadding().encodeToString(accessTokenBytes));
+                out.writeString(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(accessTokenBytes));
                 return Base64.getEncoder().encodeToString(out.bytes().toBytesRef().bytes);
             }
         } else {
@@ -2051,7 +2051,7 @@ public class TokenService {
                     StreamOutput encryptedStreamOutput = new OutputStreamStreamOutput(encryptedOutput)
                 ) {
                     encryptedStreamOutput.setTransportVersion(version);
-                    encryptedStreamOutput.writeString(Base64.getUrlEncoder().withoutPadding().encodeToString(accessTokenBytes));
+                    encryptedStreamOutput.writeString(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(accessTokenBytes));
                     // StreamOutput needs to be closed explicitly because it wraps CipherOutputStream
                     encryptedStreamOutput.close();
                     return new String(os.toByteArray(), StandardCharsets.UTF_8);
@@ -2072,7 +2072,7 @@ public class TokenService {
             try (BytesStreamOutput out = new BytesStreamOutput(VERSION_BYTES + TOKEN_LENGTH)) {
                 out.setTransportVersion(version);
                 TransportVersion.writeVersion(version, out);
-                out.writeString(Base64.getUrlEncoder().withoutPadding().encodeToString(refreshTokenBytes));
+                out.writeString(Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(refreshTokenBytes));
                 return Base64.getEncoder().encodeToString(out.bytes().toBytesRef().bytes);
             }
         }
@@ -2383,7 +2383,7 @@ public class TokenService {
         char[] ref = new char[0];
         try {
             secureRandom.nextBytes(keyBytes);
-            encode = Base64.getUrlEncoder().withoutPadding().encode(keyBytes);
+            encode = Strings.BASE_64_NO_PADDING_URL_ENCODER.encode(keyBytes);
             ref = new char[encode.length];
             int len = UnicodeUtil.UTF8toUTF16(encode, 0, encode.length, ref);
             return new SecureString(Arrays.copyOfRange(ref, 0, len));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.profile;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.xcontent.ObjectParserHelper;
@@ -26,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -118,7 +118,7 @@ public record ProfileDocument(
     static String computeBaseUidForSubject(Subject subject) {
         final MessageDigest digest = MessageDigests.sha256();
         digest.update(subject.getUser().principal().getBytes(StandardCharsets.UTF_8));
-        return "u_" + Base64.getUrlEncoder().withoutPadding().encodeToString(digest.digest());
+        return "u_" + Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(digest.digest());
     }
 
     public static ProfileDocument fromXContent(XContentParser parser) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/IDGenerator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/IDGenerator.java
@@ -9,10 +9,10 @@ package org.elasticsearch.xpack.transform.transforms;
 
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.hash.MurmurHash3;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.TreeMap;
 
 /**
@@ -72,7 +72,7 @@ public final class IDGenerator {
         MurmurHash3.Hash128 hasher = MurmurHash3.hash128(buffer.bytes(), 0, buffer.length(), SEED, new MurmurHash3.Hash128());
         hashedBytes.append(Numbers.longToBytes(hasher.h1), 0, 8);
         hashedBytes.append(Numbers.longToBytes(hasher.h2), 0, 8);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashedBytes.bytes());
+        return Strings.BASE_64_NO_PADDING_URL_ENCODER.encodeToString(hashedBytes.bytes());
     }
 
     /**


### PR DESCRIPTION
Mostly not a big deal, but we use this in a couple spots where it shows up in profiling, no need to have this kind of allocation in e.g. `RandomBasedUUIDGenerator` where it's somewhat hot. Suggestions for a better place than `Strings` for this are very welcome.