### PR TITLE
Remove legacy `TransportNodesAction` wire proto utils

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -116,14 +115,12 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<
 
         NodeRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(TransportVersions.MORE_LIGHTER_NODES_REQUESTS, in);
             requestOptions = HotThreads.RequestOptions.readFrom(in);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(TransportVersions.MORE_LIGHTER_NODES_REQUESTS, out);
             requestOptions.writeTo(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import static org.elasticsearch.TransportVersions.V_8_11_X;
-
 public class TransportNodesInfoAction extends TransportNodesAction<
     NodesInfoRequest,
     NodesInfoResponse,
@@ -102,7 +100,6 @@ public class TransportNodesInfoAction extends TransportNodesAction<
 
         public NodeInfoRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(V_8_11_X, in);
             this.nodesInfoMetrics = new NodesInfoMetrics(in);
         }
 
@@ -113,7 +110,6 @@ public class TransportNodesInfoAction extends TransportNodesAction<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(V_8_11_X, out);
             nodesInfoMetrics.writeTo(out);
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -163,7 +163,6 @@ public class TransportNodesStatsAction extends TransportNodesAction<
 
         public NodeStatsRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(TransportVersions.V_8_13_0, in);
             this.nodesStatsRequestParameters = new NodesStatsRequestParameters(in);
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)
                 && in.getTransportVersion().before(TransportVersions.DROP_UNUSED_NODES_IDS)) {
@@ -192,7 +191,6 @@ public class TransportNodesStatsAction extends TransportNodesAction<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(TransportVersions.V_8_13_0, out);
             nodesStatsRequestParameters.writeTo(out);
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)
                 && out.getTransportVersion().before(TransportVersions.DROP_UNUSED_NODES_IDS)) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.admin.cluster.node.usage;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -92,7 +91,6 @@ public class TransportNodesUsageAction extends TransportNodesAction<
 
         public NodeUsageRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(TransportVersions.MORE_LIGHTER_NODES_REQUESTS, in);
             restActions = in.readBoolean();
             aggregations = in.readBoolean();
         }
@@ -105,7 +103,6 @@ public class TransportNodesUsageAction extends TransportNodesAction<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(TransportVersions.MORE_LIGHTER_NODES_REQUESTS, out);
             out.writeBoolean(restActions);
             out.writeBoolean(aggregations);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.action.admin.cluster.stats;
 
 import org.apache.lucene.store.AlreadyClosedException;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
@@ -273,7 +272,6 @@ public class TransportClusterStatsAction extends TransportNodesAction<
 
         public ClusterStatsNodeRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(TransportVersions.DROP_UNUSED_NODES_REQUESTS, in);
         }
 
         @Override
@@ -284,7 +282,6 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(TransportVersions.DROP_UNUSED_NODES_REQUESTS, out);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -11,7 +11,6 @@ package org.elasticsearch.action.support.nodes;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.FailedNodeException;
@@ -23,18 +22,14 @@ import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
@@ -253,43 +248,4 @@ public abstract class TransportNodesAction<
             );
         }
     }
-
-    /**
-     * Some {@link TransportNodesAction} implementations send the whole top-level request out to each individual node. However, the
-     * top-level request contains a lot of unnecessary junk, particularly the heavyweight {@link DiscoveryNode} instances, so we are
-     * migrating away from this practice. This method allows to skip over the unnecessary data received from an older node.
-     *
-     * @see <a href="https://github.com/elastic/elasticsearch/issues/100878">#100878</a>
-     * @param fixVersion    The {@link TransportVersion} in which the request representation was fixed, so no skipping is needed.
-     * @param in            The {@link StreamInput} in which to skip the unneeded data.
-     */
-    @UpdateForV9 // no longer necessary in v9
-    public static void skipLegacyNodesRequestHeader(TransportVersion fixVersion, StreamInput in) throws IOException {
-        if (in.getTransportVersion().before(fixVersion)) {
-            TaskId.readFromStream(in);
-            in.readStringArray();
-            in.readOptionalArray(DiscoveryNode::new, DiscoveryNode[]::new);
-            in.readOptionalTimeValue();
-        }
-    }
-
-    /**
-     * Some {@link TransportNodesAction} implementations send the whole top-level request out to each individual node. However, the
-     * top-level request contains a lot of unnecessary junk, particularly the heavyweight {@link DiscoveryNode} instances, so we are
-     * migrating away from this practice. This method allows to send a well-formed, but empty, header to older nodes that require it.
-     *
-     * @see <a href="https://github.com/elastic/elasticsearch/issues/100878">#100878</a>
-     * @param fixVersion    The {@link TransportVersion} in which the request representation was fixed, so no skipping is needed.
-     * @param out           The {@link StreamOutput} to which to send the dummy data.
-     */
-    @UpdateForV9 // no longer necessary in v9
-    public static void sendLegacyNodesRequestHeader(TransportVersion fixVersion, StreamOutput out) throws IOException {
-        if (out.getTransportVersion().before(fixVersion)) {
-            TaskId.EMPTY_TASK_ID.writeTo(out);
-            out.writeStringArray(Strings.EMPTY_ARRAY);
-            out.writeOptionalArray(null);
-            out.writeOptionalTimeValue(null);
-        }
-    }
-
 }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodesDeprecationCheckAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.deprecation;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -20,9 +19,6 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-
-import static org.elasticsearch.action.support.nodes.TransportNodesAction.sendLegacyNodesRequestHeader;
-import static org.elasticsearch.action.support.nodes.TransportNodesAction.skipLegacyNodesRequestHeader;
 
 /**
  * Runs deprecation checks on each node. Deprecation checks are performed locally so that filtered settings
@@ -43,13 +39,11 @@ public class NodesDeprecationCheckAction extends ActionType<NodesDeprecationChec
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(TransportVersions.DROP_UNUSED_NODES_REQUESTS, in);
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(TransportVersions.DROP_UNUSED_NODES_REQUESTS, out);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportTrainedModelCacheInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportTrainedModelCacheInfoAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ml.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
@@ -94,7 +93,6 @@ public class TransportTrainedModelCacheInfoAction extends TransportNodesAction<
 
         public NodeModelCacheInfoRequest(StreamInput in) throws IOException {
             super(in);
-            skipLegacyNodesRequestHeader(TransportVersions.DROP_UNUSED_NODES_REQUESTS, in);
         }
 
         @Override
@@ -105,7 +103,6 @@ public class TransportTrainedModelCacheInfoAction extends TransportNodesAction<
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            sendLegacyNodesRequestHeader(TransportVersions.DROP_UNUSED_NODES_REQUESTS, out);
         }
     }
 }


### PR DESCRIPTION
The utilities for skipping/fabricating a legacy `BaseNodesRequest` wire
protocol header are unused in v9. This commit removes them.