### PR TITLE
Fix invalid CS in `DiskThresholdDeciderTests`

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
 import org.elasticsearch.cluster.routing.UnassignedInfo.Reason;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -82,6 +83,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class DiskThresholdDeciderTests extends ESAllocationTestCase {
 
@@ -911,12 +913,34 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         firstRouting = TestShardRouting.newShardRouting("test", 0, "node1", null, true, ShardRoutingState.STARTED);
         secondRouting = TestShardRouting.newShardRouting("test", 1, "node1", "node2", true, ShardRoutingState.RELOCATING);
         ShardRouting fooRouting = TestShardRouting.newShardRouting("foo", 0, null, true, ShardRoutingState.UNASSIGNED);
+        fooRouting = fooRouting.updateUnassigned(
+            new UnassignedInfo(
+                fooRouting.unassignedInfo().reason(),
+                fooRouting.unassignedInfo().message(),
+                fooRouting.unassignedInfo().failure(),
+                fooRouting.unassignedInfo().failedAllocations(),
+                fooRouting.unassignedInfo().unassignedTimeNanos(),
+                fooRouting.unassignedInfo().unassignedTimeMillis(),
+                false,
+                fooRouting.recoverySource().getType() == RecoverySource.Type.EMPTY_STORE
+                    ? AllocationStatus.DECIDERS_NO
+                    : AllocationStatus.NO_VALID_SHARD_COPY,
+                fooRouting.unassignedInfo().failedNodeIds(),
+                fooRouting.unassignedInfo().lastAllocatedNodeId()
+            ),
+            fooRouting.recoverySource()
+        );
         firstRoutingNode = RoutingNodesHelper.routingNode("node1", discoveryNode1, firstRouting, secondRouting);
         builder = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(firstRouting.index())
                     .addIndexShard(new IndexShardRoutingTable.Builder(firstRouting.shardId()).addShard(firstRouting))
                     .addIndexShard(new IndexShardRoutingTable.Builder(secondRouting.shardId()).addShard(secondRouting))
+            )
+            .add(
+                IndexRoutingTable.builder(fooRouting.index())
+                    .addIndexShard(new IndexShardRoutingTable.Builder(fooRouting.shardId()).addShard(fooRouting))
+                    .build()
             );
         clusterState = ClusterState.builder(baseClusterState).routingTable(builder.build()).build();
         routingAllocation = new RoutingAllocation(
@@ -970,11 +994,46 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         }
 
         // Creating AllocationService instance and the services it depends on...
-        AllocationService strategy = createAllocationService(clusterInfo, diskThresholdDecider);
+        AllocationService strategy = createAllocationService(clusterInfo, diskThresholdDecider, new AllocationDecider() {
+            @Override
+            public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
+                return cannotAllocateFooShards(indexMetadata.getIndex());
+            }
+
+            @Override
+            public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return cannotAllocateFooShards(shardRouting.index());
+            }
+
+            @Override
+            public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                return cannotAllocateFooShards(shardRouting.index());
+            }
+
+            private Decision cannotAllocateFooShards(Index index) {
+                return index.getName().equals("foo") ? Decision.NO : Decision.YES;
+            }
+        });
+
+        // Populate the in-sync allocation IDs so that the overall cluster state is valid enough to run reroute()
+        final var metadataBuilder = Metadata.builder(clusterState.metadata());
+        metadataBuilder.put(
+            clusterState.metadata().index(fooRouting.index()).withInSyncAllocationIds(fooRouting.id(), Set.of(randomUUID())),
+            false
+        );
+        metadataBuilder.put(
+            clusterState.metadata()
+                .index(firstRouting.index())
+                .withInSyncAllocationIds(firstRouting.id(), Set.of(firstRouting.allocationId().getId()))
+                .withInSyncAllocationIds(secondRouting.id(), Set.of(secondRouting.allocationId().getId())),
+            false
+        );
+        final var clusterStateWithInSyncIds = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
+
         // Ensure that the reroute call doesn't alter the routing table, since the first primary is relocating away
         // and therefore we will have sufficient disk space on node1.
-        ClusterState result = strategy.reroute(clusterState, "reroute", ActionListener.noop());
-        assertThat(result, equalTo(clusterState));
+        ClusterState result = strategy.reroute(clusterStateWithInSyncIds, "reroute", ActionListener.noop());
+        assertThat(result, sameInstance(clusterStateWithInSyncIds));
         assertThat(result.routingTable().index("test").shard(0).primaryShard().state(), equalTo(STARTED));
         assertThat(result.routingTable().index("test").shard(0).primaryShard().currentNodeId(), equalTo("node1"));
         assertThat(result.routingTable().index("test").shard(0).primaryShard().relocatingNodeId(), nullValue());


### PR DESCRIPTION
Adds `fooRouting` to the routing table because it's not valid to check
it against an `AllocationDecider` otherwise. But then add another
allocation decider to prevent this shard from being assigned to a node
by the `reroute()` call, and set the shards' in-sync IDs up correctly to
make the cluster state valid enough to reroute.