### PR TITLE
Reset blockDocCount in best speed case back to 128.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/zstd/Zstd814StoredFieldsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/zstd/Zstd814StoredFieldsFormat.java
@@ -48,7 +48,7 @@ public final class Zstd814StoredFieldsFormat extends Lucene90CompressingStoredFi
     public static final String MODE_KEY = Zstd814StoredFieldsFormat.class.getSimpleName() + ".mode";
 
     public enum Mode {
-        BEST_SPEED(0, BEST_SPEED_BLOCK_SIZE, 96),
+        BEST_SPEED(0, BEST_SPEED_BLOCK_SIZE, 128),
         BEST_COMPRESSION(3, BEST_COMPRESSION_BLOCK_SIZE, 2048);
 
         final int level, blockSizeInBytes, blockDocCount;

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -59,7 +59,7 @@ public class CodecTests extends ESTestCase {
         assumeTrue("Only when zstd_stored_fields feature flag is enabled", CodecService.ZSTD_STORED_FIELDS_FEATURE_FLAG.isEnabled());
         Codec codec = createCodecService().codec("default");
         assertEquals(
-            "Zstd814StoredFieldsFormat(compressionMode=ZSTD(level=0), chunkSize=14336, maxDocsPerChunk=96, blockShift=10)",
+            "Zstd814StoredFieldsFormat(compressionMode=ZSTD(level=0), chunkSize=14336, maxDocsPerChunk=128, blockShift=10)",
             codec.storedFieldsFormat().toString()
         );
     }


### PR DESCRIPTION
Reset blockDocCount in best speed case back to 128. A docBlockDocCount didn't result in better get by id performance:
https://elasticsearch-benchmarks.elastic.co/#tracks/tsdb/nightly/default/30d (all graphs under `nightly-tsdb-indexing-throughput-revisions`)

This reverts commit 1d7e7bd2b6d5ce37e01fbdc6fff7933ce5a7a8d0.