### PR TITLE
[8.x] ES|QL: add capability checks to spatialGeometryCollectionStats test (#113022)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_geometries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_geometries.csv-spec
@@ -7,6 +7,7 @@
 ####################################################################################################
 
 spatialGeometryCollectionStats
+required_capability: spatial_shapes
 
 FROM multivalue_geometries
 | MV_EXPAND shape


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ES|QL: add capability checks to spatialGeometryCollectionStats test (#113022)