### PR TITLE
Implement incremental bulk execution

### DIFF
--- a/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
+++ b/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
@@ -26,6 +26,7 @@ public class RequestsWithoutContentIT extends ESRestTestCase {
         assertResponseException(responseException, "request body is required");
     }
 
+    @AwaitsFix(bugUrl = "need to decide how to handle this scenario")
     public void testBulkMissingBody() throws IOException {
         ResponseException responseException = expectThrows(
             ResponseException.class,

--- a/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
+++ b/distribution/archives/integ-test-zip/src/javaRestTest/java/org/elasticsearch/test/rest/RequestsWithoutContentIT.java
@@ -26,12 +26,10 @@ public class RequestsWithoutContentIT extends ESRestTestCase {
         assertResponseException(responseException, "request body is required");
     }
 
-    @AwaitsFix(bugUrl = "need to decide how to handle this scenario")
     public void testBulkMissingBody() throws IOException {
-        ResponseException responseException = expectThrows(
-            ResponseException.class,
-            () -> client().performRequest(new Request(randomBoolean() ? "POST" : "PUT", "/_bulk"))
-        );
+        Request request = new Request(randomBoolean() ? "POST" : "PUT", "/_bulk");
+        request.setJsonEntity("");
+        ResponseException responseException = expectThrows(ResponseException.class, () -> client().performRequest(request));
         assertResponseException(responseException, "request body is required");
     }
 

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -14,6 +14,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.ReferenceCounted;
 
 import org.elasticsearch.ESNetty4IntegTestCase;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -21,7 +22,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
-import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
@@ -54,7 +54,7 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             // TODO: We do not currently support in flight circuit breaker limits for bulk. However, IndexingPressure applies
-            .put(RestBulkAction.INCREMENTAL_BULK.getKey(), false)
+            .put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false)
             .put(HierarchyCircuitBreakerService.IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), LIMIT)
             .build();
     }

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
@@ -52,6 +53,8 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            // TODO: We do not currently support in flight circuit breaker limits for bulk. However, IndexingPressure applies
+            .put(RestBulkAction.INCREMENTAL_BULK.getKey(), false)
             .put(HierarchyCircuitBreakerService.IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), LIMIT)
             .build();
     }

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.http.netty4;

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import org.elasticsearch.ESNetty4IntegTestCase;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.netty4.Netty4Utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
+
+    // ensure empty http content has single 0 size chunk
+    public void testEmptyContent() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            var totalRequests = randomIntBetween(1, 10);
+            for (int reqNo = 0; reqNo < totalRequests; reqNo++) {
+                var opaqueId = opaqueId(reqNo);
+
+                // send request with empty content
+                ctx.clientChannel.writeAndFlush(fullHttpRequest(opaqueId, Unpooled.EMPTY_BUFFER));
+                var handler = ctx.awaitRestChannelAccepted(opaqueId);
+                handler.stream.next();
+
+                // should receive a single empty chunk
+                var recvChunk = safePoll(handler.recvChunks);
+                assertTrue(recvChunk.isLast);
+                assertEquals(0, recvChunk.chunk.length());
+                recvChunk.chunk.close();
+
+                // send response to process following request
+                handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+            }
+            assertBusy(() -> assertEquals("should receive all server responses", totalRequests, ctx.clientRespQueue.size()));
+        }
+    }
+
+    // ensures content integrity, no loses and re-order
+    public void testReceiveAllChunks() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            var totalRequests = randomIntBetween(1, 10);
+            for (int reqNo = 0; reqNo < totalRequests; reqNo++) {
+                var opaqueId = opaqueId(reqNo);
+
+                // this dataset will be compared with one on server side
+                var dataSize = randomIntBetween(1024, 10 * 1024 * 1024);
+                var sendData = Unpooled.wrappedBuffer(randomByteArrayOfLength(dataSize));
+                sendData.retain();
+                ctx.clientChannel.writeAndFlush(fullHttpRequest(opaqueId, sendData));
+
+                var handler = ctx.awaitRestChannelAccepted(opaqueId);
+
+                var recvData = Unpooled.buffer(dataSize);
+                while (true) {
+                    handler.stream.next();
+                    var recvChunk = safePoll(handler.recvChunks);
+                    try (recvChunk.chunk) {
+                        recvData.writeBytes(Netty4Utils.toByteBuf(recvChunk.chunk));
+                        if (recvChunk.isLast) {
+                            break;
+                        }
+                    }
+                }
+
+                assertEquals("sent and received payloads are not the same", sendData, recvData);
+                handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+            }
+            assertBusy(() -> assertEquals("should receive all server responses", totalRequests, ctx.clientRespQueue.size()));
+        }
+    }
+
+    // ensures that all queued chunks are released when connection closed
+    public void testClientConnectionCloseMidStream() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            var opaqueId = opaqueId(0);
+
+            // write half of http request
+            ctx.clientChannel.write(httpRequest(opaqueId, 2 * 1024));
+            ctx.clientChannel.writeAndFlush(randomContent(1024, false));
+
+            // await stream handler is ready and request full content
+            var handler = ctx.awaitRestChannelAccepted(opaqueId);
+            assertBusy(() -> assertEquals(1, handler.stream.chunkQueue().size()));
+
+            // enable auto-read to receive channel close event
+            handler.stream.channel().config().setAutoRead(true);
+
+            // terminate connection and wait resources are released
+            ctx.clientChannel.close();
+            assertBusy(() -> assertEquals(0, handler.stream.chunkQueue().size()));
+        }
+    }
+
+    // ensures that all queued chunks are released when server decides to close connection
+    public void testServerCloseConnectionMidStream() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            var opaqueId = opaqueId(0);
+
+            // write half of http request
+            ctx.clientChannel.write(httpRequest(opaqueId, 2 * 1024));
+            ctx.clientChannel.writeAndFlush(randomContent(1024, false));
+
+            // await stream handler is ready and request full content
+            var handler = ctx.awaitRestChannelAccepted(opaqueId);
+            assertBusy(() -> assertEquals(1, handler.stream.chunkQueue().size()));
+
+            // terminate connection on server and wait resources are released
+            handler.channel.request().getHttpChannel().close();
+            assertBusy(() -> assertEquals(0, handler.stream.chunkQueue().size()));
+        }
+    }
+
+    // ensure that client's socket buffers data when server is not consuming data
+    public void testClientBackpressure() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            var opaqueId = opaqueId(0);
+            var payloadSize = MBytes(50);
+            ctx.clientChannel.writeAndFlush(httpRequest(opaqueId, payloadSize));
+            for (int i = 0; i < 5; i++) {
+                ctx.clientChannel.writeAndFlush(randomContent(MBytes(10), false));
+            }
+            assertFalse(
+                "should not flush last content immediately",
+                ctx.clientChannel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT).isDone()
+            );
+
+            var handler = ctx.awaitRestChannelAccepted(opaqueId);
+
+            // Read buffers for socket and channel usually within few MBytes range all together.
+            // This test assumes that buffers will not exceed 10 MBytes, in other words there should
+            // be less than 10 MBytes in fly between http client's socket and rest handler. This
+            // loop ensures that reading 10 MBytes of content on server side should free almost
+            // same size in client's channel write buffer.
+            for (int mb = 0; mb <= 50; mb += 10) {
+                var minBufSize = payloadSize - MBytes(10 + mb);
+                var maxBufSize = payloadSize - MBytes(mb);
+                // it is hard to tell that client's channel is no logger flushing data
+                // it might take a few busy-iterations before channel buffer flush to kernel
+                // and bytesBeforeWritable will stop changing
+                assertBusy(() -> {
+                    var bufSize = ctx.clientChannel.bytesBeforeWritable();
+                    assertTrue(
+                        "client's channel buffer should be in range [" + minBufSize + "," + maxBufSize + "], got " + bufSize,
+                        bufSize >= minBufSize && bufSize <= maxBufSize
+                    );
+                });
+                handler.consumeBytes(MBytes(10));
+            }
+            assertTrue(handler.stream.hasLast());
+        }
+    }
+
+    private String opaqueId(int reqNo) {
+        return getTestName() + "-" + reqNo;
+    }
+
+    static int MBytes(int m) {
+        return m * 1024 * 1024;
+    }
+
+    static <T> T safePoll(BlockingDeque<T> queue) {
+        try {
+            var t = queue.poll(SAFE_AWAIT_TIMEOUT.seconds(), TimeUnit.SECONDS);
+            assertNotNull("queue is empty", t);
+            return t;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    static FullHttpRequest fullHttpRequest(String opaqueId, ByteBuf content) {
+        var req = new DefaultFullHttpRequest(HTTP_1_1, POST, ControlServerRequestPlugin.ROUTE, Unpooled.wrappedBuffer(content));
+        req.headers().add(CONTENT_LENGTH, content.readableBytes());
+        req.headers().add(CONTENT_TYPE, APPLICATION_JSON);
+        req.headers().add(Task.X_OPAQUE_ID_HTTP_HEADER, opaqueId);
+        return req;
+    }
+
+    static HttpRequest httpRequest(String opaqueId, int contentLength) {
+        return httpRequest(ControlServerRequestPlugin.ROUTE, opaqueId, contentLength);
+    }
+
+    static HttpRequest httpRequest(String uri, String opaqueId, int contentLength) {
+        var req = new DefaultHttpRequest(HTTP_1_1, POST, uri);
+        req.headers().add(CONTENT_LENGTH, contentLength);
+        req.headers().add(CONTENT_TYPE, APPLICATION_JSON);
+        req.headers().add(Task.X_OPAQUE_ID_HTTP_HEADER, opaqueId);
+        return req;
+    }
+
+    static HttpContent randomContent(int size, boolean isLast) {
+        var buf = Unpooled.wrappedBuffer(randomByteArrayOfLength(size));
+        if (isLast) {
+            return new DefaultLastHttpContent(buf);
+        } else {
+            return new DefaultHttpContent(buf);
+        }
+    }
+
+    Ctx setupClientCtx() throws Exception {
+        var nodeName = internalCluster().getRandomNodeName();
+        var clientRespQueue = new LinkedBlockingDeque<>(16);
+        var bootstrap = bootstrapClient(nodeName, clientRespQueue);
+        var channel = bootstrap.connect().sync().channel();
+        return new Ctx(getTestName(), nodeName, bootstrap, channel, clientRespQueue);
+    }
+
+    Bootstrap bootstrapClient(String node, BlockingQueue<Object> queue) {
+        var httpServer = internalCluster().getInstance(HttpServerTransport.class, node);
+        var remoteAddr = randomFrom(httpServer.boundAddress().boundAddresses());
+        return new Bootstrap().group(new NioEventLoopGroup(1))
+            .channel(NioSocketChannel.class)
+            .remoteAddress(remoteAddr.getAddress(), remoteAddr.getPort())
+            .handler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(SocketChannel ch) {
+                    var p = ch.pipeline();
+                    p.addLast(new HttpClientCodec());
+                    p.addLast(new HttpObjectAggregator(4096));
+                    p.addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
+                        @Override
+                        protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) {
+                            msg.retain();
+                            queue.add(msg);
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            queue.add(cause);
+                        }
+                    });
+                }
+            });
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.concatLists(List.of(ControlServerRequestPlugin.class), super.nodePlugins());
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false; // enable http
+    }
+
+    record Ctx(String testName, String nodeName, Bootstrap clientBootstrap, Channel clientChannel, BlockingDeque<Object> clientRespQueue)
+        implements
+            AutoCloseable {
+
+        @Override
+        public void close() throws Exception {
+            safeGet(clientChannel.close());
+            safeGet(clientBootstrap.config().group().shutdownGracefully());
+            clientRespQueue.forEach(o -> { if (o instanceof FullHttpResponse resp) resp.release(); });
+            for (var opaqueId : ControlServerRequestPlugin.handlers.keySet()) {
+                if (opaqueId.startsWith(testName)) {
+                    var handler = ControlServerRequestPlugin.handlers.get(opaqueId);
+                    handler.recvChunks.forEach(c -> c.chunk.close());
+                    handler.channel.request().getHttpChannel().close();
+                    ControlServerRequestPlugin.handlers.remove(opaqueId);
+                }
+            }
+        }
+
+        ServerRequestHandler awaitRestChannelAccepted(String opaqueId) throws Exception {
+            assertBusy(() -> assertTrue(ControlServerRequestPlugin.handlers.containsKey(opaqueId)));
+            var handler = ControlServerRequestPlugin.handlers.get(opaqueId);
+            safeAwait(handler.channelAccepted);
+            return handler;
+        }
+    }
+
+    static class ServerRequestHandler implements BaseRestHandler.RequestBodyChunkConsumer {
+        final SubscribableListener<Void> channelAccepted = new SubscribableListener<>();
+        final String opaqueId;
+        final BlockingDeque<Chunk> recvChunks = new LinkedBlockingDeque<>();
+        final Netty4HttpRequestBodyStream stream;
+        RestChannel channel;
+
+        boolean recvLast = false;
+
+        ServerRequestHandler(String opaqueId, Netty4HttpRequestBodyStream stream) {
+            this.opaqueId = opaqueId;
+            this.stream = stream;
+        }
+
+        @Override
+        public void handleChunk(RestChannel channel, ReleasableBytesReference chunk, boolean isLast) {
+            recvChunks.add(new Chunk(chunk, isLast));
+        }
+
+        @Override
+        public void accept(RestChannel channel) throws Exception {
+            this.channel = channel;
+            channelAccepted.onResponse(null);
+        }
+
+        void sendResponse(RestResponse response) {
+            channel.sendResponse(response);
+        }
+
+        void consumeBytes(int bytes) {
+            if (recvLast) {
+                return;
+            }
+            while (bytes > 0) {
+                stream.next();
+                var recvChunk = safePoll(recvChunks);
+                bytes -= recvChunk.chunk.length();
+                recvChunk.chunk.close();
+                if (recvChunk.isLast) {
+                    recvLast = true;
+                    break;
+                }
+            }
+        }
+
+        Future<?> onChannelThread(Callable<?> task) {
+            return this.stream.channel().eventLoop().submit(task);
+        }
+
+        record Chunk(ReleasableBytesReference chunk, boolean isLast) {}
+    }
+
+    // takes full control of rest handler from the outside
+    public static class ControlServerRequestPlugin extends Plugin implements ActionPlugin {
+
+        static final String ROUTE = "/_test/request-stream";
+
+        static final ConcurrentHashMap<String, ServerRequestHandler> handlers = new ConcurrentHashMap<>();
+
+        @Override
+        public Collection<RestHandler> getRestHandlers(
+            Settings settings,
+            NamedWriteableRegistry namedWriteableRegistry,
+            RestController restController,
+            ClusterSettings clusterSettings,
+            IndexScopedSettings indexScopedSettings,
+            SettingsFilter settingsFilter,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<DiscoveryNodes> nodesInCluster,
+            Predicate<NodeFeature> clusterSupportsFeature
+        ) {
+            return List.of(new BaseRestHandler() {
+                @Override
+                public String getName() {
+                    return ROUTE;
+                }
+
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(RestRequest.Method.POST, ROUTE));
+                }
+
+                @Override
+                protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+                    var stream = (Netty4HttpRequestBodyStream) request.contentStream();
+                    var opaqueId = request.getHeaders().get(Task.X_OPAQUE_ID_HTTP_HEADER).get(0);
+                    var handler = new ServerRequestHandler(opaqueId, stream);
+                    handlers.put(opaqueId, handler);
+                    return handler;
+                }
+            });
+        }
+    }
+
+}

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -153,7 +153,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         }
     }
 
-    // ensures that all queued chunks are released when connection closed
+    // ensures that all received chunks are released when connection closed
     public void testClientConnectionCloseMidStream() throws Exception {
         try (var ctx = setupClientCtx()) {
             var opaqueId = opaqueId(0);
@@ -164,18 +164,18 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
 
             // await stream handler is ready and request full content
             var handler = ctx.awaitRestChannelAccepted(opaqueId);
-            assertBusy(() -> assertEquals(1, handler.stream.chunkQueue().size()));
+            assertBusy(() -> assertNotNull(handler.stream.buf()));
 
             // enable auto-read to receive channel close event
             handler.stream.channel().config().setAutoRead(true);
 
             // terminate connection and wait resources are released
             ctx.clientChannel.close();
-            assertBusy(() -> assertEquals(0, handler.stream.chunkQueue().size()));
+            assertBusy(() -> assertNull(handler.stream.buf()));
         }
     }
 
-    // ensures that all queued chunks are released when server decides to close connection
+    // ensures that all recieved chunks are released when server decides to close connection
     public void testServerCloseConnectionMidStream() throws Exception {
         try (var ctx = setupClientCtx()) {
             var opaqueId = opaqueId(0);
@@ -186,11 +186,11 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
 
             // await stream handler is ready and request full content
             var handler = ctx.awaitRestChannelAccepted(opaqueId);
-            assertBusy(() -> assertEquals(1, handler.stream.chunkQueue().size()));
+            assertBusy(() -> assertNotNull(handler.stream.buf()));
 
             // terminate connection on server and wait resources are released
             handler.channel.request().getHttpChannel().close();
-            assertBusy(() -> assertEquals(0, handler.stream.chunkQueue().size()));
+            assertBusy(() -> assertNull(handler.stream.buf()));
         }
     }
 
@@ -470,7 +470,6 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         final BlockingDeque<Chunk> recvChunks = new LinkedBlockingDeque<>();
         final Netty4HttpRequestBodyStream stream;
         RestChannel channel;
-
         boolean recvLast = false;
 
         ServerRequestHandler(String opaqueId, Netty4HttpRequestBodyStream stream) {

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.http.netty4;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -25,11 +26,16 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpChunkedInput;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.stream.ChunkedStream;
+import io.netty.handler.stream.ChunkedWriteHandler;
 
 import org.elasticsearch.ESNetty4IntegTestCase;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -42,9 +48,13 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.http.HttpHandlingSettings;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -62,9 +72,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -78,6 +86,13 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
 public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
+        builder.put(HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH.getKey(), new ByteSizeValue(50, ByteSizeUnit.MB));
+        return builder.build();
+    }
 
     // ensure empty http content has single 0 size chunk
     public void testEmptyContent() throws Exception {
@@ -112,7 +127,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
                 var opaqueId = opaqueId(reqNo);
 
                 // this dataset will be compared with one on server side
-                var dataSize = randomIntBetween(1024, 10 * 1024 * 1024);
+                var dataSize = randomIntBetween(1024, maxContentLength());
                 var sendData = Unpooled.wrappedBuffer(randomByteArrayOfLength(dataSize));
                 sendData.retain();
                 ctx.clientChannel.writeAndFlush(fullHttpRequest(opaqueId, sendData));
@@ -213,10 +228,96 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
                         bufSize >= minBufSize && bufSize <= maxBufSize
                     );
                 });
-                handler.consumeBytes(MBytes(10));
+                handler.readBytes(MBytes(10));
             }
             assertTrue(handler.stream.hasLast());
         }
+    }
+
+    // ensures that server reply 100-continue on acceptable request size
+    public void test100Continue() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            for (int reqNo = 0; reqNo < randomIntBetween(2, 10); reqNo++) {
+                var id = opaqueId(reqNo);
+                var acceptableContentLength = randomIntBetween(0, maxContentLength());
+
+                // send request header and await 100-continue
+                var req = httpRequest(id, acceptableContentLength);
+                HttpUtil.set100ContinueExpected(req, true);
+                ctx.clientChannel.writeAndFlush(req);
+                var resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+                assertEquals(HttpResponseStatus.CONTINUE, resp.status());
+                resp.release();
+
+                // send content
+                var content = randomContent(acceptableContentLength, true);
+                ctx.clientChannel.writeAndFlush(content);
+
+                // consume content and reply 200
+                var handler = ctx.awaitRestChannelAccepted(id);
+                var consumed = handler.readAllBytes();
+                assertEquals(acceptableContentLength, consumed);
+                handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+
+                resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+                assertEquals(HttpResponseStatus.OK, resp.status());
+                resp.release();
+            }
+        }
+    }
+
+    // ensures that server reply 413-too-large on oversized request with expect-100-continue
+    public void test413TooLargeOnExpect100Continue() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            for (int reqNo = 0; reqNo < randomIntBetween(2, 10); reqNo++) {
+                var id = opaqueId(reqNo);
+                var oversized = maxContentLength() + 1;
+
+                // send request header and await 413 too large
+                var req = httpRequest(id, oversized);
+                HttpUtil.set100ContinueExpected(req, true);
+                ctx.clientChannel.writeAndFlush(req);
+                var resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+                assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, resp.status());
+                resp.release();
+
+                // terminate request
+                ctx.clientChannel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+            }
+        }
+    }
+
+    // ensures that oversized chunked encoded request has no limits at http layer
+    // rest handler is responsible for oversized requests
+    public void testOversizedChunkedEncodingNoLimits() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            for (var reqNo = 0; reqNo < randomIntBetween(2, 10); reqNo++) {
+                var id = opaqueId(reqNo);
+                var contentSize = maxContentLength() + 1;
+                var content = randomByteArrayOfLength(contentSize);
+                var is = new ByteBufInputStream(Unpooled.wrappedBuffer(content));
+                var chunkedIs = new ChunkedStream(is);
+                var httpChunkedIs = new HttpChunkedInput(chunkedIs, LastHttpContent.EMPTY_LAST_CONTENT);
+                var req = httpRequest(id, 0);
+                HttpUtil.setTransferEncodingChunked(req, true);
+
+                ctx.clientChannel.pipeline().addLast(new ChunkedWriteHandler());
+                ctx.clientChannel.writeAndFlush(req);
+                ctx.clientChannel.writeAndFlush(httpChunkedIs);
+                var handler = ctx.awaitRestChannelAccepted(id);
+                var consumed = handler.readAllBytes();
+                assertEquals(contentSize, consumed);
+                handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+
+                var resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+                assertEquals(HttpResponseStatus.OK, resp.status());
+                resp.release();
+            }
+        }
+    }
+
+    private int maxContentLength() {
+        return HttpHandlingSettings.fromSettings(internalCluster().getInstance(Settings.class)).maxContentLength();
     }
 
     private String opaqueId(int reqNo) {
@@ -369,24 +470,25 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
             channel.sendResponse(response);
         }
 
-        void consumeBytes(int bytes) {
-            if (recvLast) {
-                return;
-            }
-            while (bytes > 0) {
-                stream.next();
-                var recvChunk = safePoll(recvChunks);
-                bytes -= recvChunk.chunk.length();
-                recvChunk.chunk.close();
-                if (recvChunk.isLast) {
-                    recvLast = true;
-                    break;
+        int readBytes(int bytes) {
+            var consumed = 0;
+            if (recvLast == false) {
+                while (consumed < bytes) {
+                    stream.next();
+                    var recvChunk = safePoll(recvChunks);
+                    consumed += recvChunk.chunk.length();
+                    recvChunk.chunk.close();
+                    if (recvChunk.isLast) {
+                        recvLast = true;
+                        break;
+                    }
                 }
             }
+            return consumed;
         }
 
-        Future<?> onChannelThread(Callable<?> task) {
-            return this.stream.channel().eventLoop().submit(task);
+        int readAllBytes() {
+            return readBytes(Integer.MAX_VALUE);
         }
 
         record Chunk(ReleasableBytesReference chunk, boolean isLast) {}

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -37,6 +37,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedStream;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.ESNetty4IntegTestCase;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -52,6 +53,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.http.HttpBodyTracer;
 import org.elasticsearch.http.HttpHandlingSettings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.http.HttpTransportSettings;
@@ -66,6 +68,8 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
 import java.util.Collection;
@@ -75,6 +79,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -210,10 +215,12 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
     public void testClientBackpressure() throws Exception {
         try (var ctx = setupClientCtx()) {
             var opaqueId = opaqueId(0);
-            var payloadSize = MBytes(50);
+            var payloadSize = maxContentLength();
+            var totalParts = 10;
+            var partSize = payloadSize / totalParts;
             ctx.clientChannel.writeAndFlush(httpRequest(opaqueId, payloadSize));
-            for (int i = 0; i < 5; i++) {
-                ctx.clientChannel.writeAndFlush(randomContent(MBytes(10), false));
+            for (int i = 0; i < totalParts; i++) {
+                ctx.clientChannel.writeAndFlush(randomContent(partSize, false));
             }
             assertFalse(
                 "should not flush last content immediately",
@@ -222,16 +229,15 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
 
             var handler = ctx.awaitRestChannelAccepted(opaqueId);
 
-            // Read buffers for socket and channel usually within few MBytes range all together.
-            // This test assumes that buffers will not exceed 10 MBytes, in other words there should
-            // be less than 10 MBytes in fly between http client's socket and rest handler. This
-            // loop ensures that reading 10 MBytes of content on server side should free almost
-            // same size in client's channel write buffer.
-            for (int mb = 0; mb <= 50; mb += 10) {
-                var minBufSize = payloadSize - MBytes(10 + mb);
-                var maxBufSize = payloadSize - MBytes(mb);
+            // some data flushes from channel into OS buffer and won't be visible here, usually 4-8Mb
+            var osBufferOffset = MBytes(10);
+
+            // incrementally read data on server side and ensure client side buffer drains accordingly
+            for (int readBytes = 0; readBytes <= payloadSize; readBytes += partSize) {
+                var minBufSize = Math.max(payloadSize - readBytes - osBufferOffset, 0);
+                var maxBufSize = Math.max(payloadSize - readBytes, 0);
                 // it is hard to tell that client's channel is no logger flushing data
-                // it might take a few busy-iterations before channel buffer flush to kernel
+                // it might take a few busy-iterations before channel buffer flush to OS
                 // and bytesBeforeWritable will stop changing
                 assertBusy(() -> {
                     var bufSize = ctx.clientChannel.bytesBeforeWritable();
@@ -240,7 +246,7 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
                         bufSize >= minBufSize && bufSize <= maxBufSize
                     );
                 });
-                handler.readBytes(MBytes(10));
+                handler.readBytes(partSize);
             }
             assertTrue(handler.stream.hasLast());
         }
@@ -351,6 +357,107 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         }
     }
 
+    private static long transportStatsRequestBytesSize(Ctx ctx) {
+        var httpTransport = internalCluster().getInstance(HttpServerTransport.class, ctx.nodeName);
+        var stats = httpTransport.stats().clientStats();
+        var bytes = 0L;
+        for (var s : stats) {
+            bytes += s.requestSizeBytes();
+        }
+        return bytes;
+    }
+
+    /**
+     * ensures that {@link org.elasticsearch.http.HttpClientStatsTracker} counts streamed content bytes
+     */
+    public void testHttpClientStats() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            // need to offset starting point, since we reuse cluster and other tests already sent some data
+            var totalBytesSent = transportStatsRequestBytesSize(ctx);
+
+            for (var reqNo = 0; reqNo < randomIntBetween(2, 10); reqNo++) {
+                var id = opaqueId(reqNo);
+                var contentSize = randomIntBetween(0, maxContentLength());
+                totalBytesSent += contentSize;
+                ctx.clientChannel.writeAndFlush(httpRequest(id, contentSize));
+                ctx.clientChannel.writeAndFlush(randomContent(contentSize, true));
+                var handler = ctx.awaitRestChannelAccepted(id);
+                handler.readAllBytes();
+                handler.sendResponse(new RestResponse(RestStatus.OK, ""));
+                assertEquals(totalBytesSent, transportStatsRequestBytesSize(ctx));
+            }
+        }
+    }
+
+    /**
+     * ensures that we log parts of http body and final line
+     */
+    @TestLogging(
+        reason = "testing TRACE logging",
+        value = "org.elasticsearch.http.HttpTracer:TRACE,org.elasticsearch.http.HttpBodyTracer:TRACE"
+    )
+    public void testHttpBodyLogging() throws Exception {
+        assertHttpBodyLogging((ctx) -> () -> {
+            try {
+                var req = fullHttpRequest(opaqueId(0), randomByteBuf(8 * 1024));
+                ctx.clientChannel.writeAndFlush(req);
+                var handler = ctx.awaitRestChannelAccepted(opaqueId(0));
+                handler.readAllBytes();
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    /**
+     * ensures that we log some parts of body and final line when connection is closed in the middle
+     */
+    @TestLogging(
+        reason = "testing TRACE logging",
+        value = "org.elasticsearch.http.HttpTracer:TRACE,org.elasticsearch.http.HttpBodyTracer:TRACE"
+    )
+    public void testHttpBodyLoggingChannelClose() throws Exception {
+        assertHttpBodyLogging((ctx) -> () -> {
+            try {
+                var req = httpRequest(opaqueId(0), 2 * 8192);
+                var halfContent = randomContent(8192, false);
+                ctx.clientChannel.writeAndFlush(req);
+                ctx.clientChannel.writeAndFlush(halfContent);
+                var handler = ctx.awaitRestChannelAccepted(opaqueId(0));
+                handler.readBytes(8192);
+                ctx.clientChannel.close();
+                handler.stream.next();
+                assertBusy(() -> assertTrue(handler.streamClosed));
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+    }
+
+    // asserts that we emit at least one logging event for a part and last line
+    // http body should be large enough to split across multiple lines, > 4kb
+    private void assertHttpBodyLogging(Function<Ctx, Runnable> test) throws Exception {
+        try (var ctx = setupClientCtx()) {
+            MockLog.assertThatLogger(
+                test.apply(ctx),
+                HttpBodyTracer.class,
+                new MockLog.SeenEventExpectation(
+                    "request part",
+                    HttpBodyTracer.class.getCanonicalName(),
+                    Level.TRACE,
+                    "* request body [part *]*"
+                ),
+                new MockLog.SeenEventExpectation(
+                    "request end",
+                    HttpBodyTracer.class.getCanonicalName(),
+                    Level.TRACE,
+                    "* request body (gzip compressed, base64-encoded, and split into * parts on preceding log lines; for details see "
+                        + "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-network.html#http-rest-request-tracer)"
+                )
+            );
+        }
+    }
+
     private int maxContentLength() {
         return HttpHandlingSettings.fromSettings(internalCluster().getInstance(Settings.class)).maxContentLength();
     }
@@ -401,6 +508,10 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         } else {
             return new DefaultHttpContent(buf);
         }
+    }
+
+    static ByteBuf randomByteBuf(int size) {
+        return Unpooled.wrappedBuffer(randomByteArrayOfLength(size));
     }
 
     Ctx setupClientCtx() throws Exception {

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -316,6 +316,29 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
         }
     }
 
+    // ensures that we dont leak buffers in stream on 400-bad-request
+    // some bad requests are dispatched from rest-controller before reaching rest handler
+    // test relies on netty's buffer leak detection
+    public void testBadRequestReleaseQueuedChunks() throws Exception {
+        try (var ctx = setupClientCtx()) {
+            for (var reqNo = 0; reqNo < randomIntBetween(2, 10); reqNo++) {
+                var id = opaqueId(reqNo);
+                var contentSize = randomIntBetween(0, maxContentLength());
+                var req = httpRequest(id, contentSize);
+                var content = randomContent(contentSize, true);
+
+                // set unacceptable content-type
+                req.headers().set(CONTENT_TYPE, "unknown");
+                ctx.clientChannel.writeAndFlush(req);
+                ctx.clientChannel.writeAndFlush(content);
+
+                var resp = (FullHttpResponse) safePoll(ctx.clientRespQueue);
+                assertEquals(HttpResponseStatus.BAD_REQUEST, resp.status());
+                resp.release();
+            }
+        }
+    }
+
     private int maxContentLength() {
         return HttpHandlingSettings.fromSettings(internalCluster().getInstance(Settings.class)).maxContentLength();
     }
@@ -514,6 +537,11 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
             Predicate<NodeFeature> clusterSupportsFeature
         ) {
             return List.of(new BaseRestHandler() {
+                @Override
+                public boolean allowsUnsafeBuffers() {
+                    return true;
+                }
+
                 @Override
                 public String getName() {
                     return ROUTE;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.http.netty4;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
+
+import org.elasticsearch.http.HttpPreRequest;
+import org.elasticsearch.http.netty4.internal.HttpHeadersAuthenticatorUtils;
+
+import java.util.function.Predicate;
+
+public class Netty4HttpAggregator extends HttpObjectAggregator {
+    private static final Predicate<HttpPreRequest> IGNORE_TEST = (req) -> req.uri().startsWith("/_test/request-stream") == false;
+
+    private final Predicate<HttpPreRequest> decider;
+    private boolean shouldAggregate;
+
+    public Netty4HttpAggregator(int maxContentLength) {
+        this(maxContentLength, IGNORE_TEST);
+    }
+
+    public Netty4HttpAggregator(int maxContentLength, Predicate<HttpPreRequest> decider) {
+        super(maxContentLength);
+        this.decider = decider;
+    }
+
+    @Override
+    public boolean acceptInboundMessage(Object msg) throws Exception {
+        if (msg instanceof HttpRequest request) {
+            var preReq = HttpHeadersAuthenticatorUtils.asHttpPreRequest(request);
+            shouldAggregate = decider.test(preReq);
+        }
+        if (shouldAggregate) {
+            return super.acceptInboundMessage(msg);
+        } else {
+            return false;
+        }
+    }
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -9,19 +9,32 @@
 
 package org.elasticsearch.http.netty4;
 
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 
 import org.elasticsearch.http.HttpPreRequest;
 import org.elasticsearch.http.netty4.internal.HttpHeadersAuthenticatorUtils;
 
 import java.util.function.Predicate;
 
+/**
+ * A wrapper around {@link HttpObjectAggregator}. Provides optional content aggregation based on
+ * predicate. {@link HttpObjectAggregator} also handles Expect: 100-continue and oversized content.
+ * Unfortunately, Netty does not provide handlers for oversized messages beyond HttpObjectAggregator.
+ */
 public class Netty4HttpAggregator extends HttpObjectAggregator {
     private static final Predicate<HttpPreRequest> IGNORE_TEST = (req) -> req.uri().startsWith("/_test/request-stream") == false;
 
     private final Predicate<HttpPreRequest> decider;
-    private boolean shouldAggregate;
+    private boolean aggregating = true;
+    private boolean ignoreContentAfterContinueResponse = false;
 
     public Netty4HttpAggregator(int maxContentLength) {
         this(maxContentLength, IGNORE_TEST);
@@ -33,15 +46,43 @@ public class Netty4HttpAggregator extends HttpObjectAggregator {
     }
 
     @Override
-    public boolean acceptInboundMessage(Object msg) throws Exception {
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        assert msg instanceof HttpObject;
         if (msg instanceof HttpRequest request) {
             var preReq = HttpHeadersAuthenticatorUtils.asHttpPreRequest(request);
-            shouldAggregate = decider.test(preReq);
+            aggregating = decider.test(preReq);
         }
-        if (shouldAggregate) {
-            return super.acceptInboundMessage(msg);
+        if (aggregating || msg instanceof FullHttpRequest) {
+            super.channelRead(ctx, msg);
         } else {
-            return false;
+            handle(ctx, (HttpObject) msg);
+        }
+    }
+
+    private void handle(ChannelHandlerContext ctx, HttpObject msg) {
+        if (msg instanceof HttpRequest request) {
+            var continueResponse = newContinueResponse(request, maxContentLength(), ctx.pipeline());
+            if (continueResponse != null) {
+                // there are 3 responses expected: 100, 413, 417
+                // on 100 we pass request further and reply to client to continue
+                // on 413/417 we ignore following content
+                ctx.writeAndFlush(continueResponse);
+                var resp = (FullHttpResponse) continueResponse;
+                if (resp.status() != HttpResponseStatus.CONTINUE) {
+                    ignoreContentAfterContinueResponse = true;
+                    return;
+                }
+                HttpUtil.set100ContinueExpected(request, false);
+            }
+            ignoreContentAfterContinueResponse = false;
+            ctx.fireChannelRead(msg);
+        } else {
+            var httpContent = (HttpContent) msg;
+            if (ignoreContentAfterContinueResponse) {
+                httpContent.release();
+            } else {
+                ctx.fireChannelRead(msg);
+            }
         }
     }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpAggregator.java
@@ -36,10 +36,6 @@ public class Netty4HttpAggregator extends HttpObjectAggregator {
     private boolean aggregating = true;
     private boolean ignoreContentAfterContinueResponse = false;
 
-    public Netty4HttpAggregator(int maxContentLength) {
-        this(maxContentLength, IGNORE_TEST);
-    }
-
     public Netty4HttpAggregator(int maxContentLength, Predicate<HttpPreRequest> decider) {
         super(maxContentLength);
         this.decider = decider;
@@ -50,7 +46,7 @@ public class Netty4HttpAggregator extends HttpObjectAggregator {
         assert msg instanceof HttpObject;
         if (msg instanceof HttpRequest request) {
             var preReq = HttpHeadersAuthenticatorUtils.asHttpPreRequest(request);
-            aggregating = decider.test(preReq);
+            aggregating = decider.test(preReq) && IGNORE_TEST.test(preReq);
         }
         if (aggregating || msg instanceof FullHttpRequest) {
             super.channelRead(ctx, msg);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -128,6 +128,12 @@ public class Netty4HttpRequest implements HttpRequest {
         }
         try {
             final ByteBuf copiedContent = Unpooled.copiedBuffer(request.content());
+            HttpBody newContent;
+            if (content.isStream()) {
+                newContent = content;
+            } else {
+                newContent = Netty4Utils.fullHttpBodyFrom(copiedContent);
+            }
             return new Netty4HttpRequest(
                 sequence,
                 new DefaultFullHttpRequest(
@@ -140,7 +146,7 @@ public class Netty4HttpRequest implements HttpRequest {
                 ),
                 new AtomicBoolean(false),
                 false,
-                content
+                newContent
             );
         } finally {
             release();

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -12,6 +12,7 @@ package org.elasticsearch.http.netty4;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -21,6 +22,7 @@ import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.http.HttpResponse;
 import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
@@ -40,22 +42,40 @@ import java.util.stream.Collectors;
 public class Netty4HttpRequest implements HttpRequest {
 
     private final FullHttpRequest request;
-    private final BytesReference content;
+    private final HttpBody content;
     private final Map<String, List<String>> headers;
     private final AtomicBoolean released;
     private final Exception inboundException;
     private final boolean pooled;
     private final int sequence;
 
+    Netty4HttpRequest(int sequence, io.netty.handler.codec.http.HttpRequest request, Netty4HttpRequestBodyStream contentStream) {
+        this(
+            sequence,
+            new DefaultFullHttpRequest(
+                request.protocolVersion(),
+                request.method(),
+                request.uri(),
+                Unpooled.EMPTY_BUFFER,
+                request.headers(),
+                EmptyHttpHeaders.INSTANCE
+            ),
+            new AtomicBoolean(false),
+            false,
+            contentStream,
+            null
+        );
+    }
+
     Netty4HttpRequest(int sequence, FullHttpRequest request) {
-        this(sequence, request, new AtomicBoolean(false), true, Netty4Utils.toBytesReference(request.content()));
+        this(sequence, request, new AtomicBoolean(false), true, Netty4Utils.fullHttpBodyFrom(request.content()));
     }
 
     Netty4HttpRequest(int sequence, FullHttpRequest request, Exception inboundException) {
-        this(sequence, request, new AtomicBoolean(false), true, Netty4Utils.toBytesReference(request.content()), inboundException);
+        this(sequence, request, new AtomicBoolean(false), true, Netty4Utils.fullHttpBodyFrom(request.content()), inboundException);
     }
 
-    private Netty4HttpRequest(int sequence, FullHttpRequest request, AtomicBoolean released, boolean pooled, BytesReference content) {
+    private Netty4HttpRequest(int sequence, FullHttpRequest request, AtomicBoolean released, boolean pooled, HttpBody content) {
         this(sequence, request, released, pooled, content, null);
     }
 
@@ -64,7 +84,7 @@ public class Netty4HttpRequest implements HttpRequest {
         FullHttpRequest request,
         AtomicBoolean released,
         boolean pooled,
-        BytesReference content,
+        HttpBody content,
         Exception inboundException
     ) {
         this.sequence = sequence;
@@ -87,7 +107,7 @@ public class Netty4HttpRequest implements HttpRequest {
     }
 
     @Override
-    public BytesReference content() {
+    public HttpBody body() {
         assert released.get() == false;
         return content;
     }
@@ -119,7 +139,7 @@ public class Netty4HttpRequest implements HttpRequest {
                 ),
                 new AtomicBoolean(false),
                 false,
-                Netty4Utils.toBytesReference(copiedContent)
+                content
             );
         } finally {
             release();

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -61,7 +61,7 @@ public class Netty4HttpRequest implements HttpRequest {
                 EmptyHttpHeaders.INSTANCE
             ),
             new AtomicBoolean(false),
-            false,
+            true,
             contentStream,
             null
         );
@@ -116,6 +116,7 @@ public class Netty4HttpRequest implements HttpRequest {
     public void release() {
         if (pooled && released.compareAndSet(false, true)) {
             request.release();
+            content.close();
         }
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.http.netty4;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
+
+import org.elasticsearch.http.HttpBody;
+import org.elasticsearch.transport.netty4.Netty4Utils;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * Netty based implementation of {@link HttpBody.Stream}.
+ * This implementation utilize {@link io.netty.channel.ChannelConfig#setAutoRead(boolean)}
+ * to prevent entire payload buffering. But sometimes upstream can send few chunks of data despite
+ * autoRead=off. In this case chunks will be queued until downstream calls {@link Stream#next()}
+ */
+public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
+
+    private final Channel channel;
+    private final Queue<HttpContent> chunkQueue = new ArrayDeque<>();
+    private boolean requested = false;
+    private boolean hasLast = false;
+    private HttpBody.ChunkHandler handler;
+
+    public Netty4HttpRequestBodyStream(Channel channel) {
+        this.channel = channel;
+        channel.closeFuture().addListener((f) -> releaseQueuedChunks());
+        channel.config().setAutoRead(false);
+    }
+
+    @Override
+    public ChunkHandler handler() {
+        return handler;
+    }
+
+    @Override
+    public void setHandler(ChunkHandler chunkHandler) {
+        this.handler = chunkHandler;
+    }
+
+    private void sendQueuedOrRead() {
+        assert channel.eventLoop().inEventLoop();
+        requested = true;
+        var chunk = chunkQueue.poll();
+        if (chunk == null) {
+            channel.read();
+        } else {
+            sendChunk(chunk);
+        }
+    }
+
+    @Override
+    public void next() {
+        assert handler != null : "handler must be set before requesting next chunk";
+        if (channel.eventLoop().inEventLoop()) {
+            sendQueuedOrRead();
+        } else {
+            channel.eventLoop().submit(this::sendQueuedOrRead);
+        }
+    }
+
+    public void handleNettyContent(HttpContent httpContent) {
+        assert handler != null : "handler must be set before processing http content";
+        if (requested && chunkQueue.isEmpty()) {
+            sendChunk(httpContent);
+        } else {
+            chunkQueue.add(httpContent);
+        }
+        if (httpContent instanceof LastHttpContent) {
+            hasLast = true;
+            channel.config().setAutoRead(true);
+        }
+    }
+
+    // visible for test
+    Channel channel() {
+        return channel;
+    }
+
+    // visible for test
+    Queue<HttpContent> chunkQueue() {
+        return chunkQueue;
+    }
+
+    // visible for test
+    boolean hasLast() {
+        return hasLast;
+    }
+
+    private void sendChunk(HttpContent httpContent) {
+        assert requested;
+        requested = false;
+        var bytesRef = Netty4Utils.toReleasableBytesReference(httpContent.content());
+        var isLast = httpContent instanceof LastHttpContent;
+        handler.onNext(bytesRef, isLast);
+    }
+
+    private void releaseQueuedChunks() {
+        while (chunkQueue.isEmpty() == false) {
+            chunkQueue.poll().release();
+        }
+    }
+
+}

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -31,11 +31,12 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     private final Queue<HttpContent> chunkQueue = new ArrayDeque<>();
     private boolean requested = false;
     private boolean hasLast = false;
+    private boolean closing = false;
     private HttpBody.ChunkHandler handler;
 
     public Netty4HttpRequestBodyStream(Channel channel) {
         this.channel = channel;
-        channel.closeFuture().addListener((f) -> releaseQueuedChunks());
+        channel.closeFuture().addListener((f) -> doClose());
         channel.config().setAutoRead(false);
     }
 
@@ -71,6 +72,10 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     }
 
     public void handleNettyContent(HttpContent httpContent) {
+        if (closing) {
+            httpContent.release();
+            return;
+        }
         assert handler != null : "handler must be set before processing http content";
         if (requested && chunkQueue.isEmpty()) {
             sendChunk(httpContent);
@@ -112,4 +117,18 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         }
     }
 
+    @Override
+    public void close() {
+        if (channel.eventLoop().inEventLoop()) {
+            doClose();
+        } else {
+            channel.eventLoop().submit(this::doClose);
+        }
+    }
+
+    private void doClose() {
+        closing = true;
+        releaseQueuedChunks();
+        channel.config().setAutoRead(true);
+    }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -133,6 +133,9 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private void doClose() {
         closing = true;
+        if (handler != null) {
+            handler.close();
+        }
         if (buf != null) {
             buf.release();
             buf = null;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -9,34 +9,36 @@
 
 package org.elasticsearch.http.netty4;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
 import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
-
 /**
  * Netty based implementation of {@link HttpBody.Stream}.
  * This implementation utilize {@link io.netty.channel.ChannelConfig#setAutoRead(boolean)}
  * to prevent entire payload buffering. But sometimes upstream can send few chunks of data despite
- * autoRead=off. In this case chunks will be queued until downstream calls {@link Stream#next()}
+ * autoRead=off. In this case chunks will be buffered until downstream calls {@link Stream#next()}
  */
 public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private final Channel channel;
-    private final Queue<HttpContent> chunkQueue = new ArrayDeque<>();
-    private boolean requested = false;
+    private final ChannelFutureListener closeListener = future -> doClose();
+    private ByteBuf buf;
     private boolean hasLast = false;
+    private boolean requested = false;
     private boolean closing = false;
     private HttpBody.ChunkHandler handler;
 
+
     public Netty4HttpRequestBodyStream(Channel channel) {
         this.channel = channel;
-        channel.closeFuture().addListener((f) -> doClose());
+        Netty4Utils.addListener(channel.closeFuture(), closeListener);
         channel.config().setAutoRead(false);
     }
 
@@ -50,41 +52,49 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         this.handler = chunkHandler;
     }
 
-    private void sendQueuedOrRead() {
-        assert channel.eventLoop().inEventLoop();
-        requested = true;
-        var chunk = chunkQueue.poll();
-        if (chunk == null) {
-            channel.read();
-        } else {
-            sendChunk(chunk);
-        }
-    }
-
     @Override
     public void next() {
+        assert closing == false : "cannot request next chunk on closing stream";
         assert handler != null : "handler must be set before requesting next chunk";
-        if (channel.eventLoop().inEventLoop()) {
-            sendQueuedOrRead();
-        } else {
-            channel.eventLoop().submit(this::sendQueuedOrRead);
-        }
+        channel.eventLoop().submit(() -> {
+            requested = true;
+            if (buf == null) {
+                channel.read();
+            } else {
+                send();
+            }
+        });
     }
 
     public void handleNettyContent(HttpContent httpContent) {
+        assert hasLast == false : "receive http content on completed stream";
+        hasLast = httpContent instanceof LastHttpContent;
         if (closing) {
             httpContent.release();
-            return;
-        }
-        assert handler != null : "handler must be set before processing http content";
-        if (requested && chunkQueue.isEmpty()) {
-            sendChunk(httpContent);
         } else {
-            chunkQueue.add(httpContent);
+            addChunk(httpContent.content());
+            if (requested) {
+                send();
+            }
         }
-        if (httpContent instanceof LastHttpContent) {
-            hasLast = true;
+        if (hasLast) {
             channel.config().setAutoRead(true);
+            channel.closeFuture().removeListener(closeListener);
+        }
+    }
+
+    // adds chunk to current buffer, will allocate composite buffer when need to hold more than 1 chunk
+    private void addChunk(ByteBuf chunk) {
+        assert chunk != null;
+        if (buf == null) {
+            buf = chunk;
+        } else if (buf instanceof CompositeByteBuf comp) {
+            comp.addComponent(true, chunk);
+        } else {
+            var comp = channel.alloc().compositeBuffer();
+            comp.addComponent(true, buf);
+            comp.addComponent(true, chunk);
+            buf = comp;
         }
     }
 
@@ -94,8 +104,8 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     }
 
     // visible for test
-    Queue<HttpContent> chunkQueue() {
-        return chunkQueue;
+    ByteBuf buf() {
+        return buf;
     }
 
     // visible for test
@@ -103,18 +113,13 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         return hasLast;
     }
 
-    private void sendChunk(HttpContent httpContent) {
+    private void send() {
         assert requested;
+        assert handler != null : "must set handler before receiving next chunk";
+        var bytesRef = Netty4Utils.toReleasableBytesReference(buf);
         requested = false;
-        var bytesRef = Netty4Utils.toReleasableBytesReference(httpContent.content());
-        var isLast = httpContent instanceof LastHttpContent;
-        handler.onNext(bytesRef, isLast);
-    }
-
-    private void releaseQueuedChunks() {
-        while (chunkQueue.isEmpty() == false) {
-            chunkQueue.poll().release();
-        }
+        buf = null;
+        handler.onNext(bytesRef, hasLast);
     }
 
     @Override
@@ -128,7 +133,10 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private void doClose() {
         closing = true;
-        releaseQueuedChunks();
+        if (buf != null) {
+            buf.release();
+            buf = null;
+        }
         channel.config().setAutoRead(true);
     }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -40,7 +40,6 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     private boolean closing = false;
     private HttpBody.ChunkHandler handler;
 
-
     public Netty4HttpRequestBodyStream(Channel channel) {
         this.channel = channel;
         Netty4Utils.addListener(channel.closeFuture(), closeListener);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -37,6 +37,7 @@ import io.netty.util.AttributeKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.network.ThreadWatchdog;
@@ -97,6 +98,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
     private final TLSConfig tlsConfig;
     private final AcceptChannelHandler.AcceptPredicate acceptChannelPredicate;
     private final HttpValidator httpValidator;
+    private final IncrementalBulkService.Enabled enabled;
     private final ThreadWatchdog threadWatchdog;
     private final int readTimeoutMillis;
 
@@ -135,6 +137,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
         this.acceptChannelPredicate = acceptChannelPredicate;
         this.httpValidator = httpValidator;
         this.threadWatchdog = networkService.getThreadWatchdog();
+        this.enabled = new IncrementalBulkService.Enabled(clusterSettings);
 
         this.pipeliningMaxEvents = SETTING_PIPELINING_MAX_EVENTS.get(settings);
 
@@ -280,7 +283,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
     }
 
     public ChannelHandler configureServerChannelHandler() {
-        return new HttpChannelHandler(this, handlingSettings, tlsConfig, acceptChannelPredicate, httpValidator);
+        return new HttpChannelHandler(this, handlingSettings, tlsConfig, acceptChannelPredicate, httpValidator, enabled);
     }
 
     static final AttributeKey<Netty4HttpChannel> HTTP_CHANNEL_KEY = AttributeKey.newInstance("es-http-channel");
@@ -293,19 +296,22 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
         private final TLSConfig tlsConfig;
         private final BiPredicate<String, InetSocketAddress> acceptChannelPredicate;
         private final HttpValidator httpValidator;
+        private final IncrementalBulkService.Enabled enabled;
 
         protected HttpChannelHandler(
             final Netty4HttpServerTransport transport,
             final HttpHandlingSettings handlingSettings,
             final TLSConfig tlsConfig,
             @Nullable final BiPredicate<String, InetSocketAddress> acceptChannelPredicate,
-            @Nullable final HttpValidator httpValidator
+            @Nullable final HttpValidator httpValidator,
+            IncrementalBulkService.Enabled enabled
         ) {
             this.transport = transport;
             this.handlingSettings = handlingSettings;
             this.tlsConfig = tlsConfig;
             this.acceptChannelPredicate = acceptChannelPredicate;
             this.httpValidator = httpValidator;
+            this.enabled = enabled;
         }
 
         @Override
@@ -366,7 +372,13 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                     );
             }
             // combines the HTTP message pieces into a single full HTTP request (with headers and body)
-            final HttpObjectAggregator aggregator = new Netty4HttpAggregator(handlingSettings.maxContentLength());
+            final HttpObjectAggregator aggregator = new Netty4HttpAggregator(
+                handlingSettings.maxContentLength(),
+                httpPreRequest -> enabled.get() == false
+                    || (httpPreRequest.uri().contains("_bulk") == false
+                        || httpPreRequest.uri().contains("_bulk_update")
+                        || httpPreRequest.uri().contains("/_xpack/monitoring/_bulk"))
+            );
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             ch.pipeline()
                 .addLast("decoder_compress", new HttpContentDecompressor()) // this handles request body decompression

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -366,7 +366,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                     );
             }
             // combines the HTTP message pieces into a single full HTTP request (with headers and body)
-            final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.maxContentLength());
+            final HttpObjectAggregator aggregator = new Netty4HttpAggregator(handlingSettings.maxContentLength());
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             ch.pipeline()
                 .addLast("decoder_compress", new HttpContentDecompressor()) // this handles request body decompression

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -27,11 +27,13 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.transport.TransportException;
 
 import java.io.IOException;
@@ -126,6 +128,14 @@ public class Netty4Utils {
             final ByteBuffer[] byteBuffers = buffer.nioBuffers();
             return BytesReference.fromByteBuffers(byteBuffers);
         }
+    }
+
+    public static ReleasableBytesReference toReleasableBytesReference(final ByteBuf buffer) {
+        return new ReleasableBytesReference(toBytesReference(buffer), buffer::release);
+    }
+
+    public static HttpBody.Full fullHttpBodyFrom(final ByteBuf buf) {
+        return new HttpBody.ByteRefHttpBody(toBytesReference(buf));
     }
 
     public static Recycler<BytesRef> createRecycler(Settings settings) {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.http.netty4;

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStreamTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.flow.FlowControlHandler;
+
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.http.HttpBody;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Netty4HttpRequestBodyStreamTests extends ESTestCase {
+
+    EmbeddedChannel channel;
+    Netty4HttpRequestBodyStream stream;
+    static HttpBody.ChunkHandler discardHandler = (chunk, isLast) -> chunk.close();
+
+    @Before
+    public void createStream() {
+        channel = new EmbeddedChannel();
+        stream = new Netty4HttpRequestBodyStream(channel);
+        stream.setHandler(discardHandler); // set default handler, each test might override one
+        channel.pipeline().addLast(new SimpleChannelInboundHandler<HttpContent>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, HttpContent msg) {
+                msg.retain();
+                stream.handleNettyContent(msg);
+            }
+        });
+    }
+
+    // ensures that no chunks are sent downstream without request
+    public void testEnqueueChunksBeforeRequest() {
+        var totalChunks = randomIntBetween(1, 100);
+        for (int i = 0; i < totalChunks; i++) {
+            channel.writeInbound(randomContent(1024));
+        }
+        assertEquals(totalChunks, stream.chunkQueue().size());
+    }
+
+    // ensures all queued chunks can be flushed downstream
+    public void testFlushQueued() {
+        var chunks = new ArrayList<ReleasableBytesReference>();
+        var totalBytes = new AtomicInteger();
+        stream.setHandler((chunk, isLast) -> {
+            chunks.add(chunk);
+            totalBytes.addAndGet(chunk.length());
+        });
+        // enqueue chunks
+        var chunkSize = 1024;
+        var totalChunks = randomIntBetween(1, 100);
+        for (int i = 0; i < totalChunks; i++) {
+            channel.writeInbound(randomContent(chunkSize));
+        }
+        // consume all chunks
+        for (var i = 0; i < totalChunks; i++) {
+            stream.next();
+        }
+        assertEquals(totalChunks, chunks.size());
+        assertEquals(chunkSize * totalChunks, totalBytes.get());
+    }
+
+    // ensures that we read from channel when chunks queue is empty
+    // and pass next chunk downstream without queuing
+    public void testReadFromChannel() {
+        var gotChunks = new ArrayList<ReleasableBytesReference>();
+        var gotLast = new AtomicBoolean(false);
+        stream.setHandler((chunk, isLast) -> {
+            gotChunks.add(chunk);
+            gotLast.set(isLast);
+        });
+        channel.pipeline().addFirst(new FlowControlHandler()); // block all incoming messages, need explicit channel.read()
+        var chunkSize = 1024;
+        var totalChunks = randomIntBetween(1, 32);
+        for (int i = 0; i < totalChunks - 1; i++) {
+            channel.writeInbound(randomContent(chunkSize));
+        }
+        channel.writeInbound(randomLastContent(chunkSize));
+
+        for (int i = 0; i < totalChunks; i++) {
+            assertEquals("should not enqueue chunks", 0, stream.chunkQueue().size());
+            stream.next();
+            assertEquals("each next() should produce single chunk", i + 1, gotChunks.size());
+        }
+        assertTrue("should receive last content", gotLast.get());
+    }
+
+    HttpContent randomContent(int size, boolean isLast) {
+        var buf = Unpooled.wrappedBuffer(randomByteArrayOfLength(size));
+        if (isLast) {
+            return new DefaultLastHttpContent(buf);
+        } else {
+            return new DefaultHttpContent(buf);
+        }
+    }
+
+    HttpContent randomContent(int size) {
+        return randomContent(size, false);
+    }
+
+    HttpContent randomLastContent(int size) {
+        return randomContent(size, true);
+    }
+
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ElasticsearchWrapperException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.Request;
@@ -419,7 +420,8 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
                         handlingSettings,
                         TLSConfig.noTLS(),
                         null,
-                        randomFrom((httpPreRequest, channel, listener) -> listener.onResponse(null), null)
+                        randomFrom((httpPreRequest, channel, listener) -> listener.onResponse(null), null),
+                        new IncrementalBulkService.Enabled(clusterSettings)
                     ) {
                         @Override
                         protected void initChannel(Channel ch) throws Exception {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -905,7 +905,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
                 assertThat(channel.request().getHttpRequest().header(headerReference.get()), is(headerValueReference.get()));
                 assertThat(channel.request().getHttpRequest().method(), is(translateRequestMethod(httpMethodReference.get())));
                 // assert content is dropped
-                assertThat(channel.request().getHttpRequest().content().utf8ToString(), is(""));
+                assertThat(channel.request().getHttpRequest().body().asFull().bytes().utf8ToString(), is(""));
                 try {
                     channel.sendResponse(new RestResponse(channel, (Exception) ((ElasticsearchWrapperException) cause).getCause()));
                 } catch (IOException e) {

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
+public class IncrementalBulkRestIT extends HttpSmokeTestCase {
+
+    @SuppressWarnings("unchecked")
+    public void testIncrementalBulk() throws IOException {
+        Request createRequest = new Request("PUT", "/index_name");
+        createRequest.setJsonEntity("""
+            {
+              "settings": {
+                "index": {
+                  "number_of_shards": 1,
+                  "number_of_replicas": 1,
+                  "write.wait_for_active_shards": 2
+                }
+              }
+            }""");
+        final Response indexCreatedResponse = getRestClient().performRequest(createRequest);
+        assertThat(indexCreatedResponse.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+        Request firstBulkRequest = new Request("POST", "/index_name/_bulk");
+
+        // index documents for the rollup job
+        String bulkBody = "{\"index\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n"
+            + "{\"field\":1}\n"
+            + "{\"index\":{\"_index\":\"index_name\",\"_id\":\"2\"}}\n"
+            + "{\"field\":1}\n"
+            + "\r\n";
+
+        firstBulkRequest.setJsonEntity(bulkBody);
+
+        final Response indexSuccessFul = getRestClient().performRequest(firstBulkRequest);
+        assertThat(indexSuccessFul.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+        Request bulkRequest = new Request("POST", "/index_name/_bulk");
+
+        // index documents for the rollup job
+        final StringBuilder bulk = new StringBuilder();
+        bulk.append("{\"delete\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n");
+        int updates = 0;
+        for (int i = 0; i < 1000; i++) {
+            bulk.append("{\"index\":{\"_index\":\"index_name\"}}\n");
+            bulk.append("{\"field\":").append(i).append("}\n");
+            if (randomBoolean() && randomBoolean() && randomBoolean() && randomBoolean()) {
+                ++updates;
+                bulk.append("{\"update\":{\"_index\":\"index_name\",\"_id\":\"2\"}}\n");
+                bulk.append("{\"doc\":{\"field\":").append(i).append("}}\n");
+            }
+        }
+        bulk.append("\r\n");
+
+        bulkRequest.setJsonEntity(bulk.toString());
+
+        final Response bulkResponse = getRestClient().performRequest(bulkRequest);
+        assertThat(bulkResponse.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+        Map<String, Object> responseMap = XContentHelper.convertToMap(
+            JsonXContent.jsonXContent,
+            bulkResponse.getEntity().getContent(),
+            true
+        );
+
+        assertFalse((Boolean) responseMap.get("errors"));
+        assertThat(((List<Object>) responseMap.get("items")).size(), equalTo(1001 + updates));
+    }
+
+    public void testIncrementalMalformed() throws IOException {
+        Request createRequest = new Request("PUT", "/index_name");
+        createRequest.setJsonEntity("""
+            {
+              "settings": {
+                "index": {
+                  "number_of_shards": 1,
+                  "number_of_replicas": 1,
+                  "write.wait_for_active_shards": 2
+                }
+              }
+            }""");
+        final Response indexCreatedResponse = getRestClient().performRequest(createRequest);
+        assertThat(indexCreatedResponse.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+        Request bulkRequest = new Request("POST", "/index_name/_bulk");
+
+        // index documents for the rollup job
+        final StringBuilder bulk = new StringBuilder();
+        bulk.append("{\"index\":{\"_index\":\"index_name\"}}\n");
+        bulk.append("{\"field\":1}\n");
+        bulk.append("{}\n");
+        bulk.append("\r\n");
+
+        bulkRequest.setJsonEntity(bulk.toString());
+
+        expectThrows(ResponseException.class, () -> getRestClient().performRequest(bulkRequest));
+    }
+}

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
@@ -8,9 +8,11 @@
 
 package org.elasticsearch.http;
 
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -25,7 +27,6 @@ import static org.hamcrest.Matchers.equalTo;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
 public class IncrementalBulkRestIT extends HttpSmokeTestCase {
 
-    @SuppressWarnings("unchecked")
     public void testIncrementalBulk() throws IOException {
         Request createRequest = new Request("PUT", "/index_name");
         createRequest.setJsonEntity("""
@@ -55,35 +56,52 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
         final Response indexSuccessFul = getRestClient().performRequest(firstBulkRequest);
         assertThat(indexSuccessFul.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
 
-        Request bulkRequest = new Request("POST", "/index_name/_bulk");
+        sendLargeBulk();
+    }
+
+    public void testBulkWithIncrementalDisabled() throws IOException {
+        Request createRequest = new Request("PUT", "/index_name");
+        createRequest.setJsonEntity("""
+            {
+              "settings": {
+                "index": {
+                  "number_of_shards": 1,
+                  "number_of_replicas": 1,
+                  "write.wait_for_active_shards": 2
+                }
+              }
+            }""");
+        final Response indexCreatedResponse = getRestClient().performRequest(createRequest);
+        assertThat(indexCreatedResponse.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+        Request firstBulkRequest = new Request("POST", "/index_name/_bulk");
 
         // index documents for the rollup job
-        final StringBuilder bulk = new StringBuilder();
-        bulk.append("{\"delete\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n");
-        int updates = 0;
-        for (int i = 0; i < 1000; i++) {
-            bulk.append("{\"index\":{\"_index\":\"index_name\"}}\n");
-            bulk.append("{\"field\":").append(i).append("}\n");
-            if (randomBoolean() && randomBoolean() && randomBoolean() && randomBoolean()) {
-                ++updates;
-                bulk.append("{\"update\":{\"_index\":\"index_name\",\"_id\":\"2\"}}\n");
-                bulk.append("{\"doc\":{\"field\":").append(i).append("}}\n");
-            }
+        String bulkBody = "{\"index\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n"
+            + "{\"field\":1}\n"
+            + "{\"index\":{\"_index\":\"index_name\",\"_id\":\"2\"}}\n"
+            + "{\"field\":1}\n"
+            + "\r\n";
+
+        firstBulkRequest.setJsonEntity(bulkBody);
+
+        final Response indexSuccessFul = getRestClient().performRequest(firstBulkRequest);
+        assertThat(indexSuccessFul.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+
+        clusterAdmin().prepareUpdateSettings()
+            .setPersistentSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false).build())
+            .get();
+
+        internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(false));
+
+        try {
+            sendLargeBulk();
+        } finally {
+            internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(true));
+            clusterAdmin().prepareUpdateSettings()
+                .setPersistentSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), (String) null).build())
+                .get();
         }
-        bulk.append("\r\n");
-
-        bulkRequest.setJsonEntity(bulk.toString());
-
-        final Response bulkResponse = getRestClient().performRequest(bulkRequest);
-        assertThat(bulkResponse.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
-        Map<String, Object> responseMap = XContentHelper.convertToMap(
-            JsonXContent.jsonXContent,
-            bulkResponse.getEntity().getContent(),
-            true
-        );
-
-        assertFalse((Boolean) responseMap.get("errors"));
-        assertThat(((List<Object>) responseMap.get("items")).size(), equalTo(1001 + updates));
     }
 
     public void testIncrementalMalformed() throws IOException {
@@ -113,5 +131,38 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
         bulkRequest.setJsonEntity(bulk.toString());
 
         expectThrows(ResponseException.class, () -> getRestClient().performRequest(bulkRequest));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void sendLargeBulk() throws IOException {
+        Request bulkRequest = new Request("POST", "/index_name/_bulk");
+
+        // index documents for the rollup job
+        final StringBuilder bulk = new StringBuilder();
+        bulk.append("{\"delete\":{\"_index\":\"index_name\",\"_id\":\"1\"}}\n");
+        int updates = 0;
+        for (int i = 0; i < 1000; i++) {
+            bulk.append("{\"index\":{\"_index\":\"index_name\"}}\n");
+            bulk.append("{\"field\":").append(i).append("}\n");
+            if (randomBoolean() && randomBoolean() && randomBoolean() && randomBoolean()) {
+                ++updates;
+                bulk.append("{\"update\":{\"_index\":\"index_name\",\"_id\":\"2\"}}\n");
+                bulk.append("{\"doc\":{\"field\":").append(i).append("}}\n");
+            }
+        }
+        bulk.append("\r\n");
+
+        bulkRequest.setJsonEntity(bulk.toString());
+
+        final Response bulkResponse = getRestClient().performRequest(bulkRequest);
+        assertThat(bulkResponse.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
+        Map<String, Object> responseMap = XContentHelper.convertToMap(
+            JsonXContent.jsonXContent,
+            bulkResponse.getEntity().getContent(),
+            true
+        );
+
+        assertFalse((Boolean) responseMap.get("errors"));
+        assertThat(((List<Object>) responseMap.get("items")).size(), equalTo(1001 + updates));
     }
 }

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IncrementalBulkRestIT.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.http;
@@ -88,9 +89,7 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
         final Response indexSuccessFul = getRestClient().performRequest(firstBulkRequest);
         assertThat(indexSuccessFul.getStatusLine().getStatusCode(), equalTo(OK.getStatus()));
 
-        clusterAdmin().prepareUpdateSettings()
-            .setPersistentSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false).build())
-            .get();
+        updateClusterSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false));
 
         internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(false));
 
@@ -98,9 +97,7 @@ public class IncrementalBulkRestIT extends HttpSmokeTestCase {
             sendLargeBulk();
         } finally {
             internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(true));
-            clusterAdmin().prepareUpdateSettings()
-                .setPersistentSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), (String) null).build())
-                .get();
+            updateClusterSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), (String) null));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.ingest.IngestClientIT;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class IncrementalBulkIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(IngestClientIT.ExtendedIngestTestPlugin.class);
+    }
+
+    public void testSingleBulkRequest() {
+        String index = "test";
+        createIndex(index);
+
+        IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class);
+
+        IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+        IndexRequest indexRequest = indexRequest(index);
+
+        PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+        AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+        handler.lastItems(List.of(indexRequest), refCounted::decRef, future);
+
+        BulkResponse bulkResponse = future.actionGet();
+        assertNoFailures(bulkResponse);
+
+        refresh(index);
+
+        assertResponse(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()), searchResponse -> {
+            assertNoFailures(searchResponse);
+            assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) 1));
+        });
+
+        assertFalse(refCounted.hasReferences());
+    }
+
+    public void testMultipleBulkPartsWithBackoff() {
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        try (Releasable ignored = executorService::shutdown;) {
+            String index = "test";
+            createIndex(index);
+
+            IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class);
+            long docs = randomIntBetween(200, 400);
+
+            IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+
+            BulkResponse bulkResponse = executeBulk(docs, index, handler, executorService);
+            assertNoFailures(bulkResponse);
+
+            refresh(index);
+
+            assertResponse(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()), searchResponse -> {
+                assertNoFailures(searchResponse);
+                assertThat(searchResponse.getHits().getTotalHits().value, equalTo(docs));
+            });
+        }
+    }
+
+    public void testGlobalBulkFailure() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        CountDownLatch blockingLatch = new CountDownLatch(1);
+
+        try (Releasable ignored = executorService::shutdown; Releasable ignored2 = blockingLatch::countDown) {
+            String index = "test";
+            createIndex(index);
+
+            String randomNodeName = internalCluster().getRandomNodeName();
+            IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class, randomNodeName);
+            ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class, randomNodeName);
+
+            int threadCount = threadPool.info(ThreadPool.Names.WRITE).getMax();
+            long queueSize = threadPool.info(ThreadPool.Names.WRITE).getQueueSize().singles();
+            blockWritePool(threadCount, threadPool, blockingLatch);
+
+            Runnable runnable = () -> {};
+            for (int i = 0; i < queueSize; i++) {
+                threadPool.executor(ThreadPool.Names.WRITE).execute(runnable);
+            }
+
+            IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+            if (randomBoolean()) {
+                expectThrows(
+                    EsRejectedExecutionException.class,
+                    () -> executeBulk(randomIntBetween(200, 400), index, handler, executorService)
+                );
+            } else {
+                PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+                AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+                handler.lastItems(List.of(indexRequest(index)), refCounted::decRef, future);
+                assertFalse(refCounted.hasReferences());
+                expectThrows(EsRejectedExecutionException.class, future::actionGet);
+            }
+        }
+    }
+
+    public void testBulkLevelBulkFailureAfterFirstIncrementalRequest() throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+        try (Releasable ignored = executorService::shutdown) {
+            String index = "test";
+            createIndex(index);
+
+            String randomNodeName = internalCluster().getRandomNodeName();
+            IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class, randomNodeName);
+            ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class, randomNodeName);
+            IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+            AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+            PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+
+            int threadCount = threadPool.info(ThreadPool.Names.WRITE).getMax();
+            long queueSize = threadPool.info(ThreadPool.Names.WRITE).getQueueSize().singles();
+
+            CountDownLatch blockingLatch1 = new CountDownLatch(1);
+
+            AtomicBoolean nextRequested = new AtomicBoolean(true);
+            AtomicLong hits = new AtomicLong(0);
+            try (Releasable ignored2 = blockingLatch1::countDown;) {
+                blockWritePool(threadCount, threadPool, blockingLatch1);
+                while (nextRequested.get()) {
+                    nextRequested.set(false);
+                    refCounted.incRef();
+                    handler.addItems(List.of(indexRequest(index)), refCounted::decRef, () -> nextRequested.set(true));
+                    hits.incrementAndGet();
+                }
+            }
+            assertBusy(() -> assertTrue(nextRequested.get()));
+
+            CountDownLatch blockingLatch2 = new CountDownLatch(1);
+
+            try (Releasable ignored3 = blockingLatch2::countDown;) {
+                blockWritePool(threadCount, threadPool, blockingLatch2);
+                Runnable runnable = () -> {};
+                // Fill Queue
+                for (int i = 0; i < queueSize; i++) {
+                    threadPool.executor(ThreadPool.Names.WRITE).execute(runnable);
+                }
+
+                handler.lastItems(List.of(indexRequest(index)), refCounted::decRef, future);
+            }
+
+            // Should not throw because some succeeded
+            BulkResponse bulkResponse = future.actionGet();
+
+            assertTrue(bulkResponse.hasFailures());
+            BulkItemResponse[] items = bulkResponse.getItems();
+            assertThat(Arrays.stream(items).filter(r -> r.isFailed() == false).count(), equalTo(hits.get()));
+            assertThat(items[items.length - 1].getFailure().getCause(), instanceOf(EsRejectedExecutionException.class));
+
+            refresh(index);
+
+            assertResponse(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()), searchResponse -> {
+                assertNoFailures(searchResponse);
+                assertThat(searchResponse.getHits().getTotalHits().value, equalTo(hits.get()));
+            });
+        }
+    }
+
+    public void testShortCircuitShardLevelFailure() throws Exception {
+        String index = "test";
+        createIndex(index, 2, 0);
+
+        String coordinatingOnlyNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+
+        AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+        IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class, coordinatingOnlyNode);
+        IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+
+        AtomicBoolean nextRequested = new AtomicBoolean(true);
+        AtomicLong hits = new AtomicLong(0);
+        while (nextRequested.get()) {
+            nextRequested.set(false);
+            refCounted.incRef();
+            handler.addItems(List.of(indexRequest(index)), refCounted::decRef, () -> nextRequested.set(true));
+            hits.incrementAndGet();
+        }
+
+        assertBusy(() -> assertTrue(nextRequested.get()));
+
+        String node = findShard(resolveIndex(index), 0);
+        String secondShardNode = findShard(resolveIndex(index), 1);
+        IndexingPressure primaryPressure = internalCluster().getInstance(IndexingPressure.class, node);
+        long memoryLimit = primaryPressure.stats().getMemoryLimit();
+        try (Releasable releasable = primaryPressure.markPrimaryOperationStarted(10, memoryLimit, false)) {
+            while (nextRequested.get()) {
+                nextRequested.set(false);
+                refCounted.incRef();
+                handler.addItems(List.of(indexRequest(index)), refCounted::decRef, () -> nextRequested.set(true));
+            }
+
+            assertBusy(() -> assertTrue(nextRequested.get()));
+        }
+
+        while (nextRequested.get()) {
+            nextRequested.set(false);
+            refCounted.incRef();
+            handler.addItems(List.of(indexRequest(index)), refCounted::decRef, () -> nextRequested.set(true));
+        }
+
+        assertBusy(() -> assertTrue(nextRequested.get()));
+
+        PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+        handler.lastItems(List.of(indexRequest(index)), refCounted::decRef, future);
+
+        BulkResponse bulkResponse = future.actionGet();
+        assertTrue(bulkResponse.hasFailures());
+        for (int i = 0; i < hits.get(); ++i) {
+            assertFalse(bulkResponse.getItems()[i].isFailed());
+        }
+
+        boolean shardsOnDifferentNodes = node.equals(secondShardNode) == false;
+        for (int i = (int) hits.get(); i < bulkResponse.getItems().length; ++i) {
+            BulkItemResponse item = bulkResponse.getItems()[i];
+            if (item.getResponse() != null && item.getResponse().getShardId().id() == 1 && shardsOnDifferentNodes) {
+                assertFalse(item.isFailed());
+            } else {
+                assertTrue(item.isFailed());
+                assertThat(item.getFailure().getCause().getCause(), instanceOf(EsRejectedExecutionException.class));
+            }
+        }
+    }
+
+    public void testShortCircuitShardLevelFailureWithIngestNodeHop() throws Exception {
+        String dataOnlyNode = internalCluster().startDataOnlyNode();
+        String index = "test1";
+
+        // We ensure that the index is assigned to a non-ingest node to ensure that indexing pressure does not reject at the coordinating
+        // level.
+        createIndex(
+            index,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("index.routing.allocation.require._name", dataOnlyNode)
+                .build()
+        );
+
+        String pipelineId = "pipeline_id";
+        BytesReference pipelineSource = BytesReference.bytes(
+            jsonBuilder().startObject()
+                .field("description", "my_pipeline")
+                .startArray("processors")
+                .startObject()
+                .startObject("test")
+                .endObject()
+                .endObject()
+                .endArray()
+                .endObject()
+        );
+
+        putJsonPipeline(pipelineId, pipelineSource);
+
+        // By adding an ingest pipeline and sending the request to a coordinating node without the ingest role, we ensure that we are
+        // testing the serialization of shard level requests over the wire. This is because the transport bulk action will be dispatched to
+        // a node with the ingest role.
+        String coordinatingOnlyNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+
+        AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+        IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class, coordinatingOnlyNode);
+        IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+
+        AtomicBoolean nextRequested = new AtomicBoolean(true);
+        AtomicLong hits = new AtomicLong(0);
+        while (nextRequested.get()) {
+            nextRequested.set(false);
+            refCounted.incRef();
+            handler.addItems(List.of(indexRequest(index).setPipeline(pipelineId)), refCounted::decRef, () -> nextRequested.set(true));
+            hits.incrementAndGet();
+        }
+
+        assertBusy(() -> assertTrue(nextRequested.get()));
+
+        String node = findShard(resolveIndex(index), 0);
+        assertThat(node, equalTo(dataOnlyNode));
+        IndexingPressure primaryPressure = internalCluster().getInstance(IndexingPressure.class, node);
+        long memoryLimit = primaryPressure.stats().getMemoryLimit();
+        try (Releasable releasable = primaryPressure.markPrimaryOperationStarted(10, memoryLimit, false)) {
+            while (nextRequested.get()) {
+                nextRequested.set(false);
+                refCounted.incRef();
+                handler.addItems(List.of(indexRequest(index).setPipeline(pipelineId)), refCounted::decRef, () -> nextRequested.set(true));
+            }
+
+            assertBusy(() -> assertTrue(nextRequested.get()));
+        }
+
+        while (nextRequested.get()) {
+            nextRequested.set(false);
+            refCounted.incRef();
+            handler.addItems(List.of(indexRequest(index).setPipeline(pipelineId)), refCounted::decRef, () -> nextRequested.set(true));
+        }
+
+        assertBusy(() -> assertTrue(nextRequested.get()));
+
+        PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+        handler.lastItems(List.of(indexRequest(index)), refCounted::decRef, future);
+
+        BulkResponse bulkResponse = future.actionGet();
+        assertTrue(bulkResponse.hasFailures());
+        for (int i = 0; i < hits.get(); ++i) {
+            assertFalse(bulkResponse.getItems()[i].isFailed());
+        }
+
+        for (int i = (int) hits.get(); i < bulkResponse.getItems().length; ++i) {
+            BulkItemResponse item = bulkResponse.getItems()[i];
+            assertTrue(item.isFailed());
+            assertThat(item.getFailure().getCause().getCause(), instanceOf(EsRejectedExecutionException.class));
+        }
+    }
+
+    private static void blockWritePool(int threadCount, ThreadPool threadPool, CountDownLatch blockingLatch) throws InterruptedException {
+        CountDownLatch startedLatch = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            threadPool.executor(ThreadPool.Names.WRITE).execute(() -> {
+                startedLatch.countDown();
+                try {
+                    blockingLatch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        startedLatch.await();
+    }
+
+    private BulkResponse executeBulk(long docs, String index, IncrementalBulkService.Handler handler, ExecutorService executorService) {
+        ConcurrentLinkedQueue<DocWriteRequest<?>> queue = new ConcurrentLinkedQueue<>();
+        for (int i = 0; i < docs; i++) {
+            IndexRequest indexRequest = indexRequest(index);
+            queue.add(indexRequest);
+        }
+
+        AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+        PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+        Runnable r = new Runnable() {
+
+            @Override
+            public void run() {
+                int toRemove = Math.min(randomIntBetween(5, 10), queue.size());
+                ArrayList<DocWriteRequest<?>> docs = new ArrayList<>();
+                for (int i = 0; i < toRemove; i++) {
+                    docs.add(queue.poll());
+                }
+
+                if (queue.isEmpty()) {
+                    handler.lastItems(docs, refCounted::decRef, future);
+                } else {
+                    refCounted.incRef();
+                    handler.addItems(docs, refCounted::decRef, () -> executorService.execute(this));
+                }
+            }
+        };
+
+        executorService.execute(r);
+
+        BulkResponse bulkResponse = future.actionGet();
+        assertFalse(refCounted.hasReferences());
+        return bulkResponse;
+    }
+
+    private static IndexRequest indexRequest(String index) {
+        IndexRequest indexRequest = new IndexRequest();
+        indexRequest.index(index);
+        indexRequest.source(Map.of("field", randomAlphaOfLength(10)));
+        return indexRequest;
+    }
+
+    protected static String findShard(Index index, int shardId) {
+        for (String node : internalCluster().getNodeNames()) {
+            var indicesService = internalCluster().getInstance(IndicesService.class, node);
+            IndexService indexService = indicesService.indexService(index);
+            if (indexService != null) {
+                IndexShard shard = indexService.getShardOrNull(shardId);
+                if (shard != null && shard.isActive() && shard.routingEntry().primary()) {
+                    return node;
+                }
+            }
+        }
+        throw new AssertionError("IndexShard instance not found for shard " + new ShardId(index, shardId));
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/IncrementalBulkIT.java
@@ -90,6 +90,29 @@ public class IncrementalBulkIT extends ESIntegTestCase {
         assertFalse(refCounted.hasReferences());
     }
 
+    public void testBufferedResourcesReleasedOnClose() {
+        String index = "test";
+        createIndex(index);
+
+        String nodeName = internalCluster().getRandomNodeName();
+        IncrementalBulkService incrementalBulkService = internalCluster().getInstance(IncrementalBulkService.class, nodeName);
+        IndexingPressure indexingPressure = internalCluster().getInstance(IndexingPressure.class, nodeName);
+
+        IncrementalBulkService.Handler handler = incrementalBulkService.newBulkRequest();
+        IndexRequest indexRequest = indexRequest(index);
+
+        AbstractRefCounted refCounted = AbstractRefCounted.of(() -> {});
+        handler.addItems(List.of(indexRequest), refCounted::decRef, () -> {});
+
+        assertTrue(refCounted.hasReferences());
+        assertThat(indexingPressure.stats().getCurrentCoordinatingBytes(), greaterThan(0L));
+
+        handler.close();
+
+        assertFalse(refCounted.hasReferences());
+        assertThat(indexingPressure.stats().getCurrentCoordinatingBytes(), equalTo(0L));
+    }
+
     public void testIndexingPressureRejection() {
         String index = "test";
         createIndex(index);
@@ -303,14 +326,20 @@ public class IncrementalBulkIT extends ESIntegTestCase {
         String secondShardNode = findShard(resolveIndex(index), 1);
         IndexingPressure primaryPressure = internalCluster().getInstance(IndexingPressure.class, node);
         long memoryLimit = primaryPressure.stats().getMemoryLimit();
+        long primaryRejections = primaryPressure.stats().getPrimaryRejections();
         try (Releasable releasable = primaryPressure.markPrimaryOperationStarted(10, memoryLimit, false)) {
-            while (nextRequested.get()) {
-                nextRequested.set(false);
-                refCounted.incRef();
-                handler.addItems(List.of(indexRequest(index)), refCounted::decRef, () -> nextRequested.set(true));
+            while (primaryPressure.stats().getPrimaryRejections() == primaryRejections) {
+                while (nextRequested.get()) {
+                    nextRequested.set(false);
+                    refCounted.incRef();
+                    List<DocWriteRequest<?>> requests = new ArrayList<>();
+                    for (int i = 0; i < 20; ++i) {
+                        requests.add(indexRequest(index));
+                    }
+                    handler.addItems(requests, refCounted::decRef, () -> nextRequested.set(true));
+                }
+                assertBusy(() -> assertTrue(nextRequested.get()));
             }
-
-            assertBusy(() -> assertTrue(nextRequested.get()));
         }
 
         while (nextRequested.get()) {

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -218,6 +218,7 @@ public class TransportVersions {
     public static final TransportVersion ML_SCHEDULED_EVENT_TIME_SHIFT_CONFIGURATION = def(8_742_00_0);
     public static final TransportVersion SIMULATE_COMPONENT_TEMPLATES_SUBSTITUTIONS = def(8_743_00_0);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_EMBEDDINGS_ADDED = def(8_744_00_0);
+    public static final TransportVersion BULK_INCREMENTAL_STATE = def(8_745_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -160,6 +160,7 @@ import org.elasticsearch.action.admin.indices.template.put.TransportPutComposabl
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.validate.query.TransportValidateQueryAction;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryAction;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.bulk.SimulateBulkAction;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.bulk.TransportShardBulkAction;
@@ -448,6 +449,7 @@ public class ActionModule extends AbstractModule {
     private final List<ActionPlugin> actionPlugins;
     private final Map<String, ActionHandler<?, ?>> actions;
     private final ActionFilters actionFilters;
+    private final IncrementalBulkService bulkService;
     private final AutoCreateIndex autoCreateIndex;
     private final DestructiveOperations destructiveOperations;
     private final RestController restController;
@@ -476,7 +478,8 @@ public class ActionModule extends AbstractModule {
         ClusterService clusterService,
         RerouteService rerouteService,
         List<ReservedClusterStateHandler<?>> reservedStateHandlers,
-        RestExtension restExtension
+        RestExtension restExtension,
+        IncrementalBulkService bulkService
     ) {
         this.settings = settings;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
@@ -488,6 +491,7 @@ public class ActionModule extends AbstractModule {
         this.threadPool = threadPool;
         actions = setupActions(actionPlugins);
         actionFilters = setupActionFilters(actionPlugins);
+        this.bulkService = bulkService;
         autoCreateIndex = new AutoCreateIndex(settings, clusterSettings, indexNameExpressionResolver, systemIndices);
         destructiveOperations = new DestructiveOperations(settings, clusterSettings);
         Set<RestHeaderDefinition> headers = Stream.concat(
@@ -928,7 +932,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestCountAction());
         registerHandler.accept(new RestTermVectorsAction());
         registerHandler.accept(new RestMultiTermVectorsAction());
-        registerHandler.accept(new RestBulkAction(settings));
+        registerHandler.accept(new RestBulkAction(settings, bulkService));
         registerHandler.accept(new RestUpdateAction());
 
         registerHandler.accept(new RestSearchAction(restController.getSearchUsageHolder(), clusterSupportsFeature));

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -438,7 +438,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     private void executeBulkShardRequest(BulkShardRequest bulkShardRequest, Releasable releaseOnFinish) {
         ShardId shardId = bulkShardRequest.shardId();
 
-        // Short circuit the shark level request with the existing shard failure.
+        // Short circuit the shard level request with the existing shard failure.
         if (shortCircuitShardFailures.containsKey(shardId)) {
             handleShardFailure(bulkShardRequest, clusterService.state(), shortCircuitShardFailures.get(shardId));
             releaseOnFinish.close();

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -95,6 +95,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     private final OriginSettingClient rolloverClient;
     private final Set<String> failureStoresToBeRolledOver = ConcurrentCollections.newConcurrentSet();
     private final Set<Integer> failedRolloverRequests = ConcurrentCollections.newConcurrentSet();
+    private final Map<ShardId, Exception> shortCircuitShardFailures = ConcurrentCollections.newConcurrentMap();
     private final FailureStoreMetrics failureStoreMetrics;
 
     BulkOperation(
@@ -164,6 +165,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
         this.observer = observer;
         this.failureStoreDocumentConverter = failureStoreDocumentConverter;
         this.rolloverClient = new OriginSettingClient(client, LAZY_ROLLOVER_ORIGIN);
+        this.shortCircuitShardFailures.putAll(bulkRequest.incrementalState().shardLevelFailures());
         this.failureStoreMetrics = failureStoreMetrics;
     }
 
@@ -403,7 +405,12 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
 
     private void completeBulkOperation() {
         listener.onResponse(
-            new BulkResponse(responses.toArray(new BulkItemResponse[responses.length()]), buildTookInMillis(startTimeNanos))
+            new BulkResponse(
+                responses.toArray(new BulkItemResponse[responses.length()]),
+                buildTookInMillis(startTimeNanos),
+                BulkResponse.NO_INGEST_TOOK,
+                new BulkRequest.IncrementalState(shortCircuitShardFailures)
+            )
         );
         // Allow memory for bulk shard request items to be reclaimed before all items have been completed
         bulkRequest = null;
@@ -429,90 +436,102 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     }
 
     private void executeBulkShardRequest(BulkShardRequest bulkShardRequest, Releasable releaseOnFinish) {
-        client.executeLocally(TransportShardBulkAction.TYPE, bulkShardRequest, new ActionListener<>() {
+        ShardId shardId = bulkShardRequest.shardId();
 
-            // Lazily get the cluster state to avoid keeping it around longer than it is needed
-            private ClusterState clusterState = null;
+        // Short circuit the shark level request with the existing shard failure.
+        if (shortCircuitShardFailures.containsKey(shardId)) {
+            handleShardFailure(bulkShardRequest, clusterService.state(), shortCircuitShardFailures.get(shardId));
+            releaseOnFinish.close();
+        } else {
+            client.executeLocally(TransportShardBulkAction.TYPE, bulkShardRequest, new ActionListener<>() {
 
-            private ClusterState getClusterState() {
-                if (clusterState == null) {
-                    clusterState = clusterService.state();
-                }
-                return clusterState;
-            }
+                // Lazily get the cluster state to avoid keeping it around longer than it is needed
+                private ClusterState clusterState = null;
 
-            @Override
-            public void onResponse(BulkShardResponse bulkShardResponse) {
-                for (int idx = 0; idx < bulkShardResponse.getResponses().length; idx++) {
-                    // We zip the requests and responses together so that we can identify failed documents and potentially store them
-                    BulkItemResponse bulkItemResponse = bulkShardResponse.getResponses()[idx];
-                    BulkItemRequest bulkItemRequest = bulkShardRequest.items()[idx];
-
-                    if (bulkItemResponse.isFailed()) {
-                        assert bulkItemRequest.id() == bulkItemResponse.getItemId() : "Bulk items were returned out of order";
-                        processFailure(bulkItemRequest, bulkItemResponse.getFailure().getCause());
-                        addFailure(bulkItemResponse);
-                    } else {
-                        bulkItemResponse.getResponse().setShardInfo(bulkShardResponse.getShardInfo());
-                        responses.set(bulkItemResponse.getItemId(), bulkItemResponse);
+                private ClusterState getClusterState() {
+                    if (clusterState == null) {
+                        clusterState = clusterService.state();
                     }
+                    return clusterState;
                 }
-                completeShardOperation();
-            }
 
-            @Override
-            public void onFailure(Exception e) {
-                // create failures for all relevant requests
-                for (BulkItemRequest request : bulkShardRequest.items()) {
-                    final String indexName = request.index();
-                    DocWriteRequest<?> docWriteRequest = request.request();
+                @Override
+                public void onResponse(BulkShardResponse bulkShardResponse) {
+                    for (int idx = 0; idx < bulkShardResponse.getResponses().length; idx++) {
+                        // We zip the requests and responses together so that we can identify failed documents and potentially store them
+                        BulkItemResponse bulkItemResponse = bulkShardResponse.getResponses()[idx];
+                        BulkItemRequest bulkItemRequest = bulkShardRequest.items()[idx];
 
-                    processFailure(request, e);
-                    addFailure(docWriteRequest, request.id(), indexName, e);
-                }
-                completeShardOperation();
-            }
-
-            private void completeShardOperation() {
-                // Clear our handle on the cluster state to allow it to be cleaned up
-                clusterState = null;
-                releaseOnFinish.close();
-            }
-
-            private void processFailure(BulkItemRequest bulkItemRequest, Exception cause) {
-                var error = ExceptionsHelper.unwrapCause(cause);
-                var errorType = ElasticsearchException.getExceptionName(error);
-                DocWriteRequest<?> docWriteRequest = bulkItemRequest.request();
-                DataStream failureStoreCandidate = getRedirectTargetCandidate(docWriteRequest, getClusterState().metadata());
-                // If the candidate is not null, the BulkItemRequest targets a data stream, but we'll still have to check if
-                // it has the failure store enabled.
-                if (failureStoreCandidate != null) {
-                    // Do not redirect documents to a failure store that were already headed to one.
-                    var isFailureStoreDoc = docWriteRequest instanceof IndexRequest indexRequest && indexRequest.isWriteToFailureStore();
-                    if (isFailureStoreDoc == false
-                        && failureStoreCandidate.isFailureStoreEnabled()
-                        && error instanceof VersionConflictEngineException == false) {
-                        // Redirect to failure store.
-                        maybeMarkFailureStoreForRollover(failureStoreCandidate);
-                        addDocumentToRedirectRequests(bulkItemRequest, cause, failureStoreCandidate.getName());
-                        failureStoreMetrics.incrementFailureStore(
-                            bulkItemRequest.index(),
-                            errorType,
-                            FailureStoreMetrics.ErrorLocation.SHARD
-                        );
-                    } else {
-                        // If we can't redirect to a failure store (because either the data stream doesn't have the failure store enabled
-                        // or this request was already targeting a failure store), we increment the rejected counter.
-                        failureStoreMetrics.incrementRejected(
-                            bulkItemRequest.index(),
-                            errorType,
-                            FailureStoreMetrics.ErrorLocation.SHARD,
-                            isFailureStoreDoc
-                        );
+                        if (bulkItemResponse.isFailed()) {
+                            assert bulkItemRequest.id() == bulkItemResponse.getItemId() : "Bulk items were returned out of order";
+                            processFailure(bulkItemRequest, getClusterState(), bulkItemResponse.getFailure().getCause());
+                            addFailure(bulkItemResponse);
+                        } else {
+                            bulkItemResponse.getResponse().setShardInfo(bulkShardResponse.getShardInfo());
+                            responses.set(bulkItemResponse.getItemId(), bulkItemResponse);
+                        }
                     }
+                    completeShardOperation();
                 }
+
+                @Override
+                public void onFailure(Exception e) {
+                    assert shortCircuitShardFailures.containsKey(shardId) == false;
+                    shortCircuitShardFailures.put(shardId, e);
+
+                    // create failures for all relevant requests
+                    handleShardFailure(bulkShardRequest, getClusterState(), e);
+                    completeShardOperation();
+                }
+
+                private void completeShardOperation() {
+                    // Clear our handle on the cluster state to allow it to be cleaned up
+                    clusterState = null;
+                    releaseOnFinish.close();
+                }
+            });
+        }
+    }
+
+    private void handleShardFailure(BulkShardRequest bulkShardRequest, ClusterState clusterState, Exception e) {
+        // create failures for all relevant requests
+        for (BulkItemRequest request : bulkShardRequest.items()) {
+            final String indexName = request.index();
+            DocWriteRequest<?> docWriteRequest = request.request();
+
+            processFailure(request, clusterState, e);
+            addFailure(docWriteRequest, request.id(), indexName, e);
+        }
+    }
+
+    private void processFailure(BulkItemRequest bulkItemRequest, ClusterState clusterState, Exception cause) {
+        var error = ExceptionsHelper.unwrapCause(cause);
+        var errorType = ElasticsearchException.getExceptionName(error);
+        DocWriteRequest<?> docWriteRequest = bulkItemRequest.request();
+        DataStream failureStoreCandidate = getRedirectTargetCandidate(docWriteRequest, clusterState.metadata());
+        // If the candidate is not null, the BulkItemRequest targets a data stream, but we'll still have to check if
+        // it has the failure store enabled.
+        if (failureStoreCandidate != null) {
+            // Do not redirect documents to a failure store that were already headed to one.
+            var isFailureStoreDoc = docWriteRequest instanceof IndexRequest indexRequest && indexRequest.isWriteToFailureStore();
+            if (isFailureStoreDoc == false
+                && failureStoreCandidate.isFailureStoreEnabled()
+                && error instanceof VersionConflictEngineException == false) {
+                // Redirect to failure store.
+                maybeMarkFailureStoreForRollover(failureStoreCandidate);
+                addDocumentToRedirectRequests(bulkItemRequest, cause, failureStoreCandidate.getName());
+                failureStoreMetrics.incrementFailureStore(bulkItemRequest.index(), errorType, FailureStoreMetrics.ErrorLocation.SHARD);
+            } else {
+                // If we can't redirect to a failure store (because either the data stream doesn't have the failure store enabled
+                // or this request was already targeting a failure store), we increment the rejected counter.
+                failureStoreMetrics.incrementRejected(
+                    bulkItemRequest.index(),
+                    errorType,
+                    FailureStoreMetrics.ErrorLocation.SHARD,
+                    isFailureStoreDoc
+                );
             }
-        });
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -409,7 +409,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 responses.toArray(new BulkItemResponse[responses.length()]),
                 buildTookInMillis(startTimeNanos),
                 BulkResponse.NO_INGEST_TOOK,
-                new BulkRequest.IncrementalState(shortCircuitShardFailures)
+                new BulkRequest.IncrementalState(shortCircuitShardFailures, bulkRequest.incrementalState().indexingPressureAccounted())
             )
         );
         // Allow memory for bulk shard request items to be reclaimed before all items have been completed

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.bulk;
 
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
@@ -27,9 +28,11 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 import org.elasticsearch.xcontent.XContentType;
@@ -72,6 +75,7 @@ public class BulkRequest extends ActionRequest
     private final Set<String> indices = new HashSet<>();
 
     protected TimeValue timeout = BulkShardRequest.DEFAULT_TIMEOUT;
+    private IncrementalState incrementalState = IncrementalState.EMPTY;
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
     private RefreshPolicy refreshPolicy = RefreshPolicy.NONE;
     private String globalPipeline;
@@ -92,6 +96,11 @@ public class BulkRequest extends ActionRequest
         timeout = in.readTimeValue();
         for (DocWriteRequest<?> request : requests) {
             indices.add(Objects.requireNonNull(request.index(), "request index must not be null"));
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.BULK_INCREMENTAL_STATE)) {
+            incrementalState = new BulkRequest.IncrementalState(in);
+        } else {
+            incrementalState = BulkRequest.IncrementalState.EMPTY;
         }
     }
 
@@ -327,6 +336,10 @@ public class BulkRequest extends ActionRequest
         return this;
     }
 
+    public void incrementalState(IncrementalState incrementalState) {
+        this.incrementalState = incrementalState;
+    }
+
     /**
      * Note for internal callers (NOT high level rest client),
      * the global parameter setting is ignored when used with:
@@ -363,6 +376,10 @@ public class BulkRequest extends ActionRequest
 
     public TimeValue timeout() {
         return timeout;
+    }
+
+    public IncrementalState incrementalState() {
+        return incrementalState;
     }
 
     public String pipeline() {
@@ -436,6 +453,9 @@ public class BulkRequest extends ActionRequest
         out.writeCollection(requests, DocWriteRequest::writeDocumentRequest);
         refreshPolicy.writeTo(out);
         out.writeTimeValue(timeout);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.BULK_INCREMENTAL_STATE)) {
+            incrementalState.writeTo(out);
+        }
     }
 
     @Override
@@ -484,6 +504,20 @@ public class BulkRequest extends ActionRequest
      */
     public Map<String, ComponentTemplate> getComponentTemplateSubstitutions() throws IOException {
         return Map.of();
+    }
+
+    record IncrementalState(Map<ShardId, Exception> shardLevelFailures) implements Writeable {
+
+        static final IncrementalState EMPTY = new IncrementalState(Collections.emptyMap());
+
+        IncrementalState(StreamInput in) throws IOException {
+            this(in.readMap(ShardId::new, input -> input.readException()));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeMap(shardLevelFailures, (o, s) -> s.writeTo(o), StreamOutput::writeException);
+        }
     }
 
     /*

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -506,12 +506,12 @@ public class BulkRequest extends ActionRequest
         return Map.of();
     }
 
-    record IncrementalState(Map<ShardId, Exception> shardLevelFailures) implements Writeable {
+    record IncrementalState(Map<ShardId, Exception> shardLevelFailures, boolean indexingPressureAccounted) implements Writeable {
 
-        static final IncrementalState EMPTY = new IncrementalState(Collections.emptyMap());
+        static final IncrementalState EMPTY = new IncrementalState(Collections.emptyMap(), false);
 
         IncrementalState(StreamInput in) throws IOException {
-            this(in.readMap(ShardId::new, input -> input.readException()));
+            this(in.readMap(ShardId::new, input -> input.readException()), false);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestModifier.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestModifier.java
@@ -114,7 +114,12 @@ final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
     ActionListener<BulkResponse> wrapActionListenerIfNeeded(long ingestTookInMillis, ActionListener<BulkResponse> actionListener) {
         if (itemResponses.isEmpty()) {
             return actionListener.map(
-                response -> new BulkResponse(response.getItems(), response.getTook().getMillis(), ingestTookInMillis)
+                response -> new BulkResponse(
+                    response.getItems(),
+                    response.getTook().getMillis(),
+                    ingestTookInMillis,
+                    response.getIncrementalState()
+                )
             );
         } else {
             return actionListener.map(response -> {
@@ -139,7 +144,7 @@ final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
                     assertResponsesAreCorrect(bulkResponses, allResponses);
                 }
 
-                return new BulkResponse(allResponses, response.getTook().getMillis(), ingestTookInMillis);
+                return new BulkResponse(allResponses, response.getTook().getMillis(), ingestTookInMillis, response.getIncrementalState());
             });
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -37,12 +38,18 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
     private final BulkItemResponse[] responses;
     private final long tookInMillis;
     private final long ingestTookInMillis;
+    private final BulkRequest.IncrementalState incrementalState;
 
     public BulkResponse(StreamInput in) throws IOException {
         super(in);
         responses = in.readArray(BulkItemResponse::new, BulkItemResponse[]::new);
         tookInMillis = in.readVLong();
         ingestTookInMillis = in.readZLong();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.BULK_INCREMENTAL_STATE)) {
+            incrementalState = new BulkRequest.IncrementalState(in);
+        } else {
+            incrementalState = BulkRequest.IncrementalState.EMPTY;
+        }
     }
 
     public BulkResponse(BulkItemResponse[] responses, long tookInMillis) {
@@ -50,9 +57,19 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
     }
 
     public BulkResponse(BulkItemResponse[] responses, long tookInMillis, long ingestTookInMillis) {
+        this(responses, tookInMillis, ingestTookInMillis, BulkRequest.IncrementalState.EMPTY);
+    }
+
+    public BulkResponse(
+        BulkItemResponse[] responses,
+        long tookInMillis,
+        long ingestTookInMillis,
+        BulkRequest.IncrementalState incrementalState
+    ) {
         this.responses = responses;
         this.tookInMillis = tookInMillis;
         this.ingestTookInMillis = ingestTookInMillis;
+        this.incrementalState = incrementalState;
     }
 
     /**
@@ -60,6 +77,10 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
      */
     public TimeValue getTook() {
         return new TimeValue(tookInMillis);
+    }
+
+    public long getTookInMillis() {
+        return tookInMillis;
     }
 
     /**
@@ -74,6 +95,10 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
      */
     public long getIngestTookInMillis() {
         return ingestTookInMillis;
+    }
+
+    BulkRequest.IncrementalState getIncrementalState() {
+        return incrementalState;
     }
 
     /**
@@ -125,6 +150,9 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
         out.writeArray(responses);
         out.writeVLong(tookInMillis);
         out.writeZLong(ingestTookInMillis);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.BULK_INCREMENTAL_STATE)) {
+            incrementalState.writeTo(out);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IncrementalBulkService {
+
+    private final Client client;
+
+    public IncrementalBulkService(Client client) {
+        this.client = client;
+    }
+
+    public Handler newBulkRequest() {
+        return newBulkRequest(null, null, null);
+    }
+
+    public Handler newBulkRequest(@Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
+        return new Handler(client, waitForActiveShards, timeout, refresh);
+    }
+
+    public static class Handler {
+
+        private final Client client;
+        private final ActiveShardCount waitForActiveShards;
+        private final TimeValue timeout;
+        private final String refresh;
+
+        private final ArrayList<Releasable> releasables = new ArrayList<>(4);
+        private final ArrayList<BulkResponse> responses = new ArrayList<>(2);
+        private boolean globalFailure = false;
+        private boolean incrementalRequestSubmitted = false;
+        private Exception bulkActionLevelFailure = null;
+        private BulkRequest bulkRequest = null;
+
+        private Handler(Client client, @Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
+            this.client = client;
+            this.waitForActiveShards = waitForActiveShards != null ? ActiveShardCount.parseString(waitForActiveShards) : null;
+            this.timeout = timeout;
+            this.refresh = refresh;
+            createNewBulkRequest(BulkRequest.IncrementalState.EMPTY);
+        }
+
+        public void addItems(List<DocWriteRequest<?>> items, Releasable releasable, Runnable nextItems) {
+            if (bulkActionLevelFailure != null) {
+                shortCircuitDueToTopLevelFailure(items, releasable);
+                nextItems.run();
+            } else {
+                assert bulkRequest != null;
+                internalAddItems(items, releasable);
+
+                if (shouldBackOff()) {
+                    final boolean isFirstRequest = incrementalRequestSubmitted == false;
+                    incrementalRequestSubmitted = true;
+
+                    client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
+
+                        @Override
+                        public void onResponse(BulkResponse bulkResponse) {
+                            responses.add(bulkResponse);
+                            releaseCurrentReferences();
+                            createNewBulkRequest(bulkResponse.getIncrementalState());
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            handleBulkFailure(isFirstRequest, e);
+                        }
+                    }, nextItems::run));
+                } else {
+                    nextItems.run();
+                }
+            }
+        }
+
+        private boolean shouldBackOff() {
+            // TODO: Implement Real Memory Logic
+            return bulkRequest.requests().size() >= 16;
+        }
+
+        public void lastItems(List<DocWriteRequest<?>> items, Releasable releasable, ActionListener<BulkResponse> listener) {
+            if (bulkActionLevelFailure != null) {
+                shortCircuitDueToTopLevelFailure(items, releasable);
+                errorResponse(listener);
+            } else {
+                assert bulkRequest != null;
+                internalAddItems(items, releasable);
+
+                client.bulk(bulkRequest, new ActionListener<>() {
+
+                    private final boolean isFirstRequest = incrementalRequestSubmitted == false;
+
+                    @Override
+                    public void onResponse(BulkResponse bulkResponse) {
+                        responses.add(bulkResponse);
+                        releaseCurrentReferences();
+                        listener.onResponse(combineResponses());
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        handleBulkFailure(isFirstRequest, e);
+                        errorResponse(listener);
+                    }
+                });
+            }
+        }
+
+        private void shortCircuitDueToTopLevelFailure(List<DocWriteRequest<?>> items, Releasable releasable) {
+            assert releasables.isEmpty();
+            assert bulkRequest == null;
+            if (globalFailure == false) {
+                addItemLevelFailures(items);
+            }
+            Releasables.close(releasable);
+        }
+
+        private void errorResponse(ActionListener<BulkResponse> listener) {
+            if (globalFailure) {
+                listener.onFailure(bulkActionLevelFailure);
+            } else {
+                listener.onResponse(combineResponses());
+            }
+        }
+
+        private void handleBulkFailure(boolean isFirstRequest, Exception e) {
+            assert bulkActionLevelFailure == null;
+            globalFailure = isFirstRequest;
+            bulkActionLevelFailure = e;
+            addItemLevelFailures(bulkRequest.requests());
+            releaseCurrentReferences();
+        }
+
+        private void addItemLevelFailures(List<DocWriteRequest<?>> items) {
+            BulkItemResponse[] bulkItemResponses = new BulkItemResponse[items.size()];
+            int idx = 0;
+            for (DocWriteRequest<?> item : items) {
+                BulkItemResponse.Failure failure = new BulkItemResponse.Failure(item.index(), item.id(), bulkActionLevelFailure);
+                bulkItemResponses[idx++] = BulkItemResponse.failure(idx, item.opType(), failure);
+            }
+
+            responses.add(new BulkResponse(bulkItemResponses, 0, 0));
+        }
+
+        private void internalAddItems(List<DocWriteRequest<?>> items, Releasable releasable) {
+            bulkRequest.add(items);
+            releasables.add(releasable);
+        }
+
+        private void createNewBulkRequest(BulkRequest.IncrementalState incrementalState) {
+            bulkRequest = new BulkRequest();
+            bulkRequest.incrementalState(incrementalState);
+
+            if (waitForActiveShards != null) {
+                bulkRequest.waitForActiveShards(waitForActiveShards);
+            }
+            if (timeout != null) {
+                bulkRequest.timeout(timeout);
+            }
+            if (refresh != null) {
+                bulkRequest.setRefreshPolicy(refresh);
+            }
+        }
+
+        private void releaseCurrentReferences() {
+            bulkRequest = null;
+            releasables.forEach(Releasable::close);
+            releasables.clear();
+        }
+
+        private BulkResponse combineResponses() {
+            long tookInMillis = 0;
+            long ingestTookInMillis = 0;
+            int itemResponseCount = 0;
+            for (BulkResponse response : responses) {
+                tookInMillis += response.getTookInMillis();
+                ingestTookInMillis += response.getIngestTookInMillis();
+                itemResponseCount += response.getItems().length;
+            }
+            BulkItemResponse[] bulkItemResponses = new BulkItemResponse[itemResponseCount];
+            int i = 0;
+            for (BulkResponse response : responses) {
+                for (BulkItemResponse itemResponse : response.getItems()) {
+                    bulkItemResponses[i++] = itemResponse;
+                }
+            }
+
+            return new BulkResponse(bulkItemResponses, tookInMillis, ingestTookInMillis);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -9,24 +9,30 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexingPressure;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class IncrementalBulkService {
 
     private final Client client;
+    private final IndexingPressure indexingPressure;
 
-    public IncrementalBulkService(Client client) {
+    public IncrementalBulkService(Client client, IndexingPressure indexingPressure) {
         this.client = client;
+        this.indexingPressure = indexingPressure;
     }
 
     public Handler newBulkRequest() {
@@ -34,12 +40,15 @@ public class IncrementalBulkService {
     }
 
     public Handler newBulkRequest(@Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
-        return new Handler(client, waitForActiveShards, timeout, refresh);
+        return new Handler(client, indexingPressure, waitForActiveShards, timeout, refresh);
     }
 
     public static class Handler {
 
+        public static final BulkRequest.IncrementalState EMPTY_STATE = new BulkRequest.IncrementalState(Collections.emptyMap(), true);
+
         private final Client client;
+        private final IndexingPressure indexingPressure;
         private final ActiveShardCount waitForActiveShards;
         private final TimeValue timeout;
         private final String refresh;
@@ -51,12 +60,19 @@ public class IncrementalBulkService {
         private Exception bulkActionLevelFailure = null;
         private BulkRequest bulkRequest = null;
 
-        private Handler(Client client, @Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
+        private Handler(
+            Client client,
+            IndexingPressure indexingPressure,
+            @Nullable String waitForActiveShards,
+            @Nullable TimeValue timeout,
+            @Nullable String refresh
+        ) {
             this.client = client;
+            this.indexingPressure = indexingPressure;
             this.waitForActiveShards = waitForActiveShards != null ? ActiveShardCount.parseString(waitForActiveShards) : null;
             this.timeout = timeout;
             this.refresh = refresh;
-            createNewBulkRequest(BulkRequest.IncrementalState.EMPTY);
+            createNewBulkRequest(EMPTY_STATE);
         }
 
         public void addItems(List<DocWriteRequest<?>> items, Releasable releasable, Runnable nextItems) {
@@ -65,35 +81,39 @@ public class IncrementalBulkService {
                 nextItems.run();
             } else {
                 assert bulkRequest != null;
-                internalAddItems(items, releasable);
+                if (internalAddItems(items, releasable)) {
+                    if (shouldBackOff()) {
+                        final boolean isFirstRequest = incrementalRequestSubmitted == false;
+                        incrementalRequestSubmitted = true;
 
-                if (shouldBackOff()) {
-                    final boolean isFirstRequest = incrementalRequestSubmitted == false;
-                    incrementalRequestSubmitted = true;
+                        client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
 
-                    client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
+                            @Override
+                            public void onResponse(BulkResponse bulkResponse) {
+                                responses.add(bulkResponse);
+                                releaseCurrentReferences();
+                                createNewBulkRequest(
+                                    new BulkRequest.IncrementalState(bulkResponse.getIncrementalState().shardLevelFailures(), true)
+                                );
+                            }
 
-                        @Override
-                        public void onResponse(BulkResponse bulkResponse) {
-                            responses.add(bulkResponse);
-                            releaseCurrentReferences();
-                            createNewBulkRequest(bulkResponse.getIncrementalState());
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            handleBulkFailure(isFirstRequest, e);
-                        }
-                    }, nextItems::run));
+                            @Override
+                            public void onFailure(Exception e) {
+                                handleBulkFailure(isFirstRequest, e);
+                            }
+                        }, nextItems));
+                    } else {
+                        nextItems.run();
+                    }
                 } else {
                     nextItems.run();
                 }
+
             }
         }
 
         private boolean shouldBackOff() {
-            // TODO: Implement Real Memory Logic
-            return bulkRequest.requests().size() >= 16;
+            return indexingPressure.shouldSplitBulks();
         }
 
         public void lastItems(List<DocWriteRequest<?>> items, Releasable releasable, ActionListener<BulkResponse> listener) {
@@ -102,25 +122,27 @@ public class IncrementalBulkService {
                 errorResponse(listener);
             } else {
                 assert bulkRequest != null;
-                internalAddItems(items, releasable);
+                if (internalAddItems(items, releasable)) {
+                    client.bulk(bulkRequest, new ActionListener<>() {
 
-                client.bulk(bulkRequest, new ActionListener<>() {
+                        private final boolean isFirstRequest = incrementalRequestSubmitted == false;
 
-                    private final boolean isFirstRequest = incrementalRequestSubmitted == false;
+                        @Override
+                        public void onResponse(BulkResponse bulkResponse) {
+                            responses.add(bulkResponse);
+                            releaseCurrentReferences();
+                            listener.onResponse(combineResponses());
+                        }
 
-                    @Override
-                    public void onResponse(BulkResponse bulkResponse) {
-                        responses.add(bulkResponse);
-                        releaseCurrentReferences();
-                        listener.onResponse(combineResponses());
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        handleBulkFailure(isFirstRequest, e);
-                        errorResponse(listener);
-                    }
-                });
+                        @Override
+                        public void onFailure(Exception e) {
+                            handleBulkFailure(isFirstRequest, e);
+                            errorResponse(listener);
+                        }
+                    });
+                } else {
+                    errorResponse(listener);
+                }
             }
         }
 
@@ -160,9 +182,22 @@ public class IncrementalBulkService {
             responses.add(new BulkResponse(bulkItemResponses, 0, 0));
         }
 
-        private void internalAddItems(List<DocWriteRequest<?>> items, Releasable releasable) {
-            bulkRequest.add(items);
-            releasables.add(releasable);
+        private boolean internalAddItems(List<DocWriteRequest<?>> items, Releasable releasable) {
+            try {
+                bulkRequest.add(items);
+                releasables.add(releasable);
+                releasables.add(
+                    indexingPressure.markCoordinatingOperationStarted(
+                        items.size(),
+                        items.stream().mapToLong(Accountable::ramBytesUsed).sum(),
+                        false
+                    )
+                );
+                return true;
+            } catch (EsRejectedExecutionException e) {
+                handleBulkFailure(incrementalRequestSubmitted == false, e);
+                return false;
+            }
         }
 
         private void createNewBulkRequest(BulkRequest.IncrementalState incrementalState) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
@@ -22,7 +23,6 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexingPressure;
-import org.elasticsearch.rest.action.document.RestBulkAction;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,48 +30,46 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.settings.Setting.boolSetting;
+
 public class IncrementalBulkService {
 
+    public static final Setting<Boolean> INCREMENTAL_BULK = boolSetting(
+        "rest.incremental_bulk",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
     private final Client client;
+    private final AtomicBoolean enabledForTests = new AtomicBoolean(true);
     private final IndexingPressure indexingPressure;
     private final ThreadContext threadContext;
-    private final Supplier<Boolean> enabled;
 
     public IncrementalBulkService(Client client, IndexingPressure indexingPressure, ThreadContext threadContext) {
-        this(client, indexingPressure, threadContext, new Enabled());
-    }
-
-    public IncrementalBulkService(
-        Client client,
-        IndexingPressure indexingPressure,
-        ThreadContext threadContext,
-        ClusterSettings clusterSettings
-    ) {
-        this(client, indexingPressure, threadContext, new Enabled(clusterSettings));
-    }
-
-    public IncrementalBulkService(
-        Client client,
-        IndexingPressure indexingPressure,
-        ThreadContext threadContext,
-        Supplier<Boolean> enabled
-    ) {
         this.client = client;
         this.indexingPressure = indexingPressure;
         this.threadContext = threadContext;
-        this.enabled = enabled;
-    }
-
-    public boolean incrementalBulkEnabled() {
-        return enabled.get();
     }
 
     public Handler newBulkRequest() {
+        ensureEnabled();
         return newBulkRequest(null, null, null);
     }
 
     public Handler newBulkRequest(@Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
+        ensureEnabled();
         return new Handler(client, threadContext, indexingPressure, waitForActiveShards, timeout, refresh);
+    }
+
+    private void ensureEnabled() {
+        if (enabledForTests.get() == false) {
+            throw new AssertionError("Unexpected incremental bulk request");
+        }
+    }
+
+    // This method only exists to tests that the feature flag works. Remove once we no longer need the flag.
+    public void setForTests(boolean value) {
+        enabledForTests.set(value);
     }
 
     public static class Enabled implements Supplier<Boolean> {
@@ -81,8 +79,8 @@ public class IncrementalBulkService {
         public Enabled() {}
 
         public Enabled(ClusterSettings clusterSettings) {
-            incrementalBulksEnabled.set(clusterSettings.get(RestBulkAction.INCREMENTAL_BULK));
-            clusterSettings.addSettingsUpdateConsumer(RestBulkAction.INCREMENTAL_BULK, incrementalBulksEnabled::set);
+            incrementalBulksEnabled.set(clusterSettings.get(INCREMENTAL_BULK));
+            clusterSettings.addSettingsUpdateConsumer(INCREMENTAL_BULK, incrementalBulksEnabled::set);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -14,25 +14,56 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.rest.action.document.RestBulkAction;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public class IncrementalBulkService {
 
     private final Client client;
     private final IndexingPressure indexingPressure;
+    private final ThreadContext threadContext;
+    private final Supplier<Boolean> enabled;
 
-    public IncrementalBulkService(Client client, IndexingPressure indexingPressure) {
+    public IncrementalBulkService(Client client, IndexingPressure indexingPressure, ThreadContext threadContext) {
+        this(client, indexingPressure, threadContext, new Enabled());
+    }
+
+    public IncrementalBulkService(
+        Client client,
+        IndexingPressure indexingPressure,
+        ThreadContext threadContext,
+        ClusterSettings clusterSettings
+    ) {
+        this(client, indexingPressure, threadContext, new Enabled(clusterSettings));
+    }
+
+    public IncrementalBulkService(
+        Client client,
+        IndexingPressure indexingPressure,
+        ThreadContext threadContext,
+        Supplier<Boolean> enabled
+    ) {
         this.client = client;
         this.indexingPressure = indexingPressure;
+        this.threadContext = threadContext;
+        this.enabled = enabled;
+    }
+
+    public boolean incrementalBulkEnabled() {
+        return enabled.get();
     }
 
     public Handler newBulkRequest() {
@@ -40,14 +71,32 @@ public class IncrementalBulkService {
     }
 
     public Handler newBulkRequest(@Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
-        return new Handler(client, indexingPressure, waitForActiveShards, timeout, refresh);
+        return new Handler(client, threadContext, indexingPressure, waitForActiveShards, timeout, refresh);
     }
 
-    public static class Handler {
+    public static class Enabled implements Supplier<Boolean> {
+
+        private final AtomicBoolean incrementalBulksEnabled = new AtomicBoolean(true);
+
+        public Enabled() {}
+
+        public Enabled(ClusterSettings clusterSettings) {
+            incrementalBulksEnabled.set(clusterSettings.get(RestBulkAction.INCREMENTAL_BULK));
+            clusterSettings.addSettingsUpdateConsumer(RestBulkAction.INCREMENTAL_BULK, incrementalBulksEnabled::set);
+        }
+
+        @Override
+        public Boolean get() {
+            return incrementalBulksEnabled.get();
+        }
+    }
+
+    public static class Handler implements Releasable {
 
         public static final BulkRequest.IncrementalState EMPTY_STATE = new BulkRequest.IncrementalState(Collections.emptyMap(), true);
 
         private final Client client;
+        private final ThreadContext threadContext;
         private final IndexingPressure indexingPressure;
         private final ActiveShardCount waitForActiveShards;
         private final TimeValue timeout;
@@ -57,17 +106,21 @@ public class IncrementalBulkService {
         private final ArrayList<BulkResponse> responses = new ArrayList<>(2);
         private boolean globalFailure = false;
         private boolean incrementalRequestSubmitted = false;
+        private ThreadContext.StoredContext requestContext;
         private Exception bulkActionLevelFailure = null;
         private BulkRequest bulkRequest = null;
 
-        private Handler(
+        protected Handler(
             Client client,
+            ThreadContext threadContext,
             IndexingPressure indexingPressure,
             @Nullable String waitForActiveShards,
             @Nullable TimeValue timeout,
             @Nullable String refresh
         ) {
             this.client = client;
+            this.threadContext = threadContext;
+            this.requestContext = threadContext.newStoredContext();
             this.indexingPressure = indexingPressure;
             this.waitForActiveShards = waitForActiveShards != null ? ActiveShardCount.parseString(waitForActiveShards) : null;
             this.timeout = timeout;
@@ -85,30 +138,34 @@ public class IncrementalBulkService {
                     if (shouldBackOff()) {
                         final boolean isFirstRequest = incrementalRequestSubmitted == false;
                         incrementalRequestSubmitted = true;
+                        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+                            requestContext.restore();
+                            client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
 
-                        client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
+                                @Override
+                                public void onResponse(BulkResponse bulkResponse) {
+                                    responses.add(bulkResponse);
+                                    releaseCurrentReferences();
+                                    createNewBulkRequest(
+                                        new BulkRequest.IncrementalState(bulkResponse.getIncrementalState().shardLevelFailures(), true)
+                                    );
+                                }
 
-                            @Override
-                            public void onResponse(BulkResponse bulkResponse) {
-                                responses.add(bulkResponse);
-                                releaseCurrentReferences();
-                                createNewBulkRequest(
-                                    new BulkRequest.IncrementalState(bulkResponse.getIncrementalState().shardLevelFailures(), true)
-                                );
-                            }
-
-                            @Override
-                            public void onFailure(Exception e) {
-                                handleBulkFailure(isFirstRequest, e);
-                            }
-                        }, nextItems));
+                                @Override
+                                public void onFailure(Exception e) {
+                                    handleBulkFailure(isFirstRequest, e);
+                                }
+                            }, () -> {
+                                requestContext = threadContext.newStoredContext();
+                                nextItems.run();
+                            }));
+                        }
                     } else {
                         nextItems.run();
                     }
                 } else {
                     nextItems.run();
                 }
-
             }
         }
 
@@ -123,23 +180,26 @@ public class IncrementalBulkService {
             } else {
                 assert bulkRequest != null;
                 if (internalAddItems(items, releasable)) {
-                    client.bulk(bulkRequest, new ActionListener<>() {
+                    try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
+                        requestContext.restore();
+                        client.bulk(bulkRequest, new ActionListener<>() {
 
-                        private final boolean isFirstRequest = incrementalRequestSubmitted == false;
+                            private final boolean isFirstRequest = incrementalRequestSubmitted == false;
 
-                        @Override
-                        public void onResponse(BulkResponse bulkResponse) {
-                            responses.add(bulkResponse);
-                            releaseCurrentReferences();
-                            listener.onResponse(combineResponses());
-                        }
+                            @Override
+                            public void onResponse(BulkResponse bulkResponse) {
+                                responses.add(bulkResponse);
+                                releaseCurrentReferences();
+                                listener.onResponse(combineResponses());
+                            }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            handleBulkFailure(isFirstRequest, e);
-                            errorResponse(listener);
-                        }
-                    });
+                            @Override
+                            public void onFailure(Exception e) {
+                                handleBulkFailure(isFirstRequest, e);
+                                errorResponse(listener);
+                            }
+                        });
+                    }
                 } else {
                     errorResponse(listener);
                 }
@@ -239,6 +299,11 @@ public class IncrementalBulkService {
             }
 
             return new BulkResponse(bulkItemResponses, tookInMillis, ingestTookInMillis);
+        }
+
+        @Override
+        public void close() {
+            // TODO: Implement
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -112,7 +112,12 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
             clusterService.state().metadata().getIndicesLookup(),
             systemIndices
         );
-        final Releasable releasable = indexingPressure.markCoordinatingOperationStarted(indexingOps, indexingBytes, isOnlySystem);
+        final Releasable releasable;
+        if (bulkRequest.incrementalState().indexingPressureAccounted()) {
+            releasable = () -> {};
+        } else {
+            releasable = indexingPressure.markCoordinatingOperationStarted(indexingOps, indexingBytes, isOnlySystem);
+        }
         final ActionListener<BulkResponse> releasingListener = ActionListener.runBefore(listener, releasable::close);
         final Executor executor = isOnlySystem ? systemWriteExecutor : writeExecutor;
         ensureClusterStateThenForkAndExecute(task, bulkRequest, executor, releasingListener);

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -560,6 +560,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         FsHealthService.REFRESH_INTERVAL_SETTING,
         FsHealthService.SLOW_PATH_LOGGING_THRESHOLD_SETTING,
         IndexingPressure.MAX_INDEXING_BYTES,
+        IndexingPressure.SPLIT_BULK_THRESHOLD,
         ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN,
         DataTier.ENFORCE_DEFAULT_TIER_PREFERENCE_SETTING,
         CoordinationDiagnosticsService.IDENTITY_CHANGES_THRESHOLD_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.settings;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.bulk.WriteAckDelay;
 import org.elasticsearch.action.datastreams.autosharding.DataStreamAutoShardingService;
 import org.elasticsearch.action.ingest.SimulatePipelineTransportAction;
@@ -113,7 +114,6 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.readiness.ReadinessService;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.SearchService;
@@ -243,7 +243,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         Metadata.SETTING_READ_ONLY_SETTING,
         Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING,
         ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE,
-        RestBulkAction.INCREMENTAL_BULK,
+        IncrementalBulkService.INCREMENTAL_BULK,
         RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
         RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,
         RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -113,6 +113,7 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.readiness.ReadinessService;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.action.document.RestBulkAction;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.SearchService;
@@ -242,6 +243,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         Metadata.SETTING_READ_ONLY_SETTING,
         Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING,
         ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE,
+        RestBulkAction.INCREMENTAL_BULK,
         RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING,
         RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC_SETTING,
         RecoverySettings.INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING,

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.http;

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.core.Nullable;
+
+/**
+ * A super-interface for different HTTP content implementations
+ */
+public sealed interface HttpBody permits HttpBody.Full, HttpBody.Stream {
+
+    static Full fromBytesReference(BytesReference bytesRef) {
+        return new ByteRefHttpBody(bytesRef);
+    }
+
+    static Full empty() {
+        return new ByteRefHttpBody(BytesArray.EMPTY);
+    }
+
+    default boolean isFull() {
+        return this instanceof Full;
+    }
+
+    default boolean isStream() {
+        return this instanceof Stream;
+    }
+
+    /**
+     * Assumes that HTTP body is a full content. If not sure, use {@link HttpBody#isFull()}.
+     */
+    default Full asFull() {
+        assert this instanceof Full;
+        return (Full) this;
+    }
+
+    /**
+     * Assumes that HTTP body is a lazy-stream. If not sure, use {@link HttpBody#isStream()}.
+     */
+    default Stream asStream() {
+        assert this instanceof Stream;
+        return (Stream) this;
+    }
+
+    /**
+     * Full content represents a complete http body content that can be accessed immediately.
+     */
+    non-sealed interface Full extends HttpBody {
+        BytesReference bytes();
+    }
+
+    /**
+     * Stream is a lazy-loaded content. Stream supports only single handler, this handler must be
+     * set before requesting next chunk.
+     */
+    non-sealed interface Stream extends HttpBody {
+        /**
+         * Returns current handler
+         */
+        @Nullable
+        ChunkHandler handler();
+
+        /**
+         * Sets handler that can handle next chunk
+         */
+        void setHandler(ChunkHandler chunkHandler);
+
+        /**
+         * Request next chunk of data from the network. The size of the chunk depends on following
+         * factors. If request is not compressed then chunk size will be up to
+         * {@link HttpTransportSettings#SETTING_HTTP_MAX_CHUNK_SIZE}. If request is compressed then
+         * chunk size will be up to max_chunk_size * compression_ratio. Multiple calls can be
+         * deduplicated when next chunk is not yet available. It's recommended to call "next" once
+         * for every chunk.
+         * <pre>
+         * {@code
+         *     stream.setHandler((chunk, isLast) -> {
+         *         processChunk(chunk);
+         *         if (isLast == false) {
+         *             stream.next();
+         *         }
+         *     });
+         * }
+         * </pre>
+         */
+        void next();
+    }
+
+    @FunctionalInterface
+    interface ChunkHandler {
+        void onNext(ReleasableBytesReference chunk, boolean isLast);
+    }
+
+    record ByteRefHttpBody(BytesReference bytes) implements Full {}
+}

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -74,6 +74,13 @@ public sealed interface HttpBody extends Releasable permits HttpBody.Full, HttpB
         ChunkHandler handler();
 
         /**
+         * Adds tracing chunk handler. Tracing handler will be invoked before main handler, and
+         * should never release or call for next chunk. It should be used for monitoring and
+         * logging purposes.
+         */
+        void addTracingHandler(ChunkHandler chunkHandler);
+
+        /**
          * Sets handler that can handle next chunk
          */
         void setHandler(ChunkHandler chunkHandler);

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -100,8 +100,11 @@ public sealed interface HttpBody extends Releasable permits HttpBody.Full, HttpB
     }
 
     @FunctionalInterface
-    interface ChunkHandler {
+    interface ChunkHandler extends Releasable {
         void onNext(ReleasableBytesReference chunk, boolean isLast);
+
+        @Override
+        default void close() {}
     }
 
     record ByteRefHttpBody(BytesReference bytes) implements Full {}

--- a/server/src/main/java/org/elasticsearch/http/HttpBody.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpBody.java
@@ -13,11 +13,12 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 
 /**
  * A super-interface for different HTTP content implementations
  */
-public sealed interface HttpBody permits HttpBody.Full, HttpBody.Stream {
+public sealed interface HttpBody extends Releasable permits HttpBody.Full, HttpBody.Stream {
 
     static Full fromBytesReference(BytesReference bytesRef) {
         return new ByteRefHttpBody(bytesRef);
@@ -56,6 +57,9 @@ public sealed interface HttpBody permits HttpBody.Full, HttpBody.Stream {
      */
     non-sealed interface Full extends HttpBody {
         BytesReference bytes();
+
+        @Override
+        default void close() {}
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
@@ -229,6 +229,8 @@ public class HttpClientStatsTracker {
             requestCount += 1;
             if (httpRequest.body().isFull()) {
                 requestSizeBytes += httpRequest.body().asFull().bytes().length();
+            } else {
+                httpRequest.body().asStream().addTracingHandler((chunk, last) -> requestSizeBytes += chunk.length());
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
@@ -227,7 +227,9 @@ public class HttpClientStatsTracker {
             lastRequestTimeMillis = currentTimeMillis;
             lastUri = httpRequest.uri();
             requestCount += 1;
-            requestSizeBytes += httpRequest.content().length();
+            if (httpRequest.body().isFull()) {
+                requestSizeBytes += httpRequest.body().asFull().bytes().length();
+            }
         }
 
         private static String getFirstValueForHeader(final HttpRequest request, final String header) {

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -28,7 +28,7 @@ public interface HttpRequest extends HttpPreRequest {
         HTTP_1_1
     }
 
-    BytesReference content();
+    HttpBody body();
 
     List<String> strictCookies();
 
@@ -47,7 +47,7 @@ public interface HttpRequest extends HttpPreRequest {
     Exception getInboundException();
 
     /**
-     * Release any resources associated with this request. Implementations should be idempotent. The behavior of {@link #content()}
+     * Release any resources associated with this request. Implementations should be idempotent. The behavior of {@link #body()}
      * after this method has been invoked is undefined and implementation specific.
      */
     void release();

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.repositories.reservedstate.ReservedRepositoryAction;
 import org.elasticsearch.action.admin.indices.template.reservedstate.ReservedComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.FailureStoreMetrics;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.datastreams.autosharding.DataStreamAutoShardingService;
 import org.elasticsearch.action.ingest.ReservedPipelineAction;
 import org.elasticsearch.action.search.SearchExecutionStatsCollector;
@@ -979,6 +980,7 @@ class NodeConstruction {
         );
         final HttpServerTransport httpServerTransport = serviceProvider.newHttpTransport(pluginsService, networkModule);
         final IndexingPressure indexingLimits = new IndexingPressure(settings);
+        final IncrementalBulkService incrementalBulkService = new IncrementalBulkService(client);
 
         SnapshotsService snapshotsService = new SnapshotsService(
             settings,
@@ -1140,6 +1142,7 @@ class NodeConstruction {
             b.bind(PageCacheRecycler.class).toInstance(pageCacheRecycler);
             b.bind(IngestService.class).toInstance(ingestService);
             b.bind(IndexingPressure.class).toInstance(indexingLimits);
+            b.bind(IncrementalBulkService.class).toInstance(incrementalBulkService);
             b.bind(AggregationUsageService.class).toInstance(searchModule.getValuesSourceRegistry().getUsageService());
             b.bind(MetaStateService.class).toInstance(metaStateService);
             b.bind(IndicesService.class).toInstance(indicesService);

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -980,7 +980,7 @@ class NodeConstruction {
         );
         final HttpServerTransport httpServerTransport = serviceProvider.newHttpTransport(pluginsService, networkModule);
         final IndexingPressure indexingLimits = new IndexingPressure(settings);
-        final IncrementalBulkService incrementalBulkService = new IncrementalBulkService(client);
+        final IncrementalBulkService incrementalBulkService = new IncrementalBulkService(client, indexingLimits);
 
         SnapshotsService snapshotsService = new SnapshotsService(
             settings,

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -895,8 +895,7 @@ class NodeConstruction {
         final IncrementalBulkService incrementalBulkService = new IncrementalBulkService(
             client,
             indexingLimits,
-            threadPool.getThreadContext(),
-            clusterService.getClusterSettings()
+            threadPool.getThreadContext()
         );
 
         ActionModule actionModule = new ActionModule(

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -425,8 +425,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         MethodHandlers methodHandlers,
         ThreadContext threadContext
     ) throws Exception {
-        final int contentLength = request.contentLength();
-        if (contentLength > 0) {
+        if (request.hasContent()) {
             if (isContentTypeDisallowed(request) || handler.mediaTypesValid(request) == false) {
                 sendContentTypeErrorMessage(request.getAllHeaderValues("Content-Type"), channel);
                 return;
@@ -454,6 +453,9 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 return;
             }
         }
+        // TODO: estimate streamed content size for circuit breaker,
+        // something like http_max_chunk_size * avg_compression_ratio(for compressed content)
+        final int contentLength = request.isFullContent() ? request.contentLength() : 0;
         try {
             if (handler.canTripCircuitBreaker()) {
                 inFlightRequestsBreaker(circuitBreakerService).addEstimateBytesAndMaybeBreak(contentLength, "<http_request>");

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -24,6 +24,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.http.HttpChannel;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.telemetry.tracing.Traceable;
@@ -304,16 +305,28 @@ public class RestRequest implements ToXContent.Params, Traceable {
     }
 
     public boolean hasContent() {
-        return contentLength() > 0;
+        return isStreamedContent() || contentLength() > 0;
     }
 
     public int contentLength() {
-        return httpRequest.content().length();
+        return httpRequest.body().asFull().bytes().length();
+    }
+
+    public boolean isFullContent() {
+        return httpRequest.body().isFull();
     }
 
     public BytesReference content() {
         this.contentConsumed = true;
-        return httpRequest.content();
+        return httpRequest.body().asFull().bytes();
+    }
+
+    public boolean isStreamedContent() {
+        return httpRequest.body().isStream();
+    }
+
+    public HttpBody.Stream contentStream() {
+        return httpRequest.body().asStream();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -11,21 +11,38 @@ package org.elasticsearch.rest.action.document;
 
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkRequestParser;
 import org.elasticsearch.action.bulk.BulkShardRequest;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
+import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
+import static org.elasticsearch.common.settings.Setting.boolSetting;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
@@ -40,12 +57,21 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
  */
 @ServerlessScope(Scope.PUBLIC)
 public class RestBulkAction extends BaseRestHandler {
+
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in bulk requests is deprecated.";
+    public static final Setting<Boolean> INCREMENTAL_BULK = boolSetting(
+        "rest.incremental_bulk",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
 
     private final boolean allowExplicitIndex;
+    private final IncrementalBulkService bulkHandler;
 
-    public RestBulkAction(Settings settings) {
+    public RestBulkAction(Settings settings, IncrementalBulkService bulkHandler) {
         this.allowExplicitIndex = MULTI_ALLOW_EXPLICIT_INDEX.get(settings);
+        this.bulkHandler = bulkHandler;
     }
 
     @Override
@@ -67,38 +93,181 @@ public class RestBulkAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        if (request.getRestApiVersion() == RestApiVersion.V_7 && request.hasParam("type")) {
-            request.param("type");
-        }
-        BulkRequest bulkRequest = new BulkRequest();
-        String defaultIndex = request.param("index");
-        String defaultRouting = request.param("routing");
-        FetchSourceContext defaultFetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
-        String defaultPipeline = request.param("pipeline");
-        boolean defaultListExecutedPipelines = request.paramAsBoolean("list_executed_pipelines", false);
-        String waitForActiveShards = request.param("wait_for_active_shards");
-        if (waitForActiveShards != null) {
-            bulkRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
-        }
-        Boolean defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false);
-        boolean defaultRequireDataStream = request.paramAsBoolean(DocWriteRequest.REQUIRE_DATA_STREAM, false);
-        bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
-        bulkRequest.setRefreshPolicy(request.param("refresh"));
-        bulkRequest.add(
-            request.requiredContent(),
-            defaultIndex,
-            defaultRouting,
-            defaultFetchSourceContext,
-            defaultPipeline,
-            defaultRequireAlias,
-            defaultRequireDataStream,
-            defaultListExecutedPipelines,
-            allowExplicitIndex,
-            request.getXContentType(),
-            request.getRestApiVersion()
-        );
+        if (bulkHandler.incrementalBulkEnabled() == false) {
+            if (request.getRestApiVersion() == RestApiVersion.V_7 && request.hasParam("type")) {
+                request.param("type");
+            }
+            BulkRequest bulkRequest = new BulkRequest();
+            String defaultIndex = request.param("index");
+            String defaultRouting = request.param("routing");
+            FetchSourceContext defaultFetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
+            String defaultPipeline = request.param("pipeline");
+            boolean defaultListExecutedPipelines = request.paramAsBoolean("list_executed_pipelines", false);
+            String waitForActiveShards = request.param("wait_for_active_shards");
+            if (waitForActiveShards != null) {
+                bulkRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
+            }
+            Boolean defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false);
+            boolean defaultRequireDataStream = request.paramAsBoolean(DocWriteRequest.REQUIRE_DATA_STREAM, false);
+            bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
+            bulkRequest.setRefreshPolicy(request.param("refresh"));
+            bulkRequest.add(
+                request.requiredContent(),
+                defaultIndex,
+                defaultRouting,
+                defaultFetchSourceContext,
+                defaultPipeline,
+                defaultRequireAlias,
+                defaultRequireDataStream,
+                defaultListExecutedPipelines,
+                allowExplicitIndex,
+                request.getXContentType(),
+                request.getRestApiVersion()
+            );
 
-        return channel -> client.bulk(bulkRequest, new RestRefCountedChunkedToXContentListener<>(channel));
+            return channel -> client.bulk(bulkRequest, new RestRefCountedChunkedToXContentListener<>(channel));
+        } else {
+            if (request.getRestApiVersion() == RestApiVersion.V_7 && request.hasParam("type")) {
+                request.param("type");
+            }
+
+            String waitForActiveShards = request.param("wait_for_active_shards");
+            TimeValue timeout = request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT);
+            String refresh = request.param("refresh");
+            return new ChunkHandler(allowExplicitIndex, request, () -> bulkHandler.newBulkRequest(waitForActiveShards, timeout, refresh));
+        }
+    }
+
+    static class ChunkHandler implements BaseRestHandler.RequestBodyChunkConsumer {
+
+        private final boolean allowExplicitIndex;
+        private final RestRequest request;
+
+        private final Map<String, String> stringDeduplicator = new HashMap<>();
+        private final String defaultIndex;
+        private final String defaultRouting;
+        private final FetchSourceContext defaultFetchSourceContext;
+        private final String defaultPipeline;
+        private final boolean defaultListExecutedPipelines;
+        private final Boolean defaultRequireAlias;
+        private final boolean defaultRequireDataStream;
+        private final BulkRequestParser parser;
+        private final Supplier<IncrementalBulkService.Handler> handlerSupplier;
+        private IncrementalBulkService.Handler handler;
+
+        private volatile RestChannel restChannel;
+        private boolean isException;
+        private final ArrayDeque<ReleasableBytesReference> unParsedChunks = new ArrayDeque<>(4);
+        private final ArrayList<DocWriteRequest<?>> items = new ArrayList<>(4);
+
+        ChunkHandler(boolean allowExplicitIndex, RestRequest request, Supplier<IncrementalBulkService.Handler> handlerSupplier) {
+            this.allowExplicitIndex = allowExplicitIndex;
+            this.request = request;
+            this.defaultIndex = request.param("index");
+            this.defaultRouting = request.param("routing");
+            this.defaultFetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
+            this.defaultPipeline = request.param("pipeline");
+            this.defaultListExecutedPipelines = request.paramAsBoolean("list_executed_pipelines", false);
+            this.defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false);
+            this.defaultRequireDataStream = request.paramAsBoolean(DocWriteRequest.REQUIRE_DATA_STREAM, false);
+            // TODO: Fix type deprecation logging
+            this.parser = new BulkRequestParser(false, request.getRestApiVersion());
+            this.handlerSupplier = handlerSupplier;
+        }
+
+        @Override
+        public void accept(RestChannel restChannel) {
+            this.restChannel = restChannel;
+            this.handler = handlerSupplier.get();
+            request.contentStream().next();
+        }
+
+        @Override
+        public void handleChunk(RestChannel channel, ReleasableBytesReference chunk, boolean isLast) {
+            assert handler != null;
+            assert channel == restChannel;
+            if (isException) {
+                chunk.close();
+                return;
+            }
+
+            final BytesReference data;
+            int bytesConsumed;
+            try {
+                unParsedChunks.add(chunk);
+
+                if (unParsedChunks.size() > 1) {
+                    data = CompositeBytesReference.of(unParsedChunks.toArray(new ReleasableBytesReference[0]));
+                } else {
+                    data = chunk;
+                }
+
+                // TODO: Check that the behavior here vs. globalRouting, globalPipeline, globalRequireAlias, globalRequireDatsStream in
+                // BulkRequest#add is fine
+                bytesConsumed = parser.incrementalParse(
+                    data,
+                    defaultIndex,
+                    defaultRouting,
+                    defaultFetchSourceContext,
+                    defaultPipeline,
+                    defaultRequireAlias,
+                    defaultRequireDataStream,
+                    defaultListExecutedPipelines,
+                    allowExplicitIndex,
+                    request.getXContentType(),
+                    (request, type) -> items.add(request),
+                    items::add,
+                    items::add,
+                    isLast == false,
+                    stringDeduplicator
+                );
+
+            } catch (Exception e) {
+                // TODO: This needs to be better
+                Releasables.close(handler);
+                Releasables.close(unParsedChunks);
+                unParsedChunks.clear();
+                new RestToXContentListener<>(channel).onFailure(e);
+                isException = true;
+                return;
+            }
+
+            final ArrayList<Releasable> releasables = accountParsing(bytesConsumed);
+            if (isLast) {
+                assert unParsedChunks.isEmpty();
+                assert channel != null;
+                ArrayList<DocWriteRequest<?>> toPass = new ArrayList<>(items);
+                items.clear();
+                handler.lastItems(toPass, () -> Releasables.close(releasables), new RestRefCountedChunkedToXContentListener<>(channel));
+            } else if (items.isEmpty() == false) {
+                ArrayList<DocWriteRequest<?>> toPass = new ArrayList<>(items);
+                items.clear();
+                handler.addItems(toPass, () -> Releasables.close(releasables), () -> request.contentStream().next());
+            } else {
+                assert releasables.isEmpty();
+                request.contentStream().next();
+            }
+        }
+
+        @Override
+        public void close() {
+            RequestBodyChunkConsumer.super.close();
+        }
+
+        private ArrayList<Releasable> accountParsing(int bytesConsumed) {
+            ArrayList<Releasable> releasables = new ArrayList<>(unParsedChunks.size());
+            while (bytesConsumed > 0) {
+                ReleasableBytesReference reference = unParsedChunks.removeFirst();
+                releasables.add(reference);
+                if (bytesConsumed >= reference.length()) {
+                    bytesConsumed -= reference.length();
+                } else {
+                    unParsedChunks.addFirst(reference.retainedSlice(bytesConsumed, reference.length() - bytesConsumed));
+                    bytesConsumed = 0;
+                }
+            }
+            return releasables;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.common.settings.Setting.boolSetting;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
@@ -59,12 +57,6 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestBulkAction extends BaseRestHandler {
 
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in bulk requests is deprecated.";
-    public static final Setting<Boolean> INCREMENTAL_BULK = boolSetting(
-        "rest.incremental_bulk",
-        true,
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
 
     private final boolean allowExplicitIndex;
     private final IncrementalBulkService bulkHandler;
@@ -93,7 +85,7 @@ public class RestBulkAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        if (bulkHandler.incrementalBulkEnabled() == false) {
+        if (request.isStreamedContent() == false) {
             if (request.getRestApiVersion() == RestApiVersion.V_7 && request.hasParam("type")) {
                 request.param("type");
             }

--- a/server/src/test/java/org/elasticsearch/action/ActionModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionModuleTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.action.admin.cluster.node.info.TransportNodesInfoAction;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -129,7 +130,8 @@ public class ActionModuleTests extends ESTestCase {
             mock(ClusterService.class),
             null,
             List.of(),
-            RestExtension.allowAll()
+            RestExtension.allowAll(),
+            new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
         );
         actionModule.initRestHandlers(null, null);
         // At this point the easiest way to confirm that a handler is loaded is to try to register another one on top of it and to fail
@@ -193,7 +195,8 @@ public class ActionModuleTests extends ESTestCase {
                 mock(ClusterService.class),
                 null,
                 List.of(),
-                RestExtension.allowAll()
+                RestExtension.allowAll(),
+                new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
             );
             Exception e = expectThrows(IllegalArgumentException.class, () -> actionModule.initRestHandlers(null, null));
             assertThat(e.getMessage(), startsWith("Cannot replace existing handler for [/_nodes] for method: GET"));
@@ -250,7 +253,8 @@ public class ActionModuleTests extends ESTestCase {
                 mock(ClusterService.class),
                 null,
                 List.of(),
-                RestExtension.allowAll()
+                RestExtension.allowAll(),
+                new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
             );
             actionModule.initRestHandlers(null, null);
             // At this point the easiest way to confirm that a handler is loaded is to try to register another one on top of it and to fail
@@ -300,7 +304,8 @@ public class ActionModuleTests extends ESTestCase {
                     mock(ClusterService.class),
                     null,
                     List.of(),
-                    RestExtension.allowAll()
+                    RestExtension.allowAll(),
+                    new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
                 )
             );
             assertThat(
@@ -341,7 +346,8 @@ public class ActionModuleTests extends ESTestCase {
                     mock(ClusterService.class),
                     null,
                     List.of(),
-                    RestExtension.allowAll()
+                    RestExtension.allowAll(),
+                    new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
                 )
             );
             assertThat(

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionModule;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -1177,7 +1178,8 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             mock(ClusterService.class),
             null,
             List.of(),
-            RestExtension.allowAll()
+            RestExtension.allowAll(),
+            new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
@@ -120,7 +120,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             assertThat(clientStats.remoteAddress(), equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
             assertThat(clientStats.lastUri(), equalTo(httpRequest1.uri()));
             assertThat(clientStats.requestCount(), equalTo(1L));
-            requestLength += httpRequest1.content().length();
+            requestLength += httpRequest1.body().asFull().bytes().length();
             assertThat(clientStats.requestSizeBytes(), equalTo(requestLength));
             assertThat(clientStats.closedTimeMillis(), equalTo(-1L));
             assertThat(clientStats.openedTimeMillis(), equalTo(openTimeMillis));
@@ -150,7 +150,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             assertThat(clientStats.remoteAddress(), equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
             assertThat(clientStats.lastUri(), equalTo(httpRequest2.uri()));
             assertThat(clientStats.requestCount(), equalTo(2L));
-            requestLength += httpRequest2.content().length();
+            requestLength += httpRequest2.body().asFull().bytes().length();
             assertThat(clientStats.requestSizeBytes(), equalTo(requestLength));
             assertThat(clientStats.closedTimeMillis(), equalTo(-1L));
             assertThat(clientStats.openedTimeMillis(), equalTo(openTimeMillis));

--- a/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
+++ b/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.http;
 
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
@@ -49,8 +48,8 @@ class TestHttpRequest implements HttpRequest {
     }
 
     @Override
-    public BytesReference content() {
-        return BytesArray.EMPTY;
+    public HttpBody body() {
+        return HttpBody.empty();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.http.HttpHeadersValidationException;
 import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.http.HttpRequest;
@@ -831,11 +832,11 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public BytesReference content() {
+            public HttpBody body() {
                 if (hasContent) {
-                    return new BytesArray("test");
+                    return HttpBody.fromBytesReference(new BytesArray("test"));
                 }
-                return BytesArray.EMPTY;
+                return HttpBody.empty();
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.http.HttpChannel;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -87,7 +88,7 @@ public class RestRequestTests extends ESTestCase {
     private <T extends Exception> void runConsumesContentTest(final CheckedConsumer<RestRequest, T> consumer, final boolean expected) {
         final HttpRequest httpRequest = mock(HttpRequest.class);
         when(httpRequest.uri()).thenReturn("");
-        when(httpRequest.content()).thenReturn(new BytesArray(new byte[1]));
+        when(httpRequest.body()).thenReturn(HttpBody.fromBytesReference(new BytesArray(new byte[1])));
         when(httpRequest.getHeaders()).thenReturn(
             Collections.singletonMap("Content-Type", Collections.singletonList(randomFrom("application/json", "application/x-ndjson")))
         );

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -212,6 +212,9 @@ public class RestBulkActionTests extends ESTestCase {
                 }
 
                 @Override
+                public void addTracingHandler(ChunkHandler chunkHandler) {}
+
+                @Override
                 public void setHandler(ChunkHandler chunkHandler) {}
 
                 @Override

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -11,23 +11,37 @@ package org.elasticsearch.rest.action.document;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
+import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.XContentType;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
@@ -51,7 +65,10 @@ public class RestBulkActionTests extends ESTestCase {
             };
             final Map<String, String> params = new HashMap<>();
             params.put("pipeline", "timestamps");
-            new RestBulkAction(settings(IndexVersion.current()).build()).handleRequest(
+            new RestBulkAction(
+                settings(IndexVersion.current()).build(),
+                new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY), () -> false)
+            ).handleRequest(
                 new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk").withParams(params).withContent(new BytesArray("""
                     {"index":{"_id":"1"}}
                     {"field1":"val1"}
@@ -83,7 +100,15 @@ public class RestBulkActionTests extends ESTestCase {
             };
             Map<String, String> params = new HashMap<>();
             {
-                new RestBulkAction(settings(IndexVersion.current()).build()).handleRequest(
+                new RestBulkAction(
+                    settings(IndexVersion.current()).build(),
+                    new IncrementalBulkService(
+                        mock(Client.class),
+                        mock(IndexingPressure.class),
+                        new ThreadContext(Settings.EMPTY),
+                        () -> false
+                    )
+                ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
                         .withContent(new BytesArray("""
@@ -104,7 +129,15 @@ public class RestBulkActionTests extends ESTestCase {
             {
                 params.put("list_executed_pipelines", "true");
                 bulkCalled.set(false);
-                new RestBulkAction(settings(IndexVersion.current()).build()).handleRequest(
+                new RestBulkAction(
+                    settings(IndexVersion.current()).build(),
+                    new IncrementalBulkService(
+                        mock(Client.class),
+                        mock(IndexingPressure.class),
+                        new ThreadContext(Settings.EMPTY),
+                        () -> false
+                    )
+                ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
                         .withContent(new BytesArray("""
@@ -124,7 +157,15 @@ public class RestBulkActionTests extends ESTestCase {
             }
             {
                 bulkCalled.set(false);
-                new RestBulkAction(settings(IndexVersion.current()).build()).handleRequest(
+                new RestBulkAction(
+                    settings(IndexVersion.current()).build(),
+                    new IncrementalBulkService(
+                        mock(Client.class),
+                        mock(IndexingPressure.class),
+                        new ThreadContext(Settings.EMPTY),
+                        () -> false
+                    )
+                ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
                         .withContent(new BytesArray("""
@@ -145,7 +186,15 @@ public class RestBulkActionTests extends ESTestCase {
             {
                 params.remove("list_executed_pipelines");
                 bulkCalled.set(false);
-                new RestBulkAction(settings(IndexVersion.current()).build()).handleRequest(
+                new RestBulkAction(
+                    settings(IndexVersion.current()).build(),
+                    new IncrementalBulkService(
+                        mock(Client.class),
+                        mock(IndexingPressure.class),
+                        new ThreadContext(Settings.EMPTY),
+                        () -> false
+                    )
+                ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
                         .withContent(new BytesArray("""
@@ -164,5 +213,96 @@ public class RestBulkActionTests extends ESTestCase {
                 assertThat(listExecutedPipelinesRequest2.get(), equalTo(false));
             }
         }
+    }
+
+    public void testIncrementalParsing() {
+        ArrayList<DocWriteRequest<?>> docs = new ArrayList<>();
+        AtomicBoolean isLast = new AtomicBoolean(false);
+        AtomicBoolean next = new AtomicBoolean(false);
+
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
+            .withMethod(RestRequest.Method.POST)
+            .withBody(new HttpBody.Stream() {
+                @Override
+                public void close() {}
+
+                @Override
+                public ChunkHandler handler() {
+                    return null;
+                }
+
+                @Override
+                public void setHandler(ChunkHandler chunkHandler) {}
+
+                @Override
+                public void next() {
+                    next.set(true);
+                }
+            })
+            .withHeaders(Map.of("Content-Type", Collections.singletonList("application/json")))
+            .build();
+        FakeRestChannel channel = new FakeRestChannel(request, false, 1);
+
+        RestBulkAction.ChunkHandler chunkHandler = new RestBulkAction.ChunkHandler(
+            true,
+            request,
+            () -> new IncrementalBulkService.Handler(null, new ThreadContext(Settings.EMPTY), null, null, null, null) {
+
+                @Override
+                public void addItems(List<DocWriteRequest<?>> items, Releasable releasable, Runnable nextItems) {
+                    releasable.close();
+                    docs.addAll(items);
+                }
+
+                @Override
+                public void lastItems(List<DocWriteRequest<?>> items, Releasable releasable, ActionListener<BulkResponse> listener) {
+                    releasable.close();
+                    docs.addAll(items);
+                    isLast.set(true);
+                }
+            }
+        );
+
+        chunkHandler.accept(channel);
+        ReleasableBytesReference r1 = new ReleasableBytesReference(new BytesArray("{\"index\":{\"_index\":\"index_name\"}}\n"), () -> {});
+        chunkHandler.handleChunk(channel, r1, false);
+        assertThat(docs, empty());
+        assertTrue(next.get());
+        next.set(false);
+        assertFalse(isLast.get());
+
+        ReleasableBytesReference r2 = new ReleasableBytesReference(new BytesArray("{\"field\":1}"), () -> {});
+        chunkHandler.handleChunk(channel, r2, false);
+        assertThat(docs, empty());
+        assertTrue(next.get());
+        next.set(false);
+        assertFalse(isLast.get());
+        assertTrue(r1.hasReferences());
+        assertTrue(r2.hasReferences());
+
+        ReleasableBytesReference r3 = new ReleasableBytesReference(new BytesArray("\n{\"delete\":"), () -> {});
+        chunkHandler.handleChunk(channel, r3, false);
+        assertThat(docs, hasSize(1));
+        assertFalse(next.get());
+        assertFalse(isLast.get());
+        assertFalse(r1.hasReferences());
+        assertFalse(r2.hasReferences());
+        assertTrue(r3.hasReferences());
+
+        ReleasableBytesReference r4 = new ReleasableBytesReference(new BytesArray("{\"_index\":\"test\",\"_id\":\"2\"}}"), () -> {});
+        chunkHandler.handleChunk(channel, r4, false);
+        assertThat(docs, hasSize(1));
+        assertTrue(next.get());
+        next.set(false);
+        assertFalse(isLast.get());
+
+        ReleasableBytesReference r5 = new ReleasableBytesReference(new BytesArray("\n"), () -> {});
+        chunkHandler.handleChunk(channel, r5, true);
+        assertThat(docs, hasSize(2));
+        assertFalse(next.get());
+        assertTrue(isLast.get());
+        assertFalse(r3.hasReferences());
+        assertFalse(r4.hasReferences());
+        assertFalse(r5.hasReferences());
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -67,7 +67,7 @@ public class RestBulkActionTests extends ESTestCase {
             params.put("pipeline", "timestamps");
             new RestBulkAction(
                 settings(IndexVersion.current()).build(),
-                new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY), () -> false)
+                new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
             ).handleRequest(
                 new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk").withParams(params).withContent(new BytesArray("""
                     {"index":{"_id":"1"}}
@@ -102,12 +102,7 @@ public class RestBulkActionTests extends ESTestCase {
             {
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(
-                        mock(Client.class),
-                        mock(IndexingPressure.class),
-                        new ThreadContext(Settings.EMPTY),
-                        () -> false
-                    )
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -131,12 +126,7 @@ public class RestBulkActionTests extends ESTestCase {
                 bulkCalled.set(false);
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(
-                        mock(Client.class),
-                        mock(IndexingPressure.class),
-                        new ThreadContext(Settings.EMPTY),
-                        () -> false
-                    )
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -159,12 +149,7 @@ public class RestBulkActionTests extends ESTestCase {
                 bulkCalled.set(false);
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(
-                        mock(Client.class),
-                        mock(IndexingPressure.class),
-                        new ThreadContext(Settings.EMPTY),
-                        () -> false
-                    )
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -188,12 +173,7 @@ public class RestBulkActionTests extends ESTestCase {
                 bulkCalled.set(false);
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(
-                        mock(Client.class),
-                        mock(IndexingPressure.class),
-                        new ThreadContext(Settings.EMPTY),
-                        () -> false
-                    )
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -125,6 +125,7 @@ import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.MergeSchedulerConfig;
 import org.elasticsearch.index.MockEngineFactoryPlugin;
@@ -2103,6 +2104,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE.getKey(),
                 randomFrom(1, 2, SearchRequest.DEFAULT_PRE_FILTER_SHARD_SIZE)
             );
+        if (randomBoolean()) {
+            builder.put(IndexingPressure.SPLIT_BULK_THRESHOLD.getKey(), randomFrom("256B", "1KB", "64KB"));
+        }
         return builder.build();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequest;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainResponse;
@@ -48,6 +49,8 @@ import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.ingest.DeletePipelineRequest;
 import org.elasticsearch.action.ingest.DeletePipelineTransportAction;
@@ -192,6 +195,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -1776,11 +1780,49 @@ public abstract class ESIntegTestCase extends ESTestCase {
             );
             logger.info("Index [{}] docs async: [{}] bulk: [{}] partitions [{}]", builders.size(), false, true, partition.size());
             for (List<IndexRequestBuilder> segmented : partition) {
-                BulkRequestBuilder bulkBuilder = client().prepareBulk();
-                for (IndexRequestBuilder indexRequestBuilder : segmented) {
-                    bulkBuilder.add(indexRequestBuilder);
+                BulkResponse actionGet;
+                if (randomBoolean()) {
+                    BulkRequestBuilder bulkBuilder = client().prepareBulk();
+                    for (IndexRequestBuilder indexRequestBuilder : segmented) {
+                        bulkBuilder.add(indexRequestBuilder);
+                    }
+                    actionGet = bulkBuilder.get();
+                } else {
+                    IncrementalBulkService bulkService = internalCluster().getInstance(IncrementalBulkService.class);
+                    IncrementalBulkService.Handler handler = bulkService.newBulkRequest();
+
+                    ConcurrentLinkedQueue<IndexRequest> queue = new ConcurrentLinkedQueue<>();
+                    segmented.forEach(b -> queue.add(b.request()));
+
+                    PlainActionFuture<BulkResponse> future = new PlainActionFuture<>();
+                    AtomicInteger runs = new AtomicInteger(0);
+                    Runnable r = new Runnable() {
+
+                        @Override
+                        public void run() {
+                            int toRemove = Math.min(randomIntBetween(5, 10), queue.size());
+                            ArrayList<DocWriteRequest<?>> docs = new ArrayList<>();
+                            for (int i = 0; i < toRemove; i++) {
+                                docs.add(queue.poll());
+                            }
+
+                            if (queue.isEmpty()) {
+                                handler.lastItems(docs, () -> {}, future);
+                            } else {
+                                handler.addItems(docs, () -> {}, () -> {
+                                    // Every 10 runs dispatch to new thread to prevent stackoverflow
+                                    if (runs.incrementAndGet() % 10 == 0) {
+                                        new Thread(this).start();
+                                    } else {
+                                        this.run();
+                                    }
+                                });
+                            }
+                        }
+                    };
+                    r.run();
+                    actionGet = future.actionGet();
                 }
-                BulkResponse actionGet = bulkBuilder.get();
                 assertThat(actionGet.hasFailures() ? actionGet.buildFailureMessage() : "", actionGet.hasFailures(), equalTo(false));
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.http.HttpChannel;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.http.HttpResponse;
@@ -54,24 +55,24 @@ public class FakeRestRequest extends RestRequest {
 
         private final Method method;
         private final String uri;
-        private final BytesReference content;
+        private final HttpBody content;
         private final Map<String, List<String>> headers;
         private final Exception inboundException;
 
         public FakeHttpRequest(Method method, String uri, BytesReference content, Map<String, List<String>> headers) {
-            this(method, uri, content, headers, null);
+            this(method, uri, content == null ? HttpBody.empty() : HttpBody.fromBytesReference(content), headers, null);
         }
 
         private FakeHttpRequest(
             Method method,
             String uri,
-            BytesReference content,
+            HttpBody content,
             Map<String, List<String>> headers,
             Exception inboundException
         ) {
             this.method = method;
             this.uri = uri;
-            this.content = content == null ? BytesArray.EMPTY : content;
+            this.content = content;
             this.headers = headers;
             this.inboundException = inboundException;
         }
@@ -87,7 +88,7 @@ public class FakeRestRequest extends RestRequest {
         }
 
         @Override
-        public BytesReference content() {
+        public HttpBody body() {
             return content;
         }
 
@@ -195,7 +196,7 @@ public class FakeRestRequest extends RestRequest {
 
         private Map<String, String> params = new HashMap<>();
 
-        private BytesReference content = BytesArray.EMPTY;
+        private HttpBody content = HttpBody.empty();
 
         private String path = "/";
 
@@ -221,7 +222,7 @@ public class FakeRestRequest extends RestRequest {
         }
 
         public Builder withContent(BytesReference contentBytes, XContentType xContentType) {
-            this.content = contentBytes;
+            this.content = HttpBody.fromBytesReference(contentBytes);
             if (xContentType != null) {
                 headers.put("Content-Type", Collections.singletonList(xContentType.mediaType()));
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -229,6 +229,11 @@ public class FakeRestRequest extends RestRequest {
             return this;
         }
 
+        public Builder withBody(HttpBody body) {
+            this.content = body;
+            return this;
+        }
+
         public Builder withPath(String path) {
             this.path = path;
             return this;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -822,7 +823,8 @@ public class SecurityTests extends ESTestCase {
                 mock(ClusterService.class),
                 null,
                 List.of(),
-                RestExtension.allowAll()
+                RestExtension.allowAll(),
+                new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
             );
             actionModule.initRestHandlers(null, null);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -2644,7 +2644,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         checkedFields.put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedFields.put(LoggingAuditTrail.URL_PATH_FIELD_NAME, "_uri");
         if (includeRequestBody && Strings.hasLength(request.content())) {
-            checkedFields.put(LoggingAuditTrail.REQUEST_BODY_FIELD_NAME, request.getHttpRequest().content().utf8ToString());
+            checkedFields.put(LoggingAuditTrail.REQUEST_BODY_FIELD_NAME, request.getHttpRequest().body().asFull().bytes().utf8ToString());
         }
         if (params.isEmpty() == false) {
             checkedFields.put(LoggingAuditTrail.URL_QUERY_FIELD_NAME, "foo=bar&evac=true");


### PR DESCRIPTION
This commit adds a mechanism of splitting bulk requests when a
coordinating nodes is under memory pressure. In order to do that it
adds a new mechanism of http stream handling. And the proper framework
to use this with bulk requests.