### PR TITLE
Fix `ignore_above` for flattened fields

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
@@ -1,0 +1,109 @@
+---
+flattened ignore_above single-value field:
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+                ignore_above: 5
+              flat:
+                type: flattened
+                ignore_above: 5
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        refresh: true
+        body:
+          keyword: "foo"
+          flat: { "value": "foo" }
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        refresh: true
+        body:
+          keyword: "foo bar"
+          flat: { "value": "foo bar" }
+
+  - do:
+      search:
+        index: test
+        body:
+          fields:
+            - keyword
+            - flat
+          query:
+            match_all: {}
+
+  - match: { hits.total.value: 2 }
+
+  - match: { hits.hits.0._source.keyword: "foo" }
+  - match: { hits.hits.0._source.flat.value: "foo" }
+  - match: { hits.hits.1._source.keyword: "foo bar" }
+  - match: { hits.hits.1._source.flat.value: "foo bar" }
+
+  - match: { hits.hits.0.fields.keyword.0: "foo" }
+  - match: { hits.hits.0.fields.flat.0.value: "foo" }
+  - match: { hits.hits.1.fields.keyword.0: null }
+  - match: { hits.hits.1.fields.flat.0.value: null }
+
+---
+flattened ignore_above multi-value field:
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+                ignore_above: 5
+              flat:
+                type: flattened
+                ignore_above: 5
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        refresh: true
+        body:
+          keyword: ["foo","bar"]
+          flat: { "value": ["foo", "bar"] }
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        refresh: true
+        body:
+          keyword: ["foobar", "foo", "bar"]
+          flat: { "value": ["foobar", "foo", "bar"] }
+
+  - do:
+      search:
+        index: test
+        body:
+          fields:
+            - keyword
+            - flat
+          query:
+            match_all: { }
+
+  - match: { hits.total.value: 2 }
+
+  - match: { hits.hits.0._source.keyword: ["foo", "bar"] }
+  - match: { hits.hits.0._source.flat.value: ["foo", "bar"] }
+  - match: { hits.hits.1._source.keyword: ["foobar", "foo", "bar"] }
+  - match: { hits.hits.1._source.flat.value: ["foobar", "foo", "bar"] }
+
+  - match: { hits.hits.0.fields.keyword: [ "foo", "bar" ] }
+  - match: { hits.hits.0.fields.flat.0.value: [ "foo", "bar" ] }
+  - match: { hits.hits.1.fields.keyword: [ "foo", "bar" ] }
+  - match: { hits.hits.1.fields.flat.0.value: [ "foo", "bar" ] }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
@@ -51,7 +51,7 @@ flattened ignore_above single-value field:
   - match: { hits.hits.1._source.flat.key: "foo bar key" }
 
   - match: { hits.hits.0.fields.keyword.0: "foo" }
-  - match: { hits.hits.0.fields.flat.0.value: ["foo"] }
+  - match: { hits.hits.0.fields.flat.0.value: "foo" }
   - match: { hits.hits.1.fields.keyword.0: null }
   - match: { hits.hits.1.fields.flat.0.value: null }
 
@@ -86,7 +86,7 @@ flattened ignore_above multi-value field:
         refresh: true
         body:
           keyword: ["foobar", "foo", "bar"]
-          flat: { "value": ["foobar", "foo", "bar"], "key": ["foo key", "bar key"]}
+          flat: { "value": ["foobar", "foo"], "key": ["foo key", "bar key"]}
 
   - do:
       search:
@@ -104,12 +104,12 @@ flattened ignore_above multi-value field:
   - match: { hits.hits.0._source.flat.value: ["foo", "bar"] }
   - match: { hits.hits.0._source.flat.key: "foo bar array key" }
   - match: { hits.hits.1._source.keyword: ["foobar", "foo", "bar"] }
-  - match: { hits.hits.1._source.flat.value: ["foobar", "foo", "bar"] }
+  - match: { hits.hits.1._source.flat.value: ["foobar", "foo"] }
   - match: { hits.hits.1._source.flat.key: ["foo key", "bar key"] }
 
   - match: { hits.hits.0.fields.keyword: [ "foo", "bar" ] }
-  - match: { hits.hits.0.fields.flat.0.value: [ "foo", "bar" ] }
+  - match: { hits.hits.0.fields.flat.0.value: ["foo", "bar"] }
   - match: { hits.hits.0.fields.flat.0.key: null }
   - match: { hits.hits.1.fields.keyword: [ "foo", "bar" ] }
-  - match: { hits.hits.1.fields.flat.0.value: [ "foo", "bar" ] }
+  - match: { hits.hits.1.fields.flat.0.value: "foo" }
   - match: { hits.hits.1.fields.flat.0.key: null }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
@@ -20,7 +20,7 @@ flattened ignore_above single-value field:
         refresh: true
         body:
           keyword: "foo"
-          flat: { "value": "foo" }
+          flat: { "value": "foo", "key": "foo key" }
 
   - do:
       index:
@@ -29,7 +29,7 @@ flattened ignore_above single-value field:
         refresh: true
         body:
           keyword: "foo bar"
-          flat: { "value": "foo bar" }
+          flat: { "value": "foo bar",  "key": "foo bar key"}
 
   - do:
       search:
@@ -45,11 +45,13 @@ flattened ignore_above single-value field:
 
   - match: { hits.hits.0._source.keyword: "foo" }
   - match: { hits.hits.0._source.flat.value: "foo" }
+  - match: { hits.hits.0._source.flat.key: "foo key" }
   - match: { hits.hits.1._source.keyword: "foo bar" }
   - match: { hits.hits.1._source.flat.value: "foo bar" }
+  - match: { hits.hits.1._source.flat.key: "foo bar key" }
 
   - match: { hits.hits.0.fields.keyword.0: "foo" }
-  - match: { hits.hits.0.fields.flat.0.value: "foo" }
+  - match: { hits.hits.0.fields.flat.0.value: ["foo"] }
   - match: { hits.hits.1.fields.keyword.0: null }
   - match: { hits.hits.1.fields.flat.0.value: null }
 
@@ -75,7 +77,7 @@ flattened ignore_above multi-value field:
         refresh: true
         body:
           keyword: ["foo","bar"]
-          flat: { "value": ["foo", "bar"] }
+          flat: { "value": ["foo", "bar"], "key": "foo bar array key" }
 
   - do:
       index:
@@ -84,7 +86,7 @@ flattened ignore_above multi-value field:
         refresh: true
         body:
           keyword: ["foobar", "foo", "bar"]
-          flat: { "value": ["foobar", "foo", "bar"] }
+          flat: { "value": ["foobar", "foo", "bar"], "key": ["foo key", "bar key"]}
 
   - do:
       search:
@@ -100,10 +102,14 @@ flattened ignore_above multi-value field:
 
   - match: { hits.hits.0._source.keyword: ["foo", "bar"] }
   - match: { hits.hits.0._source.flat.value: ["foo", "bar"] }
+  - match: { hits.hits.0._source.flat.key: "foo bar array key" }
   - match: { hits.hits.1._source.keyword: ["foobar", "foo", "bar"] }
   - match: { hits.hits.1._source.flat.value: ["foobar", "foo", "bar"] }
+  - match: { hits.hits.1._source.flat.key: ["foo key", "bar key"] }
 
   - match: { hits.hits.0.fields.keyword: [ "foo", "bar" ] }
   - match: { hits.hits.0.fields.flat.0.value: [ "foo", "bar" ] }
+  - match: { hits.hits.0.fields.flat.0.key: null }
   - match: { hits.hits.1.fields.keyword: [ "foo", "bar" ] }
   - match: { hits.hits.1.fields.flat.0.value: [ "foo", "bar" ] }
+  - match: { hits.hits.1.fields.flat.0.key: null }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
@@ -1,5 +1,8 @@
 ---
 flattened ignore_above single-value field:
+  - requires:
+      cluster_features: [ "flattened.ignore_above_support" ]
+      reason: introduce ignore_above support in flattened fields
   - do:
       indices.create:
         index: test
@@ -57,6 +60,9 @@ flattened ignore_above single-value field:
 
 ---
 flattened ignore_above multi-value field:
+  - requires:
+      cluster_features: [ "flattened.ignore_above_support" ]
+      reason: introduce ignore_above support in flattened fields
   - do:
       indices.create:
         index: test

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
 import java.util.Set;
@@ -38,7 +39,8 @@ public class MapperFeatures implements FeatureSpecification {
             SourceFieldMapper.SYNTHETIC_SOURCE_STORED_FIELDS_ADVANCE_FIX,
             Mapper.SYNTHETIC_SOURCE_KEEP_FEATURE,
             SourceFieldMapper.SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT,
-            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX
+            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX,
+            FlattenedFieldMapper.IGNORE_ABOVE_SUPPORT
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -768,8 +768,9 @@ public final class FlattenedFieldMapper extends FieldMapper {
                         if (valueAsString.length() <= ignoreAbove) {
                             return valueAsString;
                         }
+                        return null;
                     }
-                    return null;
+                    return entryValue;
                 }
             };
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -752,8 +752,12 @@ public final class FlattenedFieldMapper extends FieldMapper {
                     if (entryValue instanceof List<?> valueAsList) {
                         final List<Object> validValues = new ArrayList<>();
                         for (Object value : valueAsList) {
-                            if (value instanceof String valueAsString && valueAsString.length() <= ignoreAbove) {
-                                validValues.add(valueAsString);
+                            if (value instanceof String valueAsString) {
+                                if (valueAsString.length() <= ignoreAbove) {
+                                    validValues.add(valueAsString);
+                                }
+                            } else {
+                                validValues.add(value);
                             }
                         }
                         if (validValues.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -262,7 +262,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             this.isDimension = isDimension;
         }
 
-        private KeyedFlattenedFieldType(String rootName, String key, RootFlattenedFieldType ref, int ignoreAbove) {
+        private KeyedFlattenedFieldType(String rootName, String key, RootFlattenedFieldType ref) {
             this(
                 rootName,
                 ref.isIndexed(),
@@ -771,7 +771,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
 
         @Override
         public MappedFieldType getChildFieldType(String childPath) {
-            return new KeyedFlattenedFieldType(name(), childPath, this, ignoreAbove);
+            return new KeyedFlattenedFieldType(name(), childPath, this);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -107,6 +108,8 @@ import java.util.function.Function;
  *  character (see {@link FlattenedFieldParser#SEPARATOR}).
  */
 public final class FlattenedFieldMapper extends FieldMapper {
+
+    public static final NodeFeature IGNORE_ABOVE_SUPPORT = new NodeFeature("flattened.ignore_above_support");
 
     public static final String CONTENT_TYPE = "flattened";
     public static final String KEYED_FIELD_SUFFIX = "._keyed";

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -731,7 +731,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
                         final Map<String, Object> result = filterIgnoredValues((Map<String, Object>) valueAsMap);
                         return result.isEmpty() ? null : result;
                     }
-                    if (value instanceof String valueAsString && valueAsString.length() < ignoreAbove) {
+                    if (value instanceof String valueAsString && valueAsString.length() <= ignoreAbove) {
                         return valueAsString;
                     }
                     return null;
@@ -749,7 +749,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
                     if (entryValue instanceof List<?> valueAsList) {
                         final List<Object> validValues = new ArrayList<>();
                         for (Object value : valueAsList) {
-                            if (value instanceof String valueAsString && valueAsString.length() < ignoreAbove) {
+                            if (value instanceof String valueAsString && valueAsString.length() <= ignoreAbove) {
                                 validValues.add(valueAsString);
                             }
                         }
@@ -762,7 +762,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
                         }
                         return validValues;
                     } else if (entryValue instanceof String valueAsString) {
-                        if (valueAsString.length() < ignoreAbove) {
+                        if (valueAsString.length() <= ignoreAbove) {
                             return valueAsString;
                         }
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -740,7 +740,10 @@ public final class FlattenedFieldMapper extends FieldMapper {
                 private Map<String, Object> filterIgnoredValues(final Map<String, Object> values) {
                     final Map<String, Object> result = new HashMap<>();
                     for (final Map.Entry<String, Object> entry : values.entrySet()) {
-                        result.put(entry.getKey(), filterIgnoredValues(entry.getValue()));
+                        Object value = filterIgnoredValues(entry.getValue());
+                        if (value != null) {
+                            result.put(entry.getKey(), value);
+                        }
                     }
                     return result;
                 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
@@ -211,4 +211,10 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
             fetchSourceValue(createDefaultFieldType(3), sourceValue)
         );
     }
+
+    public void testFetchSourceValueFilterStringsOnly() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of("the quick brown", 1_234_567, "jumps over", 2_456));
+
+        assertEquals(List.of(Map.of("key1", List.of(1_234_567, 2_456))), fetchSourceValue(createDefaultFieldType(8), sourceValue));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.RootFlattenedFieldType;
@@ -192,6 +193,41 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
 
         assertEquals(
             List.of(Map.of("key2", List.of("one", "two"), "key3", "hi")),
+            fetchSourceValue(createDefaultFieldType(3), sourceValue)
+        );
+    }
+
+    public void testFetchSourceValueWithMixedFieldTypes() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of("one", 1, "two", 2));
+
+        assertEquals(List.of(Map.of("key1", List.of("one", 1, "two", 2))), fetchSourceValue(createDefaultFieldType(3), sourceValue));
+    }
+
+    public void testFetchSourceValueWithNonString() throws IOException {
+        Map<String, Object> sourceValue = Map.of(
+            "key1",
+            List.of(100, 200),
+            "key2",
+            List.of(new int[] { 1, 2, 3 }, new double[] { 1.5, 1.6 }),
+            "key3",
+            50L,
+            "key4",
+            new Tuple<>(10, 100)
+        );
+
+        assertEquals(
+            List.of(
+                Map.of(
+                    "key1",
+                    List.of(100, 200),
+                    "key2",
+                    List.of(new int[] { 1, 2, 3 }, new double[] { 1.5, 1.6 }),
+                    "key3",
+                    50L,
+                    "key4",
+                    new Tuple<>(10, 100)
+                )
+            ),
             fetchSourceValue(createDefaultFieldType(3), sourceValue)
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
@@ -171,4 +171,28 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
         assertEquals(List.of(), fetchSourceValue(createDefaultFieldType(10), sourceValue));
         assertEquals(List.of(sourceValue), fetchSourceValue(createDefaultFieldType(20), sourceValue));
     }
+
+    public void testFetchSourceValueWithList() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of("one", "two", "three"));
+
+        assertEquals(List.of(Map.of("key1", List.of("one", "two"))), fetchSourceValue(createDefaultFieldType(3), sourceValue));
+    }
+
+    public void testFetchSourceValueWithMultipleFields() throws IOException {
+        Map<String, Object> sourceValue = Map.of(
+            "key1",
+            "test",
+            "key2",
+            List.of("one", "two", "three"),
+            "key3",
+            "hi",
+            "key4",
+            List.of("the quick brown fox", "jumps over the lazy dog")
+        );
+
+        assertEquals(
+            List.of(Map.of("key2", List.of("one", "two"), "key3", "hi")),
+            fetchSourceValue(createDefaultFieldType(3), sourceValue)
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
@@ -204,30 +204,10 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchSourceValueWithNonString() throws IOException {
-        Map<String, Object> sourceValue = Map.of(
-            "key1",
-            List.of(100, 200),
-            "key2",
-            List.of(new int[] { 1, 2, 3 }, new double[] { 1.5, 1.6 }),
-            "key3",
-            50L,
-            "key4",
-            new Tuple<>(10, 100)
-        );
+        Map<String, Object> sourceValue = Map.of("key1", List.of(100, 200), "key2", 50L, "key3", new Tuple<>(10, 100));
 
         assertEquals(
-            List.of(
-                Map.of(
-                    "key1",
-                    List.of(100, 200),
-                    "key2",
-                    List.of(new int[] { 1, 2, 3 }, new double[] { 1.5, 1.6 }),
-                    "key3",
-                    50L,
-                    "key4",
-                    new Tuple<>(10, 100)
-                )
-            ),
+            List.of(Map.of("key1", List.of(100, 200), "key2", 50L, "key3", new Tuple<>(10, 100))),
             fetchSourceValue(createDefaultFieldType(3), sourceValue)
         );
     }


### PR DESCRIPTION
Flattened fields do no actually use `ignore_above`. When retrieving source, `ignore_above` behaves
as expected. Anyway, it is ignored when fetching field values through the fields API. In that case
values are returned no matter the `ignore_above` setting. Here we implement the filtering logic
in the `ValueFecther` implementation of `RootFlattenedFieldType`.