### PR TITLE
ES|QL: Fix ResolvedEnrichPolicy serialization (bwc) in v 8.15

### DIFF
--- a/docs/changelog/112985.yaml
+++ b/docs/changelog/112985.yaml
@@ -2,4 +2,5 @@ pr: 112985
 summary: "ES|QL: Fix `ResolvedEnrichPolicy` serialization (bwc) in v 8.15"
 area: ES|QL
 type: bug
-issues: []
+issues:
+ - 112968

--- a/docs/changelog/112985.yaml
+++ b/docs/changelog/112985.yaml
@@ -1,0 +1,5 @@
+pr: 112985
+summary: "ES|QL: Fix `ResolvedEnrichPolicy` serialization (bwc) in v 8.15"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DateEsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DateEsField.java
@@ -30,7 +30,7 @@ public class DateEsField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         out.writeBoolean(isAggregatable());

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
@@ -58,7 +58,7 @@ public class EsField implements Writeable {
         this.isAlias = isAlias;
     }
 
-    protected EsField(StreamInput in) throws IOException {
+    public EsField(StreamInput in) throws IOException {
         this.name = in.readString();
         this.esDataType = DataType.readFrom(in);
         this.properties = in.readImmutableMap(EsField::readFrom);
@@ -80,7 +80,7 @@ public class EsField implements Writeable {
     /**
      * This needs to be overridden by subclasses for specific serialization
      */
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeString(esDataType.typeName());
         out.writeMap(properties, (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
@@ -60,7 +60,7 @@ public class InvalidMappedField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeString(errorMessage);
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/KeywordEsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/KeywordEsField.java
@@ -70,7 +70,7 @@ public class KeywordEsField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         out.writeBoolean(isAggregatable());

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/TextEsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/TextEsField.java
@@ -36,7 +36,7 @@ public class TextEsField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         out.writeBoolean(isAggregatable());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/ResolvedEnrichPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/ResolvedEnrichPolicy.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.enrich;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -29,8 +30,15 @@ public record ResolvedEnrichPolicy(
             in.readString(),
             in.readStringCollectionAsList(),
             in.readMap(StreamInput::readString),
-            in.readMap(EsField::readFrom)
+            in.readMap(getEsFieldReader(in))
         );
+    }
+
+    private static Reader<EsField> getEsFieldReader(StreamInput in) {
+        if (in.getTransportVersion().isPatchFrom(TransportVersions.ESQL_ATTRIBUTE_CACHED_SERIALIZATION_8_15)) {
+            return EsField::readFrom;
+        }
+        return EsField::new;
     }
 
     @Override
@@ -45,7 +53,13 @@ public record ResolvedEnrichPolicy(
              * There are lots of subtypes of ESField, but we always write the field
              * as though it were the base class.
              */
-            (o, v) -> new EsField(v.getName(), v.getDataType(), v.getProperties(), v.isAggregatable(), v.isAlias()).writeTo(o)
+            (o, v) -> {
+                if (out.getTransportVersion().isPatchFrom(TransportVersions.ESQL_ATTRIBUTE_CACHED_SERIALIZATION_8_15)) {
+                    new EsField(v.getName(), v.getDataType(), v.getProperties(), v.isAggregatable(), v.isAlias()).writeTo(o);
+                } else {
+                    new EsField(v.getName(), v.getDataType(), v.getProperties(), v.isAggregatable(), v.isAlias()).writeContent(o);
+                }
+            }
         );
     }
 }


### PR DESCRIPTION
Before the fix introduced by https://github.com/elastic/elasticsearch/pull/112865, `ResolvedEnrichPolicy` did not serialize `EsField` as a `NamedWriteable` 

Fixes #112968