### PR TITLE
Add documentation for terms_set minimum_should_match parameter

### DIFF
--- a/docs/reference/query-dsl/terms-set-query.asciidoc
+++ b/docs/reference/query-dsl/terms-set-query.asciidoc
@@ -159,12 +159,22 @@ GET /job-candidates/_search
 `terms`::
 +
 --
-(Required, array of strings) Array of terms you wish to find in the provided
+(Required, array) Array of terms you wish to find in the provided
 `<field>`. To return a document, a required number of terms must exactly match
 the field values, including whitespace and capitalization.
 
-The required number of matching terms is defined in the
-`minimum_should_match_field` or `minimum_should_match_script` parameter.
+The required number of matching terms is defined in the `minimum_should_match`,
+`minimum_should_match_field` or `minimum_should_match_script` parameters. Exactly
+one of these parameters must be provided.
+--
+
+`minimum_should_match`::
++
+--
+(Optional) Specification for the number of matching terms required to return
+a document.
+
+For valid values, see <<query-dsl-minimum-should-match, `minimum_should_match` parameter>>.
 --
 
 `minimum_should_match_field`::


### PR DESCRIPTION
Elasticsearch has supported the `minimum_should_match` parameter for the `terms_set` query since 8.10.0 (PR https://github.com/elastic/elasticsearch/pull/96082). As mentioned in the original issue ticket (https://github.com/elastic/elasticsearch/pull/94095) the additional parameter is not currently documented, so this PR adds documentation.

This PR also removes the incorrect documented constraint that the `terms` parameter must consist solely of strings. In fact each term can be any valid FieldValue, as in the normal `terms` query.

For example, when querying against a field mapped as type `date` the term may be specified with a JSON number as described at (https://www.elastic.co/guide/en/elasticsearch/reference/8.15/date.html).