### PR TITLE
ES|QL: Fix ResolvedEnrichPolicy serialization (bwc) in >= 8.16

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DateEsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DateEsField.java
@@ -30,7 +30,7 @@ public class DateEsField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         out.writeBoolean(isAggregatable());

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
@@ -59,7 +59,7 @@ public class EsField implements Writeable {
         this.isAlias = isAlias;
     }
 
-    protected EsField(StreamInput in) throws IOException {
+    public EsField(StreamInput in) throws IOException {
         this.name = in.readString();
         this.esDataType = readDataType(in);
         this.properties = in.readImmutableMap(EsField::readFrom);
@@ -97,7 +97,7 @@ public class EsField implements Writeable {
     /**
      * This needs to be overridden by subclasses for specific serialization
      */
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(name);
         esDataType.writeTo(out);
         out.writeMap(properties, (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
@@ -60,7 +60,7 @@ public class InvalidMappedField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeString(errorMessage);
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/KeywordEsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/KeywordEsField.java
@@ -70,7 +70,7 @@ public class KeywordEsField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         out.writeBoolean(isAggregatable());

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/TextEsField.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/TextEsField.java
@@ -36,7 +36,7 @@ public class TextEsField extends EsField {
     }
 
     @Override
-    protected void writeContent(StreamOutput out) throws IOException {
+    public void writeContent(StreamOutput out) throws IOException {
         out.writeString(getName());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         out.writeBoolean(isAggregatable());


### PR DESCRIPTION
Before the fixes related to cached EsField serialization, `ResolvedEnrichPolicy` did not serialize `EsField` as a `NamedWriteable`

This problem makes v 8.15 CI fail, but not >= 8.16 (the problem only happens with enrich policy serialization in CCS, and 8.16 has different mechanics, so it's not CCS compatible with 8.15). 
Anyway, this is technically the correct serialization for previous versions.

Related to https://github.com/elastic/elasticsearch/issues/112968