### PR TITLE
ES|QL: add capability checks to spatialGeometryCollectionStats test

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_geometries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_geometries.csv-spec
@@ -7,6 +7,7 @@
 ####################################################################################################
 
 spatialGeometryCollectionStats
+required_capability: spatial_shapes
 
 FROM multivalue_geometries
 | MV_EXPAND shape


### PR DESCRIPTION
The bwc test failed on 8.16 vs. 8.11 and 8.12 (PR CI with `test-full-bwc` label)