### PR TITLE
Add system thread attribute to SearchTransportService metrics

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportAPMMetrics.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportAPMMetrics.java
@@ -15,6 +15,7 @@ import org.elasticsearch.telemetry.metric.MeterRegistry;
 public class SearchTransportAPMMetrics {
     public static final String SEARCH_ACTION_LATENCY_BASE_METRIC = "es.search.nodes.transport_actions.latency.histogram";
     public static final String ACTION_ATTRIBUTE_NAME = "action";
+    public static final String SYSTEM_THREAD_ATTRIBUTE_NAME = "system_thread";
 
     public static final String QUERY_CAN_MATCH_NODE_METRIC = "shards_can_match";
     public static final String DFS_ACTION_METRIC = "dfs_query_then_fetch/shard_dfs_phase";

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -80,6 +80,7 @@ import static org.elasticsearch.action.search.SearchTransportAPMMetrics.QUERY_FE
 import static org.elasticsearch.action.search.SearchTransportAPMMetrics.QUERY_ID_ACTION_METRIC;
 import static org.elasticsearch.action.search.SearchTransportAPMMetrics.QUERY_SCROLL_ACTION_METRIC;
 import static org.elasticsearch.action.search.SearchTransportAPMMetrics.RANK_SHARD_FEATURE_ACTION_METRIC;
+import static org.elasticsearch.action.search.SearchTransportAPMMetrics.SYSTEM_THREAD_ATTRIBUTE_NAME;
 
 /**
  * An encapsulation of {@link org.elasticsearch.search.SearchService} operations exposed through
@@ -666,7 +667,12 @@ public class SearchTransportService {
     ) {
         var threadPool = transportService.getThreadPool();
         var latencies = searchTransportMetrics.getActionLatencies();
-        Map<String, Object> attributes = Map.of(ACTION_ATTRIBUTE_NAME, actionQualifier);
+        Map<String, Object> attributes = Map.of(
+            ACTION_ATTRIBUTE_NAME,
+            actionQualifier,
+            SYSTEM_THREAD_ATTRIBUTE_NAME,
+            ThreadPool.isSystemThreadPool()
+        );
         return (request, channel, task) -> {
             var startTime = threadPool.relativeTimeInMillis();
             try {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -667,14 +667,14 @@ public class SearchTransportService {
     ) {
         var threadPool = transportService.getThreadPool();
         var latencies = searchTransportMetrics.getActionLatencies();
-        Map<String, Object> attributes = Map.of(
-            ACTION_ATTRIBUTE_NAME,
-            actionQualifier,
-            SYSTEM_THREAD_ATTRIBUTE_NAME,
-            ThreadPool.isSystemThreadPool()
-        );
         return (request, channel, task) -> {
             var startTime = threadPool.relativeTimeInMillis();
+            Map<String, Object> attributes = Map.of(
+                ACTION_ATTRIBUTE_NAME,
+                actionQualifier,
+                SYSTEM_THREAD_ATTRIBUTE_NAME,
+                ThreadPool.isSystemThreadPool()
+            );
             try {
                 transportRequestHandler.messageReceived(request, channel, task);
             } finally {

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -118,6 +119,13 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
     public static final String THREAD_POOL_METRIC_NAME_ACTIVE = ".threads.active.current";
     public static final String THREAD_POOL_METRIC_NAME_LARGEST = ".threads.largest.current";
     public static final String THREAD_POOL_METRIC_NAME_REJECTED = ".threads.rejected.total";
+
+    private static final Set<String> SYSTEM_THREAD_POOLS = Set.of(
+        Names.SYSTEM_READ,
+        Names.SYSTEM_WRITE,
+        Names.SYSTEM_CRITICAL_READ,
+        Names.SYSTEM_CRITICAL_WRITE
+    );
 
     public enum ThreadPoolType {
         @Deprecated(forRemoval = true)
@@ -1107,5 +1115,11 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
                 : testingMethod.getClassName() + "#" + testingMethod.getMethodName() + " is called recursively";
         }
         return true;
+    }
+
+    public static boolean isSystemThreadPool() {
+        final var threadName = Thread.currentThread().getName();
+        final var executorName = EsExecutors.executorName(threadName);
+        return executorName != null && SYSTEM_THREAD_POOLS.contains(executorName);
     }
 }


### PR DESCRIPTION
Adds a `system_thread` attribute to metrics collected in the `SearchTransportService`.

This will allow to remove system indices from search metrics, to avoid polluting metrics with internal ES operations.