### PR TITLE
Remove version dependent logic from ShingleTokenFilterFactory

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/analysis/ShingleTokenFilterFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/ShingleTokenFilterFactory.java
@@ -11,25 +11,17 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.shingle.ShingleFilter;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.lucene.analysis.miscellaneous.DisableGraphAttribute;
 
 public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
 
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(ShingleTokenFilterFactory.class);
-
     private final Factory factory;
-
-    private final IndexSettings indexSettings;
 
     public ShingleTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(name, settings);
-        this.indexSettings = indexSettings;
         int maxAllowedShingleDiff = indexSettings.getMaxShingleDiff();
         Integer maxShingleSize = settings.getAsInt("max_shingle_size", ShingleFilter.DEFAULT_MAX_SHINGLE_SIZE);
         Integer minShingleSize = settings.getAsInt("min_shingle_size", ShingleFilter.DEFAULT_MIN_SHINGLE_SIZE);
@@ -37,28 +29,17 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
 
         int shingleDiff = maxShingleSize - minShingleSize + (outputUnigrams ? 1 : 0);
         if (shingleDiff > maxAllowedShingleDiff) {
-            if (indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.V_7_0_0)) {
-                throw new IllegalArgumentException(
-                    "In Shingle TokenFilter the difference between max_shingle_size and min_shingle_size (and +1 if outputting unigrams)"
-                        + " must be less than or equal to: ["
-                        + maxAllowedShingleDiff
-                        + "] but was ["
-                        + shingleDiff
-                        + "]. This limit"
-                        + " can be set by changing the ["
-                        + IndexSettings.MAX_SHINGLE_DIFF_SETTING.getKey()
-                        + "] index level setting."
-                );
-            } else {
-                DEPRECATION_LOGGER.warn(
-                    DeprecationCategory.ANALYSIS,
-                    "excessive_shingle_diff",
-                    "Deprecated big difference between maxShingleSize and minShingleSize"
-                        + " in Shingle TokenFilter, expected difference must be less than or equal to: ["
-                        + maxAllowedShingleDiff
-                        + "]"
-                );
-            }
+            throw new IllegalArgumentException(
+                "In Shingle TokenFilter the difference between max_shingle_size and min_shingle_size (and +1 if outputting unigrams)"
+                    + " must be less than or equal to: ["
+                    + maxAllowedShingleDiff
+                    + "] but was ["
+                    + shingleDiff
+                    + "]. This limit"
+                    + " can be set by changing the ["
+                    + IndexSettings.MAX_SHINGLE_DIFF_SETTING.getKey()
+                    + "] index level setting."
+            );
         }
 
         Boolean outputUnigramsIfNoShingles = settings.getAsBoolean("output_unigrams_if_no_shingles", false);
@@ -82,17 +63,7 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
 
     @Override
     public TokenFilterFactory getSynonymFilter() {
-        if (indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.V_7_0_0)) {
-            throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
-        } else {
-            DEPRECATION_LOGGER.warn(
-                DeprecationCategory.ANALYSIS,
-                "synonym_tokenfilters",
-                "Token filter " + name() + "] will not be usable to parse synonym after v7.0"
-            );
-        }
-        return this;
-
+        throw new IllegalArgumentException("Token filter [" + name() + "] cannot be used to parse synonyms");
     }
 
     public Factory getInnerFactory() {
@@ -109,7 +80,7 @@ public class ShingleTokenFilterFactory extends AbstractTokenFilterFactory {
         private final String tokenSeparator;
         private final String fillerToken;
 
-        private int minShingleSize;
+        private final int minShingleSize;
 
         private final String name;
 


### PR DESCRIPTION
This commit removes conditionals for logic that no longer needs to be version dependent, in that all indices in the cluster will match such condition.

Relates to #27211,#34331