### PR TITLE
Check latest repoData before applying workaround for missing shardGen file

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -209,9 +209,6 @@ tests:
 - class: org.elasticsearch.script.StatsSummaryTests
   method: testEqualsAndHashCode
   issue: https://github.com/elastic/elasticsearch/issues/112439
-- class: org.elasticsearch.snapshots.ConcurrentSnapshotsIT
-  method: testMasterFailoverOnFinalizationLoop
-  issue: https://github.com/elastic/elasticsearch/issues/112811
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJobAfterMissingAliases
   issue: https://github.com/elastic/elasticsearch/issues/112823

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -36,6 +36,7 @@ import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.AbstractDisruptionTestCase;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshotsIntegritySuppressor;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoryConflictException;
@@ -1108,23 +1109,28 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         waitForBlock(masterName, repoName);
 
         final String snapshotOne = snapshotNames.get(0);
-        final ActionFuture<AcknowledgedResponse> deleteSnapshotOne = startDeleteSnapshot(repoName, snapshotOne);
-        awaitNDeletionsInProgress(1);
-        networkDisruption.startDisrupting();
-        ensureStableCluster(3, dataNode);
+        // Suppress assertion error on missing shard generation file since the new master may delete it
+        // while the old master still tries access it. This is OK since the old master will ultimately
+        // find out the failover and abort its operations.
+        try (var ignored = new BlobStoreIndexShardSnapshotsIntegritySuppressor()) {
+            final ActionFuture<AcknowledgedResponse> deleteSnapshotOne = startDeleteSnapshot(repoName, snapshotOne);
+            awaitNDeletionsInProgress(1);
+            networkDisruption.startDisrupting();
+            ensureStableCluster(3, dataNode);
 
-        unblockNode(repoName, masterName);
-        networkDisruption.stopDisrupting();
-        ensureStableCluster(4);
+            unblockNode(repoName, masterName);
+            networkDisruption.stopDisrupting();
+            ensureStableCluster(4);
 
-        assertSuccessful(snapshotOther);
-        try {
-            deleteSnapshotOne.actionGet();
-        } catch (RepositoryException re) {
-            // ignored
-        } catch (SnapshotMissingException re) {
-            // When master node is isolated during this test, the newly elected master takes over and executes the snapshot deletion. In
-            // this case the retried delete snapshot operation on the new master can fail with SnapshotMissingException
+            assertSuccessful(snapshotOther);
+            try {
+                deleteSnapshotOne.actionGet();
+            } catch (RepositoryException re) {
+                // ignored
+            } catch (SnapshotMissingException re) {
+                // When master node is isolated during this test, the newly elected master takes over and executes the snapshot deletion. In
+                // this case the retried delete snapshot operation on the new master can fail with SnapshotMissingException
+            }
         }
         awaitNoMoreRunningOperations();
     }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -596,7 +596,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 existingSnapshots = tuple.v1();
             } else {
                 newGen = ShardGeneration.newGeneration();
-                existingSnapshots = buildBlobStoreIndexShardSnapshots(index, Collections.emptySet(), shardContainer, shardGeneration).v1();
+                existingSnapshots = buildBlobStoreIndexShardSnapshots(
+                    index,
+                    shardNum,
+                    Collections.emptySet(),
+                    shardContainer,
+                    shardGeneration
+                ).v1();
                 existingShardGen = shardGeneration;
             }
             SnapshotFiles existingTargetFiles = null;
@@ -1309,6 +1315,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         newGen = -1L;
                         blobStoreIndexShardSnapshots = buildBlobStoreIndexShardSnapshots(
                             indexId,
+                            shardId,
                             originalShardBlobs,
                             shardContainer,
                             originalRepositoryData.shardGenerations().getShardGen(indexId, shardId)
@@ -3203,6 +3210,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             snapshotStatus.ensureNotAborted();
             Tuple<BlobStoreIndexShardSnapshots, ShardGeneration> tuple = buildBlobStoreIndexShardSnapshots(
                 context.indexId(),
+                shardId.id(),
                 blobs,
                 shardContainer,
                 generation
@@ -3848,7 +3856,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             blobs = shardContainer.listBlobsByPrefix(OperationPurpose.SNAPSHOT_METADATA, SNAPSHOT_INDEX_PREFIX).keySet();
         }
 
-        return buildBlobStoreIndexShardSnapshots(indexId, blobs, shardContainer, shardGen).v1();
+        return buildBlobStoreIndexShardSnapshots(indexId, shardId, blobs, shardContainer, shardGen).v1();
     }
 
     /**
@@ -3856,6 +3864,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * the given list of blobs in the shard container.
      *
      * @param indexId    {@link IndexId} identifying the corresponding index
+     * @param shardId    The 0-based shard id, see also {@link ShardId#id()}
      * @param blobs      list of blobs in repository
      * @param generation shard generation or {@code null} in case there was no shard generation tracked in the {@link RepositoryData} for
      *                   this shard because its snapshot was created in a version older than
@@ -3864,6 +3873,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      */
     private Tuple<BlobStoreIndexShardSnapshots, ShardGeneration> buildBlobStoreIndexShardSnapshots(
         IndexId indexId,
+        int shardId,
         Set<String> blobs,
         BlobContainer shardContainer,
         @Nullable ShardGeneration generation
@@ -3883,6 +3893,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     generation
                 );
             } catch (NoSuchFileException noSuchFileException) {
+                final long latestGeneration = latestIndexBlobId();
+                final RepositoryData currentRepositoryData = getRepositoryData(latestGeneration);
+                if (currentRepositoryData.shardGenerations().hasShardGen(new RepositoryShardId(indexId, shardId)) == false) {
+                    // Master has concurrently mutated the shard generation. This can happen when master fails over
+                    // which is "expected". We do not need the following workaround in this case.
+                    throw noSuchFileException;
+                }
+
                 // This shouldn't happen (absent an external force deleting blobs from the repo) but in practice we've found bugs in the way
                 // we manipulate shard generation UUIDs under concurrent snapshot load which can lead to incorrectly deleting a referenced
                 // shard-level `index-UUID` blob during finalization. We definitely want to treat this as a test failure (see the `assert`


### PR DESCRIPTION
It is expected that the old master may attempt to read a shardGen file that is deleted by the new master. This PR checks the latest repo data before applying the workaround (or throwing AssertionError) for missing shardGen files.

Relates: #112337
Resolves: #112811

