### PR TITLE
[ML] Revert "Mute org.elasticsearch.xpack.test.rest.XPackRestIT org.elasti…

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -210,8 +210,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJobAfterMissingAliases
   issue: https://github.com/elastic/elasticsearch/issues/112823
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/111944
 - class: org.elasticsearch.datastreams.logsdb.qa.StandardVersusLogsIndexModeRandomDataChallengeRestIT
   method: testDateHistogramAggregation
   issue: https://github.com/elastic/elasticsearch/issues/112919


### PR DESCRIPTION
…csearch.xpack.test.rest.XPackRestIT #111944"

This reverts commit b712ab57cd5d468b68046fdbf0c97757e1f23556.

The tests failed because of #111684 which has since been reverted

Closes #111944