### PR TITLE
[8.15] Emit deprecation warning when executing one of the rollup APIs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -852,6 +852,9 @@ buildRestTests.setups['library'] = '''
 
 '''
 buildRestTests.setups['sensor_rollup_job'] = '''
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: dummy-rollup-index
@@ -882,9 +885,10 @@ buildRestTests.setups['sensor_rollup_job'] = '''
               node:
                 type: keyword
   - do:
-      raw:
-        method: PUT
-        path: _rollup/job/sensor
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
+      rollup.put_job:
+        id: sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -914,6 +918,9 @@ buildRestTests.setups['sensor_rollup_job'] = '''
             }
 '''
 buildRestTests.setups['sensor_started_rollup_job'] = '''
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: dummy-rollup-index
@@ -963,9 +970,10 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
           {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
 
   - do:
-      raw:
-        method: PUT
-        path: _rollup/job/sensor
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
+      rollup.put_job:
+        id: sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -994,9 +1002,10 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
                 ]
             }
   - do:
-      raw:
-        method: POST
-        path: _rollup/job/sensor/_start
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
+      rollup.start_job:
+        id: sensor
 '''
 
 buildRestTests.setups['sensor_index'] = '''

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -80,6 +80,7 @@ If we have a rollup job named `sensor`, it can be deleted with:
 DELETE _rollup/job/sensor
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which will return the response:
 

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -89,6 +89,7 @@ job can be retrieved with:
 GET _rollup/job/sensor
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The API yields the following response:
 
@@ -192,6 +193,7 @@ PUT _rollup/job/sensor2 <1>
 GET _rollup/job/_all <2>
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 <1> We create a second job with name `sensor2`
 <2> Then request all jobs by using `_all` in the GetJobs API
 

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -281,6 +281,7 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 <1> This configuration enables date histograms to be used on the `timestamp`
 field and `terms` aggregations to be used on the `node` field.
 <2> This configuration defines metrics over two fields: `temperature` and

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -83,6 +83,7 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 We can then retrieve the rollup capabilities of that index pattern (`sensor-*`)
 via the following command:
@@ -92,6 +93,7 @@ via the following command:
 GET _rollup/data/sensor-*
 --------------------------------------------------
 // TEST[continued]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which will yield the following response:
 
@@ -164,6 +166,7 @@ We could also retrieve the same information with a request to `_all`:
 GET _rollup/data/_all
 --------------------------------------------------
 // TEST[continued]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 But note that if we use the concrete index name (`sensor-1`), we'll retrieve no
 rollup capabilities:
@@ -173,6 +176,7 @@ rollup capabilities:
 GET _rollup/data/sensor-1
 --------------------------------------------------
 // TEST[continued]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 [source,console-result]
 ----

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -80,6 +80,7 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 If at a later date, we'd like to determine what jobs and capabilities were
 stored in the `sensor_rollup` index, we can use the get rollup index API:
@@ -89,6 +90,7 @@ stored in the `sensor_rollup` index, we can use the get rollup index API:
 GET /sensor_rollup/_rollup/data
 --------------------------------------------------
 // TEST[continued]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Note how we are requesting the concrete rollup index name (`sensor_rollup`) as
 the first part of the URL. This will yield the following response:
@@ -164,3 +166,4 @@ instead of explicit indices:
 GET /*_rollup/_rollup/data
 --------------------------------------------------
 // TEST[continued]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -105,6 +105,7 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 This rolls up the `sensor-*` pattern and stores the results in `sensor_rollup`.
 To search this rolled up data, we need to use the `_rollup_search` endpoint.
@@ -127,6 +128,7 @@ GET /sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
 // TEST[s/_rollup_search/_rollup_search?filter_path=took,timed_out,terminated_early,_shards,hits,aggregations/]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The query is targeting the `sensor_rollup` data, since this contains the rollup
 data as configured in the job. A `max` aggregation has been used on the
@@ -182,6 +184,7 @@ GET sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[continued]
 // TEST[catch:/illegal_argument_exception/]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 [source,console-result]
 ----
@@ -225,6 +228,7 @@ GET sensor-1,sensor_rollup/_rollup_search <1>
 --------------------------------------------------
 // TEST[continued]
 // TEST[s/_rollup_search/_rollup_search?filter_path=took,timed_out,terminated_early,_shards,hits,aggregations/]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 <1> Note the URI now searches `sensor-1` and `sensor_rollup` at the same time
 
 When the search is executed, the rollup search endpoint does two things:

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -51,6 +51,7 @@ If we have already created a {rollup-job} named `sensor`, it can be started with
 POST _rollup/job/sensor/_start
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which will return the response:
 

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -76,6 +76,7 @@ the indexer has fully stopped. This is accomplished with the
 POST _rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s
 --------------------------------------------------
 // TEST[setup:sensor_started_rollup_job]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The parameter blocks the API call from returning until either the job has moved
 to `STOPPED` or the specified time has elapsed. If the specified time elapses

--- a/docs/reference/rollup/migrating-to-downsampling.asciidoc
+++ b/docs/reference/rollup/migrating-to-downsampling.asciidoc
@@ -51,6 +51,7 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The equivalent <<tsds,time series data stream (TSDS)>> setup that uses downsampling via DSL:
 

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -64,6 +64,7 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 We give the job the ID of "sensor" (in the url: `PUT _rollup/job/sensor`), and tell it to rollup the index pattern `"sensor-*"`.
 This job will find and rollup any index that matches that pattern. Rollup summaries are then stored in the `"sensor_rollup"` index.
@@ -143,6 +144,7 @@ To start the job, execute this command:
 POST _rollup/job/sensor/_start
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 [discrete]
 ==== Searching the rolled results
@@ -167,6 +169,7 @@ GET /sensor_rollup/_rollup_search
 }
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 It's a simple aggregation that calculates the maximum of the `temperature` field. But you'll notice that it is being sent to the `sensor_rollup`
 index instead of the raw `sensor-*` indices. And you'll also notice that it is using the `_rollup_search` endpoint. Otherwise the syntax
@@ -198,6 +201,7 @@ If you were to execute that query, you'd receive a result that looks like a norm
 ----
 // TESTRESPONSE[s/"took" : 102/"took" : $body.$_path/]
 // TESTRESPONSE[s/"_shards" : \.\.\. /"_shards" : $body.$_path/]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The only notable difference is that Rollup search results have zero `hits`, because we aren't really searching the original, live data any
 more. Otherwise it's identical syntax.
@@ -244,6 +248,7 @@ GET /sensor_rollup/_rollup_search
 }
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which returns a corresponding response:
 

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -56,6 +56,7 @@ GET sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
 // TEST[catch:/illegal_argument_exception/]
+// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The response will tell you that the field and aggregation were not possible, because no rollup jobs were found which contained them:
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -157,6 +157,20 @@ public abstract class ESRestTestCase extends ESTestCase {
 
     private static final Pattern SEMANTIC_VERSION_PATTERN = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)\\D?.*");
 
+    private static final String EXPECTED_ROLLUP_WARNING_MESSAGE =
+        "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.";
+    public static final RequestOptions.Builder ROLLUP_REQUESTS_OPTIONS = RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
+        // Either no warning, because of bwc integration test OR
+        // the expected warning, because on current version
+        if (warnings.isEmpty()) {
+            return false;
+        } else if (warnings.size() == 1 && EXPECTED_ROLLUP_WARNING_MESSAGE.equals(warnings.get(0))) {
+            return false;
+        } else {
+            return true;
+        }
+    });
+
     /**
      * Convert the entity from a {@link Response} into a map of maps.
      * Consumes the underlying HttpEntity, releasing any resources it may be holding.
@@ -1278,7 +1292,9 @@ public abstract class ESRestTestCase extends ESTestCase {
     private void wipeRollupJobs() throws IOException {
         final Response response;
         try {
-            response = adminClient().performRequest(new Request("GET", "/_rollup/job/_all"));
+            var request = new Request("GET", "/_rollup/job/_all");
+            request.setOptions(ROLLUP_REQUESTS_OPTIONS);
+            response = adminClient().performRequest(request);
         } catch (ResponseException e) {
             // If we don't see the rollup endpoint (possibly because of running against an older ES version) we just bail
             if (e.getResponse().getStatusLine().getStatusCode() == RestStatus.NOT_FOUND.getStatus()) {
@@ -1298,6 +1314,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             @SuppressWarnings("unchecked")
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
             Request request = new Request("POST", "/_rollup/job/" + jobId + "/_stop");
+            request.setOptions(ROLLUP_REQUESTS_OPTIONS);
             setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND);
             request.addParameter("wait_for_completion", "true");
             request.addParameter("timeout", "10s");
@@ -1309,6 +1326,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             @SuppressWarnings("unchecked")
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
             Request request = new Request("DELETE", "/_rollup/job/" + jobId);
+            request.setOptions(ROLLUP_REQUESTS_OPTIONS);
             setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND); // 404s imply someone was racing us to delete this
             logger.debug("deleting rollup job [{}]", jobId);
             adminClient().performRequest(request);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
@@ -1272,6 +1272,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
 
         String rollupJobId = "rollup-" + jobId;
         Request createRollupRequest = new Request("PUT", "/_rollup/job/" + rollupJobId);
+        createRollupRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         createRollupRequest.setJsonEntity("""
             {
             "index_pattern": "airline-data-aggs",
@@ -1299,18 +1300,26 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
                 ]
             }""");
         client().performRequest(createRollupRequest);
-        client().performRequest(new Request("POST", "/_rollup/job/" + rollupJobId + "/_start"));
+        var startRolupRequest = new Request("POST", "/_rollup/job/" + rollupJobId + "/_start");
+        startRolupRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
+        client().performRequest(startRolupRequest);
 
         assertBusy(() -> {
-            Response getRollup = client().performRequest(new Request("GET", "/_rollup/job/" + rollupJobId));
+            var getRollupRequest = new Request("GET", "/_rollup/job/" + rollupJobId);
+            getRollupRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
+            Response getRollup = client().performRequest(getRollupRequest);
             String body = EntityUtils.toString(getRollup.getEntity());
             assertThat(body, containsString("\"job_state\":\"started\""));
             assertThat(body, containsString("\"rollups_indexed\":4"));
         }, 60, TimeUnit.SECONDS);
 
-        client().performRequest(new Request("POST", "/_rollup/job/" + rollupJobId + "/_stop"));
+        var stopRollupRequest = new Request("POST", "/_rollup/job/" + rollupJobId + "/_stop");
+        stopRollupRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
+        client().performRequest(stopRollupRequest);
         assertBusy(() -> {
-            Response getRollup = client().performRequest(new Request("GET", "/_rollup/job/" + rollupJobId));
+            var getRollupRequest = new Request("GET", "/_rollup/job/" + rollupJobId);
+            getRollupRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
+            Response getRollup = client().performRequest(getRollupRequest);
             assertThat(EntityUtils.toString(getRollup.getEntity()), containsString("\"job_state\":\"stopped\""));
         }, 60, TimeUnit.SECONDS);
 
@@ -1827,6 +1836,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
 
         String rollupJobId = "rollup-" + jobId;
         Request createRollupRequest = new Request("PUT", "/_rollup/job/" + rollupJobId);
+        createRollupRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         createRollupRequest.setJsonEntity("""
             {
             "index_pattern": "airline-data-aggs",

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -70,6 +70,10 @@ import java.util.function.Supplier;
 
 public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin {
 
+    public static final String DEPRECATION_MESSAGE =
+        "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.";
+    public static final String DEPRECATION_KEY = "rollup_removal";
+
     // Introduced in ES version 6.3
     public static final int ROLLUP_VERSION_V1 = 1;
     // Introduced in ES Version 6.4

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportDeleteRollupJobAction.java
@@ -17,6 +17,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportDeleteRollupJobAction.java
@@ -31,11 +31,16 @@ import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.List;
 
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
+
 public class TransportDeleteRollupJobAction extends TransportTasksAction<
     RollupJobTask,
     DeleteRollupJobAction.Request,
     DeleteRollupJobAction.Response,
     DeleteRollupJobAction.Response> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportDeleteRollupJobAction.class);
 
     @Inject
     public TransportDeleteRollupJobAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
@@ -52,6 +57,7 @@ public class TransportDeleteRollupJobAction extends TransportTasksAction<
 
     @Override
     protected void doExecute(Task task, DeleteRollupJobAction.Request request, ActionListener<DeleteRollupJobAction.Response> listener) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         final ClusterState state = clusterService.state();
         final DiscoveryNodes nodes = state.nodes();
 
@@ -93,7 +99,6 @@ public class TransportDeleteRollupJobAction extends TransportTasksAction<
         RollupJobTask jobTask,
         ActionListener<DeleteRollupJobAction.Response> listener
     ) {
-
         assert jobTask.getConfig().getId().equals(request.getId());
         IndexerState state = ((RollupJobStatus) jobTask.getStatus()).getIndexerState();
         if (state.equals(IndexerState.STOPPED)) {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupCapsAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupCapsAction.java
@@ -32,7 +32,12 @@ import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
+
 public class TransportGetRollupCapsAction extends HandledTransportAction<GetRollupCapsAction.Request, GetRollupCapsAction.Response> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportGetRollupCapsAction.class);
 
     private final ClusterService clusterService;
     private final Executor managementExecutor;
@@ -53,6 +58,7 @@ public class TransportGetRollupCapsAction extends HandledTransportAction<GetRoll
 
     @Override
     protected void doExecute(Task task, GetRollupCapsAction.Request request, ActionListener<GetRollupCapsAction.Response> listener) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         // Workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
         managementExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(request.getIndexPattern(), l)));
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
@@ -32,9 +32,14 @@ import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
+
 public class TransportGetRollupIndexCapsAction extends HandledTransportAction<
     GetRollupIndexCapsAction.Request,
     GetRollupIndexCapsAction.Response> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportGetRollupCapsAction.class);
 
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver resolver;
@@ -66,6 +71,7 @@ public class TransportGetRollupIndexCapsAction extends HandledTransportAction<
         GetRollupIndexCapsAction.Request request,
         ActionListener<GetRollupIndexCapsAction.Response> listener
     ) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         // Workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
         managementExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(request, l)));
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupJobAction.java
@@ -17,6 +17,8 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupJobAction.java
@@ -34,11 +34,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
+
 public class TransportGetRollupJobAction extends TransportTasksAction<
     RollupJobTask,
     GetRollupJobsAction.Request,
     GetRollupJobsAction.Response,
     GetRollupJobsAction.Response> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportGetRollupCapsAction.class);
 
     @Inject
     public TransportGetRollupJobAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
@@ -55,6 +60,7 @@ public class TransportGetRollupJobAction extends TransportTasksAction<
 
     @Override
     protected void doExecute(Task task, GetRollupJobsAction.Request request, ActionListener<GetRollupJobsAction.Response> listener) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         final ClusterState state = clusterService.state();
         final DiscoveryNodes nodes = state.nodes();
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -63,10 +63,13 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.core.ClientHelper.assertNoAuthorizationHeader;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
 
 public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNodeAction<PutRollupJobAction.Request> {
 
     private static final Logger LOGGER = LogManager.getLogger(TransportPutRollupJobAction.class);
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportPutRollupJobAction.class);
     private static final XContentParserConfiguration PARSER_CONFIGURATION = XContentParserConfiguration.EMPTY.withFiltering(
         Set.of("_doc._meta._rollup"),
         null,
@@ -75,7 +78,6 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
 
     private final PersistentTasksService persistentTasksService;
     private final Client client;
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TransportPutRollupJobAction.class);
 
     @Inject
     public TransportPutRollupJobAction(
@@ -109,6 +111,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         ClusterState clusterState,
         ActionListener<AcknowledgedResponse> listener
     ) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
         checkForDeprecatedTZ(request);
 
@@ -150,7 +153,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         String timeZone = request.getConfig().getGroupConfig().getDateHistogram().getTimeZone();
         String modernTZ = DateUtils.DEPRECATED_LONG_TIMEZONES.get(timeZone);
         if (modernTZ != null) {
-            deprecationLogger.warn(
+            DEPRECATION_LOGGER.warn(
                 DeprecationCategory.PARSING,
                 "deprecated_timezone",
                 "Creating Rollup job ["

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -28,6 +28,8 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -73,8 +75,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
 
 public class TransportRollupSearchAction extends TransportAction<SearchRequest, SearchResponse> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportRollupSearchAction.class);
 
     private final Client client;
     private final NamedWriteableRegistry registry;
@@ -115,6 +121,7 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
 
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         String[] indices = resolver.concreteIndexNames(clusterService.state(), request);
         RollupSearchContext rollupSearchContext = separateIndices(indices, clusterService.state().getMetadata().indices());
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
@@ -14,6 +14,8 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
@@ -16,17 +16,23 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.List;
 
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
+
 public class TransportStartRollupAction extends TransportTasksAction<
     RollupJobTask,
     StartRollupJobAction.Request,
     StartRollupJobAction.Response,
     StartRollupJobAction.Response> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportStartRollupAction.class);
 
     @Inject
     public TransportStartRollupAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
@@ -44,6 +50,12 @@ public class TransportStartRollupAction extends TransportTasksAction<
     @Override
     protected List<RollupJobTask> processTasks(StartRollupJobAction.Request request) {
         return TransportTaskHelper.doProcessTasks(request.getId(), taskManager);
+    }
+
+    @Override
+    protected void doExecute(Task task, StartRollupJobAction.Request request, ActionListener<StartRollupJobAction.Response> listener) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
+        super.doExecute(task, request, listener);
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.CancellableTask;

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
@@ -29,11 +29,16 @@ import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
+import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
+
 public class TransportStopRollupAction extends TransportTasksAction<
     RollupJobTask,
     StopRollupJobAction.Request,
     StopRollupJobAction.Response,
     StopRollupJobAction.Response> {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportStopRollupAction.class);
 
     private final ThreadPool threadPool;
 
@@ -63,6 +68,7 @@ public class TransportStopRollupAction extends TransportTasksAction<
 
     @Override
     protected void doExecute(Task task, StopRollupJobAction.Request request, ActionListener<StopRollupJobAction.Response> listener) {
+        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         super.doExecute(task, request, listener);
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_streams/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_streams/10_data_stream_resolvability.yml
@@ -148,6 +148,8 @@
 
   - do:
       # Should not raise error
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "logs*"
   - do:
@@ -473,6 +475,8 @@
         index: simple-data-stream1
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "simple-data-stream1"
         body:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/delete_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/delete_job.yml
@@ -1,6 +1,8 @@
 setup:
+  - requires:
+    test_runner_features: [ "allowed_warnings" ]
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -48,11 +50,16 @@ setup:
               }
             ]
           }
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
 
 ---
 "Test basic delete_job":
-
+  - requires:
+    test_runner_features: ["allowed_warnings"]
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -93,11 +100,15 @@ setup:
             job_state: "stopped"
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.delete_job:
         id: foo
   - is_true: acknowledged
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
   - match:
@@ -107,6 +118,8 @@ setup:
 "Test delete job twice":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -147,11 +160,15 @@ setup:
             job_state: "stopped"
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.delete_job:
         id: foo
   - is_true: acknowledged
 
   - do:
+      allowed_warnings:
+        - The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.
       rollup.get_jobs:
         id: foo
   - match:
@@ -161,6 +178,8 @@ setup:
 "Test delete running job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -201,11 +220,15 @@ setup:
             job_state: "stopped"
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.start_job:
         id: foo
   - is_true: started
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: request
       rollup.delete_job:
         id: foo
@@ -217,6 +240,8 @@ setup:
 "Test delete non-existent job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /the task with id \[does_not_exist\] doesn't exist/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_jobs.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_jobs.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -29,6 +29,8 @@ setup:
 "Test basic get_jobs":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -55,6 +57,8 @@ setup:
   - is_true: acknowledged
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -97,6 +101,8 @@ setup:
 "Test get with no jobs":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: "_all"
 
@@ -106,6 +112,8 @@ setup:
 "Test get missing job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_caps.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -46,6 +46,8 @@ setup:
                 my-id: { }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -78,6 +80,8 @@ setup:
 "Verify one job caps":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_caps:
         id: "foo"
 
@@ -101,6 +105,8 @@ setup:
 "Verify two job caps":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -125,6 +131,8 @@ setup:
             ]
           }
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_caps:
         id: "foo"
 
@@ -160,6 +168,8 @@ setup:
 "Verify all caps":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -185,6 +195,8 @@ setup:
           }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -210,6 +222,8 @@ setup:
           }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_caps:
         id: "_all"
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -47,6 +47,8 @@ setup:
                 my-id: { }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -79,6 +81,8 @@ setup:
 "Verify one job caps by rollup index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "foo_rollup"
 
@@ -102,6 +106,8 @@ setup:
 "Verify two job caps by rollup index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -126,6 +132,8 @@ setup:
             ]
           }
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "foo_rollup"
 
@@ -162,6 +170,8 @@ setup:
 "Verify two different job caps by rollup index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -190,6 +200,8 @@ setup:
         index: "foo_rollup"
 
   - match:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       foo_rollup:
         rollup_jobs:
           - job_id: "foo"
@@ -209,6 +221,8 @@ setup:
 "Verify all job caps by rollup index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -233,6 +247,8 @@ setup:
             ]
           }
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -258,6 +274,8 @@ setup:
           }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "_all"
 
@@ -308,6 +326,8 @@ setup:
 "Verify job caps by rollup index comma delimited list":
 
 - do:
+    allowed_warnings:
+      - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
     headers:
       Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
     rollup.put_job:
@@ -332,6 +352,8 @@ setup:
           ]
         }
 - do:
+    allowed_warnings:
+      - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
     headers:
       Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
     rollup.put_job:
@@ -357,6 +379,8 @@ setup:
         }
 
 - do:
+    allowed_warnings:
+      - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
     rollup.get_rollup_index_caps:
       index: "foo_rollup2,foo_rollup"
 
@@ -407,6 +431,8 @@ setup:
 "Verify index pattern":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -431,6 +457,8 @@ setup:
             ]
           }
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -456,6 +484,8 @@ setup:
           }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "*_rollup2"
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
@@ -196,12 +196,12 @@ setup:
             ]
           }
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "foo_rollup"
 
   - match:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       foo_rollup:
         rollup_jobs:
           - job_id: "foo"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/put_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/put_job.yml
@@ -42,6 +42,8 @@ setup:
 ---
 "Test basic put_job":
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -68,6 +70,8 @@ setup:
   - is_true: acknowledged
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -116,6 +120,8 @@ setup:
 "Test put_job with existing name":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -142,6 +148,8 @@ setup:
   - is_true: acknowledged
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Cannot create rollup job \[foo\] because job was previously created \(existing metadata\)/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -173,6 +181,8 @@ setup:
       indices.create:
         index: non-rollup
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Rollup data cannot be added to existing indices that contain non-rollup data/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -203,6 +213,8 @@ setup:
 "Try to include headers":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /unknown field \[headers\]/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -235,6 +247,8 @@ setup:
 "Validation failures":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Could not find a \[numeric\] or \[date,date_nanos\] field with name \[field_doesnt_exist\] in any of the indices matching the index pattern/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -268,6 +282,8 @@ setup:
         index: dummy-rollup-index
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /new rollup jobs are not allowed in clusters that don't have any rollup usage, since rollup has been deprecated/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -297,6 +313,8 @@ setup:
 "Unknown Metric":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Unsupported metric \[does_not_exist\]/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -338,6 +356,7 @@ setup:
   - do:
       allowed_warnings:
         - "index [foo_rollup] matches multiple legacy templates [global, test], composable templates will only match a single template"
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -413,6 +432,8 @@ setup:
       reason: Comma delimited index pattern introduced in 8.2.0
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -439,6 +460,8 @@ setup:
   - is_true: acknowledged
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: bar
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/rollup_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/rollup_search.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -29,6 +29,8 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.put_job:
         id: foo
         body:  >
@@ -139,6 +141,8 @@ setup:
 "Basic Search":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -166,6 +170,8 @@ setup:
       cluster_features: ["gte_v6.6.0"]
       reason: rest_total_hits_as_int was introduced in 6.6.0
   - do:
+      allowed_warnings:
+        - The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -191,6 +197,8 @@ setup:
 "Formatted Date Histo":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -217,6 +225,8 @@ setup:
 "Empty aggregation":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         rest_total_hits_as_int: true
         index: "foo_rollup"
@@ -232,6 +242,8 @@ setup:
 "Empty aggregation with new response format":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -249,6 +261,8 @@ setup:
 "Search with Metric":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -282,6 +296,8 @@ setup:
 "Search with Query":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -317,6 +333,8 @@ setup:
 "Search with MatchAll and Second Job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -427,6 +445,8 @@ setup:
 
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -460,6 +480,8 @@ setup:
 "Search with Query and Second Job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -570,6 +592,8 @@ setup:
 
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -605,6 +629,8 @@ setup:
 "Search with Query and Second Job different intervals":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -714,6 +740,8 @@ setup:
             "_rollup.version": 1
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -749,6 +777,8 @@ setup:
 "Wildcards matching single rollup index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup*"
         body:
@@ -787,6 +817,8 @@ setup:
                 type: integer
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -837,6 +869,8 @@ setup:
         name: rollup_alias
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "rollup_alias"
         body:
@@ -875,6 +909,8 @@ setup:
                 type: integer
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -908,6 +944,8 @@ setup:
         name: rollup_alias
 
   - do:
+       allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
        catch: /RollupSearch currently only supports searching one rollup index at a time\./
        rollup.rollup_search:
          index: "rollup_alias"
@@ -943,6 +981,8 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       warnings:
         - "Creating Rollup job [tz] with timezone [Canada/Mountain], but [Canada/Mountain] has been deprecated by the IANA.  Use [America/Edmonton] instead."
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.put_job:
         id: tz
         body:  >
@@ -1012,6 +1052,8 @@ setup:
             "_rollup.version": 2
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1039,6 +1081,8 @@ setup:
   - match: { aggregations.histo.buckets.2.the_max.value: 3 }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1162,6 +1206,8 @@ setup:
             "_rollup.version": 2
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1190,6 +1236,8 @@ setup:
 
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1221,6 +1269,8 @@ setup:
 "Search with typed_keys":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         typed_keys: true
@@ -1254,6 +1304,8 @@ setup:
 "Search error against live index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: bad_request
       rollup.rollup_search:
         index: "foo"
@@ -1270,6 +1322,8 @@ setup:
 "Search error against rollup and live index":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: bad_request
       rollup.rollup_search:
         index: "foo*"
@@ -1285,6 +1339,8 @@ setup:
 "Search error no matching indices":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Must specify at least one concrete index/
       rollup.rollup_search:
         index: "bar*"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/start_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/start_job.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -25,6 +25,8 @@ setup:
                 my-id: { }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -53,6 +55,8 @@ setup:
 "Test start nonexistent job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Task for Rollup Job \[does_not_exist\] not found/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -64,6 +68,8 @@ setup:
 "Test start job twice":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -71,6 +77,8 @@ setup:
   - is_true: started
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/stop_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/stop_job.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: headers
+      features: ["allowed_warnings", "headers"]
   - do:
       indices.create:
         index: foo
@@ -25,6 +25,8 @@ setup:
                 my-id: { }
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -53,6 +55,8 @@ setup:
 "Test stop nonexistent job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Task for Rollup Job \[does_not_exist\] not found/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -64,6 +68,8 @@ setup:
 "Test stop job twice":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -71,6 +77,8 @@ setup:
   - is_true: started
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -78,6 +86,8 @@ setup:
   - is_true: stopped
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -88,6 +98,8 @@ setup:
 "Test stop non-started job":
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -98,6 +110,8 @@ setup:
 ---
 "Test wait_for_completion default timeout":
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -105,6 +119,8 @@ setup:
   - is_true: started
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -115,6 +131,8 @@ setup:
 ---
 "Test wait_for_completion with custom timeout":
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -122,6 +140,8 @@ setup:
   - is_true: started
 
   - do:
+      allowed_warnings:
+        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -468,7 +468,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
             // create the rollup job
             final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
-
+            createRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             String intervalType;
             if (clusterHasFeature(RestTestLegacyFeatures.SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM)) {
                 intervalType = "fixed_interval";
@@ -501,6 +501,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
             // start the rollup job
             final Request startRollupJobRequest = new Request("POST", "/_rollup/job/rollup-job-test/_start");
+            startRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -880,6 +881,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
         // check that the rollup job is started using the RollUp API
         final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
+        getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         Map<String, Object> getRollupJobResponse = entityAsMap(client().performRequest(getRollupJobRequest));
         Map<?, ?> job = getJob(getRollupJobResponse, rollupJob);
         assertNotNull(job);
@@ -922,7 +924,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
     private void waitForRollUpJob(final String rollupJob, final Matcher<?> expectedStates) throws Exception {
         assertBusy(() -> {
             final Request getRollupJobRequest = new Request("GET", "/_rollup/job/" + rollupJob);
-
+            getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 

--- a/x-pack/qa/multi-node/src/javaRestTest/java/org/elasticsearch/multi_node/RollupIT.java
+++ b/x-pack/qa/multi-node/src/javaRestTest/java/org/elasticsearch/multi_node/RollupIT.java
@@ -128,6 +128,7 @@ public class RollupIT extends ESRestTestCase {
 
         // create the rollup job
         final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
+        createRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         int pageSize = randomIntBetween(2, 50);
         // fast cron so test runs quickly
         createRollupJobRequest.setJsonEntity(Strings.format("""
@@ -154,11 +155,13 @@ public class RollupIT extends ESRestTestCase {
                 ]
             }""", pageSize));
 
+        assertWarnings();
         var createRollupJobResponse = responseAsMap(client().performRequest(createRollupJobRequest));
         assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
         // start the rollup job
         final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-job-test/_start");
+        startRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         var startRollupJobResponse = responseAsMap(client().performRequest(startRollupJobRequest));
         assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -167,6 +170,7 @@ public class RollupIT extends ESRestTestCase {
         // Wait for the job to finish, by watching how many rollup docs we've indexed
         assertBusy(() -> {
             final Request getRollupJobRequest = new Request("GET", "_rollup/job/rollup-job-test");
+            getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 
@@ -211,6 +215,7 @@ public class RollupIT extends ESRestTestCase {
         var liveBody = responseAsMap(liveResponse);
 
         request = new Request("GET", "results-rollup/_rollup_search");
+        request.setOptions(ROLLUP_REQUESTS_OPTIONS);
         request.setJsonEntity(jsonRequestBody);
         Response rollupResponse = client().performRequest(request);
         var rollupBody = responseAsMap(rollupResponse);
@@ -223,6 +228,7 @@ public class RollupIT extends ESRestTestCase {
 
         request = new Request("GET", "rollup-docs/_rollup_search");
         request.setJsonEntity(jsonRequestBody);
+        request.setOptions(ROLLUP_REQUESTS_OPTIONS);
         Response liveRollupResponse = client().performRequest(request);
         var liveRollupBody = responseAsMap(liveRollupResponse);
 
@@ -241,6 +247,7 @@ public class RollupIT extends ESRestTestCase {
 
         // check that the rollup job is started using the RollUp API
         final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
+        getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         var getRollupJobResponse = responseAsMap(client().performRequest(getRollupJobRequest));
         Map<?, ?> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
@@ -286,6 +293,7 @@ public class RollupIT extends ESRestTestCase {
     private void waitForRollUpJob(final String rollupJob, String[] expectedStates) throws Exception {
         assertBusy(() -> {
             final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
+            getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 


### PR DESCRIPTION
Backporting #112807 to 8.15 branch.
Currently none of the rollup APIs deprecation warning. Only the reference docs indicate that rollup has been deprecated.

Relates to #112690