### PR TITLE
[8.x] Tune down generation of null values in LogsDB data generation (#112890)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultWrappersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultWrappersHandler.java
@@ -27,7 +27,8 @@ public class DefaultWrappersHandler implements DataSourceHandler {
     }
 
     private static Function<Supplier<Object>, Supplier<Object>> injectNulls() {
-        return (values) -> () -> ESTestCase.randomBoolean() ? null : values.get();
+        // Inject some nulls but majority of data should be non-null (as it likely is in reality).
+        return (values) -> () -> ESTestCase.randomDouble() <= 0.05 ? null : values.get();
     }
 
     private static Function<Supplier<Object>, Supplier<Object>> wrapInArray() {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Tune down generation of null values in LogsDB data generation (#112890)