### PR TITLE
update-branch should sync lucene_snapshot with 8.x

### DIFF
--- a/.buildkite/scripts/lucene-snapshot/update-branch.sh
+++ b/.buildkite/scripts/lucene-snapshot/update-branch.sh
@@ -7,12 +7,21 @@ if [[ "$BUILDKITE_BRANCH" != "lucene_snapshot"* ]]; then
   exit 1
 fi
 
-echo --- Updating "$BUILDKITE_BRANCH" branch with main
+if [[ "$BUILDKITE_BRANCH" == "lucene_snapshot_10" ]]; then
+  UPSTREAM="main"
+elif [[ "$BUILDKITE_BRANCH" == "lucene_snapshot" ]]; then
+  UPSTREAM="8.x"
+else
+  echo "Error: unknown branch: $BUILDKITE_BRANCH"
+  exit 1
+fi
+
+echo --- Updating "$BUILDKITE_BRANCH" branch with "$UPSTREAM"
 
 git config --global user.name elasticsearchmachine
 git config --global user.email 'infra-root+elasticsearchmachine@elastic.co'
 
 git checkout "$BUILDKITE_BRANCH"
-git fetch origin main
-git merge --no-edit origin/main
+git fetch origin "$UPSTREAM"
+git merge --no-edit "origin/$UPSTREAM"
 git push origin "$BUILDKITE_BRANCH"


### PR DESCRIPTION
This commit fixes the update-branch script so that the `lucene_snapshot` branch is sync'ed with the  Elasticsearch `8.x` branch. 

This change is necessary since:
 * Elasticsearch 8.x will contain Lucene 9.x - this is the `lucene_snapshot` branch. While,
 * Elasticsearch 9.x will contain Lucene 10.x - this is the `lucene_snapshot_10` branch