### PR TITLE
Rework interfaces for the geoip processor

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.ingest.geoip;
 
-import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.db.Reader;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ingest.SimulateDocumentBaseResult;
@@ -738,8 +738,8 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
 
     @SuppressForbidden(reason = "Maxmind API requires java.io.File")
     private void parseDatabase(Path tempFile) throws IOException {
-        try (DatabaseReader databaseReader = new DatabaseReader.Builder(tempFile.toFile()).build()) {
-            assertNotNull(databaseReader.getMetadata());
+        try (Reader reader = new Reader(tempFile.toFile())) {
+            assertNotNull(reader.getMetadata());
         }
     }
 

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
@@ -13,7 +13,6 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.VersionType;
@@ -206,10 +205,10 @@ public class ReloadingDatabasesWhilePerformingGeoLookupsIT extends ESTestCase {
     private static void lazyLoadReaders(DatabaseNodeService databaseNodeService) throws IOException {
         if (databaseNodeService.get("GeoLite2-City.mmdb") != null) {
             databaseNodeService.get("GeoLite2-City.mmdb").getDatabaseType();
-            databaseNodeService.get("GeoLite2-City.mmdb").getCity(InetAddresses.forString("2.125.160.216"));
+            databaseNodeService.get("GeoLite2-City.mmdb").getCity("2.125.160.216");
         }
         databaseNodeService.get("GeoLite2-City-Test.mmdb").getDatabaseType();
-        databaseNodeService.get("GeoLite2-City-Test.mmdb").getCity(InetAddresses.forString("2.125.160.216"));
+        databaseNodeService.get("GeoLite2-City-Test.mmdb").getCity("2.125.160.216");
     }
 
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -87,7 +87,7 @@ import static org.elasticsearch.ingest.geoip.GeoIpTaskState.getGeoIpTaskState;
  * if there is an old instance of this database then that is closed.
  * 4) Cleanup locally loaded databases that are no longer mentioned in {@link GeoIpTaskState}.
  */
-public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeable {
+public final class DatabaseNodeService implements IpDatabaseProvider, Closeable {
 
     private static final Logger logger = LogManager.getLogger(DatabaseNodeService.class);
 
@@ -221,7 +221,7 @@ public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeab
     }
 
     @Override
-    public GeoIpDatabase getDatabase(String name) {
+    public IpDatabase getDatabase(String name) {
         return getDatabaseReaderLazyLoader(name);
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Facilitates lazy loading of the database reader, so that when the geoip plugin is installed, but not used,
  * no memory is being wasted on the database reader.
  */
-class DatabaseReaderLazyLoader implements GeoIpDatabase, Closeable {
+class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
 
     private static final boolean LOAD_DATABASE_ON_HEAP = Booleans.parseBoolean(System.getProperty("es.geoip.load_db_on_heap", "false"));
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.ingest.geoip.stats.CacheStats;
 
-import java.net.InetAddress;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -62,11 +61,7 @@ final class GeoIpCache {
     }
 
     @SuppressWarnings("unchecked")
-    <T extends AbstractResponse> T putIfAbsent(
-        InetAddress ip,
-        String databasePath,
-        Function<InetAddress, AbstractResponse> retrieveFunction
-    ) {
+    <T extends AbstractResponse> T putIfAbsent(String ip, String databasePath, Function<String, AbstractResponse> retrieveFunction) {
         // can't use cache.computeIfAbsent due to the elevated permissions for the jackson (run via the cache loader)
         CacheKey cacheKey = new CacheKey(ip, databasePath);
         long cacheStart = relativeNanoTimeProvider.getAsLong();
@@ -98,7 +93,7 @@ final class GeoIpCache {
     }
 
     // only useful for testing
-    AbstractResponse get(InetAddress ip, String databasePath) {
+    AbstractResponse get(String ip, String databasePath) {
         CacheKey cacheKey = new CacheKey(ip, databasePath);
         return cache.get(cacheKey);
     }
@@ -141,5 +136,5 @@ final class GeoIpCache {
      * path is needed to be included in the cache key. For example, if we only used the IP address as the key the City and ASN the same
      * IP may be in both with different values and we need to cache both.
      */
-    private record CacheKey(InetAddress ip, String databasePath) {}
+    private record CacheKey(String ip, String databasePath) {}
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
@@ -222,7 +221,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getTraits().getIpAddress());
                 case COUNTRY_ISO_CODE -> {
                     String countryIsoCode = country.getIsoCode();
                     if (countryIsoCode != null) {
@@ -301,7 +300,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getTraits().getIpAddress());
                 case COUNTRY_ISO_CODE -> {
                     String countryIsoCode = country.getIsoCode();
                     if (countryIsoCode != null) {
@@ -343,7 +342,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getIpAddress());
                 case ASN -> {
                     if (asn != null) {
                         geoData.put("asn", asn);
@@ -380,7 +379,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getIpAddress());
                 case HOSTING_PROVIDER -> {
                     geoData.put("hosting_provider", isHostingProvider);
                 }
@@ -415,7 +414,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getIpAddress());
                 case CONNECTION_TYPE -> {
                     if (connectionType != null) {
                         geoData.put("connection_type", connectionType.toString());
@@ -437,7 +436,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getIpAddress());
                 case DOMAIN -> {
                     if (domain != null) {
                         geoData.put("domain", domain);
@@ -485,7 +484,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getTraits().getIpAddress());
                 case COUNTRY_ISO_CODE -> {
                     String countryIsoCode = country.getIsoCode();
                     if (countryIsoCode != null) {
@@ -638,7 +637,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         Map<String, Object> geoData = new HashMap<>();
         for (Property property : this.properties) {
             switch (property) {
-                case IP -> geoData.put("ip", NetworkAddress.format(ipAddress));
+                case IP -> geoData.put("ip", response.getIpAddress());
                 case ASN -> {
                     if (asn != null) {
                         geoData.put("asn", asn);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -29,7 +29,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
@@ -37,7 +36,6 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.geoip.Database.Property;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -165,7 +163,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return ingestDocument;
     }
 
-    private Map<String, Object> getGeoData(IpDatabase ipDatabase, String ip) throws IOException {
+    private Map<String, Object> getGeoData(IpDatabase ipDatabase, String ipAddress) throws IOException {
         final String databaseType = ipDatabase.getDatabaseType();
         final Database database;
         try {
@@ -173,7 +171,6 @@ public final class GeoIpProcessor extends AbstractProcessor {
         } catch (IllegalArgumentException e) {
             throw new ElasticsearchParseException(e.getMessage(), e);
         }
-        final InetAddress ipAddress = InetAddresses.forString(ip);
         return switch (database) {
             case City -> retrieveCityGeoData(ipDatabase, ipAddress);
             case Country -> retrieveCountryGeoData(ipDatabase, ipAddress);
@@ -207,7 +204,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return properties;
     }
 
-    private Map<String, Object> retrieveCityGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveCityGeoData(IpDatabase ipDatabase, String ipAddress) {
         CityResponse response = ipDatabase.getCity(ipAddress);
         if (response == null) {
             return Map.of();
@@ -289,7 +286,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveCountryGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveCountryGeoData(IpDatabase ipDatabase, String ipAddress) {
         CountryResponse response = ipDatabase.getCountry(ipAddress);
         if (response == null) {
             return Map.of();
@@ -330,7 +327,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveAsnGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveAsnGeoData(IpDatabase ipDatabase, String ipAddress) {
         AsnResponse response = ipDatabase.getAsn(ipAddress);
         if (response == null) {
             return Map.of();
@@ -363,7 +360,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveAnonymousIpGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveAnonymousIpGeoData(IpDatabase ipDatabase, String ipAddress) {
         AnonymousIpResponse response = ipDatabase.getAnonymousIp(ipAddress);
         if (response == null) {
             return Map.of();
@@ -403,7 +400,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveConnectionTypeGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveConnectionTypeGeoData(IpDatabase ipDatabase, String ipAddress) {
         ConnectionTypeResponse response = ipDatabase.getConnectionType(ipAddress);
         if (response == null) {
             return Map.of();
@@ -425,7 +422,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveDomainGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveDomainGeoData(IpDatabase ipDatabase, String ipAddress) {
         DomainResponse response = ipDatabase.getDomain(ipAddress);
         if (response == null) {
             return Map.of();
@@ -447,7 +444,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveEnterpriseGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveEnterpriseGeoData(IpDatabase ipDatabase, String ipAddress) {
         EnterpriseResponse response = ipDatabase.getEnterprise(ipAddress);
         if (response == null) {
             return Map.of();
@@ -620,7 +617,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveIspGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+    private Map<String, Object> retrieveIspGeoData(IpDatabase ipDatabase, String ipAddress) {
         IspResponse response = ipDatabase.getIsp(ipAddress);
         if (response == null) {
             return Map.of();

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -62,7 +62,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     private final String field;
     private final Supplier<Boolean> isValid;
     private final String targetField;
-    private final CheckedSupplier<GeoIpDatabase, IOException> supplier;
+    private final CheckedSupplier<IpDatabase, IOException> supplier;
     private final Set<Property> properties;
     private final boolean ignoreMissing;
     private final boolean firstOnly;
@@ -85,7 +85,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         final String tag,
         final String description,
         final String field,
-        final CheckedSupplier<GeoIpDatabase, IOException> supplier,
+        final CheckedSupplier<IpDatabase, IOException> supplier,
         final Supplier<Boolean> isValid,
         final String targetField,
         final Set<Property> properties,
@@ -121,8 +121,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
             throw new IllegalArgumentException("field [" + field + "] is null, cannot extract geoip information.");
         }
 
-        GeoIpDatabase geoIpDatabase = this.supplier.get();
-        if (geoIpDatabase == null) {
+        IpDatabase ipDatabase = this.supplier.get();
+        if (ipDatabase == null) {
             if (ignoreMissing == false) {
                 tag(ingestDocument, databaseFile);
             }
@@ -131,7 +131,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
         try {
             if (ip instanceof String ipString) {
-                Map<String, Object> geoData = getGeoData(geoIpDatabase, ipString);
+                Map<String, Object> geoData = getGeoData(ipDatabase, ipString);
                 if (geoData.isEmpty() == false) {
                     ingestDocument.setFieldValue(targetField, geoData);
                 }
@@ -142,7 +142,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
                     if (ipAddr instanceof String == false) {
                         throw new IllegalArgumentException("array in field [" + field + "] should only contain strings");
                     }
-                    Map<String, Object> geoData = getGeoData(geoIpDatabase, (String) ipAddr);
+                    Map<String, Object> geoData = getGeoData(ipDatabase, (String) ipAddr);
                     if (geoData.isEmpty()) {
                         geoDataList.add(null);
                         continue;
@@ -161,13 +161,13 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 throw new IllegalArgumentException("field [" + field + "] should contain only string or array of strings");
             }
         } finally {
-            geoIpDatabase.release();
+            ipDatabase.release();
         }
         return ingestDocument;
     }
 
-    private Map<String, Object> getGeoData(GeoIpDatabase geoIpDatabase, String ip) throws IOException {
-        final String databaseType = geoIpDatabase.getDatabaseType();
+    private Map<String, Object> getGeoData(IpDatabase ipDatabase, String ip) throws IOException {
+        final String databaseType = ipDatabase.getDatabaseType();
         final Database database;
         try {
             database = Database.getDatabase(databaseType, databaseFile);
@@ -176,14 +176,14 @@ public final class GeoIpProcessor extends AbstractProcessor {
         }
         final InetAddress ipAddress = InetAddresses.forString(ip);
         return switch (database) {
-            case City -> retrieveCityGeoData(geoIpDatabase, ipAddress);
-            case Country -> retrieveCountryGeoData(geoIpDatabase, ipAddress);
-            case Asn -> retrieveAsnGeoData(geoIpDatabase, ipAddress);
-            case AnonymousIp -> retrieveAnonymousIpGeoData(geoIpDatabase, ipAddress);
-            case ConnectionType -> retrieveConnectionTypeGeoData(geoIpDatabase, ipAddress);
-            case Domain -> retrieveDomainGeoData(geoIpDatabase, ipAddress);
-            case Enterprise -> retrieveEnterpriseGeoData(geoIpDatabase, ipAddress);
-            case Isp -> retrieveIspGeoData(geoIpDatabase, ipAddress);
+            case City -> retrieveCityGeoData(ipDatabase, ipAddress);
+            case Country -> retrieveCountryGeoData(ipDatabase, ipAddress);
+            case Asn -> retrieveAsnGeoData(ipDatabase, ipAddress);
+            case AnonymousIp -> retrieveAnonymousIpGeoData(ipDatabase, ipAddress);
+            case ConnectionType -> retrieveConnectionTypeGeoData(ipDatabase, ipAddress);
+            case Domain -> retrieveDomainGeoData(ipDatabase, ipAddress);
+            case Enterprise -> retrieveEnterpriseGeoData(ipDatabase, ipAddress);
+            case Isp -> retrieveIspGeoData(ipDatabase, ipAddress);
         };
     }
 
@@ -208,8 +208,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return properties;
     }
 
-    private Map<String, Object> retrieveCityGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        CityResponse response = geoIpDatabase.getCity(ipAddress);
+    private Map<String, Object> retrieveCityGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        CityResponse response = ipDatabase.getCity(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -290,8 +290,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveCountryGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        CountryResponse response = geoIpDatabase.getCountry(ipAddress);
+    private Map<String, Object> retrieveCountryGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        CountryResponse response = ipDatabase.getCountry(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -331,8 +331,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveAsnGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        AsnResponse response = geoIpDatabase.getAsn(ipAddress);
+    private Map<String, Object> retrieveAsnGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        AsnResponse response = ipDatabase.getAsn(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -364,8 +364,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveAnonymousIpGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        AnonymousIpResponse response = geoIpDatabase.getAnonymousIp(ipAddress);
+    private Map<String, Object> retrieveAnonymousIpGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        AnonymousIpResponse response = ipDatabase.getAnonymousIp(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -404,8 +404,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveConnectionTypeGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        ConnectionTypeResponse response = geoIpDatabase.getConnectionType(ipAddress);
+    private Map<String, Object> retrieveConnectionTypeGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        ConnectionTypeResponse response = ipDatabase.getConnectionType(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -426,8 +426,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveDomainGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        DomainResponse response = geoIpDatabase.getDomain(ipAddress);
+    private Map<String, Object> retrieveDomainGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        DomainResponse response = ipDatabase.getDomain(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -448,8 +448,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveEnterpriseGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        EnterpriseResponse response = geoIpDatabase.getEnterprise(ipAddress);
+    private Map<String, Object> retrieveEnterpriseGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        EnterpriseResponse response = ipDatabase.getEnterprise(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -621,8 +621,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         return geoData;
     }
 
-    private Map<String, Object> retrieveIspGeoData(GeoIpDatabase geoIpDatabase, InetAddress ipAddress) {
-        IspResponse response = geoIpDatabase.getIsp(ipAddress);
+    private Map<String, Object> retrieveIspGeoData(IpDatabase ipDatabase, InetAddress ipAddress) {
+        IspResponse response = ipDatabase.getIsp(ipAddress);
         if (response == null) {
             return Map.of();
         }
@@ -680,23 +680,23 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     /**
-     * Retrieves and verifies a {@link GeoIpDatabase} instance for each execution of the {@link GeoIpProcessor}. Guards against missing
+     * Retrieves and verifies a {@link IpDatabase} instance for each execution of the {@link GeoIpProcessor}. Guards against missing
      * custom databases, and ensures that database instances are of the proper type before use.
      */
-    public static final class DatabaseVerifyingSupplier implements CheckedSupplier<GeoIpDatabase, IOException> {
-        private final GeoIpDatabaseProvider geoIpDatabaseProvider;
+    public static final class DatabaseVerifyingSupplier implements CheckedSupplier<IpDatabase, IOException> {
+        private final IpDatabaseProvider ipDatabaseProvider;
         private final String databaseFile;
         private final String databaseType;
 
-        public DatabaseVerifyingSupplier(GeoIpDatabaseProvider geoIpDatabaseProvider, String databaseFile, String databaseType) {
-            this.geoIpDatabaseProvider = geoIpDatabaseProvider;
+        public DatabaseVerifyingSupplier(IpDatabaseProvider ipDatabaseProvider, String databaseFile, String databaseType) {
+            this.ipDatabaseProvider = ipDatabaseProvider;
             this.databaseFile = databaseFile;
             this.databaseType = databaseType;
         }
 
         @Override
-        public GeoIpDatabase get() throws IOException {
-            GeoIpDatabase loader = geoIpDatabaseProvider.getDatabase(databaseFile);
+        public IpDatabase get() throws IOException {
+            IpDatabase loader = ipDatabaseProvider.getDatabase(databaseFile);
             if (loader == null) {
                 return null;
             }
@@ -716,10 +716,10 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     public static final class Factory implements Processor.Factory {
 
-        private final GeoIpDatabaseProvider geoIpDatabaseProvider;
+        private final IpDatabaseProvider ipDatabaseProvider;
 
-        public Factory(GeoIpDatabaseProvider geoIpDatabaseProvider) {
-            this.geoIpDatabaseProvider = geoIpDatabaseProvider;
+        public Factory(IpDatabaseProvider ipDatabaseProvider) {
+            this.ipDatabaseProvider = ipDatabaseProvider;
         }
 
         @Override
@@ -746,8 +746,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 deprecationLogger.warn(DeprecationCategory.OTHER, "default_databases_message", DEFAULT_DATABASES_DEPRECATION_MESSAGE);
             }
 
-            GeoIpDatabase geoIpDatabase = geoIpDatabaseProvider.getDatabase(databaseFile);
-            if (geoIpDatabase == null) {
+            IpDatabase ipDatabase = ipDatabaseProvider.getDatabase(databaseFile);
+            if (ipDatabase == null) {
                 // It's possible that the database could be downloaded via the GeoipDownloader process and could become available
                 // at a later moment, so a processor impl is returned that tags documents instead. If a database cannot be sourced then the
                 // processor will continue to tag documents with a warning until it is remediated by providing a database or changing the
@@ -757,9 +757,9 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
             final String databaseType;
             try {
-                databaseType = geoIpDatabase.getDatabaseType();
+                databaseType = ipDatabase.getDatabaseType();
             } finally {
-                geoIpDatabase.release();
+                ipDatabase.release();
             }
 
             final Database database;
@@ -779,8 +779,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 processorTag,
                 description,
                 ipField,
-                new DatabaseVerifyingSupplier(geoIpDatabaseProvider, databaseFile, databaseType),
-                () -> geoIpDatabaseProvider.isValid(databaseFile),
+                new DatabaseVerifyingSupplier(ipDatabaseProvider, databaseFile, databaseType),
+                () -> ipDatabaseProvider.isValid(databaseFile),
                 targetField,
                 properties,
                 ignoreMissing,

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabase.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabase.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 /**
- * Provides a uniform interface for interacting with various GeoIP databases.
+ * Provides a uniform interface for interacting with various ip databases.
  */
-public interface GeoIpDatabase {
+public interface IpDatabase {
 
     /**
      * @return the database type as it is detailed in the database file metadata

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabase.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabase.java
@@ -21,7 +21,6 @@ import com.maxmind.geoip2.model.IspResponse;
 import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
-import java.net.InetAddress;
 
 /**
  * Provides a uniform interface for interacting with various ip databases.
@@ -40,7 +39,7 @@ public interface IpDatabase {
      * @throws UnsupportedOperationException may be thrown if the implementation does not support retrieving city data
      */
     @Nullable
-    CityResponse getCity(InetAddress ipAddress);
+    CityResponse getCity(String ipAddress);
 
     /**
      * @param ipAddress the IP address to look up
@@ -48,7 +47,7 @@ public interface IpDatabase {
      * @throws UnsupportedOperationException may be thrown if the implementation does not support retrieving country data
      */
     @Nullable
-    CountryResponse getCountry(InetAddress ipAddress);
+    CountryResponse getCountry(String ipAddress);
 
     /**
      * @param ipAddress the IP address to look up
@@ -57,22 +56,22 @@ public interface IpDatabase {
      * @throws UnsupportedOperationException may be thrown if the implementation does not support retrieving ASN data
      */
     @Nullable
-    AsnResponse getAsn(InetAddress ipAddress);
+    AsnResponse getAsn(String ipAddress);
 
     @Nullable
-    AnonymousIpResponse getAnonymousIp(InetAddress ipAddress);
+    AnonymousIpResponse getAnonymousIp(String ipAddress);
 
     @Nullable
-    ConnectionTypeResponse getConnectionType(InetAddress ipAddress);
+    ConnectionTypeResponse getConnectionType(String ipAddress);
 
     @Nullable
-    DomainResponse getDomain(InetAddress ipAddress);
+    DomainResponse getDomain(String ipAddress);
 
     @Nullable
-    EnterpriseResponse getEnterprise(InetAddress ipAddress);
+    EnterpriseResponse getEnterprise(String ipAddress);
 
     @Nullable
-    IspResponse getIsp(InetAddress ipAddress);
+    IspResponse getIsp(String ipAddress);
 
     /**
      * Releases the current database object. Called after processing a single document. Databases should be closed or returned to a

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabaseProvider.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabaseProvider.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.ingest.geoip;
 
 /**
- * Provides construction and initialization logic for {@link GeoIpDatabase} instances.
+ * Provides construction and initialization logic for {@link IpDatabase} instances.
  */
-public interface GeoIpDatabaseProvider {
+public interface IpDatabaseProvider {
 
     /**
      * Determines if the given database name corresponds to an expired database. Expired databases will not be loaded.
@@ -30,5 +30,5 @@ public interface GeoIpDatabaseProvider {
      * @param name the name of the database to provide.
      * @return a ready-to-use database instance, or <code>null</code> if no database could be loaded.
      */
-    GeoIpDatabase getDatabase(String name);
+    IpDatabase getDatabase(String name);
 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/ConfigDatabasesTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/ConfigDatabasesTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.ingest.geoip;
 
 import com.maxmind.geoip2.model.CityResponse;
 
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -127,7 +126,7 @@ public class ConfigDatabasesTests extends ESTestCase {
 
             DatabaseReaderLazyLoader loader = configDatabases.getDatabase("GeoLite2-City.mmdb");
             assertThat(loader.getDatabaseType(), equalTo("GeoLite2-City"));
-            CityResponse cityResponse = loader.getCity(InetAddresses.forString("89.160.20.128"));
+            CityResponse cityResponse = loader.getCity("89.160.20.128");
             assertThat(cityResponse.getCity().getName(), equalTo("Tumba"));
             assertThat(cache.count(), equalTo(1));
         }
@@ -139,7 +138,7 @@ public class ConfigDatabasesTests extends ESTestCase {
 
             DatabaseReaderLazyLoader loader = configDatabases.getDatabase("GeoLite2-City.mmdb");
             assertThat(loader.getDatabaseType(), equalTo("GeoLite2-City"));
-            CityResponse cityResponse = loader.getCity(InetAddresses.forString("89.160.20.128"));
+            CityResponse cityResponse = loader.getCity("89.160.20.128");
             assertThat(cityResponse.getCity().getName(), equalTo("Linköping"));
             assertThat(cache.count(), equalTo(1));
         });

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpCacheTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpCacheTests.java
@@ -11,12 +11,10 @@ package org.elasticsearch.ingest.geoip;
 
 import com.maxmind.geoip2.model.AbstractResponse;
 
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.ingest.geoip.stats.CacheStats;
 import org.elasticsearch.test.ESTestCase;
 
-import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -32,34 +30,34 @@ public class GeoIpCacheTests extends ESTestCase {
         AbstractResponse response2 = mock(AbstractResponse.class);
 
         // add a key
-        AbstractResponse cachedResponse = cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db", ip -> response1);
+        AbstractResponse cachedResponse = cache.putIfAbsent("127.0.0.1", "path/to/db", ip -> response1);
         assertSame(cachedResponse, response1);
-        assertSame(cachedResponse, cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db", ip -> response1));
-        assertSame(cachedResponse, cache.get(InetAddresses.forString("127.0.0.1"), "path/to/db"));
+        assertSame(cachedResponse, cache.putIfAbsent("127.0.0.1", "path/to/db", ip -> response1));
+        assertSame(cachedResponse, cache.get("127.0.0.1", "path/to/db"));
 
         // evict old key by adding another value
-        cachedResponse = cache.putIfAbsent(InetAddresses.forString("127.0.0.2"), "path/to/db", ip -> response2);
+        cachedResponse = cache.putIfAbsent("127.0.0.2", "path/to/db", ip -> response2);
         assertSame(cachedResponse, response2);
-        assertSame(cachedResponse, cache.putIfAbsent(InetAddresses.forString("127.0.0.2"), "path/to/db", ip -> response2));
-        assertSame(cachedResponse, cache.get(InetAddresses.forString("127.0.0.2"), "path/to/db"));
-        assertNotSame(response1, cache.get(InetAddresses.forString("127.0.0.1"), "path/to/db"));
+        assertSame(cachedResponse, cache.putIfAbsent("127.0.0.2", "path/to/db", ip -> response2));
+        assertSame(cachedResponse, cache.get("127.0.0.2", "path/to/db"));
+        assertNotSame(response1, cache.get("127.0.0.1", "path/to/db"));
     }
 
     public void testCachesNoResult() {
         GeoIpCache cache = new GeoIpCache(1);
         final AtomicInteger count = new AtomicInteger(0);
-        Function<InetAddress, AbstractResponse> countAndReturnNull = (ip) -> {
+        Function<String, AbstractResponse> countAndReturnNull = (ip) -> {
             count.incrementAndGet();
             return null;
         };
 
-        AbstractResponse response = cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db", countAndReturnNull);
+        AbstractResponse response = cache.putIfAbsent("127.0.0.1", "path/to/db", countAndReturnNull);
         assertNull(response);
-        assertNull(cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db", countAndReturnNull));
+        assertNull(cache.putIfAbsent("127.0.0.1", "path/to/db", countAndReturnNull));
         assertEquals(1, count.get());
 
         // the cached value is not actually *null*, it's the NO_RESULT sentinel
-        assertSame(GeoIpCache.NO_RESULT, cache.get(InetAddresses.forString("127.0.0.1"), "path/to/db"));
+        assertSame(GeoIpCache.NO_RESULT, cache.get("127.0.0.1", "path/to/db"));
     }
 
     public void testCacheKey() {
@@ -67,17 +65,17 @@ public class GeoIpCacheTests extends ESTestCase {
         AbstractResponse response1 = mock(AbstractResponse.class);
         AbstractResponse response2 = mock(AbstractResponse.class);
 
-        assertSame(response1, cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db1", ip -> response1));
-        assertSame(response2, cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db2", ip -> response2));
-        assertSame(response1, cache.get(InetAddresses.forString("127.0.0.1"), "path/to/db1"));
-        assertSame(response2, cache.get(InetAddresses.forString("127.0.0.1"), "path/to/db2"));
+        assertSame(response1, cache.putIfAbsent("127.0.0.1", "path/to/db1", ip -> response1));
+        assertSame(response2, cache.putIfAbsent("127.0.0.1", "path/to/db2", ip -> response2));
+        assertSame(response1, cache.get("127.0.0.1", "path/to/db1"));
+        assertSame(response2, cache.get("127.0.0.1", "path/to/db2"));
     }
 
     public void testThrowsFunctionsException() {
         GeoIpCache cache = new GeoIpCache(1);
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> cache.putIfAbsent(InetAddresses.forString("127.0.0.1"), "path/to/db", ip -> {
+            () -> cache.putIfAbsent("127.0.0.1", "path/to/db", ip -> {
                 throw new IllegalArgumentException("bad");
             })
         );
@@ -96,9 +94,9 @@ public class GeoIpCacheTests extends ESTestCase {
         GeoIpCache cache = new GeoIpCache(maxCacheSize, () -> testNanoTime.addAndGet(TimeValue.timeValueMillis(1).getNanos()));
         AbstractResponse response = mock(AbstractResponse.class);
         String databasePath = "path/to/db1";
-        InetAddress key1 = InetAddresses.forString("127.0.0.1");
-        InetAddress key2 = InetAddresses.forString("127.0.0.2");
-        InetAddress key3 = InetAddresses.forString("127.0.0.3");
+        String key1 = "127.0.0.1";
+        String key2 = "127.0.0.2";
+        String key3 = "127.0.0.3";
 
         cache.putIfAbsent(key1, databasePath, ip -> response); // cache miss
         cache.putIfAbsent(key2, databasePath, ip -> response); // cache miss

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -287,9 +287,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
     public void testBuildUnsupportedDatabase() throws Exception {
         // mock up some unsupported database (it has a databaseType that we don't recognize)
-        GeoIpDatabase database = mock(GeoIpDatabase.class);
+        IpDatabase database = mock(IpDatabase.class);
         when(database.getDatabaseType()).thenReturn("some-unsupported-database");
-        GeoIpDatabaseProvider provider = mock(GeoIpDatabaseProvider.class);
+        IpDatabaseProvider provider = mock(IpDatabaseProvider.class);
         when(provider.getDatabase(anyString())).thenReturn(database);
 
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(provider);
@@ -306,9 +306,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
     public void testBuildNullDatabase() throws Exception {
         // mock up a provider that returns a null databaseType
-        GeoIpDatabase database = mock(GeoIpDatabase.class);
+        IpDatabase database = mock(IpDatabase.class);
         when(database.getDatabaseType()).thenReturn(null);
-        GeoIpDatabaseProvider provider = mock(GeoIpDatabaseProvider.class);
+        IpDatabaseProvider provider = mock(IpDatabaseProvider.class);
         when(provider.getDatabase(anyString())).thenReturn(database);
 
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(provider);

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -785,7 +785,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
 
-    private CheckedSupplier<GeoIpDatabase, IOException> loader(final String path) {
+    private CheckedSupplier<IpDatabase, IOException> loader(final String path) {
         var loader = loader(path, null);
         return () -> loader;
     }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MaxMindSupportTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MaxMindSupportTests.java
@@ -57,7 +57,7 @@ import static org.hamcrest.Matchers.equalTo;
  * - Fail if we add support for a new mmdb file type (enterprise for example) but don't update the test with which fields we do and do not
  *   support.
  * - Fail if MaxMind adds a new mmdb file type that we don't know about
- * - Fail if we expose a MaxMind type through GeoIpDatabase, but don't update the test to know how to handle it
+ * - Fail if we expose a MaxMind type through IpDatabase, but don't update the test to know how to handle it
  */
 public class MaxMindSupportTests extends ESTestCase {
 
@@ -469,7 +469,7 @@ public class MaxMindSupportTests extends ESTestCase {
     }
 
     /*
-     * This tests that this test has a mapping in TYPE_TO_MAX_MIND_CLASS for all MaxMind classes exposed through GeoIpDatabase.
+     * This tests that this test has a mapping in TYPE_TO_MAX_MIND_CLASS for all MaxMind classes exposed through IpDatabase.
      */
     public void testUsedMaxMindResponseClassesAreAccountedFor() {
         Set<Class<? extends AbstractResponse>> usedMaxMindResponseClasses = getUsedMaxMindResponseClasses();
@@ -479,7 +479,7 @@ public class MaxMindSupportTests extends ESTestCase {
             supportedMaxMindClasses
         );
         assertThat(
-            "GeoIpDatabase exposes MaxMind response classes that this test does not know what to do with. Add mappings to "
+            "IpDatabase exposes MaxMind response classes that this test does not know what to do with. Add mappings to "
                 + "TYPE_TO_MAX_MIND_CLASS for the following: "
                 + usedButNotSupportedMaxMindResponseClasses,
             usedButNotSupportedMaxMindResponseClasses,
@@ -490,7 +490,7 @@ public class MaxMindSupportTests extends ESTestCase {
             usedMaxMindResponseClasses
         );
         assertThat(
-            "This test claims to support MaxMind response classes that are not exposed in GeoIpDatabase. Remove the following from "
+            "This test claims to support MaxMind response classes that are not exposed in IpDatabase. Remove the following from "
                 + "TYPE_TO_MAX_MIND_CLASS: "
                 + supportedButNotUsedMaxMindClasses,
             supportedButNotUsedMaxMindClasses,
@@ -618,11 +618,11 @@ public class MaxMindSupportTests extends ESTestCase {
     }
 
     /*
-     * This returns all AbstractResponse classes that are returned from getter methods on GeoIpDatabase.
+     * This returns all AbstractResponse classes that are returned from getter methods on IpDatabase.
      */
     private static Set<Class<? extends AbstractResponse>> getUsedMaxMindResponseClasses() {
         Set<Class<? extends AbstractResponse>> result = new HashSet<>();
-        Method[] methods = GeoIpDatabase.class.getMethods();
+        Method[] methods = IpDatabase.class.getMethods();
         for (Method method : methods) {
             if (method.getName().startsWith("get")) {
                 Class<?> returnType = method.getReturnType();


### PR DESCRIPTION
Renames two of the interfaces used by the `geoip` processor, and makes them '`String`-centric' rather than '`InetAddress`-centric'. Additionally, it reworks the implementation of the interface to rely on the lower-level `com.maxmind.db.Reader` rather than the higher-level `com.maxmind.geoip2.DatabaseReader`.

This PR is intended as an internal refactoring only, there's not supposed to be any user-facing consequences of this change[^1].

This is related to some of the work I've been doing on #109655, and which I'm trying to bring to `main` a bit at a time -- after this PR has been merged I'll be able to merge `main` into that PR and drop a lot of WIP from my machine.

This PR is finished work, and it's intended to be reviewable and merge-able as is, but I don't want to get overly focused on the precise details of the internal implementation -- some of it is [Falsework](https://en.wikipedia.org/wiki/Falsework) that will be smoothed out in subsequent PRs. That's not meant to preclude there being discussion about it, though, of course!

[^1]: Note: actually, though, it results in a ~10% speed up in the cache-hit -heavy case because it puts `InetAddress` parsing on the cache-miss path (only) rather than on the cache-hit and cache-miss paths.