### PR TITLE
[8.16][ESQL] Remove spatial MultiValuesCombiner abstraction (#112914)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -40,8 +40,8 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
 
 public abstract class SpatialRelatesFunction extends BinarySpatialFunction
     implements
-    EvaluatorMapper,
-    SpatialEvaluatorFactory.SpatialSourceSupplier {
+        EvaluatorMapper,
+        SpatialEvaluatorFactory.SpatialSourceSupplier {
 
     protected SpatialRelatesFunction(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues, false);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -17,10 +17,6 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.EvalOperator;
-import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.geometry.GeometryCollection;
-import org.elasticsearch.geometry.MultiPoint;
-import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.mapper.ShapeIndexer;
 import org.elasticsearch.lucene.spatial.Component2DVisitor;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
@@ -33,8 +29,6 @@ import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -46,8 +40,8 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
 
 public abstract class SpatialRelatesFunction extends BinarySpatialFunction
     implements
-        EvaluatorMapper,
-        SpatialEvaluatorFactory.SpatialSourceSupplier {
+    EvaluatorMapper,
+    SpatialEvaluatorFactory.SpatialSourceSupplier {
 
     protected SpatialRelatesFunction(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues, false);
@@ -169,23 +163,13 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
             return visitor.matches();
         }
 
-        protected boolean geometryRelatesGeometries(MultiValuesCombiner left, MultiValuesCombiner right) throws IOException {
-            Component2D rightComponent2D = asLuceneComponent2D(crsType, right.combined());
-            return geometryRelatesGeometry(left, rightComponent2D);
-        }
-
-        private boolean geometryRelatesGeometry(MultiValuesCombiner left, Component2D rightComponent2D) throws IOException {
-            GeometryDocValueReader leftDocValueReader = asGeometryDocValueReader(coordinateEncoder, shapeIndexer, left.combined());
-            return geometryRelatesGeometry(leftDocValueReader, rightComponent2D);
-        }
-
         protected void processSourceAndConstant(BooleanBlock.Builder builder, int position, BytesRefBlock left, @Fixed Component2D right)
             throws IOException {
             if (left.getValueCount(position) < 1) {
                 builder.appendNull();
             } else {
-                MultiValuesBytesRef leftValues = new MultiValuesBytesRef(left, position);
-                builder.appendBoolean(geometryRelatesGeometry(leftValues, right));
+                final GeometryDocValueReader reader = asGeometryDocValueReader(coordinateEncoder, shapeIndexer, left, position);
+                builder.appendBoolean(geometryRelatesGeometry(reader, right));
             }
         }
 
@@ -194,9 +178,9 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
             if (left.getValueCount(position) < 1 || right.getValueCount(position) < 1) {
                 builder.appendNull();
             } else {
-                MultiValuesBytesRef leftValues = new MultiValuesBytesRef(left, position);
-                MultiValuesBytesRef rightValues = new MultiValuesBytesRef(right, position);
-                builder.appendBoolean(geometryRelatesGeometries(leftValues, rightValues));
+                final GeometryDocValueReader reader = asGeometryDocValueReader(coordinateEncoder, shapeIndexer, left, position);
+                final Component2D component2D = asLuceneComponent2D(crsType, right, position);
+                builder.appendBoolean(geometryRelatesGeometry(reader, component2D));
             }
         }
 
@@ -209,8 +193,14 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
             if (leftValue.getValueCount(position) < 1) {
                 builder.appendNull();
             } else {
-                MultiValuesLong leftValues = new MultiValuesLong(leftValue, position, spatialCoordinateType::longAsPoint);
-                builder.appendBoolean(geometryRelatesGeometry(leftValues, rightValue));
+                final GeometryDocValueReader reader = asGeometryDocValueReader(
+                    coordinateEncoder,
+                    shapeIndexer,
+                    leftValue,
+                    position,
+                    spatialCoordinateType::longAsPoint
+                );
+                builder.appendBoolean(geometryRelatesGeometry(reader, rightValue));
             }
         }
 
@@ -223,100 +213,16 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
             if (leftValue.getValueCount(position) < 1 || rightValue.getValueCount(position) < 1) {
                 builder.appendNull();
             } else {
-                MultiValuesLong leftValues = new MultiValuesLong(leftValue, position, spatialCoordinateType::longAsPoint);
-                MultiValuesBytesRef rightValues = new MultiValuesBytesRef(rightValue, position);
-                builder.appendBoolean(geometryRelatesGeometries(leftValues, rightValues));
+                final GeometryDocValueReader reader = asGeometryDocValueReader(
+                    coordinateEncoder,
+                    shapeIndexer,
+                    leftValue,
+                    position,
+                    spatialCoordinateType::longAsPoint
+                );
+                final Component2D component2D = asLuceneComponent2D(crsType, rightValue, position);
+                builder.appendBoolean(geometryRelatesGeometry(reader, component2D));
             }
-        }
-    }
-
-    /**
-     * When dealing with ST_CONTAINS and ST_WITHIN we need to pre-combine the field geometries for multi-values in order
-     * to perform the relationship check. This means instead of relying on the generated evaluators to iterate over all
-     * values in a multi-value field, the entire block is passed into the spatial function, and we combine the values into
-     * a geometry collection or multipoint.
-     */
-    protected interface MultiValuesCombiner {
-        Geometry combined();
-    }
-
-    /**
-     * Values read from source will be encoded as WKB in BytesRefBlock. The block contains multiple rows, and within
-     * each row multiple values, so we need to efficiently iterate over only the values required for the requested row.
-     * This class works for point and shape fields, because both are extracted into the same block encoding.
-     * However, we do detect if all values in the field are actually points and create a MultiPoint instead of a GeometryCollection.
-     */
-    protected static class MultiValuesBytesRef implements MultiValuesCombiner {
-        private final BytesRefBlock valueBlock;
-        private final int valueCount;
-        private final BytesRef scratch = new BytesRef();
-        private final int firstValue;
-
-        MultiValuesBytesRef(BytesRefBlock valueBlock, int position) {
-            this.valueBlock = valueBlock;
-            this.firstValue = valueBlock.getFirstValueIndex(position);
-            this.valueCount = valueBlock.getValueCount(position);
-        }
-
-        @Override
-        public Geometry combined() {
-            int valueIndex = firstValue;
-            boolean allPoints = true;
-            if (valueCount == 1) {
-                return fromBytesRef(valueBlock.getBytesRef(valueIndex, scratch));
-            }
-            List<Geometry> geometries = new ArrayList<>();
-            while (valueIndex < firstValue + valueCount) {
-                geometries.add(fromBytesRef(valueBlock.getBytesRef(valueIndex++, scratch)));
-                if (geometries.get(geometries.size() - 1) instanceof Point == false) {
-                    allPoints = false;
-                }
-            }
-            return allPoints ? new MultiPoint(asPointList(geometries)) : new GeometryCollection<>(geometries);
-        }
-
-        private List<Point> asPointList(List<Geometry> geometries) {
-            List<Point> points = new ArrayList<>(geometries.size());
-            for (Geometry geometry : geometries) {
-                points.add((Point) geometry);
-            }
-            return points;
-        }
-
-        protected Geometry fromBytesRef(BytesRef bytesRef) {
-            return SpatialCoordinateTypes.UNSPECIFIED.wkbToGeometry(bytesRef);
-        }
-    }
-
-    /**
-     * Point values read from doc-values will be encoded as in LogBlock. The block contains multiple rows, and within
-     * each row multiple values, so we need to efficiently iterate over only the values required for the requested row.
-     * Since the encoding differs for GEO and CARTESIAN, we need the decoder function to be passed in the constructor.
-     */
-    protected static class MultiValuesLong implements MultiValuesCombiner {
-        private final LongBlock valueBlock;
-        private final Function<Long, Point> decoder;
-        private final int valueCount;
-        private final int firstValue;
-
-        MultiValuesLong(LongBlock valueBlock, int position, Function<Long, Point> decoder) {
-            this.valueBlock = valueBlock;
-            this.decoder = decoder;
-            this.firstValue = valueBlock.getFirstValueIndex(position);
-            this.valueCount = valueBlock.getValueCount(position);
-        }
-
-        @Override
-        public Geometry combined() {
-            int valueIndex = firstValue;
-            if (valueCount == 1) {
-                return decoder.apply(valueBlock.getLong(valueIndex));
-            }
-            List<Point> points = new ArrayList<>();
-            while (valueIndex < firstValue + valueCount) {
-                points.add(decoder.apply(valueBlock.getLong(valueIndex++)));
-            }
-            return new MultiPoint(points);
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
@@ -13,9 +13,13 @@ import org.apache.lucene.geo.XYGeometry;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.LuceneGeometriesUtils;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.mapper.ShapeIndexer;
@@ -31,19 +35,18 @@ import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.core.expression.Foldables.valueOf;
 
 public class SpatialRelatesUtils {
 
-    /**
-     * This function is used to convert a spatial constant to a lucene Component2D.
-     * When both left and right sides are constants, we convert the left to a doc-values byte array and the right to a Component2D.
-     */
+    /** Converts a {@link Expression} into a {@link Component2D}. */
     static Component2D asLuceneComponent2D(BinarySpatialFunction.SpatialCrsType crsType, Expression expression) {
         return asLuceneComponent2D(crsType, makeGeometryFromLiteral(expression));
     }
 
+    /** Converts a {@link Geometry} into a {@link Component2D}. */
     static Component2D asLuceneComponent2D(BinarySpatialFunction.SpatialCrsType crsType, Geometry geometry) {
         if (crsType == BinarySpatialFunction.SpatialCrsType.GEO) {
             var luceneGeometries = LuceneGeometriesUtils.toLatLonGeometry(geometry, true, t -> {});
@@ -54,15 +57,23 @@ public class SpatialRelatesUtils {
         }
     }
 
+    /** Converts a {@link BytesRefBlock} at a given {@code position} into a {@link Component2D}. */
+    static Component2D asLuceneComponent2D(BinarySpatialFunction.SpatialCrsType type, BytesRefBlock valueBlock, int position) {
+        return asLuceneComponent2D(type, asGeometry(valueBlock, position));
+    }
+
     /**
-     * This function is used to convert a spatial constant to an array of lucene Component2Ds.
-     * When both left and right sides are constants, we convert the left to a doc-values byte array and the right to a Component2D[].
+     * Converts a {@link Expression} at a given {@code position} into a {@link Component2D} array.
      * The reason for generating an array instead of a single component is for multi-shape support with ST_CONTAINS.
      */
     static Component2D[] asLuceneComponent2Ds(BinarySpatialFunction.SpatialCrsType crsType, Expression expression) {
         return asLuceneComponent2Ds(crsType, makeGeometryFromLiteral(expression));
     }
 
+    /**
+     * Converts a {@link Geometry} at a given {@code position} into a {@link Component2D} array.
+     * The reason for generating an array instead of a single component is for multi-shape support with ST_CONTAINS.
+     */
     static Component2D[] asLuceneComponent2Ds(BinarySpatialFunction.SpatialCrsType crsType, Geometry geometry) {
         if (crsType == BinarySpatialFunction.SpatialCrsType.GEO) {
             var luceneGeometries = LuceneGeometriesUtils.toLatLonGeometry(geometry, true, t -> {});
@@ -73,10 +84,12 @@ public class SpatialRelatesUtils {
         }
     }
 
-    /**
-     * This function is used to convert a spatial constant to a doc-values byte array.
-     * When both left and right sides are constants, we convert the left to a doc-values byte array and the right to a Component2D.
-     */
+    /** Converts a {@link BytesRefBlock} at a given {@code position} into a {@link Component2D} array. */
+    static Component2D[] asLuceneComponent2Ds(BinarySpatialFunction.SpatialCrsType type, BytesRefBlock valueBlock, int position) {
+        return asLuceneComponent2Ds(type, asGeometry(valueBlock, position));
+    }
+
+    /** Converts a {@link Expression} into a {@link GeometryDocValueReader} */
     static GeometryDocValueReader asGeometryDocValueReader(BinarySpatialFunction.SpatialCrsType crsType, Expression expression)
         throws IOException {
         Geometry geometry = makeGeometryFromLiteral(expression);
@@ -92,11 +105,7 @@ public class SpatialRelatesUtils {
 
     }
 
-    /**
-     * Converting shapes into doc-values byte arrays is needed under two situations:
-     * - If both left and right are constants, we convert the right to Component2D and the left to doc-values for comparison
-     * - If the right is a constant and no lucene push-down was possible, we get WKB in the left and convert it to doc-values for comparison
-     */
+    /** Converts a {@link Geometry} into a {@link GeometryDocValueReader} */
     static GeometryDocValueReader asGeometryDocValueReader(CoordinateEncoder encoder, ShapeIndexer shapeIndexer, Geometry geometry)
         throws IOException {
         GeometryDocValueReader reader = new GeometryDocValueReader();
@@ -108,6 +117,50 @@ public class SpatialRelatesUtils {
         centroidCalculator.add(geometry);
         reader.reset(GeometryDocValueWriter.write(shapeIndexer.indexShape(geometry), encoder, centroidCalculator));
         return reader;
+    }
+
+    /** Converts a {@link LongBlock} at a give {@code position} into a {@link GeometryDocValueReader} */
+    static GeometryDocValueReader asGeometryDocValueReader(
+        CoordinateEncoder encoder,
+        ShapeIndexer shapeIndexer,
+        LongBlock valueBlock,
+        int position,
+        Function<Long, Point> decoder
+    ) throws IOException {
+        final int firstValueIndex = valueBlock.getFirstValueIndex(position);
+        final int valueCount = valueBlock.getValueCount(position);
+        if (valueCount == 1) {
+            return asGeometryDocValueReader(encoder, shapeIndexer, decoder.apply(valueBlock.getLong(firstValueIndex)));
+        }
+        final List<Point> points = new ArrayList<>(valueCount);
+        for (int i = 0; i < valueCount; i++) {
+            points.add(decoder.apply(valueBlock.getLong(firstValueIndex + i)));
+        }
+        return asGeometryDocValueReader(encoder, shapeIndexer, new MultiPoint(points));
+    }
+
+    /** Converts a {@link BytesRefBlock} at a given {code position} into a {@link GeometryDocValueReader} */
+    static GeometryDocValueReader asGeometryDocValueReader(
+        CoordinateEncoder encoder,
+        ShapeIndexer shapeIndexer,
+        BytesRefBlock valueBlock,
+        int position
+    ) throws IOException {
+        return asGeometryDocValueReader(encoder, shapeIndexer, asGeometry(valueBlock, position));
+    }
+
+    private static Geometry asGeometry(BytesRefBlock valueBlock, int position) {
+        final BytesRef scratch = new BytesRef();
+        final int firstValueIndex = valueBlock.getFirstValueIndex(position);
+        final int valueCount = valueBlock.getValueCount(position);
+        if (valueCount == 1) {
+            return SpatialCoordinateTypes.UNSPECIFIED.wkbToGeometry(valueBlock.getBytesRef(firstValueIndex, scratch));
+        }
+        final List<Geometry> geometries = new ArrayList<>(valueCount);
+        for (int i = 0; i < valueCount; i++) {
+            geometries.add(SpatialCoordinateTypes.UNSPECIFIED.wkbToGeometry(valueBlock.getBytesRef(firstValueIndex + i, scratch)));
+        }
+        return new GeometryCollection<>(geometries);
     }
 
     /**


### PR DESCRIPTION
We recently added the MultiValuesCombiner abstraction to handle mutivalues in the spatial case. I think this is not really necessary and can be replaced by a few static methods in SpatialRelatesUtils where similar methods already exist.

backport https://github.com/elastic/elasticsearch/pull/112914