### PR TITLE
[ML] fix test compilation related to `SenderService` API

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
@@ -213,6 +213,7 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
             PlainActionFuture<List<ChunkedInferenceServiceResults>> listener = new PlainActionFuture<>();
             service.chunkedInfer(
                 model,
+                null,
                 input,
                 new HashMap<>(),
                 InputType.INGEST,


### PR DESCRIPTION
Fixed test compilation error introduced in: https://github.com/elastic/elasticsearch/pull/112718/files