### PR TITLE
[8.x] [plugin/apm-data]Fallback to ILM for non-dsl-only mode if DSL unavailable (#112759)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -121,7 +121,20 @@ public class ClusterServiceUtils {
     }
 
     public static ClusterService createClusterService(ThreadPool threadPool, DiscoveryNode localNode, ClusterSettings clusterSettings) {
-        Settings settings = Settings.builder().put("node.name", "test").put("cluster.name", "ClusterServiceTests").build();
+        return createClusterService(threadPool, localNode, Settings.EMPTY, clusterSettings);
+    }
+
+    public static ClusterService createClusterService(
+        ThreadPool threadPool,
+        DiscoveryNode localNode,
+        Settings providedSettings,
+        ClusterSettings clusterSettings
+    ) {
+        Settings settings = Settings.builder()
+            .put("node.name", "test")
+            .put("cluster.name", "ClusterServiceTests")
+            .put(providedSettings)
+            .build();
         ClusterService clusterService = new ClusterService(
             settings,
             clusterSettings,

--- a/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistry.java
+++ b/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistry.java
@@ -16,6 +16,9 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.template.YamlTemplateRegistry;
 
+import java.util.function.Predicate;
+
+import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.isDataStreamsLifecycleOnlyMode;
 import static org.elasticsearch.xpack.apmdata.APMPlugin.APM_DATA_REGISTRY_ENABLED;
 
 /**
@@ -33,7 +36,15 @@ public class APMIndexTemplateRegistry extends YamlTemplateRegistry {
         NamedXContentRegistry xContentRegistry,
         FeatureService featureService
     ) {
-        super(nodeSettings, clusterService, threadPool, client, xContentRegistry, featureService);
+        super(
+            nodeSettings,
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry,
+            featureService,
+            templateFilter(isDataStreamsLifecycleOnlyMode(clusterService.getSettings()))
+        );
     }
 
     @Override
@@ -57,5 +68,10 @@ public class APMIndexTemplateRegistry extends YamlTemplateRegistry {
     @Override
     protected String getOrigin() {
         return ClientHelper.APM_ORIGIN;
+    }
+
+    private static Predicate<String> templateFilter(boolean dslOnlyMode) {
+        // Load ILM files only when the server supports ILM i.e. dsl-only-mode is false
+        return templateName -> dslOnlyMode == false || templateName.endsWith("@ilm") == false;
     }
 }

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.app-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.app-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for logs-apm.app if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: logs-apm.app_logs-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm.error-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for logs-apm.error if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: logs-apm.error_logs-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.app-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.app-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.app if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.app_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.internal-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.internal-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.internal if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.internal_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.10m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.10m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_destination.10m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_destination_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.1m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.1m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_destination.1m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_destination_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.60m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination.60m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_destination.60m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_destination_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.10m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.10m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_summary.10m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_summary_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.1m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.1m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_summary.1m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_summary_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.60m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary.60m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_summary.60m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_summary_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.10m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.10m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_transaction.10m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_transaction_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.1m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.1m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_transaction.1m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_transaction_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.60m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction.60m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.service_transaction.60m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.service_transaction_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.10m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.10m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.transaction.10m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.transaction_10m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.1m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.1m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.transaction.1m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.transaction_1m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.60m-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction.60m-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for metrics-apm.transaction.60m if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: metrics-apm.transaction_60m_metrics-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for traces-apm if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.traces-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.rum-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.rum-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for traces-apm.rum if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.rum_traces-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.sampled-fallback@ilm.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/traces-apm.sampled-fallback@ilm.yaml
@@ -1,0 +1,11 @@
+---
+version: ${xpack.apmdata.template.version}
+_meta:
+  description: Fallback to ILM policy for traces-apm.sampled if data stream lifecycle not defined
+  managed: true
+template:
+  settings:
+    index:
+      lifecycle:
+        name: traces-apm.sampled_traces-default_policy
+        prefer_ilm: false

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
@@ -12,12 +12,14 @@ composed_of:
 - apm@settings
 - apm-10d@lifecycle
 - logs-apm@settings
+- logs-apm.app-fallback@ilm
 - logs@custom
 - logs-apm.app@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - logs@custom
 - logs-apm.app@custom
+- logs-apm.app-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -14,12 +14,14 @@ composed_of:
 - apm-10d@lifecycle
 - logs-apm@settings
 - logs-apm.error@mappings
+- logs-apm.error-fallback@ilm
 - logs@custom
 - logs-apm.error@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - logs@custom
 - logs-apm.error@custom
+- logs-apm.error-fallback@ilm
 template:
   mappings:
     properties:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
@@ -13,12 +13,14 @@ composed_of:
 - apm-90d@lifecycle
 - metrics-apm@mappings
 - metrics-apm@settings
+- metrics-apm.app-fallback@ilm
 - metrics@custom
 - metrics-apm.app@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.app@custom
+- metrics-apm.app-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
@@ -14,12 +14,14 @@ composed_of:
 - apm-90d@lifecycle
 - metrics-apm@mappings
 - metrics-apm@settings
+- metrics-apm.internal-fallback@ilm
 - metrics@custom
 - metrics-apm.internal@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.internal@custom
+- metrics-apm.internal-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_destination@mappings
+- metrics-apm.service_destination.10m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_destination.10m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_destination.10m@custom
+- metrics-apm.service_destination.10m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
@@ -15,12 +15,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_destination@mappings
+- metrics-apm.service_destination.1m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_destination.1m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_destination.1m@custom
+- metrics-apm.service_destination.1m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_destination@mappings
+- metrics-apm.service_destination.60m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_destination.60m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_destination.60m@custom
+- metrics-apm.service_destination.60m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_summary@mappings
+- metrics-apm.service_summary.10m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_summary.10m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_summary.10m@custom
+- metrics-apm.service_summary.10m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
@@ -15,12 +15,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_summary@mappings
+- metrics-apm.service_summary.1m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_summary.1m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_summary.1m@custom
+- metrics-apm.service_summary.1m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_summary@mappings
+- metrics-apm.service_summary.60m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_summary.60m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_summary.60m@custom
+- metrics-apm.service_summary.60m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_transaction@mappings
+- metrics-apm.service_transaction.10m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_transaction.10m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_transaction.10m@custom
+- metrics-apm.service_transaction.10m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
@@ -15,12 +15,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_transaction@mappings
+- metrics-apm.service_transaction.1m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_transaction.1m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_transaction.1m@custom
+- metrics-apm.service_transaction.1m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.service_transaction@mappings
+- metrics-apm.service_transaction.60m-fallback@ilm
 - metrics@custom
 - metrics-apm.service_transaction.60m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.service_transaction.60m@custom
+- metrics-apm.service_transaction.60m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.transaction@mappings
+- metrics-apm.transaction.10m-fallback@ilm
 - metrics@custom
 - metrics-apm.transaction.10m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.transaction.10m@custom
+- metrics-apm.transaction.10m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
@@ -15,12 +15,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.transaction@mappings
+- metrics-apm.transaction.1m-fallback@ilm
 - metrics@custom
 - metrics-apm.transaction.1m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.transaction.1m@custom
+- metrics-apm.transaction.1m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
@@ -16,12 +16,14 @@ composed_of:
 - metrics-apm@mappings
 - metrics-apm@settings
 - metrics-apm.transaction@mappings
+- metrics-apm.transaction.60m-fallback@ilm
 - metrics@custom
 - metrics-apm.transaction.60m@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - metrics@custom
 - metrics-apm.transaction.60m@custom
+- metrics-apm.transaction.60m-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
@@ -14,12 +14,14 @@ composed_of:
 - apm-90d@lifecycle
 - traces-apm@mappings
 - traces-apm.rum@mappings
+- traces-apm.rum-fallback@ilm
 - traces@custom
 - traces-apm.rum@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - traces@custom
 - traces-apm.rum@custom
+- traces-apm.rum-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
@@ -11,12 +11,14 @@ composed_of:
 - traces@mappings
 - apm@mappings
 - apm@settings
+- traces-apm.sampled-fallback@ilm
 - traces@custom
 - traces-apm.sampled@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - traces@custom
 - traces-apm.sampled@custom
+- traces-apm.sampled-fallback@ilm
 template:
   lifecycle:
     data_retention: 1h

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
@@ -13,12 +13,14 @@ composed_of:
 - apm@settings
 - apm-10d@lifecycle
 - traces-apm@mappings
+- traces-apm-fallback@ilm
 - traces@custom
 - traces-apm@custom
 - ecs@mappings
 ignore_missing_component_templates:
 - traces@custom
 - traces-apm@custom
+- traces-apm-fallback@ilm
 template:
   settings:
     index:

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 9
+version: 10
 
 component-templates:
   # Data lifecycle.
@@ -25,6 +25,26 @@ component-templates:
   - metrics-apm.transaction@mappings
   - traces-apm@mappings
   - traces-apm.rum@mappings
+  # The below files allow to fallback to ILM if DSL configurations are not present
+  - logs-apm.app-fallback@ilm
+  - logs-apm.error-fallback@ilm
+  - metrics-apm.app-fallback@ilm
+  - metrics-apm.internal-fallback@ilm
+  - metrics-apm.service_destination.10m-fallback@ilm
+  - metrics-apm.service_destination.1m-fallback@ilm
+  - metrics-apm.service_destination.60m-fallback@ilm
+  - metrics-apm.service_summary.10m-fallback@ilm
+  - metrics-apm.service_summary.1m-fallback@ilm
+  - metrics-apm.service_summary.60m-fallback@ilm
+  - metrics-apm.service_transaction.10m-fallback@ilm
+  - metrics-apm.service_transaction.1m-fallback@ilm
+  - metrics-apm.service_transaction.60m-fallback@ilm
+  - metrics-apm.transaction.10m-fallback@ilm
+  - metrics-apm.transaction.1m-fallback@ilm
+  - metrics-apm.transaction.60m-fallback@ilm
+  - traces-apm-fallback@ilm
+  - traces-apm.rum-fallback@ilm
+  - traces-apm.sampled-fallback@ilm
 
 index-templates:
   - logs-apm.app@template

--- a/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMDSLOnlyTests.java
+++ b/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMDSLOnlyTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.apmdata;
+
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.datastreams.DataStreamFeatures;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class APMDSLOnlyTests extends ESTestCase {
+    private APMIndexTemplateRegistry apmIndexTemplateRegistry;
+    private ThreadPool threadPool;
+    private VerifyingClient client;
+
+    @Before
+    public void createRegistryAndClient() {
+        final ClusterSettings clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            Stream.concat(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(), Set.of(APMPlugin.APM_DATA_REGISTRY_ENABLED).stream())
+                .collect(Collectors.toSet())
+        );
+
+        threadPool = new TestThreadPool(this.getClass().getName());
+        client = new VerifyingClient(threadPool);
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create("node", "node");
+        Settings additionalSettings = Settings.builder().put(DataStreamLifecycle.DATA_STREAMS_LIFECYCLE_ONLY_SETTING_NAME, true).build();
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(
+            threadPool,
+            discoveryNode,
+            additionalSettings,
+            clusterSettings
+        );
+        FeatureService featureService = new FeatureService(List.of(new DataStreamFeatures()));
+
+        apmIndexTemplateRegistry = new APMIndexTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            threadPool,
+            client,
+            NamedXContentRegistry.EMPTY,
+            featureService
+        );
+        apmIndexTemplateRegistry.setEnabled(true);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public void testNoILMComponentTemplateInstalled() throws Exception {
+        for (Map.Entry<String, ComponentTemplate> entry : apmIndexTemplateRegistry.getComponentTemplateConfigs().entrySet()) {
+            final String name = entry.getKey();
+            final int atIndex = name.lastIndexOf('@');
+            assertThat(atIndex, not(equalTo(-1)));
+            // No ILM templates should have been loaded
+            assertThat(name.substring(atIndex + 1), not(equalTo("ilm")));
+        }
+    }
+}

--- a/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
@@ -312,11 +312,15 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
             // Each index template should be composed of the following optional component templates:
             // <data_stream.type>@custom
             // <data_stream.type>-<data_stream.dataset>@custom
+            // <data_stream.type>-fallback@ilm
             final List<String> optionalComponentTemplates = template.composedOf()
                 .stream()
                 .filter(t -> template.getIgnoreMissingComponentTemplates().contains(t))
                 .toList();
-            assertThat(optionalComponentTemplates, containsInAnyOrder(namePrefix + "@custom", dataStreamType + "@custom"));
+            assertThat(
+                optionalComponentTemplates,
+                containsInAnyOrder(namePrefix + "@custom", dataStreamType + "@custom", namePrefix + "-fallback@ilm")
+            );
 
             // There should be no required custom component templates.
             final List<String> requiredCustomComponentTemplates = template.getRequiredComponentTemplates()
@@ -374,6 +378,20 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
 
         ClusterChangedEvent event = createClusterChangedEvent(Map.of(), Map.of(), nodes);
         apmIndexTemplateRegistry.clusterChanged(event);
+    }
+
+    public void testILMComponentTemplatesInstalled() throws Exception {
+        int ilmFallbackCount = 0;
+        for (Map.Entry<String, ComponentTemplate> entry : apmIndexTemplateRegistry.getComponentTemplateConfigs().entrySet()) {
+            final String name = entry.getKey();
+            final int atIndex = name.lastIndexOf('@');
+            assertThat(atIndex, not(equalTo(-1)));
+            if ("ilm".equals(name.substring(atIndex + 1))) {
+                ilmFallbackCount++;
+            }
+        }
+        // Each index template should have a corresponding ILM fallback policy
+        assertThat(apmIndexTemplateRegistry.getComposableTemplateConfigs().size(), equalTo(ilmFallbackCount));
     }
 
     private Map<String, ComponentTemplate> getIndependentComponentTemplateConfigs() {

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/10_apm.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/10_apm.yml
@@ -81,3 +81,27 @@ setup:
   - length: {hits.hits: 1}
   - match: {hits.hits.0.fields.event\.success_count: [1]}
   - match: {hits.hits.0.fields.span\.duration\.us: [123]}
+
+---
+"Test ILM fallback component-template installation with dsl-only mode false":
+  - skip:
+      reason: contains is a newly added assertion
+      features: contains
+  - do:
+      cluster.get_component_template:
+        name: "*-fallback@ilm"
+  - length: {component_templates: 19}
+  - contains: {component_templates: {name: metrics-apm.app-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.internal-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_destination.1m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_destination.10m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_destination.60m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_summary.1m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_summary.10m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_summary.60m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_transaction.1m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_transaction.10m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.service_transaction.60m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.transaction.1m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.transaction.10m-fallback@ilm}}
+  - contains: {component_templates: {name: metrics-apm.transaction.60m-fallback@ilm}}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class ResourceUtils {
+
     static byte[] loadVersionedResourceUTF8(Class<?> clazz, String name, int version, String versionProperty) {
         return loadVersionedResourceUTF8(clazz, name, version, versionProperty, Map.of());
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[plugin/apm-data]Fallback to ILM for non-dsl-only mode if DSL unavailable (#112759)](https://github.com/elastic/elasticsearch/pull/112759)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)