### PR TITLE
[8.x] Unmute CCS tests, they should work now (#112969)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -118,8 +118,6 @@ tests:
 - class: org.elasticsearch.search.retriever.RankDocRetrieverBuilderIT
   method: testRankDocsRetrieverWithCollapse
   issue: https://github.com/elastic/elasticsearch/issues/112254
-- class: org.elasticsearch.search.ccs.CCSUsageTelemetryIT
-  issue: https://github.com/elastic/elasticsearch/issues/112324
 - class: org.elasticsearch.datastreams.logsdb.qa.StandardVersusLogsIndexModeRandomDataChallengeRestIT
   method: testMatchAllQuery
   issue: https://github.com/elastic/elasticsearch/issues/112374
@@ -129,9 +127,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testMultiIndexDelete
   issue: https://github.com/elastic/elasticsearch/issues/112381
-- class: org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshotTests
-  method: testToXContent
-  issue: https://github.com/elastic/elasticsearch/issues/112325
 - class: org.elasticsearch.search.retriever.RankDocRetrieverBuilderIT
   method: testRankDocsRetrieverWithNestedQuery
   issue: https://github.com/elastic/elasticsearch/issues/112421


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Unmute CCS tests, they should work now (#112969)