### PR TITLE
Properly handle empty incremental bulk requests

### DIFF
--- a/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
+++ b/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
@@ -26,11 +26,12 @@ public class RequestsWithoutContentIT extends ESRestTestCase {
         assertResponseException(responseException, "request body is required");
     }
 
-    @AwaitsFix(bugUrl = "need to decide how to handle this scenario")
     public void testBulkMissingBody() throws IOException {
+        Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
+        request.setJsonEntity("");
         ResponseException responseException = expectThrows(
             ResponseException.class,
-            () -> client().performRequest(new Request(randomBoolean() ? "POST" : "PUT", "/_bulk"))
+            () -> client().performRequest(request)
         );
         assertResponseException(responseException, "request body is required");
     }

--- a/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
+++ b/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
@@ -29,10 +29,7 @@ public class RequestsWithoutContentIT extends ESRestTestCase {
     public void testBulkMissingBody() throws IOException {
         Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
         request.setJsonEntity("");
-        ResponseException responseException = expectThrows(
-            ResponseException.class,
-            () -> client().performRequest(request)
-        );
+        ResponseException responseException = expectThrows(ResponseException.class, () -> client().performRequest(request));
         assertResponseException(responseException, "request body is required");
     }
 

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
@@ -23,10 +23,37 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.rest.RestStatus.OK;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
 public class IncrementalBulkRestIT extends HttpSmokeTestCase {
+
+    public void testBulkMissingBody() throws IOException {
+        Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
+        request.setJsonEntity("");
+        ResponseException responseException = expectThrows(
+            ResponseException.class,
+            () -> getRestClient().performRequest(request)
+        );
+        assertEquals(400, responseException.getResponse().getStatusLine().getStatusCode());
+        assertThat(responseException.getMessage(), containsString("request body is required"));
+    }
+
+    public void testBulkRequestBodyImproperlyTerminated() throws IOException {
+        Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
+        // missing final line of the bulk body. cannot process
+        request.setJsonEntity("{\"index\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n"
+            + "{\"field\":1}\n"
+            + "{\"index\":{\"_index\":\"index_name\",\"_id\":\"2\"}");
+        ResponseException responseException = expectThrows(
+            ResponseException.class,
+            () -> getRestClient().performRequest(request)
+        );
+        responseException.printStackTrace();
+        assertEquals(400, responseException.getResponse().getStatusLine().getStatusCode());
+        assertThat(responseException.getMessage(), containsString("could not parse bulk request body"));
+    }
 
     public void testIncrementalBulk() throws IOException {
         Request createRequest = new Request("PUT", "/index_name");

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
@@ -32,10 +32,7 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
     public void testBulkMissingBody() throws IOException {
         Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
         request.setJsonEntity("");
-        ResponseException responseException = expectThrows(
-            ResponseException.class,
-            () -> getRestClient().performRequest(request)
-        );
+        ResponseException responseException = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
         assertEquals(400, responseException.getResponse().getStatusLine().getStatusCode());
         assertThat(responseException.getMessage(), containsString("request body is required"));
     }
@@ -43,14 +40,12 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
     public void testBulkRequestBodyImproperlyTerminated() throws IOException {
         Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
         // missing final line of the bulk body. cannot process
-        request.setJsonEntity("{\"index\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n"
-            + "{\"field\":1}\n"
-            + "{\"index\":{\"_index\":\"index_name\",\"_id\":\"2\"}");
-        ResponseException responseException = expectThrows(
-            ResponseException.class,
-            () -> getRestClient().performRequest(request)
+        request.setJsonEntity(
+            "{\"index\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n"
+                + "{\"field\":1}\n"
+                + "{\"index\":{\"_index\":\"index_name\",\"_id\":\"2\"}"
         );
-        responseException.printStackTrace();
+        ResponseException responseException = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
         assertEquals(400, responseException.getResponse().getStatusLine().getStatusCode());
         assertThat(responseException.getMessage(), containsString("could not parse bulk request body"));
     }


### PR DESCRIPTION
This commit ensures we properly throw exceptions when an empty bulk
request is received with the incremental handling enabled.