### PR TITLE
[8.x] Add LogsDB challenge tests for reindexing (#112849)

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/AbstractChallengeRestTest.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/AbstractChallengeRestTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractChallengeRestTest extends ESRestTestCase {
     private XContentBuilder contenderMappings;
     private Settings.Builder baselineSettings;
     private Settings.Builder contenderSettings;
-    private RestClient client;
+    protected RestClient client;
 
     @ClassRule()
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/DataGenerationHelper.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/DataGenerationHelper.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.datastreams.logsdb.qa;

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/DataGenerationHelper.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/DataGenerationHelper.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.ObjectMapper;
+import org.elasticsearch.logsdb.datageneration.DataGenerator;
+import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
+import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceHandler;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
+import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
+import org.elasticsearch.logsdb.datageneration.fields.PredefinedField;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class DataGenerationHelper {
+    private final ObjectMapper.Subobjects subobjects;
+    private final boolean keepArraySource;
+
+    private final DataGenerator dataGenerator;
+
+    DataGenerationHelper() {
+        // TODO enable subobjects: auto
+        // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using copy_to.
+        this.subobjects = ESTestCase.randomValueOtherThan(
+            ObjectMapper.Subobjects.AUTO,
+            () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
+        );
+        this.keepArraySource = ESTestCase.randomBoolean();
+
+        var specificationBuilder = DataGeneratorSpecification.builder().withFullyDynamicMapping(ESTestCase.randomBoolean());
+        if (subobjects != ObjectMapper.Subobjects.ENABLED) {
+            specificationBuilder = specificationBuilder.withNestedFieldsLimit(0);
+        }
+        this.dataGenerator = new DataGenerator(specificationBuilder.withDataSourceHandlers(List.of(new DataSourceHandler() {
+            @Override
+            public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
+                if (subobjects == ObjectMapper.Subobjects.ENABLED) {
+                    // Use default behavior
+                    return null;
+                }
+
+                assert request.isNested() == false;
+
+                // "enabled: false" is not compatible with subobjects: false
+                // "dynamic: false/strict/runtime" is not compatible with subobjects: false
+                return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
+                    var parameters = new HashMap<String, Object>();
+                    parameters.put("subobjects", subobjects.toString());
+                    if (ESTestCase.randomBoolean()) {
+                        parameters.put("dynamic", "true");
+                    }
+                    if (ESTestCase.randomBoolean()) {
+                        parameters.put("enabled", "true");
+                    }
+                    return parameters;
+                });
+            }
+        }))
+            .withPredefinedFields(
+                List.of(
+                    // Customized because it always needs doc_values for aggregations.
+                    new PredefinedField.WithGenerator("host.name", new FieldDataGenerator() {
+                        @Override
+                        public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
+                            return b -> b.startObject().field("type", "keyword").endObject();
+                        }
+
+                        @Override
+                        public CheckedConsumer<XContentBuilder, IOException> fieldValueGenerator() {
+                            return b -> b.value(ESTestCase.randomAlphaOfLength(5));
+                        }
+                    }),
+                    // Needed for terms query
+                    new PredefinedField.WithGenerator("method", new FieldDataGenerator() {
+                        @Override
+                        public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
+                            return b -> b.startObject().field("type", "keyword").endObject();
+                        }
+
+                        @Override
+                        public CheckedConsumer<XContentBuilder, IOException> fieldValueGenerator() {
+                            return b -> b.value(ESTestCase.randomFrom("put", "post", "get"));
+                        }
+                    }),
+
+                    // Needed for histogram aggregation
+                    new PredefinedField.WithGenerator("memory_usage_bytes", new FieldDataGenerator() {
+                        @Override
+                        public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
+                            return b -> b.startObject().field("type", "long").endObject();
+                        }
+
+                        @Override
+                        public CheckedConsumer<XContentBuilder, IOException> fieldValueGenerator() {
+                            // We can generate this using standard long field but we would get "too many buckets"
+                            return b -> b.value(ESTestCase.randomLongBetween(1000, 2000));
+                        }
+                    })
+                )
+            )
+            .build());
+    }
+
+    DataGenerator getDataGenerator() {
+        return dataGenerator;
+    }
+
+    void logsDbMapping(XContentBuilder builder) throws IOException {
+        dataGenerator.writeMapping(builder);
+    }
+
+    void standardMapping(XContentBuilder builder) throws IOException {
+        if (subobjects != ObjectMapper.Subobjects.ENABLED) {
+            dataGenerator.writeMapping(builder, Map.of("subobjects", subobjects.toString()));
+        } else {
+            dataGenerator.writeMapping(builder);
+        }
+    }
+
+    void logsDbSettings(Settings.Builder builder) {
+        if (keepArraySource) {
+            builder.put(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING.getKey(), "arrays");
+        }
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.datastreams.logsdb.qa;

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * This test compares behavior of a logsdb data stream and a standard index mode data stream
+ * containing data reindexed from initial data stream.
+ * There should be no differences between such two data streams.
+ */
+public class LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT extends ReindexChallengeRestIT {
+    public String getBaselineDataStreamName() {
+        return "logs-apache-baseline";
+    }
+
+    public String getContenderDataStreamName() {
+        return "standard-apache-reindexed-contender";
+    }
+
+    @Override
+    public void baselineSettings(Settings.Builder builder) {
+        dataGenerationHelper.logsDbSettings(builder);
+    }
+
+    @Override
+    public void contenderSettings(Settings.Builder builder) {
+
+    }
+
+    @Override
+    public void baselineMappings(XContentBuilder builder) throws IOException {
+        dataGenerationHelper.logsDbMapping(builder);
+    }
+
+    @Override
+    public void contenderMappings(XContentBuilder builder) throws IOException {
+        dataGenerationHelper.standardMapping(builder);
+    }
+
+    @Override
+    public Response indexContenderDocuments(CheckedSupplier<List<XContentBuilder>, IOException> documentsSupplier) throws IOException {
+        var reindexRequest = new Request("POST", "/_reindex?refresh=true");
+        reindexRequest.setJsonEntity(String.format(Locale.ROOT, """
+            {
+                "source": {
+                    "index": "%s"
+                },
+                "dest": {
+                  "index": "%s",
+                  "op_type": "create"
+                }
+            }
+            """, getBaselineDataStreamName(), getContenderDataStreamName()));
+        var response = client.performRequest(reindexRequest);
+        assertOK(response);
+
+        var body = entityAsMap(response);
+        assertThat("encountered failures when performing reindex:\n " + body, body.get("failures"), equalTo(List.of()));
+
+        return response;
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusReindexedLogsDbChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusReindexedLogsDbChallengeRestIT.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.datastreams.logsdb.qa;

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusReindexedLogsDbChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/LogsDbVersusReindexedLogsDbChallengeRestIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * This test compares behavior of a logsdb data stream and a data stream containing
+ * data reindexed from initial data stream.
+ * There should be no differences between such two data streams.
+ */
+public class LogsDbVersusReindexedLogsDbChallengeRestIT extends ReindexChallengeRestIT {
+    public String getBaselineDataStreamName() {
+        return "logs-apache-baseline";
+    }
+
+    public String getContenderDataStreamName() {
+        return "logs-apache-reindexed-contender";
+    }
+
+    @Override
+    public void baselineSettings(Settings.Builder builder) {
+        dataGenerationHelper.logsDbSettings(builder);
+    }
+
+    @Override
+    public void contenderSettings(Settings.Builder builder) {
+        dataGenerationHelper.logsDbSettings(builder);
+    }
+
+    @Override
+    public void baselineMappings(XContentBuilder builder) throws IOException {
+        dataGenerationHelper.logsDbMapping(builder);
+    }
+
+    @Override
+    public void contenderMappings(XContentBuilder builder) throws IOException {
+        dataGenerationHelper.logsDbMapping(builder);
+    }
+
+    @Override
+    public Response indexContenderDocuments(CheckedSupplier<List<XContentBuilder>, IOException> documentsSupplier) throws IOException {
+        var reindexRequest = new Request("POST", "/_reindex?refresh=true");
+        reindexRequest.setJsonEntity(String.format(Locale.ROOT, """
+            {
+                "source": {
+                    "index": "%s"
+                },
+                "dest": {
+                  "index": "%s",
+                  "op_type": "create"
+                }
+            }
+            """, getBaselineDataStreamName(), getContenderDataStreamName()));
+        var response = client.performRequest(reindexRequest);
+        assertOK(response);
+
+        var body = entityAsMap(response);
+        assertThat("encountered failures when performing reindex:\n " + body, body.get("failures"), equalTo(List.of()));
+
+        return response;
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/ReindexChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/ReindexChallengeRestIT.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.datastreams.logsdb.qa;

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/ReindexChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/ReindexChallengeRestIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class ReindexChallengeRestIT extends StandardVersusLogsIndexModeRandomDataChallengeRestIT {
+    @Override
+    public Response indexContenderDocuments(CheckedSupplier<List<XContentBuilder>, IOException> documentsSupplier) throws IOException {
+        var reindexRequest = new Request("POST", "/_reindex?refresh=true");
+        reindexRequest.setJsonEntity(String.format(Locale.ROOT, """
+            {
+                "source": {
+                    "index": "%s"
+                },
+                "dest": {
+                  "index": "%s",
+                  "op_type": "create"
+                }
+            }
+            """, getBaselineDataStreamName(), getContenderDataStreamName()));
+        var response = client.performRequest(reindexRequest);
+        assertOK(response);
+
+        var body = entityAsMap(response);
+        assertThat("encountered failures when performing reindex:\n " + body, body.get("failures"), equalTo(List.of()));
+
+        return response;
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -13,11 +13,11 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.datastreams.logsdb.qa.matchers.MatchResult;
 import org.elasticsearch.datastreams.logsdb.qa.matchers.Matcher;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -185,7 +185,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         int numberOfDocuments = ESTestCase.randomIntBetween(100, 200);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
-        assertDocumentIndexing(documents);
+        indexDocuments(documents);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
             .size(numberOfDocuments);
@@ -203,7 +203,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         int numberOfDocuments = ESTestCase.randomIntBetween(100, 200);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
-        assertDocumentIndexing(documents);
+        indexDocuments(documents);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.termQuery("method", "put"))
             .size(numberOfDocuments);
@@ -221,7 +221,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         int numberOfDocuments = ESTestCase.randomIntBetween(100, 200);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
-        assertDocumentIndexing(documents);
+        indexDocuments(documents);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
             .size(numberOfDocuments)
@@ -239,7 +239,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         int numberOfDocuments = ESTestCase.randomIntBetween(100, 200);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
-        assertDocumentIndexing(documents);
+        indexDocuments(documents);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
             .size(0)
@@ -257,7 +257,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         int numberOfDocuments = ESTestCase.randomIntBetween(100, 200);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
-        assertDocumentIndexing(documents);
+        indexDocuments(documents);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
             .aggregation(AggregationBuilders.dateHistogram("agg").field("@timestamp").calendarInterval(DateHistogramInterval.SECOND))
@@ -269,6 +269,28 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
             .ignoringSort(true)
             .isEqualTo(getAggregationBuckets(queryContender(searchSourceBuilder), "agg"));
         assertTrue(matchResult.getMessage(), matchResult.isMatch());
+    }
+
+    @Override
+    public Response indexBaselineDocuments(CheckedSupplier<List<XContentBuilder>, IOException> documentsSupplier) throws IOException {
+        var response = super.indexBaselineDocuments(documentsSupplier);
+
+        assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(RestStatus.OK.getStatus()));
+        var baselineResponseBody = entityAsMap(response);
+        assertThat("errors in baseline bulk response:\n " + baselineResponseBody, baselineResponseBody.get("errors"), equalTo(false));
+
+        return response;
+    }
+
+    @Override
+    public Response indexContenderDocuments(CheckedSupplier<List<XContentBuilder>, IOException> documentsSupplier) throws IOException {
+        var response = super.indexContenderDocuments(documentsSupplier);
+
+        assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(RestStatus.OK.getStatus()));
+        var contenderResponseBody = entityAsMap(response);
+        assertThat("errors in contender bulk response:\n " + contenderResponseBody, contenderResponseBody.get("errors"), equalTo(false));
+
+        return response;
     }
 
     private List<XContentBuilder> generateDocuments(int numberOfDocuments) throws IOException {
@@ -319,15 +341,7 @@ public class StandardVersusLogsIndexModeChallengeRestIT extends AbstractChalleng
         return buckets;
     }
 
-    private void assertDocumentIndexing(List<XContentBuilder> documents) throws IOException {
-        final Tuple<Response, Response> tuple = indexDocuments(() -> documents, () -> documents);
-
-        assertThat(tuple.v1().getStatusLine().getStatusCode(), Matchers.equalTo(RestStatus.OK.getStatus()));
-        var baselineResponseBody = entityAsMap(tuple.v1());
-        assertThat("errors in baseline bulk response:\n " + baselineResponseBody, baselineResponseBody.get("errors"), equalTo(false));
-
-        assertThat(tuple.v2().getStatusLine().getStatusCode(), Matchers.equalTo(RestStatus.OK.getStatus()));
-        var contenderResponseBody = entityAsMap(tuple.v2());
-        assertThat("errors in contender bulk response:\n " + contenderResponseBody, contenderResponseBody.get("errors"), equalTo(false));
+    private void indexDocuments(List<XContentBuilder> documents) throws IOException {
+        indexDocuments(() -> documents, () -> documents);
     }
 }

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
@@ -12,150 +12,44 @@ package org.elasticsearch.datastreams.logsdb.qa;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.FormatNames;
-import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.ObjectMapper;
-import org.elasticsearch.logsdb.datageneration.DataGenerator;
-import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
-import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.datasource.DataSourceHandler;
-import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
-import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
-import org.elasticsearch.logsdb.datageneration.fields.PredefinedField;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Challenge test (see {@link StandardVersusLogsIndexModeChallengeRestIT}) that uses randomly generated
  * mapping and documents in order to cover more code paths and permutations.
  */
 public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends StandardVersusLogsIndexModeChallengeRestIT {
-    private final ObjectMapper.Subobjects subobjects;
-    private final boolean keepArraySource;
-
-    private final DataGenerator dataGenerator;
+    protected final DataGenerationHelper dataGenerationHelper;
 
     public StandardVersusLogsIndexModeRandomDataChallengeRestIT() {
         super();
-        // TODO enable subobjects: auto
-        // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using copy_to.
-        this.subobjects = randomValueOtherThan(ObjectMapper.Subobjects.AUTO, () -> randomFrom(ObjectMapper.Subobjects.values()));
-        this.keepArraySource = randomBoolean();
-
-        var specificationBuilder = DataGeneratorSpecification.builder().withFullyDynamicMapping(randomBoolean());
-        if (subobjects != ObjectMapper.Subobjects.ENABLED) {
-            specificationBuilder = specificationBuilder.withNestedFieldsLimit(0);
-        }
-        this.dataGenerator = new DataGenerator(specificationBuilder.withDataSourceHandlers(List.of(new DataSourceHandler() {
-            @Override
-            public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
-                if (subobjects == ObjectMapper.Subobjects.ENABLED) {
-                    // Use default behavior
-                    return null;
-                }
-
-                assert request.isNested() == false;
-
-                // "enabled: false" is not compatible with subobjects: false
-                // "dynamic: false/strict/runtime" is not compatible with subobjects: false
-                return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
-                    var parameters = new HashMap<String, Object>();
-                    parameters.put("subobjects", subobjects.toString());
-                    if (ESTestCase.randomBoolean()) {
-                        parameters.put("dynamic", "true");
-                    }
-                    if (ESTestCase.randomBoolean()) {
-                        parameters.put("enabled", "true");
-                    }
-                    return parameters;
-                });
-            }
-        }))
-            .withPredefinedFields(
-                List.of(
-                    // Customized because it always needs doc_values for aggregations.
-                    new PredefinedField.WithGenerator("host.name", new FieldDataGenerator() {
-                        @Override
-                        public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-                            return b -> b.startObject().field("type", "keyword").endObject();
-                        }
-
-                        @Override
-                        public CheckedConsumer<XContentBuilder, IOException> fieldValueGenerator() {
-                            return b -> b.value(randomAlphaOfLength(5));
-                        }
-                    }),
-                    // Needed for terms query
-                    new PredefinedField.WithGenerator("method", new FieldDataGenerator() {
-                        @Override
-                        public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-                            return b -> b.startObject().field("type", "keyword").endObject();
-                        }
-
-                        @Override
-                        public CheckedConsumer<XContentBuilder, IOException> fieldValueGenerator() {
-                            return b -> b.value(randomFrom("put", "post", "get"));
-                        }
-                    }),
-
-                    // Needed for histogram aggregation
-                    new PredefinedField.WithGenerator("memory_usage_bytes", new FieldDataGenerator() {
-                        @Override
-                        public CheckedConsumer<XContentBuilder, IOException> mappingWriter() {
-                            return b -> b.startObject().field("type", "long").endObject();
-                        }
-
-                        @Override
-                        public CheckedConsumer<XContentBuilder, IOException> fieldValueGenerator() {
-                            // We can generate this using standard long field but we would get "too many buckets"
-                            return b -> b.value(randomLongBetween(1000, 2000));
-                        }
-                    })
-                )
-            )
-            .build());
-    }
-
-    @Override
-    protected final Settings restClientSettings() {
-        return Settings.builder()
-            .put(super.restClientSettings())
-            .put(org.elasticsearch.test.rest.ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "9000s")
-            .build();
+        dataGenerationHelper = new DataGenerationHelper();
     }
 
     @Override
     public void baselineMappings(XContentBuilder builder) throws IOException {
-        dataGenerator.writeMapping(builder);
+        dataGenerationHelper.standardMapping(builder);
     }
 
     @Override
     public void contenderMappings(XContentBuilder builder) throws IOException {
-        if (subobjects != ObjectMapper.Subobjects.ENABLED) {
-            dataGenerator.writeMapping(builder, Map.of("subobjects", subobjects.toString()));
-        } else {
-            dataGenerator.writeMapping(builder);
-        }
+        dataGenerationHelper.logsDbMapping(builder);
     }
 
     @Override
     public void contenderSettings(Settings.Builder builder) {
-        if (keepArraySource) {
-            builder.put(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING.getKey(), "arrays");
-        }
+        super.contenderSettings(builder);
+        dataGenerationHelper.logsDbSettings(builder);
     }
 
     @Override
     protected XContentBuilder generateDocument(final Instant timestamp) throws IOException {
         var document = XContentFactory.jsonBuilder();
-        dataGenerator.generateDocument(document, doc -> {
+        dataGenerationHelper.getDataGenerator().generateDocument(document, doc -> {
             doc.field("@timestamp", DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(timestamp));
         });
 

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusStandardReindexedIntoLogsDbChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusStandardReindexedIntoLogsDbChallengeRestIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * This test compares behavior of a standard index mode data stream and a
+ * logsdb data stream containing data reindexed from initial data stream.
+ * There should be no differences between such two data streams.
+ */
+public class StandardVersusStandardReindexedIntoLogsDbChallengeRestIT extends ReindexChallengeRestIT {
+    public String getBaselineDataStreamName() {
+        return "standard-apache-baseline";
+    }
+
+    public String getContenderDataStreamName() {
+        return "logs-apache-reindexed-contender";
+    }
+
+    @Override
+    public void baselineSettings(Settings.Builder builder) {
+
+    }
+
+    @Override
+    public void contenderSettings(Settings.Builder builder) {
+        dataGenerationHelper.logsDbSettings(builder);
+    }
+
+    @Override
+    public void baselineMappings(XContentBuilder builder) throws IOException {
+        dataGenerationHelper.standardMapping(builder);
+    }
+
+    @Override
+    public void contenderMappings(XContentBuilder builder) throws IOException {
+        dataGenerationHelper.logsDbMapping(builder);
+    }
+}

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusStandardReindexedIntoLogsDbChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusStandardReindexedIntoLogsDbChallengeRestIT.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.datastreams.logsdb.qa;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add LogsDB challenge tests for reindexing (#112849)