### PR TITLE
[ML} Revert "Mute org.elasticsearch.xpack.test.rest.XPackRestIT org.elasti…

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -98,8 +98,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authc.kerberos.KerberosTicketValidatorTests
   method: testWhenKeyTabWithInvalidContentFailsValidation
   issue: https://github.com/elastic/elasticsearch/issues/112631
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/111944
 
 # Examples:
 #


### PR DESCRIPTION
…csearch.xpack.test.rest.XPackRestIT #111944"

The tests failed because of https://github.com/elastic/elasticsearch/pull/111684 which has since been reverted

