### PR TITLE
[8.x backport] Add CircuitBreaker to TDigest, Step 1: Arrays to BigArrays (#112810)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/tdigest/TDigestBench.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/tdigest/TDigestBench.java
@@ -21,9 +21,9 @@
 
 package org.elasticsearch.benchmark.tdigest;
 
-import org.elasticsearch.tdigest.AVLTreeDigest;
 import org.elasticsearch.tdigest.MergingDigest;
 import org.elasticsearch.tdigest.TDigest;
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -61,13 +61,19 @@ public class TDigestBench {
         MERGE {
             @Override
             TDigest create(double compression) {
-                return new MergingDigest(compression, (int) (10 * compression));
+                return new MergingDigest(WrapperTDigestArrays.INSTANCE, compression, (int) (10 * compression));
             }
         },
         AVL_TREE {
             @Override
             TDigest create(double compression) {
-                return new AVLTreeDigest(compression);
+                return TDigest.createAvlTreeDigest(WrapperTDigestArrays.INSTANCE, compression);
+            }
+        },
+        HYBRID {
+            @Override
+            TDigest create(double compression) {
+                return TDigest.createHybridDigest(WrapperTDigestArrays.INSTANCE, compression);
             }
         };
 
@@ -77,7 +83,7 @@ public class TDigestBench {
     @Param({ "100", "300" })
     double compression;
 
-    @Param({ "MERGE", "AVL_TREE" })
+    @Param({ "MERGE", "AVL_TREE", "HYBRID" })
     TDigestFactory tdigestFactory;
 
     @Param({ "NORMAL", "GAUSSIAN" })

--- a/libs/tdigest/src/main/java/module-info.java
+++ b/libs/tdigest/src/main/java/module-info.java
@@ -19,4 +19,5 @@
 
 module org.elasticsearch.tdigest {
     exports org.elasticsearch.tdigest;
+    exports org.elasticsearch.tdigest.arrays;
 }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/AVLGroupTree.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/AVLGroupTree.java
@@ -21,8 +21,11 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.TDigestDoubleArray;
+import org.elasticsearch.tdigest.arrays.TDigestLongArray;
+
 import java.util.AbstractCollection;
-import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -32,20 +35,20 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
     /* For insertions into the tree */
     private double centroid;
     private long count;
-    private double[] centroids;
-    private long[] counts;
-    private long[] aggregatedCounts;
+    private final TDigestDoubleArray centroids;
+    private final TDigestLongArray counts;
+    private final TDigestLongArray aggregatedCounts;
     private final IntAVLTree tree;
 
-    AVLGroupTree() {
-        tree = new IntAVLTree() {
+    AVLGroupTree(TDigestArrays arrays) {
+        tree = new IntAVLTree(arrays) {
 
             @Override
             protected void resize(int newCapacity) {
                 super.resize(newCapacity);
-                centroids = Arrays.copyOf(centroids, newCapacity);
-                counts = Arrays.copyOf(counts, newCapacity);
-                aggregatedCounts = Arrays.copyOf(aggregatedCounts, newCapacity);
+                centroids.resize(newCapacity);
+                counts.resize(newCapacity);
+                aggregatedCounts.resize(newCapacity);
             }
 
             @Override
@@ -56,13 +59,13 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
 
             @Override
             protected void copy(int node) {
-                centroids[node] = centroid;
-                counts[node] = count;
+                centroids.set(node, centroid);
+                counts.set(node, count);
             }
 
             @Override
             protected int compare(int node) {
-                if (centroid < centroids[node]) {
+                if (centroid < centroids.get(node)) {
                     return -1;
                 } else {
                     // upon equality, the newly added node is considered greater
@@ -73,13 +76,13 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
             @Override
             protected void fixAggregates(int node) {
                 super.fixAggregates(node);
-                aggregatedCounts[node] = counts[node] + aggregatedCounts[left(node)] + aggregatedCounts[right(node)];
+                aggregatedCounts.set(node, counts.get(node) + aggregatedCounts.get(left(node)) + aggregatedCounts.get(right(node)));
             }
 
         };
-        centroids = new double[tree.capacity()];
-        counts = new long[tree.capacity()];
-        aggregatedCounts = new long[tree.capacity()];
+        centroids = arrays.newDoubleArray(tree.capacity());
+        counts = arrays.newLongArray(tree.capacity());
+        aggregatedCounts = arrays.newLongArray(tree.capacity());
     }
 
     /**
@@ -107,14 +110,14 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
      * Return the mean for the provided node.
      */
     public double mean(int node) {
-        return centroids[node];
+        return centroids.get(node);
     }
 
     /**
      * Return the count for the provided node.
      */
     public long count(int node) {
-        return counts[node];
+        return counts.get(node);
     }
 
     /**
@@ -167,7 +170,7 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
         int floor = IntAVLTree.NIL;
         for (int node = tree.root(); node != IntAVLTree.NIL;) {
             final int left = tree.left(node);
-            final long leftCount = aggregatedCounts[left];
+            final long leftCount = aggregatedCounts.get(left);
             if (leftCount <= sum) {
                 floor = node;
                 sum -= leftCount + count(node);
@@ -199,11 +202,11 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
      */
     public long headSum(int node) {
         final int left = tree.left(node);
-        long sum = aggregatedCounts[left];
+        long sum = aggregatedCounts.get(left);
         for (int n = node, p = tree.parent(node); p != IntAVLTree.NIL; n = p, p = tree.parent(n)) {
             if (n == tree.right(p)) {
                 final int leftP = tree.left(p);
-                sum += counts[p] + aggregatedCounts[leftP];
+                sum += counts.get(p) + aggregatedCounts.get(leftP);
             }
         }
         return sum;
@@ -243,7 +246,7 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
      * Return the total count of points that have been added to the tree.
      */
     public long sum() {
-        return aggregatedCounts[tree.root()];
+        return aggregatedCounts.get(tree.root());
     }
 
     void checkBalance() {
@@ -255,7 +258,9 @@ final class AVLGroupTree extends AbstractCollection<Centroid> {
     }
 
     private void checkAggregates(int node) {
-        assert aggregatedCounts[node] == counts[node] + aggregatedCounts[tree.left(node)] + aggregatedCounts[tree.right(node)];
+        assert aggregatedCounts.get(node) == counts.get(node) + aggregatedCounts.get(tree.left(node)) + aggregatedCounts.get(
+            tree.right(node)
+        );
         if (node != IntAVLTree.NIL) {
             checkAggregates(tree.left(node));
             checkAggregates(tree.right(node));

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/AVLTreeDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/AVLTreeDigest.java
@@ -21,6 +21,8 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -29,6 +31,8 @@ import java.util.Random;
 import static org.elasticsearch.tdigest.IntAVLTree.NIL;
 
 public class AVLTreeDigest extends AbstractTDigest {
+    private final TDigestArrays arrays;
+
     final Random gen = new Random();
     private final double compression;
     private AVLGroupTree summary;
@@ -46,9 +50,10 @@ public class AVLTreeDigest extends AbstractTDigest {
      *                    quantiles.  Conversely, you should expect to track about 5 N centroids for this
      *                    accuracy.
      */
-    public AVLTreeDigest(double compression) {
+    AVLTreeDigest(TDigestArrays arrays, double compression) {
+        this.arrays = arrays;
         this.compression = compression;
-        summary = new AVLGroupTree();
+        summary = new AVLGroupTree(arrays);
     }
 
     /**
@@ -149,7 +154,7 @@ public class AVLTreeDigest extends AbstractTDigest {
         needsCompression = false;
 
         AVLGroupTree centroids = summary;
-        this.summary = new AVLGroupTree();
+        this.summary = new AVLGroupTree(arrays);
 
         final int[] nodes = new int[centroids.size()];
         nodes[0] = centroids.first();

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Dist.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Dist.java
@@ -21,6 +21,8 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestDoubleArray;
+
 import java.util.List;
 import java.util.function.Function;
 
@@ -102,6 +104,10 @@ public class Dist {
         return cdf(x, data.size(), data::get);
     }
 
+    public static double cdf(final double x, TDigestDoubleArray data) {
+        return cdf(x, data.size(), data::get);
+    }
+
     private static double quantile(final double q, final int length, Function<Integer, Double> elementGetter) {
         if (length == 0) {
             return Double.NaN;
@@ -131,6 +137,10 @@ public class Dist {
     }
 
     public static double quantile(final double q, List<Double> data) {
+        return quantile(q, data.size(), data::get);
+    }
+
+    public static double quantile(final double q, TDigestDoubleArray data) {
         return quantile(q, data.size(), data::get);
     }
 }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/HybridDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/HybridDigest.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+
 import java.util.Collection;
 
 /**
@@ -32,6 +34,8 @@ import java.util.Collection;
  */
 public class HybridDigest extends AbstractTDigest {
 
+    private final TDigestArrays arrays;
+
     // See MergingDigest's compression param.
     private final double compression;
 
@@ -39,7 +43,7 @@ public class HybridDigest extends AbstractTDigest {
     private final long maxSortingSize;
 
     // This is set to null when the implementation switches to MergingDigest.
-    private SortingDigest sortingDigest = new SortingDigest();
+    private SortingDigest sortingDigest;
 
     // This gets initialized when the implementation switches to MergingDigest.
     private MergingDigest mergingDigest;
@@ -51,9 +55,11 @@ public class HybridDigest extends AbstractTDigest {
      * @param compression The compression factor for the MergingDigest
      * @param maxSortingSize The sample size limit for switching from a {@link SortingDigest} to a {@link MergingDigest} implementation
      */
-    HybridDigest(double compression, long maxSortingSize) {
+    HybridDigest(TDigestArrays arrays, double compression, long maxSortingSize) {
+        this.arrays = arrays;
         this.compression = compression;
         this.maxSortingSize = maxSortingSize;
+        this.sortingDigest = new SortingDigest(arrays);
     }
 
     /**
@@ -62,11 +68,11 @@ public class HybridDigest extends AbstractTDigest {
      *
      * @param compression The compression factor for the MergingDigest
      */
-    HybridDigest(double compression) {
+    HybridDigest(TDigestArrays arrays, double compression) {
         // The default maxSortingSize is calculated so that the SortingDigest will have comparable size with the MergingDigest
         // at the point where implementations switch, e.g. for default compression 100 SortingDigest allocates ~16kB and MergingDigest
         // allocates ~15kB.
-        this(compression, Math.round(compression) * 20);
+        this(arrays, compression, Math.round(compression) * 20);
     }
 
     @Override
@@ -98,9 +104,9 @@ public class HybridDigest extends AbstractTDigest {
         // Check if we need to switch implementations.
         assert sortingDigest != null;
         if (sortingDigest.size() + size >= maxSortingSize) {
-            mergingDigest = new MergingDigest(compression);
-            for (double value : sortingDigest.values) {
-                mergingDigest.add(value);
+            mergingDigest = new MergingDigest(arrays, compression);
+            for (int i = 0; i < sortingDigest.values.size(); i++) {
+                mergingDigest.add(sortingDigest.values.get(i));
             }
             mergingDigest.reserve(size);
             // Release the allocated SortingDigest.

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/IntAVLTree.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/IntAVLTree.java
@@ -21,6 +21,10 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.TDigestByteArray;
+import org.elasticsearch.tdigest.arrays.TDigestIntArray;
+
 import java.util.Arrays;
 
 /**
@@ -30,7 +34,6 @@ import java.util.Arrays;
  * identifiers as indices.
  */
 abstract class IntAVLTree {
-
     /**
      * We use <code>0</code> instead of <code>-1</code> so that left(NIL) works without
      * condition.
@@ -44,22 +47,22 @@ abstract class IntAVLTree {
 
     private final NodeAllocator nodeAllocator;
     private int root;
-    private int[] parent;
-    private int[] left;
-    private int[] right;
-    private byte[] depth;
+    private final TDigestIntArray parent;
+    private final TDigestIntArray left;
+    private final TDigestIntArray right;
+    private final TDigestByteArray depth;
 
-    IntAVLTree(int initialCapacity) {
+    IntAVLTree(TDigestArrays arrays, int initialCapacity) {
         nodeAllocator = new NodeAllocator();
         root = NIL;
-        parent = new int[initialCapacity];
-        left = new int[initialCapacity];
-        right = new int[initialCapacity];
-        depth = new byte[initialCapacity];
+        parent = arrays.newIntArray(initialCapacity);
+        left = arrays.newIntArray(initialCapacity);
+        right = arrays.newIntArray(initialCapacity);
+        depth = arrays.newByteArray(initialCapacity);
     }
 
-    IntAVLTree() {
-        this(16);
+    IntAVLTree(TDigestArrays arrays) {
+        this(arrays, 16);
     }
 
     /**
@@ -74,7 +77,7 @@ abstract class IntAVLTree {
      * can hold.
      */
     public int capacity() {
-        return parent.length;
+        return parent.size();
     }
 
     /**
@@ -82,10 +85,10 @@ abstract class IntAVLTree {
      * <code>newCapacity</code> (excluded).
      */
     protected void resize(int newCapacity) {
-        parent = Arrays.copyOf(parent, newCapacity);
-        left = Arrays.copyOf(left, newCapacity);
-        right = Arrays.copyOf(right, newCapacity);
-        depth = Arrays.copyOf(depth, newCapacity);
+        parent.resize(newCapacity);
+        left.resize(newCapacity);
+        right.resize(newCapacity);
+        depth.resize(newCapacity);
     }
 
     /**
@@ -99,28 +102,28 @@ abstract class IntAVLTree {
      * Return the parent of the provided node.
      */
     public int parent(int node) {
-        return parent[node];
+        return parent.get(node);
     }
 
     /**
      * Return the left child of the provided node.
      */
     public int left(int node) {
-        return left[node];
+        return left.get(node);
     }
 
     /**
      * Return the right child of the provided node.
      */
     public int right(int node) {
-        return right[node];
+        return right.get(node);
     }
 
     /**
      * Return the depth nodes that are stored below <code>node</code> including itself.
      */
     public int depth(int node) {
-        return depth[node];
+        return depth.get(node);
     }
 
     /**
@@ -493,23 +496,23 @@ abstract class IntAVLTree {
 
     private void parent(int node, int parent) {
         assert node != NIL;
-        this.parent[node] = parent;
+        this.parent.set(node, parent);
     }
 
     private void left(int node, int left) {
         assert node != NIL;
-        this.left[node] = left;
+        this.left.set(node, left);
     }
 
     private void right(int node, int right) {
         assert node != NIL;
-        this.right[node] = right;
+        this.right.set(node, right);
     }
 
     private void depth(int node, int depth) {
         assert node != NIL;
         assert depth >= 0 && depth <= Byte.MAX_VALUE;
-        this.depth[node] = (byte) depth;
+        this.depth.set(node, (byte) depth);
     }
 
     void checkBalance(int node) {

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
@@ -21,6 +21,10 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.TDigestDoubleArray;
+import org.elasticsearch.tdigest.arrays.TDigestIntArray;
+
 import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Iterator;
@@ -62,6 +66,8 @@ import java.util.Iterator;
  * what the AVLTreeDigest uses and no dynamic allocation is required at all.
  */
 public class MergingDigest extends AbstractTDigest {
+    private final TDigestArrays arrays;
+
     private int mergeCount = 0;
 
     private final double publicCompression;
@@ -70,26 +76,26 @@ public class MergingDigest extends AbstractTDigest {
     // points to the first unused centroid
     private int lastUsedCell;
 
-    // sum_i weight[i] See also unmergedWeight
+    // sum_i weight.get(i) See also unmergedWeight
     private double totalWeight = 0;
 
     // number of points that have been added to each merged centroid
-    private final double[] weight;
+    private final TDigestDoubleArray weight;
     // mean of points added to each merged centroid
-    private final double[] mean;
+    private final TDigestDoubleArray mean;
 
-    // sum_i tempWeight[i]
+    // sum_i tempWeight.get(i)
     private double unmergedWeight = 0;
 
     // this is the index of the next temporary centroid
     // this is a more Java-like convention than lastUsedCell uses
     private int tempUsed = 0;
-    private final double[] tempWeight;
-    private final double[] tempMean;
+    private final TDigestDoubleArray tempWeight;
+    private final TDigestDoubleArray tempMean;
 
     // array used for sorting the temp centroids. This is a field
     // to avoid allocations during operation
-    private final int[] order;
+    private final TDigestIntArray order;
 
     // if true, alternate upward and downward merge passes
     public boolean useAlternatingSort = true;
@@ -109,8 +115,8 @@ public class MergingDigest extends AbstractTDigest {
      *
      * @param compression The compression factor
      */
-    public MergingDigest(double compression) {
-        this(compression, -1);
+    public MergingDigest(TDigestArrays arrays, double compression) {
+        this(arrays, compression, -1);
     }
 
     /**
@@ -119,9 +125,9 @@ public class MergingDigest extends AbstractTDigest {
      * @param compression Compression factor for t-digest.  Same as 1/\delta in the paper.
      * @param bufferSize  How many samples to retain before merging.
      */
-    public MergingDigest(double compression, int bufferSize) {
+    public MergingDigest(TDigestArrays arrays, double compression, int bufferSize) {
         // we can guarantee that we only need ceiling(compression).
-        this(compression, bufferSize, -1);
+        this(arrays, compression, bufferSize, -1);
     }
 
     /**
@@ -131,7 +137,9 @@ public class MergingDigest extends AbstractTDigest {
      * @param bufferSize  Number of temporary centroids
      * @param size        Size of main buffer
      */
-    public MergingDigest(double compression, int bufferSize, int size) {
+    public MergingDigest(TDigestArrays arrays, double compression, int bufferSize, int size) {
+        this.arrays = arrays;
+
         // ensure compression >= 10
         // default size = 2 * ceil(compression)
         // default bufferSize = 5 * size
@@ -205,12 +213,12 @@ public class MergingDigest extends AbstractTDigest {
             bufferSize = 2 * size;
         }
 
-        weight = new double[size];
-        mean = new double[size];
+        weight = arrays.newDoubleArray(size);
+        mean = arrays.newDoubleArray(size);
 
-        tempWeight = new double[bufferSize];
-        tempMean = new double[bufferSize];
-        order = new int[bufferSize];
+        tempWeight = arrays.newDoubleArray(bufferSize);
+        tempMean = arrays.newDoubleArray(bufferSize);
+        order = arrays.newIntArray(bufferSize);
 
         lastUsedCell = 0;
     }
@@ -218,12 +226,12 @@ public class MergingDigest extends AbstractTDigest {
     @Override
     public void add(double x, long w) {
         checkValue(x);
-        if (tempUsed >= tempWeight.length - lastUsedCell - 1) {
+        if (tempUsed >= tempWeight.size() - lastUsedCell - 1) {
             mergeNewValues();
         }
         int where = tempUsed++;
-        tempWeight[where] = w;
-        tempMean[where] = x;
+        tempWeight.set(where, w);
+        tempMean.set(where, x);
         unmergedWeight += w;
         if (x < min) {
             min = x;
@@ -252,22 +260,22 @@ public class MergingDigest extends AbstractTDigest {
     }
 
     private void merge(
-        double[] incomingMean,
-        double[] incomingWeight,
+        TDigestDoubleArray incomingMean,
+        TDigestDoubleArray incomingWeight,
         int incomingCount,
-        int[] incomingOrder,
+        TDigestIntArray incomingOrder,
         double unmergedWeight,
         boolean runBackwards,
         double compression
     ) {
         // when our incoming buffer fills up, we combine our existing centroids with the incoming data,
         // and then reduce the centroids by merging if possible
-        System.arraycopy(mean, 0, incomingMean, incomingCount, lastUsedCell);
-        System.arraycopy(weight, 0, incomingWeight, incomingCount, lastUsedCell);
+        incomingMean.set(incomingCount, mean, 0, lastUsedCell);
+        incomingWeight.set(incomingCount, weight, 0, lastUsedCell);
         incomingCount += lastUsedCell;
 
         if (incomingOrder == null) {
-            incomingOrder = new int[incomingCount];
+            incomingOrder = arrays.newIntArray(incomingCount);
         }
         Sort.stableSort(incomingOrder, incomingMean, incomingCount);
 
@@ -280,8 +288,8 @@ public class MergingDigest extends AbstractTDigest {
 
         // start by copying the least incoming value to the normal buffer
         lastUsedCell = 0;
-        mean[lastUsedCell] = incomingMean[incomingOrder[0]];
-        weight[lastUsedCell] = incomingWeight[incomingOrder[0]];
+        mean.set(lastUsedCell, incomingMean.get(incomingOrder.get(0)));
+        weight.set(lastUsedCell, incomingWeight.get(incomingOrder.get(0)));
         double wSoFar = 0;
 
         // weight will contain all zeros after this loop
@@ -290,8 +298,8 @@ public class MergingDigest extends AbstractTDigest {
         double k1 = scale.k(0, normalizer);
         double wLimit = totalWeight * scale.q(k1 + 1, normalizer);
         for (int i = 1; i < incomingCount; i++) {
-            int ix = incomingOrder[i];
-            double proposedWeight = weight[lastUsedCell] + incomingWeight[ix];
+            int ix = incomingOrder.get(i);
+            double proposedWeight = weight.get(lastUsedCell) + incomingWeight.get(ix);
             double projectedW = wSoFar + proposedWeight;
             boolean addThis;
             if (useWeightLimit) {
@@ -305,7 +313,7 @@ public class MergingDigest extends AbstractTDigest {
                 // force first and last centroid to never merge
                 addThis = false;
             }
-            if (lastUsedCell == mean.length - 1) {
+            if (lastUsedCell == mean.size() - 1) {
                 // use the last centroid, there's no more
                 addThis = true;
             }
@@ -313,22 +321,26 @@ public class MergingDigest extends AbstractTDigest {
             if (addThis) {
                 // next point will fit
                 // so merge into existing centroid
-                weight[lastUsedCell] += incomingWeight[ix];
-                mean[lastUsedCell] = mean[lastUsedCell] + (incomingMean[ix] - mean[lastUsedCell]) * incomingWeight[ix]
-                    / weight[lastUsedCell];
-                incomingWeight[ix] = 0;
+                weight.set(lastUsedCell, weight.get(lastUsedCell) + incomingWeight.get(ix));
+                mean.set(
+                    lastUsedCell,
+                    mean.get(lastUsedCell) + (incomingMean.get(ix) - mean.get(lastUsedCell)) * incomingWeight.get(ix) / weight.get(
+                        lastUsedCell
+                    )
+                );
+                incomingWeight.set(ix, 0);
             } else {
                 // didn't fit ... move to next output, copy out first centroid
-                wSoFar += weight[lastUsedCell];
+                wSoFar += weight.get(lastUsedCell);
                 if (useWeightLimit == false) {
                     k1 = scale.k(wSoFar / totalWeight, normalizer);
                     wLimit = totalWeight * scale.q(k1 + 1, normalizer);
                 }
 
                 lastUsedCell++;
-                mean[lastUsedCell] = incomingMean[ix];
-                weight[lastUsedCell] = incomingWeight[ix];
-                incomingWeight[ix] = 0;
+                mean.set(lastUsedCell, incomingMean.get(ix));
+                weight.set(lastUsedCell, incomingWeight.get(ix));
+                incomingWeight.set(ix, 0);
             }
         }
         // points to next empty cell
@@ -337,7 +349,7 @@ public class MergingDigest extends AbstractTDigest {
         // sanity check
         double sum = 0;
         for (int i = 0; i < lastUsedCell; i++) {
-            sum += weight[i];
+            sum += weight.get(i);
         }
         assert sum == totalWeight;
         if (runBackwards) {
@@ -345,8 +357,8 @@ public class MergingDigest extends AbstractTDigest {
             Sort.reverse(weight, 0, lastUsedCell);
         }
         if (totalWeight > 0) {
-            min = Math.min(min, mean[0]);
-            max = Math.max(max, mean[lastUsedCell - 1]);
+            min = Math.min(min, mean.get(0));
+            max = Math.max(max, mean.get(lastUsedCell - 1));
         }
     }
 
@@ -387,8 +399,8 @@ public class MergingDigest extends AbstractTDigest {
                 // we have one or more centroids == x, treat them as one
                 // dw will accumulate the weight of all of the centroids at x
                 double dw = 0;
-                for (int i = 0; i < lastUsedCell && Double.compare(mean[i], x) == 0; i++) {
-                    dw += weight[i];
+                for (int i = 0; i < lastUsedCell && Double.compare(mean.get(i), x) == 0; i++) {
+                    dw += weight.get(i);
                 }
                 return dw / 2.0 / size();
             }
@@ -398,31 +410,32 @@ public class MergingDigest extends AbstractTDigest {
             }
             if (x == max) {
                 double dw = 0;
-                for (int i = lastUsedCell - 1; i >= 0 && Double.compare(mean[i], x) == 0; i--) {
-                    dw += weight[i];
+                for (int i = lastUsedCell - 1; i >= 0 && Double.compare(mean.get(i), x) == 0; i--) {
+                    dw += weight.get(i);
                 }
                 return (size() - dw / 2.0) / size();
             }
 
             // initially, we set left width equal to right width
-            double left = (mean[1] - mean[0]) / 2;
+            double left = (mean.get(1) - mean.get(0)) / 2;
             double weightSoFar = 0;
 
             for (int i = 0; i < lastUsedCell - 1; i++) {
-                double right = (mean[i + 1] - mean[i]) / 2;
-                if (x < mean[i] + right) {
-                    double value = (weightSoFar + weight[i] * interpolate(x, mean[i] - left, mean[i] + right)) / size();
+                double right = (mean.get(i + 1) - mean.get(i)) / 2;
+                if (x < mean.get(i) + right) {
+                    double value = (weightSoFar + weight.get(i) * interpolate(x, mean.get(i) - left, mean.get(i) + right)) / size();
                     return Math.max(value, 0.0);
                 }
-                weightSoFar += weight[i];
+                weightSoFar += weight.get(i);
                 left = right;
             }
 
             // for the last element, assume right width is same as left
             int lastOffset = lastUsedCell - 1;
-            double right = (mean[lastOffset] - mean[lastOffset - 1]) / 2;
-            if (x < mean[lastOffset] + right) {
-                return (weightSoFar + weight[lastOffset] * interpolate(x, mean[lastOffset] - right, mean[lastOffset] + right)) / size();
+            double right = (mean.get(lastOffset) - mean.get(lastOffset - 1)) / 2;
+            if (x < mean.get(lastOffset) + right) {
+                return (weightSoFar + weight.get(lastOffset) * interpolate(x, mean.get(lastOffset) - right, mean.get(lastOffset) + right))
+                    / size();
             }
             return 1;
         }
@@ -440,7 +453,7 @@ public class MergingDigest extends AbstractTDigest {
             return Double.NaN;
         } else if (lastUsedCell == 1) {
             // with one data point, all quantiles lead to Rome
-            return mean[0];
+            return mean.get(0);
         }
 
         // we know that there are at least two centroids now
@@ -458,40 +471,40 @@ public class MergingDigest extends AbstractTDigest {
             return max;
         }
 
-        double weightSoFar = weight[0] / 2;
+        double weightSoFar = weight.get(0) / 2;
 
         // if the left centroid has more than one sample, we still know
         // that one sample occurred at min so we can do some interpolation
-        if (weight[0] > 1 && index < weightSoFar) {
+        if (weight.get(0) > 1 && index < weightSoFar) {
             // there is a single sample at min so we interpolate with less weight
-            return weightedAverage(min, weightSoFar - index, mean[0], index);
+            return weightedAverage(min, weightSoFar - index, mean.get(0), index);
         }
 
         // if the right-most centroid has more than one sample, we still know
         // that one sample occurred at max so we can do some interpolation
-        if (weight[n - 1] > 1 && totalWeight - index <= weight[n - 1] / 2) {
-            return max - (totalWeight - index - 1) / (weight[n - 1] / 2 - 1) * (max - mean[n - 1]);
+        if (weight.get(n - 1) > 1 && totalWeight - index <= weight.get(n - 1) / 2) {
+            return max - (totalWeight - index - 1) / (weight.get(n - 1) / 2 - 1) * (max - mean.get(n - 1));
         }
 
         // in between extremes we interpolate between centroids
         for (int i = 0; i < n - 1; i++) {
-            double dw = (weight[i] + weight[i + 1]) / 2;
+            double dw = (weight.get(i) + weight.get(i + 1)) / 2;
             if (weightSoFar + dw > index) {
                 // centroids i and i+1 bracket our current point
                 double z1 = index - weightSoFar;
                 double z2 = weightSoFar + dw - index;
-                return weightedAverage(mean[i], z2, mean[i + 1], z1);
+                return weightedAverage(mean.get(i), z2, mean.get(i + 1), z1);
             }
             weightSoFar += dw;
         }
 
-        assert weight[n - 1] >= 1;
-        assert index >= totalWeight - weight[n - 1];
+        assert weight.get(n - 1) >= 1;
+        assert index >= totalWeight - weight.get(n - 1);
 
         // Interpolate between the last mean and the max.
         double z1 = index - weightSoFar;
-        double z2 = weight[n - 1] / 2.0 - z1;
-        return weightedAverage(mean[n - 1], z1, max, z2);
+        double z2 = weight.get(n - 1) / 2.0 - z1;
+        return weightedAverage(mean.get(n - 1), z1, max, z2);
     }
 
     @Override
@@ -518,7 +531,7 @@ public class MergingDigest extends AbstractTDigest {
 
                     @Override
                     public Centroid next() {
-                        Centroid rc = new Centroid(mean[i], (long) weight[i]);
+                        Centroid rc = new Centroid(mean.get(i), (long) weight.get(i));
                         i++;
                         return rc;
                     }
@@ -553,7 +566,7 @@ public class MergingDigest extends AbstractTDigest {
 
     @Override
     public int byteSize() {
-        return 48 + 8 * (mean.length + weight.length + tempMean.length + tempWeight.length) + 4 * order.length;
+        return 48 + 8 * (mean.size() + weight.size() + tempMean.size() + tempWeight.size()) + 4 * order.size();
     }
 
     @Override

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Sort.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Sort.java
@@ -21,7 +21,9 @@
 
 package org.elasticsearch.tdigest;
 
-import java.util.Arrays;
+import org.elasticsearch.tdigest.arrays.TDigestDoubleArray;
+import org.elasticsearch.tdigest.arrays.TDigestIntArray;
+
 import java.util.Random;
 
 /**
@@ -37,204 +39,12 @@ public class Sort {
      * @param values  The values to sort.
      * @param n       The number of values to sort
      */
-    public static void stableSort(int[] order, double[] values, int n) {
+    public static void stableSort(TDigestIntArray order, TDigestDoubleArray values, int n) {
         for (int i = 0; i < n; i++) {
-            order[i] = i;
+            order.set(i, i);
         }
         stableQuickSort(order, values, 0, n, 64);
         stableInsertionSort(order, values, 0, n, 64);
-    }
-
-    /**
-     * Two-key quick sort on (values, weights) using an index array
-     *
-     * @param order   Indexes into values
-     * @param values  The values to sort.
-     * @param weights The secondary sort key
-     * @param n       The number of values to sort
-     * @return true if the values were already sorted
-     */
-    public static boolean sort(int[] order, double[] values, double[] weights, int n) {
-        if (weights == null) {
-            weights = Arrays.copyOf(values, values.length);
-        }
-        boolean r = sort(order, values, weights, 0, n);
-        // now adjust all runs with equal value so that bigger weights are nearer
-        // the median
-        double medianWeight = 0;
-        for (int i = 0; i < n; i++) {
-            medianWeight += weights[i];
-        }
-        medianWeight = medianWeight / 2;
-        int i = 0;
-        double soFar = 0;
-        double nextGroup = 0;
-        while (i < n) {
-            int j = i;
-            while (j < n && values[order[j]] == values[order[i]]) {
-                double w = weights[order[j]];
-                nextGroup += w;
-                j++;
-            }
-            if (j > i + 1) {
-                if (soFar >= medianWeight) {
-                    // entire group is in last half, reverse the order
-                    reverse(order, i, j - i);
-                } else if (nextGroup > medianWeight) {
-                    // group straddles the median, but not necessarily evenly
-                    // most elements are probably unit weight if there are many
-                    double[] scratch = new double[j - i];
-
-                    double netAfter = nextGroup + soFar - 2 * medianWeight;
-                    // heuristically adjust weights to roughly balance around median
-                    double max = weights[order[j - 1]];
-                    for (int k = j - i - 1; k >= 0; k--) {
-                        double weight = weights[order[i + k]];
-                        if (netAfter < 0) {
-                            // sort in normal order
-                            scratch[k] = weight;
-                            netAfter += weight;
-                        } else {
-                            // sort reversed, but after normal items
-                            scratch[k] = 2 * max + 1 - weight;
-                            netAfter -= weight;
-                        }
-                    }
-                    // sort these balanced weights
-                    int[] sub = new int[j - i];
-                    sort(sub, scratch, scratch, 0, j - i);
-                    int[] tmp = Arrays.copyOfRange(order, i, j);
-                    for (int k = 0; k < j - i; k++) {
-                        order[i + k] = tmp[sub[k]];
-                    }
-                }
-            }
-            soFar = nextGroup;
-            i = j;
-        }
-        return r;
-    }
-
-    /**
-     * Two-key quick sort on (values, weights) using an index array
-     *
-     * @param order   Indexes into values
-     * @param values  The values to sort
-     * @param weights The weights that define the secondary ordering
-     * @param start   The first element to sort
-     * @param n       The number of values to sort
-     * @return True if the values were in order without sorting
-     */
-    private static boolean sort(int[] order, double[] values, double[] weights, int start, int n) {
-        boolean inOrder = true;
-        for (int i = start; i < start + n; i++) {
-            if (inOrder && i < start + n - 1) {
-                inOrder = values[i] < values[i + 1] || (values[i] == values[i + 1] && weights[i] <= weights[i + 1]);
-            }
-            order[i] = i;
-        }
-        if (inOrder) {
-            return true;
-        }
-        quickSort(order, values, weights, start, start + n, 64);
-        insertionSort(order, values, weights, start, start + n, 64);
-        return false;
-    }
-
-    /**
-     * Standard two-key quick sort on (values, weights) except that sorting is done on an index array
-     * rather than the values themselves
-     *
-     * @param order   The pre-allocated index array
-     * @param values  The values to sort
-     * @param weights The weights (secondary key)
-     * @param start   The beginning of the values to sort
-     * @param end     The value after the last value to sort
-     * @param limit   The minimum size to recurse down to.
-     */
-    private static void quickSort(int[] order, double[] values, double[] weights, int start, int end, int limit) {
-        // the while loop implements tail-recursion to avoid excessive stack calls on nasty cases
-        while (end - start > limit) {
-
-            // pivot by a random element
-            int pivotIndex = start + prng.nextInt(end - start);
-            double pivotValue = values[order[pivotIndex]];
-            double pivotWeight = weights[order[pivotIndex]];
-
-            // move pivot to beginning of array
-            swap(order, start, pivotIndex);
-
-            // we use a three way partition because many duplicate values is an important case
-
-            int low = start + 1;   // low points to first value not known to be equal to pivotValue
-            int high = end;        // high points to first value > pivotValue
-            int i = low;           // i scans the array
-            while (i < high) {
-                // invariant: (values,weights)[order[k]] == (pivotValue, pivotWeight) for k in [0..low)
-                // invariant: (values,weights)[order[k]] < (pivotValue, pivotWeight) for k in [low..i)
-                // invariant: (values,weights)[order[k]] > (pivotValue, pivotWeight) for k in [high..end)
-                // in-loop: i < high
-                // in-loop: low < high
-                // in-loop: i >= low
-                double vi = values[order[i]];
-                double wi = weights[order[i]];
-                if (vi == pivotValue && wi == pivotWeight) {
-                    if (low != i) {
-                        swap(order, low, i);
-                    } else {
-                        i++;
-                    }
-                    low++;
-                } else if (vi > pivotValue || (vi == pivotValue && wi > pivotWeight)) {
-                    high--;
-                    swap(order, i, high);
-                } else {
-                    // vi < pivotValue || (vi == pivotValue && wi < pivotWeight)
-                    i++;
-                }
-            }
-            // invariant: (values,weights)[order[k]] == (pivotValue, pivotWeight) for k in [0..low)
-            // invariant: (values,weights)[order[k]] < (pivotValue, pivotWeight) for k in [low..i)
-            // invariant: (values,weights)[order[k]] > (pivotValue, pivotWeight) for k in [high..end)
-            // assert i == high || low == high therefore, we are done with partition
-
-            // at this point, i==high, from [start,low) are == pivot, [low,high) are < and [high,end) are >
-            // we have to move the values equal to the pivot into the middle. To do this, we swap pivot
-            // values into the top end of the [low,high) range stopping when we run out of destinations
-            // or when we run out of values to copy
-            int from = start;
-            int to = high - 1;
-            for (i = 0; from < low && to >= low; i++) {
-                swap(order, from++, to--);
-            }
-            if (from == low) {
-                // ran out of things to copy. This means that the last destination is the boundary
-                low = to + 1;
-            } else {
-                // ran out of places to copy to. This means that there are uncopied pivots and the
-                // boundary is at the beginning of those
-                low = from;
-            }
-
-            // checkPartition(order, values, pivotValue, start, low, high, end);
-
-            // now recurse, but arrange it so we handle the longer limit by tail recursion
-            // we have to sort the pivot values because they may have different weights
-            // we can't do that, however until we know how much weight is in the left and right
-            if (low - start < end - high) {
-                // left side is smaller
-                quickSort(order, values, weights, start, low, limit);
-
-                // this is really a way to do
-                // quickSort(order, values, high, end, limit);
-                start = high;
-            } else {
-                quickSort(order, values, weights, high, end, limit);
-                // this is really a way to do
-                // quickSort(order, values, start, low, limit);
-                end = low;
-            }
-        }
     }
 
     /**
@@ -248,14 +58,14 @@ public class Sort {
      * @param end    The value after the last value to sort
      * @param limit  The minimum size to recurse down to.
      */
-    private static void stableQuickSort(int[] order, double[] values, int start, int end, int limit) {
+    private static void stableQuickSort(TDigestIntArray order, TDigestDoubleArray values, int start, int end, int limit) {
         // the while loop implements tail-recursion to avoid excessive stack calls on nasty cases
         while (end - start > limit) {
 
             // pivot by a random element
             int pivotIndex = start + prng.nextInt(end - start);
-            double pivotValue = values[order[pivotIndex]];
-            int pv = order[pivotIndex];
+            double pivotValue = values.get(order.get(pivotIndex));
+            int pv = order.get(pivotIndex);
 
             // move pivot to beginning of array
             swap(order, start, pivotIndex);
@@ -272,8 +82,8 @@ public class Sort {
                 // in-loop: i < high
                 // in-loop: low < high
                 // in-loop: i >= low
-                double vi = values[order[i]];
-                int pi = order[i];
+                double vi = values.get(order.get(i));
+                int pi = order.get(i);
                 if (vi == pivotValue && pi == pv) {
                     if (low != i) {
                         swap(order, low, i);
@@ -333,247 +143,10 @@ public class Sort {
         }
     }
 
-    /**
-     * Quick sort in place of several paired arrays.  On return,
-     * keys[...] is in order and the values[] arrays will be
-     * reordered as well in the same way.
-     *
-     * @param key    Values to sort on
-     * @param values The auxiliary values to sort.
-     */
-    public static void sort(double[] key, double[]... values) {
-        sort(key, 0, key.length, values);
-    }
-
-    /**
-     * Quick sort using an index array.  On return,
-     * values[order[i]] is in order as i goes start..n
-     *  @param key    Values to sort on
-     * @param start  The first element to sort
-     * @param n      The number of values to sort
-     * @param values The auxiliary values to sort.
-     */
-    public static void sort(double[] key, int start, int n, double[]... values) {
-        quickSort(key, values, start, start + n, 8);
-        insertionSort(key, values, start, start + n, 8);
-    }
-
-    /**
-     * Standard quick sort except that sorting rearranges parallel arrays
-     *
-     * @param key    Values to sort on
-     * @param values The auxiliary values to sort.
-     * @param start  The beginning of the values to sort
-     * @param end    The value after the last value to sort
-     * @param limit  The minimum size to recurse down to.
-     */
-    private static void quickSort(double[] key, double[][] values, int start, int end, int limit) {
-        // the while loop implements tail-recursion to avoid excessive stack calls on nasty cases
-        while (end - start > limit) {
-
-            // median of three values for the pivot
-            int a = start;
-            int b = (start + end) / 2;
-            int c = end - 1;
-
-            int pivotIndex;
-            double pivotValue;
-            double va = key[a];
-            double vb = key[b];
-            double vc = key[c];
-
-            if (va > vb) {
-                if (vc > va) {
-                    // vc > va > vb
-                    pivotIndex = a;
-                    pivotValue = va;
-                } else {
-                    // va > vb, va >= vc
-                    if (vc < vb) {
-                        // va > vb > vc
-                        pivotIndex = b;
-                        pivotValue = vb;
-                    } else {
-                        // va >= vc >= vb
-                        pivotIndex = c;
-                        pivotValue = vc;
-                    }
-                }
-            } else {
-                // vb >= va
-                if (vc > vb) {
-                    // vc > vb >= va
-                    pivotIndex = b;
-                    pivotValue = vb;
-                } else {
-                    // vb >= va, vb >= vc
-                    if (vc < va) {
-                        // vb >= va > vc
-                        pivotIndex = a;
-                        pivotValue = va;
-                    } else {
-                        // vb >= vc >= va
-                        pivotIndex = c;
-                        pivotValue = vc;
-                    }
-                }
-            }
-
-            // move pivot to beginning of array
-            swap(start, pivotIndex, key, values);
-
-            // we use a three way partition because many duplicate values is an important case
-
-            int low = start + 1;   // low points to first value not known to be equal to pivotValue
-            int high = end;        // high points to first value > pivotValue
-            int i = low;           // i scans the array
-            while (i < high) {
-                // invariant: values[order[k]] == pivotValue for k in [0..low)
-                // invariant: values[order[k]] < pivotValue for k in [low..i)
-                // invariant: values[order[k]] > pivotValue for k in [high..end)
-                // in-loop: i < high
-                // in-loop: low < high
-                // in-loop: i >= low
-                double vi = key[i];
-                if (vi == pivotValue) {
-                    if (low != i) {
-                        swap(low, i, key, values);
-                    } else {
-                        i++;
-                    }
-                    low++;
-                } else if (vi > pivotValue) {
-                    high--;
-                    swap(i, high, key, values);
-                } else {
-                    // vi < pivotValue
-                    i++;
-                }
-            }
-            // invariant: values[order[k]] == pivotValue for k in [0..low)
-            // invariant: values[order[k]] < pivotValue for k in [low..i)
-            // invariant: values[order[k]] > pivotValue for k in [high..end)
-            // assert i == high || low == high therefore, we are done with partition
-
-            // at this point, i==high, from [start,low) are == pivot, [low,high) are < and [high,end) are >
-            // we have to move the values equal to the pivot into the middle. To do this, we swap pivot
-            // values into the top end of the [low,high) range stopping when we run out of destinations
-            // or when we run out of values to copy
-            int from = start;
-            int to = high - 1;
-            for (i = 0; from < low && to >= low; i++) {
-                swap(from++, to--, key, values);
-            }
-            if (from == low) {
-                // ran out of things to copy. This means that the last destination is the boundary
-                low = to + 1;
-            } else {
-                // ran out of places to copy to. This means that there are uncopied pivots and the
-                // boundary is at the beginning of those
-                low = from;
-            }
-
-            // checkPartition(order, values, pivotValue, start, low, high, end);
-
-            // now recurse, but arrange it so we handle the longer limit by tail recursion
-            if (low - start < end - high) {
-                quickSort(key, values, start, low, limit);
-
-                // this is really a way to do
-                // quickSort(order, values, high, end, limit);
-                start = high;
-            } else {
-                quickSort(key, values, high, end, limit);
-                // this is really a way to do
-                // quickSort(order, values, start, low, limit);
-                end = low;
-            }
-        }
-    }
-
-    /**
-     * Limited range insertion sort.  We assume that no element has to move more than limit steps
-     * because quick sort has done its thing. This version works on parallel arrays of keys and values.
-     *
-     * @param key    The array of keys
-     * @param values The values we are sorting
-     * @param start  The starting point of the sort
-     * @param end    The ending point of the sort
-     * @param limit  The largest amount of disorder
-     */
-    private static void insertionSort(double[] key, double[][] values, int start, int end, int limit) {
-        // loop invariant: all values start ... i-1 are ordered
-        for (int i = start + 1; i < end; i++) {
-            double v = key[i];
-            int m = Math.max(i - limit, start);
-            for (int j = i; j >= m; j--) {
-                if (j == m || key[j - 1] <= v) {
-                    if (j < i) {
-                        System.arraycopy(key, j, key, j + 1, i - j);
-                        key[j] = v;
-                        for (double[] value : values) {
-                            double tmp = value[i];
-                            System.arraycopy(value, j, value, j + 1, i - j);
-                            value[j] = tmp;
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-    }
-
-    private static void swap(int[] order, int i, int j) {
-        int t = order[i];
-        order[i] = order[j];
-        order[j] = t;
-    }
-
-    private static void swap(int i, int j, double[] key, double[]... values) {
-        double t = key[i];
-        key[i] = key[j];
-        key[j] = t;
-
-        for (int k = 0; k < values.length; k++) {
-            t = values[k][i];
-            values[k][i] = values[k][j];
-            values[k][j] = t;
-        }
-    }
-
-    /**
-     * Limited range insertion sort with primary and secondary key.  We assume that no
-     * element has to move more than limit steps because quick sort has done its thing.
-     *
-     * If weights (the secondary key) is null, then only the primary key is used.
-     *
-     * This sort is inherently stable.
-     *
-     * @param order   The permutation index
-     * @param values  The values we are sorting
-     * @param weights The secondary key for sorting
-     * @param start   Where to start the sort
-     * @param n       How many elements to sort
-     * @param limit   The largest amount of disorder
-     */
-    private static void insertionSort(int[] order, double[] values, double[] weights, int start, int n, int limit) {
-        for (int i = start + 1; i < n; i++) {
-            int t = order[i];
-            double v = values[order[i]];
-            double w = weights == null ? 0 : weights[order[i]];
-            int m = Math.max(i - limit, start);
-            // values in [start, i) are ordered
-            // scan backwards to find where to stick t
-            for (int j = i; j >= m; j--) {
-                if (j == 0 || values[order[j - 1]] < v || (values[order[j - 1]] == v && (weights == null || weights[order[j - 1]] <= w))) {
-                    if (j < i) {
-                        System.arraycopy(order, j, order, j + 1, i - j);
-                        order[j] = t;
-                    }
-                    break;
-                }
-            }
-        }
+    private static void swap(TDigestIntArray order, int i, int j) {
+        int t = order.get(i);
+        order.set(i, order.get(j));
+        order.set(j, t);
     }
 
     /**
@@ -587,19 +160,19 @@ public class Sort {
      * @param n       How many elements to sort
      * @param limit   The largest amount of disorder
      */
-    private static void stableInsertionSort(int[] order, double[] values, int start, int n, int limit) {
+    private static void stableInsertionSort(TDigestIntArray order, TDigestDoubleArray values, int start, int n, int limit) {
         for (int i = start + 1; i < n; i++) {
-            int t = order[i];
-            double v = values[order[i]];
-            int vi = order[i];
+            int t = order.get(i);
+            double v = values.get(order.get(i));
+            int vi = order.get(i);
             int m = Math.max(i - limit, start);
             // values in [start, i) are ordered
             // scan backwards to find where to stick t
             for (int j = i; j >= m; j--) {
-                if (j == 0 || values[order[j - 1]] < v || (values[order[j - 1]] == v && (order[j - 1] <= vi))) {
+                if (j == 0 || values.get(order.get(j - 1)) < v || (values.get(order.get(j - 1)) == v && (order.get(j - 1) <= vi))) {
                     if (j < i) {
-                        System.arraycopy(order, j, order, j + 1, i - j);
-                        order[j] = t;
+                        order.set(j + 1, order, j, i - j);
+                        order.set(j, t);
                     }
                     break;
                 }
@@ -608,41 +181,32 @@ public class Sort {
     }
 
     /**
-     * Reverses an array in-place.
-     *
-     * @param order The array to reverse
-     */
-    public static void reverse(int[] order) {
-        reverse(order, 0, order.length);
-    }
-
-    /**
-     * Reverses part of an array. See {@link #reverse(int[])}
+     * Reverses part of an array.
      *
      * @param order  The array containing the data to reverse.
      * @param offset Where to start reversing.
      * @param length How many elements to reverse
      */
-    public static void reverse(int[] order, int offset, int length) {
+    public static void reverse(TDigestIntArray order, int offset, int length) {
         for (int i = 0; i < length / 2; i++) {
-            int t = order[offset + i];
-            order[offset + i] = order[offset + length - i - 1];
-            order[offset + length - i - 1] = t;
+            int t = order.get(offset + i);
+            order.set(offset + i, order.get(offset + length - i - 1));
+            order.set(offset + length - i - 1, t);
         }
     }
 
     /**
-     * Reverses part of an array. See {@link #reverse(int[])}
+     * Reverses part of an array.
      *
      * @param order  The array containing the data to reverse.
      * @param offset Where to start reversing.
      * @param length How many elements to reverse
      */
-    public static void reverse(double[] order, int offset, int length) {
+    public static void reverse(TDigestDoubleArray order, int offset, int length) {
         for (int i = 0; i < length / 2; i++) {
-            double t = order[offset + i];
-            order[offset + i] = order[offset + length - i - 1];
-            order[offset + length - i - 1] = t;
+            double t = order.get(offset + i);
+            order.set(offset + i, order.get(offset + length - i - 1));
+            order.set(offset + length - i - 1, t);
         }
     }
 }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/SortingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/SortingDigest.java
@@ -19,10 +19,11 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.TDigestDoubleArray;
+
 import java.util.AbstractCollection;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 
 /**
@@ -31,17 +32,20 @@ import java.util.Iterator;
  * samples, at the expense of allocating much more memory.
  */
 public class SortingDigest extends AbstractTDigest {
-
     // Tracks all samples. Gets sorted on quantile and cdf calls.
-    final ArrayList<Double> values = new ArrayList<>();
+    final TDigestDoubleArray values;
 
     // Indicates if all values have been sorted.
     private boolean isSorted = true;
 
+    public SortingDigest(TDigestArrays arrays) {
+        values = arrays.newDoubleArray(0);
+    }
+
     @Override
     public void add(double x, long w) {
         checkValue(x);
-        isSorted = isSorted && (values.isEmpty() || values.get(values.size() - 1) <= x);
+        isSorted = isSorted && (values.size() == 0 || values.get(values.size() - 1) <= x);
         for (int i = 0; i < w; i++) {
             values.add(x);
         }
@@ -52,7 +56,7 @@ public class SortingDigest extends AbstractTDigest {
     @Override
     public void compress() {
         if (isSorted == false) {
-            Collections.sort(values);
+            values.sort();
             isSorted = true;
         }
     }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/TDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/TDigest.java
@@ -21,6 +21,8 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+
 import java.util.Collection;
 import java.util.Locale;
 
@@ -48,8 +50,8 @@ public abstract class TDigest {
      *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
      * @return the MergingDigest
      */
-    public static TDigest createMergingDigest(double compression) {
-        return new MergingDigest(compression);
+    public static TDigest createMergingDigest(TDigestArrays arrays, double compression) {
+        return new MergingDigest(arrays, compression);
     }
 
     /**
@@ -61,8 +63,8 @@ public abstract class TDigest {
      *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
      * @return the AvlTreeDigest
      */
-    public static TDigest createAvlTreeDigest(double compression) {
-        return new AVLTreeDigest(compression);
+    public static TDigest createAvlTreeDigest(TDigestArrays arrays, double compression) {
+        return new AVLTreeDigest(arrays, compression);
     }
 
     /**
@@ -71,8 +73,8 @@ public abstract class TDigest {
      *
      * @return the SortingDigest
      */
-    public static TDigest createSortingDigest() {
-        return new SortingDigest();
+    public static TDigest createSortingDigest(TDigestArrays arrays) {
+        return new SortingDigest(arrays);
     }
 
     /**
@@ -84,8 +86,8 @@ public abstract class TDigest {
      *                    The number of centroids retained will be a smallish (usually less than 10) multiple of this number.
      * @return the HybridDigest
      */
-    public static TDigest createHybridDigest(double compression) {
-        return new HybridDigest(compression);
+    public static TDigest createHybridDigest(TDigestArrays arrays, double compression) {
+        return new HybridDigest(arrays, compression);
     }
 
     /**

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestArrays.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestArrays.java
@@ -19,11 +19,17 @@
  * This project is based on a modification of https://github.com/tdunning/t-digest which is licensed under the Apache 2.0 License.
  */
 
-package org.elasticsearch.tdigest;
+package org.elasticsearch.tdigest.arrays;
 
-public class HybridDigestTests extends TDigestTests {
+/**
+ * Minimal interface for BigArrays-like classes used within TDigest.
+ */
+public interface TDigestArrays {
+    TDigestDoubleArray newDoubleArray(int initialSize);
 
-    protected DigestFactory factory(final double compression) {
-        return () -> new HybridDigest(arrays(), compression);
-    }
+    TDigestIntArray newIntArray(int initialSize);
+
+    TDigestLongArray newLongArray(int initialSize);
+
+    TDigestByteArray newByteArray(int initialSize);
 }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestByteArray.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestByteArray.java
@@ -19,11 +19,20 @@
  * This project is based on a modification of https://github.com/tdunning/t-digest which is licensed under the Apache 2.0 License.
  */
 
-package org.elasticsearch.tdigest;
+package org.elasticsearch.tdigest.arrays;
 
-public class HybridDigestTests extends TDigestTests {
+/**
+ * Minimal interface for ByteArray-like classes used within TDigest.
+ */
+public interface TDigestByteArray {
+    int size();
 
-    protected DigestFactory factory(final double compression) {
-        return () -> new HybridDigest(arrays(), compression);
-    }
+    byte get(int index);
+
+    void set(int index, byte value);
+
+    /**
+     * Resizes the array. If the new size is bigger than the current size, the new elements are set to 0.
+     */
+    void resize(int newSize);
 }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestDoubleArray.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestDoubleArray.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * This project is based on a modification of https://github.com/tdunning/t-digest which is licensed under the Apache 2.0 License.
+ */
+
+package org.elasticsearch.tdigest.arrays;
+
+/**
+ * Minimal interface for DoubleArray-like classes used within TDigest.
+ */
+public interface TDigestDoubleArray {
+    int size();
+
+    double get(int index);
+
+    void set(int index, double value);
+
+    void add(double value);
+
+    void ensureCapacity(int requiredCapacity);
+
+    /**
+     * Resizes the array. If the new size is bigger than the current size, the new elements are set to 0.
+     */
+    void resize(int newSize);
+
+    /**
+     * Copies {@code len} elements from {@code buf} to this array.
+     */
+    default void set(int index, TDigestDoubleArray buf, int offset, int len) {
+        assert index >= 0 && index + len <= this.size();
+        assert buf != this : "This method doesn't ensure that the copy from itself will be correct";
+        for (int i = len - 1; i >= 0; i--) {
+            this.set(index + i, buf.get(offset + i));
+        }
+    }
+
+    /**
+     * Sorts the array in place in ascending order.
+     */
+    void sort();
+}

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestIntArray.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestIntArray.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * This project is based on a modification of https://github.com/tdunning/t-digest which is licensed under the Apache 2.0 License.
+ */
+
+package org.elasticsearch.tdigest.arrays;
+
+/**
+ * Minimal interface for IntArray-like classes used within TDigest.
+ */
+public interface TDigestIntArray {
+    int size();
+
+    int get(int index);
+
+    void set(int index, int value);
+
+    /**
+     * Resizes the array. If the new size is bigger than the current size, the new elements are set to 0.
+     */
+    void resize(int newSize);
+
+    /**
+     * Copies {@code len} elements from {@code buf} to this array.
+     * <p>
+     *     As this method will be used to insert elements from itself in an insertion sort,
+     *     the copy must be made in reverse order, from offset+len-1 to offset.
+     * </p>
+     */
+    default void set(int index, TDigestIntArray buf, int offset, int len) {
+        assert index >= 0 && index + len <= this.size();
+        assert buf != this || index >= offset : "To set to itself, the destination index must be greater than the source offset";
+        for (int i = len - 1; i >= 0; i--) {
+            this.set(index + i, buf.get(offset + i));
+        }
+    }
+}

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestLongArray.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/TDigestLongArray.java
@@ -19,11 +19,20 @@
  * This project is based on a modification of https://github.com/tdunning/t-digest which is licensed under the Apache 2.0 License.
  */
 
-package org.elasticsearch.tdigest;
+package org.elasticsearch.tdigest.arrays;
 
-public class HybridDigestTests extends TDigestTests {
+/**
+ * Minimal interface for LongArray-like classes used within TDigest.
+ */
+public interface TDigestLongArray {
+    int size();
 
-    protected DigestFactory factory(final double compression) {
-        return () -> new HybridDigest(arrays(), compression);
-    }
+    long get(int index);
+
+    void set(int index, long value);
+
+    /**
+     * Resizes the array. If the new size is bigger than the current size, the new elements are set to 0.
+     */
+    void resize(int newSize);
 }

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/WrapperTDigestArrays.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/arrays/WrapperTDigestArrays.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * This project is based on a modification of https://github.com/tdunning/t-digest which is licensed under the Apache 2.0 License.
+ */
+
+package org.elasticsearch.tdigest.arrays;
+
+import java.util.Arrays;
+
+/**
+ * Temporal TDigestArrays with raw arrays.
+ *
+ * <p>
+ *     Delete after the right implementation for BigArrays is made.
+ * </p>
+ */
+public class WrapperTDigestArrays implements TDigestArrays {
+
+    public static final WrapperTDigestArrays INSTANCE = new WrapperTDigestArrays();
+
+    private WrapperTDigestArrays() {}
+
+    @Override
+    public WrapperTDigestDoubleArray newDoubleArray(int initialCapacity) {
+        return new WrapperTDigestDoubleArray(initialCapacity);
+    }
+
+    @Override
+    public WrapperTDigestIntArray newIntArray(int initialSize) {
+        return new WrapperTDigestIntArray(initialSize);
+    }
+
+    @Override
+    public TDigestLongArray newLongArray(int initialSize) {
+        return new WrapperTDigestLongArray(initialSize);
+    }
+
+    @Override
+    public TDigestByteArray newByteArray(int initialSize) {
+        return new WrapperTDigestByteArray(initialSize);
+    }
+
+    public WrapperTDigestDoubleArray newDoubleArray(double[] array) {
+        return new WrapperTDigestDoubleArray(array);
+    }
+
+    public WrapperTDigestIntArray newIntArray(int[] array) {
+        return new WrapperTDigestIntArray(array);
+    }
+
+    public static class WrapperTDigestDoubleArray implements TDigestDoubleArray {
+        private double[] array;
+        private int size;
+
+        public WrapperTDigestDoubleArray(int initialSize) {
+            this(new double[initialSize]);
+        }
+
+        public WrapperTDigestDoubleArray(double[] array) {
+            this.array = array;
+            this.size = array.length;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public double get(int index) {
+            assert index >= 0 && index < size;
+            return array[index];
+        }
+
+        @Override
+        public void set(int index, double value) {
+            assert index >= 0 && index < size;
+            array[index] = value;
+        }
+
+        @Override
+        public void add(double value) {
+            ensureCapacity(size + 1);
+            array[size++] = value;
+        }
+
+        @Override
+        public void sort() {
+            Arrays.sort(array, 0, size);
+        }
+
+        @Override
+        public void ensureCapacity(int requiredCapacity) {
+            if (requiredCapacity > array.length) {
+                int newSize = array.length + (array.length >> 1);
+                if (newSize < requiredCapacity) {
+                    newSize = requiredCapacity;
+                }
+                double[] newArray = new double[newSize];
+                System.arraycopy(array, 0, newArray, 0, size);
+                array = newArray;
+            }
+        }
+
+        @Override
+        public void resize(int newSize) {
+            if (newSize > array.length) {
+                array = Arrays.copyOf(array, newSize);
+            }
+            if (newSize > size) {
+                Arrays.fill(array, size, newSize, 0);
+            }
+            size = newSize;
+        }
+    }
+
+    public static class WrapperTDigestIntArray implements TDigestIntArray {
+        private int[] array;
+        private int size;
+
+        public WrapperTDigestIntArray(int initialSize) {
+            this(new int[initialSize]);
+        }
+
+        public WrapperTDigestIntArray(int[] array) {
+            this.array = array;
+            this.size = array.length;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public int get(int index) {
+            assert index >= 0 && index < size;
+            return array[index];
+        }
+
+        @Override
+        public void set(int index, int value) {
+            assert index >= 0 && index < size;
+            array[index] = value;
+        }
+
+        @Override
+        public void resize(int newSize) {
+            if (newSize > array.length) {
+                array = Arrays.copyOf(array, newSize);
+            }
+            if (newSize > size) {
+                Arrays.fill(array, size, newSize, 0);
+            }
+            size = newSize;
+        }
+    }
+
+    public static class WrapperTDigestLongArray implements TDigestLongArray {
+        private long[] array;
+        private int size;
+
+        public WrapperTDigestLongArray(int initialSize) {
+            this(new long[initialSize]);
+        }
+
+        public WrapperTDigestLongArray(long[] array) {
+            this.array = array;
+            this.size = array.length;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public long get(int index) {
+            assert index >= 0 && index < size;
+            return array[index];
+        }
+
+        @Override
+        public void set(int index, long value) {
+            assert index >= 0 && index < size;
+            array[index] = value;
+        }
+
+        @Override
+        public void resize(int newSize) {
+            if (newSize > array.length) {
+                array = Arrays.copyOf(array, newSize);
+            }
+            if (newSize > size) {
+                Arrays.fill(array, size, newSize, 0);
+            }
+            size = newSize;
+        }
+    }
+
+    public static class WrapperTDigestByteArray implements TDigestByteArray {
+        private byte[] array;
+        private int size;
+
+        public WrapperTDigestByteArray(int initialSize) {
+            this(new byte[initialSize]);
+        }
+
+        public WrapperTDigestByteArray(byte[] array) {
+            this.array = array;
+            this.size = array.length;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public byte get(int index) {
+            assert index >= 0 && index < size;
+            return array[index];
+        }
+
+        @Override
+        public void set(int index, byte value) {
+            assert index >= 0 && index < size;
+            array[index] = value;
+        }
+
+        @Override
+        public void resize(int newSize) {
+            if (newSize > array.length) {
+                array = Arrays.copyOf(array, newSize);
+            }
+            if (newSize > size) {
+                Arrays.fill(array, size, newSize, (byte) 0);
+            }
+            size = newSize;
+        }
+    }
+}

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/AVLGroupTreeTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/AVLGroupTreeTests.java
@@ -21,12 +21,13 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 public class AVLGroupTreeTests extends ESTestCase {
 
     public void testSimpleAdds() {
-        AVLGroupTree x = new AVLGroupTree();
+        AVLGroupTree x = new AVLGroupTree(WrapperTDigestArrays.INSTANCE);
         assertEquals(IntAVLTree.NIL, x.floor(34));
         assertEquals(IntAVLTree.NIL, x.first());
         assertEquals(IntAVLTree.NIL, x.last());
@@ -45,7 +46,7 @@ public class AVLGroupTreeTests extends ESTestCase {
     }
 
     public void testBalancing() {
-        AVLGroupTree x = new AVLGroupTree();
+        AVLGroupTree x = new AVLGroupTree(WrapperTDigestArrays.INSTANCE);
         for (int i = 0; i < 101; i++) {
             x.add(new Centroid(i));
         }
@@ -59,7 +60,7 @@ public class AVLGroupTreeTests extends ESTestCase {
 
     public void testFloor() {
         // mostly tested in other tests
-        AVLGroupTree x = new AVLGroupTree();
+        AVLGroupTree x = new AVLGroupTree(WrapperTDigestArrays.INSTANCE);
         for (int i = 0; i < 101; i++) {
             x.add(new Centroid(i / 2));
         }
@@ -72,7 +73,7 @@ public class AVLGroupTreeTests extends ESTestCase {
     }
 
     public void testHeadSum() {
-        AVLGroupTree x = new AVLGroupTree();
+        AVLGroupTree x = new AVLGroupTree(WrapperTDigestArrays.INSTANCE);
         for (int i = 0; i < 1000; ++i) {
             x.add(randomDouble(), randomIntBetween(1, 10));
         }
@@ -87,7 +88,7 @@ public class AVLGroupTreeTests extends ESTestCase {
     }
 
     public void testFloorSum() {
-        AVLGroupTree x = new AVLGroupTree();
+        AVLGroupTree x = new AVLGroupTree(WrapperTDigestArrays.INSTANCE);
         int total = 0;
         for (int i = 0; i < 1000; ++i) {
             int count = randomIntBetween(1, 10);

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/AVLTreeDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/AVLTreeDigestTests.java
@@ -21,11 +21,13 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
+
 public class AVLTreeDigestTests extends TDigestTests {
 
     protected DigestFactory factory(final double compression) {
         return () -> {
-            AVLTreeDigest digest = new AVLTreeDigest(compression);
+            AVLTreeDigest digest = new AVLTreeDigest(WrapperTDigestArrays.INSTANCE, compression);
             digest.setRandomSeed(randomLong());
             return digest;
         };

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/AlternativeMergeTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/AlternativeMergeTests.java
@@ -21,6 +21,7 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -36,8 +37,8 @@ public class AlternativeMergeTests extends ESTestCase {
     public void testMerges() {
         for (int n : new int[] { 100, 1000, 10000, 100000 }) {
             for (double compression : new double[] { 50, 100, 200, 400 }) {
-                MergingDigest mergingDigest = new MergingDigest(compression);
-                AVLTreeDigest treeDigest = new AVLTreeDigest(compression);
+                MergingDigest mergingDigest = new MergingDigest(WrapperTDigestArrays.INSTANCE, compression);
+                AVLTreeDigest treeDigest = new AVLTreeDigest(WrapperTDigestArrays.INSTANCE, compression);
                 List<Double> data = new ArrayList<>();
                 Random gen = random();
                 for (int i = 0; i < n; i++) {

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/BigCountTestsMergingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/BigCountTestsMergingDigestTests.java
@@ -21,9 +21,11 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
+
 public class BigCountTestsMergingDigestTests extends BigCountTests {
     @Override
     public TDigest createDigest() {
-        return new MergingDigest(100);
+        return new MergingDigest(WrapperTDigestArrays.INSTANCE, 100);
     }
 }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/BigCountTestsTreeDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/BigCountTestsTreeDigestTests.java
@@ -21,9 +21,11 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
+
 public class BigCountTestsTreeDigestTests extends BigCountTests {
     @Override
     public TDigest createDigest() {
-        return new AVLTreeDigest(100);
+        return new AVLTreeDigest(WrapperTDigestArrays.INSTANCE, 100);
     }
 }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/ComparisonTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/ComparisonTests.java
@@ -21,6 +21,7 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -39,10 +40,10 @@ public class ComparisonTests extends ESTestCase {
 
     private void loadData(Supplier<Double> sampleGenerator) {
         final int COMPRESSION = 100;
-        avlTreeDigest = TDigest.createAvlTreeDigest(COMPRESSION);
-        mergingDigest = TDigest.createMergingDigest(COMPRESSION);
-        sortingDigest = TDigest.createSortingDigest();
-        hybridDigest = TDigest.createHybridDigest(COMPRESSION);
+        avlTreeDigest = TDigest.createAvlTreeDigest(WrapperTDigestArrays.INSTANCE, COMPRESSION);
+        mergingDigest = TDigest.createMergingDigest(WrapperTDigestArrays.INSTANCE, COMPRESSION);
+        sortingDigest = TDigest.createSortingDigest(WrapperTDigestArrays.INSTANCE);
+        hybridDigest = TDigest.createHybridDigest(WrapperTDigestArrays.INSTANCE, COMPRESSION);
         samples = new double[SAMPLE_COUNT];
 
         for (int i = 0; i < SAMPLE_COUNT; i++) {

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/IntAVLTreeTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/IntAVLTreeTests.java
@@ -21,6 +21,7 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -38,6 +39,7 @@ public class IntAVLTreeTests extends ESTestCase {
         int[] counts;
 
         IntegerBag() {
+            super(WrapperTDigestArrays.INSTANCE);
             values = new int[capacity()];
             counts = new int[capacity()];
         }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MedianTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MedianTests.java
@@ -21,13 +21,14 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 public class MedianTests extends ESTestCase {
 
     public void testAVL() {
         double[] data = new double[] { 7, 15, 36, 39, 40, 41 };
-        TDigest digest = new AVLTreeDigest(100);
+        TDigest digest = new AVLTreeDigest(WrapperTDigestArrays.INSTANCE, 100);
         for (double value : data) {
             digest.add(value);
         }
@@ -38,7 +39,7 @@ public class MedianTests extends ESTestCase {
 
     public void testMergingDigest() {
         double[] data = new double[] { 7, 15, 36, 39, 40, 41 };
-        TDigest digest = new MergingDigest(100);
+        TDigest digest = new MergingDigest(WrapperTDigestArrays.INSTANCE, 100);
         for (double value : data) {
             digest.add(value);
         }
@@ -49,7 +50,7 @@ public class MedianTests extends ESTestCase {
 
     public void testSortingDigest() {
         double[] data = new double[] { 7, 15, 36, 39, 40, 41 };
-        TDigest digest = new SortingDigest();
+        TDigest digest = new SortingDigest(WrapperTDigestArrays.INSTANCE);
         for (double value : data) {
             digest.add(value);
         }
@@ -60,7 +61,7 @@ public class MedianTests extends ESTestCase {
 
     public void testHybridDigest() {
         double[] data = new double[] { 7, 15, 36, 39, 40, 41 };
-        TDigest digest = new HybridDigest(100);
+        TDigest digest = new HybridDigest(WrapperTDigestArrays.INSTANCE, 100);
         for (double value : data) {
             digest.add(value);
         }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/MergingDigestTests.java
@@ -33,18 +33,19 @@ import java.util.Random;
 public class MergingDigestTests extends TDigestTests {
 
     protected DigestFactory factory(final double compression) {
-        return () -> new MergingDigest(compression);
+
+        return () -> new MergingDigest(arrays(), compression);
     }
 
     public void testNanDueToBadInitialization() {
         int compression = 100;
         int factor = 5;
-        MergingDigest md = new MergingDigest(compression, (factor + 1) * compression, compression);
+        MergingDigest md = new MergingDigest(arrays(), compression, (factor + 1) * compression, compression);
 
         final int M = 10;
         List<MergingDigest> mds = new ArrayList<>();
         for (int i = 0; i < M; ++i) {
-            mds.add(new MergingDigest(compression, (factor + 1) * compression, compression));
+            mds.add(new MergingDigest(arrays(), compression, (factor + 1) * compression, compression));
         }
 
         // Fill all digests with values (0,10,20,...,80).
@@ -107,7 +108,7 @@ public class MergingDigestTests extends TDigestTests {
      * Make sure that the first and last centroids have unit weight
      */
     public void testSingletonsAtEnds() {
-        TDigest d = new MergingDigest(50);
+        TDigest d = new MergingDigest(arrays(), 50);
         Random gen = random();
         double[] data = new double[100];
         for (int i = 0; i < data.length; i++) {
@@ -132,7 +133,7 @@ public class MergingDigestTests extends TDigestTests {
      * Verify centroid sizes.
      */
     public void testFill() {
-        MergingDigest x = new MergingDigest(300);
+        MergingDigest x = new MergingDigest(arrays(), 300);
         Random gen = random();
         ScaleFunction scale = x.getScaleFunction();
         double compression = x.compression();
@@ -153,7 +154,7 @@ public class MergingDigestTests extends TDigestTests {
     }
 
     public void testLargeInputSmallCompression() {
-        MergingDigest td = new MergingDigest(10);
+        MergingDigest td = new MergingDigest(arrays(), 10);
         for (int i = 0; i < 10_000_000; i++) {
             td.add(between(0, 3_600_000));
         }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/SortTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/SortTests.java
@@ -21,58 +21,58 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestIntArray;
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
 public class SortTests extends ESTestCase {
-
     public void testReverse() {
-        int[] x = new int[0];
+        TDigestIntArray x = WrapperTDigestArrays.INSTANCE.newIntArray(0);
 
         // don't crash with no input
-        Sort.reverse(x);
+        Sort.reverse(x, 0, x.size());
 
         // reverse stuff!
-        x = new int[] { 1, 2, 3, 4, 5 };
-        Sort.reverse(x);
+        x = WrapperTDigestArrays.INSTANCE.newIntArray(new int[] { 1, 2, 3, 4, 5 });
+        Sort.reverse(x, 0, x.size());
         for (int i = 0; i < 5; i++) {
-            assertEquals(5 - i, x[i]);
+            assertEquals(5 - i, x.get(i));
         }
 
         // reverse some stuff back
         Sort.reverse(x, 1, 3);
-        assertEquals(5, x[0]);
-        assertEquals(2, x[1]);
-        assertEquals(3, x[2]);
-        assertEquals(4, x[3]);
-        assertEquals(1, x[4]);
+        assertEquals(5, x.get(0));
+        assertEquals(2, x.get(1));
+        assertEquals(3, x.get(2));
+        assertEquals(4, x.get(3));
+        assertEquals(1, x.get(4));
 
         // another no-op
         Sort.reverse(x, 3, 0);
-        assertEquals(5, x[0]);
-        assertEquals(2, x[1]);
-        assertEquals(3, x[2]);
-        assertEquals(4, x[3]);
-        assertEquals(1, x[4]);
+        assertEquals(5, x.get(0));
+        assertEquals(2, x.get(1));
+        assertEquals(3, x.get(2));
+        assertEquals(4, x.get(3));
+        assertEquals(1, x.get(4));
 
-        x = new int[] { 1, 2, 3, 4, 5, 6 };
-        Sort.reverse(x);
+        x = WrapperTDigestArrays.INSTANCE.newIntArray(new int[] { 1, 2, 3, 4, 5, 6 });
+        Sort.reverse(x, 0, x.size());
         for (int i = 0; i < 6; i++) {
-            assertEquals(6 - i, x[i]);
+            assertEquals(6 - i, x.get(i));
         }
     }
 
     public void testEmpty() {
-        Sort.sort(new int[] {}, new double[] {}, null, 0);
+        sort(new int[0], new double[0], 0);
     }
 
     public void testOne() {
         int[] order = new int[1];
-        Sort.sort(order, new double[] { 1 }, new double[] { 1 }, 1);
+        sort(order, new double[] { 1 }, 1);
         assertEquals(0, order[0]);
     }
 
@@ -80,7 +80,7 @@ public class SortTests extends ESTestCase {
         int[] order = new int[6];
         double[] values = new double[6];
 
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
     }
 
@@ -92,56 +92,8 @@ public class SortTests extends ESTestCase {
             values[i] = Math.rint(10 * ((double) i / n)) / 10.0;
         }
 
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
-    }
-
-    public void testRepeatedSortByWeight() {
-        // this needs to be long enough to force coverage of both quicksort and insertion sort
-        // (i.e. >64)
-        int n = 125;
-        int[] order = new int[n];
-        double[] values = new double[n];
-        double[] weights = new double[n];
-        double totalWeight = 0;
-
-        // generate evenly distributed values and weights
-        for (int i = 0; i < n; i++) {
-            int k = ((i + 5) * 37) % n;
-            values[i] = Math.floor(k / 25.0);
-            weights[i] = (k % 25) + 1;
-            totalWeight += weights[i];
-        }
-
-        // verify: test weights should be evenly distributed
-        double[] tmp = new double[5];
-        for (int i = 0; i < n; i++) {
-            tmp[(int) values[i]] += weights[i];
-        }
-        for (double v : tmp) {
-            assertEquals(totalWeight / tmp.length, v, 0);
-        }
-
-        // now sort ...
-        Sort.sort(order, values, weights, n);
-
-        // and verify our somewhat unusual ordering of the result
-        // within the first two quintiles, value is constant, weights increase within each quintile
-        int delta = order.length / 5;
-        double sum = checkSubOrder(0.0, order, values, weights, 0, delta, 1);
-        assertEquals(totalWeight * 0.2, sum, 0);
-        sum = checkSubOrder(sum, order, values, weights, delta, 2 * delta, 1);
-        assertEquals(totalWeight * 0.4, sum, 0);
-
-        // in the middle quintile, weights go up and then down after the median
-        sum = checkMidOrder(totalWeight / 2, sum, order, values, weights, 2 * delta, 3 * delta);
-        assertEquals(totalWeight * 0.6, sum, 0);
-
-        // in the last two quintiles, weights decrease
-        sum = checkSubOrder(sum, order, values, weights, 3 * delta, 4 * delta, -1);
-        assertEquals(totalWeight * 0.8, sum, 0);
-        sum = checkSubOrder(sum, order, values, weights, 4 * delta, 5 * delta, -1);
-        assertEquals(totalWeight, sum, 0);
     }
 
     public void testStableSort() {
@@ -172,7 +124,7 @@ public class SortTests extends ESTestCase {
         }
 
         // now sort ...
-        Sort.stableSort(order, values, n);
+        sort(order, values, n);
 
         // and verify stability of the ordering
         // values must be in order and they must appear in their original ordering
@@ -184,37 +136,6 @@ public class SortTests extends ESTestCase {
         }
     }
 
-    private double checkMidOrder(double medianWeight, double sofar, int[] order, double[] values, double[] weights, int start, int end) {
-        double value = values[order[start]];
-        double last = 0;
-        assertTrue(sofar < medianWeight);
-        for (int i = start; i < end; i++) {
-            assertEquals(value, values[order[i]], 0);
-            double w = weights[order[i]];
-            assertTrue(w > 0);
-            if (sofar > medianWeight) {
-                w = 2 * medianWeight - w;
-            }
-            assertTrue(w >= last);
-            sofar += weights[order[i]];
-        }
-        assertTrue(sofar > medianWeight);
-        return sofar;
-    }
-
-    private double checkSubOrder(double sofar, int[] order, double[] values, double[] weights, int start, int end, int ordering) {
-        double lastWeight = weights[order[start]] * ordering;
-        double value = values[order[start]];
-        for (int i = start; i < end; i++) {
-            assertEquals(value, values[order[i]], 0);
-            double newOrderedWeight = weights[order[i]] * ordering;
-            assertTrue(newOrderedWeight >= lastWeight);
-            lastWeight = newOrderedWeight;
-            sofar += weights[order[i]];
-        }
-        return sofar;
-    }
-
     public void testShort() {
         int[] order = new int[6];
         double[] values = new double[6];
@@ -224,19 +145,19 @@ public class SortTests extends ESTestCase {
             values[i] = 1;
         }
 
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
 
         values[0] = 0.8;
         values[1] = 0.3;
 
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
 
         values[5] = 1.5;
         values[4] = 1.2;
 
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
     }
 
@@ -246,7 +167,7 @@ public class SortTests extends ESTestCase {
         for (int i = 0; i < 20; i++) {
             values[i] = (i * 13) % 20;
         }
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
     }
 
@@ -270,33 +191,8 @@ public class SortTests extends ESTestCase {
         values[24] = 25;
         values[26] = 25;
 
-        Sort.sort(order, values, null, values.length);
+        sort(order, values, values.length);
         checkOrder(order, values);
-    }
-
-    public void testMultiPivotsInPlace() {
-        // more pivots than low split on first pass
-        // multiple pivots, but more low data on second part of recursion
-        double[] keys = new double[30];
-        for (int i = 0; i < 9; i++) {
-            keys[i] = i + 20 * (i % 2);
-        }
-
-        for (int i = 9; i < 20; i++) {
-            keys[i] = 10;
-        }
-
-        for (int i = 20; i < 30; i++) {
-            keys[i] = i - 20 * (i % 2);
-        }
-        keys[29] = 29;
-        keys[24] = 25;
-        keys[26] = 25;
-
-        double[] v = valuesFromKeys(keys, 0);
-
-        Sort.sort(keys, v);
-        checkOrder(keys, 0, keys.length, v);
     }
 
     public void testRandomized() {
@@ -309,96 +205,9 @@ public class SortTests extends ESTestCase {
                 values[i] = rand.nextDouble();
             }
 
-            Sort.sort(order, values, null, values.length);
+            sort(order, values, values.length);
             checkOrder(order, values);
         }
-    }
-
-    public void testRandomizedShortSort() {
-        Random rand = random();
-
-        for (int k = 0; k < 100; k++) {
-            double[] keys = new double[30];
-            for (int i = 0; i < 10; i++) {
-                keys[i] = i;
-            }
-            for (int i = 10; i < 20; i++) {
-                keys[i] = rand.nextDouble();
-            }
-            for (int i = 20; i < 30; i++) {
-                keys[i] = i;
-            }
-            double[] v0 = valuesFromKeys(keys, 0);
-            double[] v1 = valuesFromKeys(keys, 1);
-
-            Sort.sort(keys, 10, 10, v0, v1);
-            checkOrder(keys, 10, 10, v0, v1);
-            checkValues(keys, 0, keys.length, v0, v1);
-            for (int i = 0; i < 10; i++) {
-                assertEquals(i, keys[i], 0);
-            }
-            for (int i = 20; i < 30; i++) {
-                assertEquals(i, keys[i], 0);
-            }
-        }
-    }
-
-    /**
-     * Generates a vector of values corresponding to a vector of keys.
-     *
-     * @param keys A vector of keys
-     * @param k    Which value vector to generate
-     * @return The new vector containing frac(key_i * 3 * 5^k)
-     */
-    private double[] valuesFromKeys(double[] keys, int k) {
-        double[] r = new double[keys.length];
-        double scale = 3;
-        for (int i = 0; i < k; i++) {
-            scale = scale * 5;
-        }
-        for (int i = 0; i < keys.length; i++) {
-            r[i] = fractionalPart(keys[i] * scale);
-        }
-        return r;
-    }
-
-    /**
-     * Verifies that keys are in order and that each value corresponds to the keys
-     *
-     * @param key    Array of keys
-     * @param start  The starting offset of keys and values to check
-     * @param length The number of keys and values to check
-     * @param values Arrays of associated values. Value_{ki} = frac(key_i * 3 * 5^k)
-     */
-    private void checkOrder(double[] key, int start, int length, double[]... values) {
-        assert start + length <= key.length;
-
-        for (int i = start; i < start + length - 1; i++) {
-            assertTrue(String.format(Locale.ROOT, "bad ordering at %d, %f > %f", i, key[i], key[i + 1]), key[i] <= key[i + 1]);
-        }
-
-        checkValues(key, start, length, values);
-    }
-
-    private void checkValues(double[] key, int start, int length, double[]... values) {
-        double scale = 3;
-        for (int k = 0; k < values.length; k++) {
-            double[] v = values[k];
-            assertEquals(key.length, v.length);
-            for (int i = start; i < length; i++) {
-                assertEquals(
-                    String.format(Locale.ROOT, "value %d not correlated, key=%.5f, k=%d, v=%.5f", i, key[i], k, values[k][i]),
-                    fractionalPart(key[i] * scale),
-                    values[k][i],
-                    0
-                );
-            }
-            scale = scale * 5;
-        }
-    }
-
-    private double fractionalPart(double v) {
-        return v - Math.floor(v);
     }
 
     private void checkOrder(int[] order, double[] values) {
@@ -417,5 +226,12 @@ public class SortTests extends ESTestCase {
         for (var entry : counts.entrySet()) {
             assertEquals(1, entry.getValue().intValue());
         }
+    }
+
+    private void sort(int[] order, double[] values, int n) {
+        var wrappedOrder = WrapperTDigestArrays.INSTANCE.newIntArray(order);
+        var wrappedValues = WrapperTDigestArrays.INSTANCE.newDoubleArray(values);
+
+        Sort.stableSort(wrappedOrder, wrappedValues, n);
     }
 }

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/SortingDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/SortingDigestTests.java
@@ -24,7 +24,7 @@ package org.elasticsearch.tdigest;
 public class SortingDigestTests extends TDigestTests {
 
     protected DigestFactory factory(final double compression) {
-        return SortingDigest::new;
+        return () -> new SortingDigest(arrays());
     }
 
     // Make this test a noop to avoid OOMs.

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/TDigestTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/TDigestTests.java
@@ -21,6 +21,8 @@
 
 package org.elasticsearch.tdigest;
 
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -541,5 +543,9 @@ public abstract class TDigestTests extends ESTestCase {
             assertTrue("Q: " + z, Double.compare(q, lastQuantile) >= 0);
             lastQuantile = q;
         }
+    }
+
+    protected static TDigestArrays arrays() {
+        return WrapperTDigestArrays.INSTANCE;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.util;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 
 import java.lang.reflect.Array;
@@ -20,6 +21,7 @@ import java.util.Arrays;
 /** Common implementation for array lists that slice data into fixed-size blocks. */
 abstract class AbstractBigArray extends AbstractArray {
 
+    @Nullable
     protected final PageCacheRecycler recycler;
     private Recycler.V<?>[] cache;
 

--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -462,6 +462,7 @@ public class BigArrays {
 
     }
 
+    @Nullable
     final PageCacheRecycler recycler;
     @Nullable
     private final CircuitBreakerService breakerService;
@@ -471,13 +472,13 @@ public class BigArrays {
     private final BigArrays circuitBreakingInstance;
     private final String breakerName;
 
-    public BigArrays(PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService, String breakerName) {
+    public BigArrays(@Nullable PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService, String breakerName) {
         // Checking the breaker is disabled if not specified
         this(recycler, breakerService, breakerName, false);
     }
 
     protected BigArrays(
-        PageCacheRecycler recycler,
+        @Nullable PageCacheRecycler recycler,
         @Nullable final CircuitBreakerService breakerService,
         String breakerName,
         boolean checkBreaker

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/EmptyTDigestState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/EmptyTDigestState.java
@@ -9,10 +9,12 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
+
 public final class EmptyTDigestState extends TDigestState {
     public EmptyTDigestState() {
         // Use the sorting implementation to minimize memory allocation.
-        super(Type.SORTING, 1.0D);
+        super(WrapperTDigestArrays.INSTANCE, Type.SORTING, 1.0D);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestState.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tdigest.Centroid;
 import org.elasticsearch.tdigest.TDigest;
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -48,13 +50,21 @@ public class TDigestState {
     private final Type type;
 
     /**
+     * @deprecated this method will be removed after all usages are replaced
+     */
+    @Deprecated
+    public static TDigestState create(double compression) {
+        return create(WrapperTDigestArrays.INSTANCE, compression);
+    }
+
+    /**
      * Default factory for TDigestState. The underlying {@link org.elasticsearch.tdigest.TDigest} implementation is optimized for
      * performance, potentially providing slightly inaccurate results compared to other, substantially slower implementations.
      * @param compression the compression factor for the underlying {@link org.elasticsearch.tdigest.TDigest} object
      * @return a TDigestState object that's optimized for performance
      */
-    public static TDigestState create(double compression) {
-        return new TDigestState(Type.defaultValue(), compression);
+    public static TDigestState create(TDigestArrays arrays, double compression) {
+        return new TDigestState(arrays, Type.defaultValue(), compression);
     }
 
     /**
@@ -62,8 +72,16 @@ public class TDigestState {
      * @param compression the compression factor for the underlying {@link org.elasticsearch.tdigest.TDigest} object
      * @return a TDigestState object that's optimized for performance
      */
-    public static TDigestState createOptimizedForAccuracy(double compression) {
-        return new TDigestState(Type.valueForHighAccuracy(), compression);
+    public static TDigestState createOptimizedForAccuracy(TDigestArrays arrays, double compression) {
+        return new TDigestState(arrays, Type.valueForHighAccuracy(), compression);
+    }
+
+    /**
+     * @deprecated this method will be removed after all usages are replaced
+     */
+    @Deprecated
+    public static TDigestState create(double compression, TDigestExecutionHint executionHint) {
+        return create(WrapperTDigestArrays.INSTANCE, compression, executionHint);
     }
 
     /**
@@ -74,10 +92,10 @@ public class TDigestState {
      * @param executionHint controls which implementation is used; accepted values are 'high_accuracy' and '' (default)
      * @return a TDigestState object
      */
-    public static TDigestState create(double compression, TDigestExecutionHint executionHint) {
+    public static TDigestState create(TDigestArrays arrays, double compression, TDigestExecutionHint executionHint) {
         return switch (executionHint) {
-            case HIGH_ACCURACY -> createOptimizedForAccuracy(compression);
-            case DEFAULT -> create(compression);
+            case HIGH_ACCURACY -> createOptimizedForAccuracy(arrays, compression);
+            case DEFAULT -> create(arrays, compression);
         };
     }
 
@@ -88,15 +106,15 @@ public class TDigestState {
      * @return a TDigestState object
      */
     public static TDigestState createUsingParamsFrom(TDigestState state) {
-        return new TDigestState(state.type, state.compression);
+        return new TDigestState(WrapperTDigestArrays.INSTANCE, state.type, state.compression);
     }
 
-    protected TDigestState(Type type, double compression) {
+    protected TDigestState(TDigestArrays arrays, Type type, double compression) {
         tdigest = switch (type) {
-            case HYBRID -> TDigest.createHybridDigest(compression);
-            case AVL_TREE -> TDigest.createAvlTreeDigest(compression);
-            case SORTING -> TDigest.createSortingDigest();
-            case MERGING -> TDigest.createMergingDigest(compression);
+            case HYBRID -> TDigest.createHybridDigest(arrays, compression);
+            case AVL_TREE -> TDigest.createAvlTreeDigest(arrays, compression);
+            case SORTING -> TDigest.createSortingDigest(arrays);
+            case MERGING -> TDigest.createMergingDigest(arrays, compression);
         };
         this.type = type;
         this.compression = compression;
@@ -120,15 +138,23 @@ public class TDigestState {
         }
     }
 
+    /**
+     * @deprecated this method will be removed after all usages are replaced
+     */
+    @Deprecated
     public static TDigestState read(StreamInput in) throws IOException {
+        return read(WrapperTDigestArrays.INSTANCE, in);
+    }
+
+    public static TDigestState read(TDigestArrays arrays, StreamInput in) throws IOException {
         double compression = in.readDouble();
         TDigestState state;
         long size = 0;
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
-            state = new TDigestState(Type.valueOf(in.readString()), compression);
+            state = new TDigestState(arrays, Type.valueOf(in.readString()), compression);
             size = in.readVLong();
         } else {
-            state = new TDigestState(Type.valueForHighAccuracy(), compression);
+            state = new TDigestState(arrays, Type.valueForHighAccuracy(), compression);
         }
         int n = in.readVInt();
         if (size > 0) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
@@ -16,6 +16,8 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.tdigest.arrays.TDigestArrays;
+import org.elasticsearch.tdigest.arrays.WrapperTDigestArrays;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
@@ -31,7 +33,7 @@ public class TDigestStateTests extends ESTestCase {
     public void testMoreThan4BValues() {
         // Regression test for #19528
         // See https://github.com/tdunning/t-digest/pull/70/files#diff-4487072cee29b939694825647928f742R439
-        TDigestState digest = TDigestState.create(100);
+        TDigestState digest = TDigestState.create(arrays(), 100);
         for (int i = 0; i < 1000; ++i) {
             digest.add(randomDouble());
         }
@@ -57,9 +59,9 @@ public class TDigestStateTests extends ESTestCase {
     public void testEqualsHashCode() {
         final TDigestState empty1 = new EmptyTDigestState();
         final TDigestState empty2 = new EmptyTDigestState();
-        final TDigestState a = TDigestState.create(200);
-        final TDigestState b = TDigestState.create(100);
-        final TDigestState c = TDigestState.create(100);
+        final TDigestState a = TDigestState.create(arrays(), 200);
+        final TDigestState b = TDigestState.create(arrays(), 100);
+        final TDigestState c = TDigestState.create(arrays(), 100);
 
         assertEquals(empty1, empty2);
         assertEquals(empty1.hashCode(), empty2.hashCode());
@@ -101,9 +103,9 @@ public class TDigestStateTests extends ESTestCase {
         final Set<TDigestState> set = new HashSet<>();
         final TDigestState empty1 = new EmptyTDigestState();
         final TDigestState empty2 = new EmptyTDigestState();
-        final TDigestState a = TDigestState.create(200);
-        final TDigestState b = TDigestState.create(100);
-        final TDigestState c = TDigestState.create(100);
+        final TDigestState a = TDigestState.create(arrays(), 200);
+        final TDigestState b = TDigestState.create(arrays(), 100);
+        final TDigestState c = TDigestState.create(arrays(), 100);
 
         a.add(randomDouble());
         b.add(randomDouble());
@@ -139,9 +141,9 @@ public class TDigestStateTests extends ESTestCase {
     }
 
     public void testFactoryMethods() {
-        TDigestState fast = TDigestState.create(100);
-        TDigestState anotherFast = TDigestState.create(100);
-        TDigestState accurate = TDigestState.createOptimizedForAccuracy(100);
+        TDigestState fast = TDigestState.create(arrays(), 100);
+        TDigestState anotherFast = TDigestState.create(arrays(), 100);
+        TDigestState accurate = TDigestState.createOptimizedForAccuracy(arrays(), 100);
         TDigestState anotherAccurate = TDigestState.createUsingParamsFrom(accurate);
 
         for (int i = 0; i < 100; i++) {
@@ -173,7 +175,7 @@ public class TDigestStateTests extends ESTestCase {
             )
         ) {
             in.setTransportVersion(version);
-            return TDigestState.read(in);
+            return TDigestState.read(arrays(), in);
 
         }
     }
@@ -188,8 +190,8 @@ public class TDigestStateTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         // Past default was the accuracy-optimized version.
-        TDigestState state = TDigestState.create(100);
-        TDigestState backwardsCompatible = TDigestState.createOptimizedForAccuracy(100);
+        TDigestState state = TDigestState.create(arrays(), 100);
+        TDigestState backwardsCompatible = TDigestState.createOptimizedForAccuracy(arrays(), 100);
         for (int i = 0; i < 1000; i++) {
             state.add(i);
             backwardsCompatible.add(i);
@@ -201,5 +203,9 @@ public class TDigestStateTests extends ESTestCase {
         TDigestState serializedBackwardsCompatible = writeToAndReadFrom(state, TransportVersions.V_8_8_1);
         assertNotEquals(serializedBackwardsCompatible, state);
         assertEquals(serializedBackwardsCompatible, backwardsCompatible);
+    }
+
+    private static TDigestArrays arrays() {
+        return WrapperTDigestArrays.INSTANCE;
     }
 }


### PR DESCRIPTION
# Backport of https://github.com/elastic/elasticsearch/pull/112810

Part of https://github.com/elastic/elasticsearch/issues/99815

## Steps
1. Migrate TDigest classes to use a custom Array implementation. Temporarily use a simple array wrapper (This PR)
2. Implement a BigArrays class and replace the wrapper with it. Add Releasable/AutoCloseable and ensure everything is closed
3. Account remaining TDigest classes size

Every step should be safely mergeable to main:
- The first one should have no impact.
- The second and third ones will start increasing the CB count partially.

## Considerations
The third step will probably require some other interface to manually count used memory _before_ creation of the classes. Something like a `TDigestCircuitBreaker`. After building this one, I've started considering if it would make sense to just do the breaker, and not migrate things to BigArrays. Simply call a `breaker.increase(...)` before array creation.

The pros I see of BigArrays:
- Automatically verified in ESTestCases. Which means tests will fail unless everything is correctly `.close()`d
- Automatic byte counting, without added calculations to the TDigests (Apart of the close() ones)

And the cons:
- Filling the code with .get()/.set()
- `.sort()` will require a custom implementation for BigArrays. Same for the `.set()` method that copies a range of an array to another

## Benchmarks
This is a comparison of the benchmarks between main (left) and this branch (right). Bigger is worse:
```
TDigest
(compression)  (distribution)  (tdigestFactory)  Score   Error  ->  Score   Error  Units
          100          NORMAL             MERGE  0,157 ± 0,248  ->  0,170 ± 0,071  us/op
          100          NORMAL          AVL_TREE  0,263 ± 0,078  ->  0,309 ± 0,170  us/op
          100          NORMAL            HYBRID  0,167 ± 0,040  ->  0,169 ± 0,042  us/op
          100        GAUSSIAN             MERGE  0,159 ± 0,041  ->  0,163 ± 0,070  us/op
          100        GAUSSIAN          AVL_TREE  0,339 ± 0,127  ->  0,336 ± 0,029  us/op
          100        GAUSSIAN            HYBRID  0,163 ± 0,049  ->  0,167 ± 0,072  us/op
          300          NORMAL             MERGE  0,174 ± 0,044  ->  0,183 ± 0,031  us/op
          300          NORMAL          AVL_TREE  0,443 ± 0,084  ->  0,438 ± 0,079  us/op
          300          NORMAL            HYBRID  0,180 ± 0,059  ->  0,184 ± 0,039  us/op
          300        GAUSSIAN             MERGE  0,167 ± 0,040  ->  0,173 ± 0,054  us/op
          300        GAUSSIAN          AVL_TREE  0,403 ± 0,098  ->  0,387 ± 0,125  us/op
          300        GAUSSIAN            HYBRID  0,183 ± 0,031  ->  0,178 ± 0,049  us/op
```

```
StableSort
(sortDirection)   Score   Error  ->   Score   Error Units
              0  16,435 ± 1,443  ->  15,909 ± 0,745 ms/op
              1   5,237 ± 0,184  ->   4,994 ± 0,461 ms/op
             -1   5,458 ± 0,398  ->   4,696 ± 0,265 ms/op
```

There's barely any relevant affectation I can see.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
