### PR TITLE
Revert: emit deprecation warning when executing one of the rollup APIs (#112807)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -853,9 +853,6 @@ buildRestTests.setups['library'] = '''
 
 '''
 buildRestTests.setups['sensor_rollup_job'] = '''
-  - requires:
-      test_runner_features: [ "allowed_warnings" ]
-
   - do:
       indices.create:
         index: dummy-rollup-index
@@ -886,10 +883,9 @@ buildRestTests.setups['sensor_rollup_job'] = '''
               node:
                 type: keyword
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
-      rollup.put_job:
-        id: sensor
+      raw:
+        method: PUT
+        path: _rollup/job/sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -919,9 +915,6 @@ buildRestTests.setups['sensor_rollup_job'] = '''
             }
 '''
 buildRestTests.setups['sensor_started_rollup_job'] = '''
-  - requires:
-      test_runner_features: [ "allowed_warnings" ]
-
   - do:
       indices.create:
         index: dummy-rollup-index
@@ -971,10 +964,9 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
           {"timestamp": 1516297294000, "temperature": 202, "voltage": 4.0, "node": "c"}
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
-      rollup.put_job:
-        id: sensor
+      raw:
+        method: PUT
+        path: _rollup/job/sensor
         body:  >
             {
                 "index_pattern": "sensor-*",
@@ -1003,10 +995,9 @@ buildRestTests.setups['sensor_started_rollup_job'] = '''
                 ]
             }
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
-      rollup.start_job:
-        id: sensor
+      raw:
+        method: POST
+        path: _rollup/job/sensor/_start
 '''
 
 buildRestTests.setups['sensor_index'] = '''

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -80,7 +80,6 @@ If we have a rollup job named `sensor`, it can be deleted with:
 DELETE _rollup/job/sensor
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which will return the response:
 

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -89,7 +89,6 @@ job can be retrieved with:
 GET _rollup/job/sensor
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The API yields the following response:
 
@@ -193,7 +192,6 @@ PUT _rollup/job/sensor2 <1>
 GET _rollup/job/_all <2>
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 <1> We create a second job with name `sensor2`
 <2> Then request all jobs by using `_all` in the GetJobs API
 

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -281,7 +281,6 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 <1> This configuration enables date histograms to be used on the `timestamp`
 field and `terms` aggregations to be used on the `node` field.
 <2> This configuration defines metrics over two fields: `temperature` and

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -83,7 +83,6 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 We can then retrieve the rollup capabilities of that index pattern (`sensor-*`)
 via the following command:
@@ -93,7 +92,6 @@ via the following command:
 GET _rollup/data/sensor-*
 --------------------------------------------------
 // TEST[continued]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which will yield the following response:
 
@@ -166,7 +164,6 @@ We could also retrieve the same information with a request to `_all`:
 GET _rollup/data/_all
 --------------------------------------------------
 // TEST[continued]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 But note that if we use the concrete index name (`sensor-1`), we'll retrieve no
 rollup capabilities:
@@ -176,7 +173,6 @@ rollup capabilities:
 GET _rollup/data/sensor-1
 --------------------------------------------------
 // TEST[continued]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 [source,console-result]
 ----

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -80,7 +80,6 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 If at a later date, we'd like to determine what jobs and capabilities were
 stored in the `sensor_rollup` index, we can use the get rollup index API:
@@ -90,7 +89,6 @@ stored in the `sensor_rollup` index, we can use the get rollup index API:
 GET /sensor_rollup/_rollup/data
 --------------------------------------------------
 // TEST[continued]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Note how we are requesting the concrete rollup index name (`sensor_rollup`) as
 the first part of the URL. This will yield the following response:
@@ -166,4 +164,3 @@ instead of explicit indices:
 GET /*_rollup/_rollup/data
 --------------------------------------------------
 // TEST[continued]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -105,7 +105,6 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 This rolls up the `sensor-*` pattern and stores the results in `sensor_rollup`.
 To search this rolled up data, we need to use the `_rollup_search` endpoint.
@@ -128,7 +127,6 @@ GET /sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
 // TEST[s/_rollup_search/_rollup_search?filter_path=took,timed_out,terminated_early,_shards,hits,aggregations/]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The query is targeting the `sensor_rollup` data, since this contains the rollup
 data as configured in the job. A `max` aggregation has been used on the
@@ -184,7 +182,6 @@ GET sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[continued]
 // TEST[catch:/illegal_argument_exception/]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 [source,console-result]
 ----
@@ -228,7 +225,6 @@ GET sensor-1,sensor_rollup/_rollup_search <1>
 --------------------------------------------------
 // TEST[continued]
 // TEST[s/_rollup_search/_rollup_search?filter_path=took,timed_out,terminated_early,_shards,hits,aggregations/]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 <1> Note the URI now searches `sensor-1` and `sensor_rollup` at the same time
 
 When the search is executed, the rollup search endpoint does two things:

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -51,7 +51,6 @@ If we have already created a {rollup-job} named `sensor`, it can be started with
 POST _rollup/job/sensor/_start
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which will return the response:
 

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -76,7 +76,6 @@ the indexer has fully stopped. This is accomplished with the
 POST _rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s
 --------------------------------------------------
 // TEST[setup:sensor_started_rollup_job]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The parameter blocks the API call from returning until either the job has moved
 to `STOPPED` or the specified time has elapsed. If the specified time elapses

--- a/docs/reference/rollup/migrating-to-downsampling.asciidoc
+++ b/docs/reference/rollup/migrating-to-downsampling.asciidoc
@@ -51,7 +51,6 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The equivalent <<tsds,time series data stream (TSDS)>> setup that uses downsampling via DSL:
 

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -64,7 +64,6 @@ PUT _rollup/job/sensor
 }
 --------------------------------------------------
 // TEST[setup:sensor_index]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 We give the job the ID of "sensor" (in the url: `PUT _rollup/job/sensor`), and tell it to rollup the index pattern `"sensor-*"`.
 This job will find and rollup any index that matches that pattern. Rollup summaries are then stored in the `"sensor_rollup"` index.
@@ -144,7 +143,6 @@ To start the job, execute this command:
 POST _rollup/job/sensor/_start
 --------------------------------------------------
 // TEST[setup:sensor_rollup_job]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 [discrete]
 ==== Searching the rolled results
@@ -169,7 +167,6 @@ GET /sensor_rollup/_rollup_search
 }
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 It's a simple aggregation that calculates the maximum of the `temperature` field. But you'll notice that it is being sent to the `sensor_rollup`
 index instead of the raw `sensor-*` indices. And you'll also notice that it is using the `_rollup_search` endpoint. Otherwise the syntax
@@ -201,7 +198,6 @@ If you were to execute that query, you'd receive a result that looks like a norm
 ----
 // TESTRESPONSE[s/"took" : 102/"took" : $body.$_path/]
 // TESTRESPONSE[s/"_shards" : \.\.\. /"_shards" : $body.$_path/]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The only notable difference is that Rollup search results have zero `hits`, because we aren't really searching the original, live data any
 more. Otherwise it's identical syntax.
@@ -248,7 +244,6 @@ GET /sensor_rollup/_rollup_search
 }
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 Which returns a corresponding response:
 

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -56,7 +56,6 @@ GET sensor_rollup/_rollup_search
 --------------------------------------------------
 // TEST[setup:sensor_prefab_data]
 // TEST[catch:/illegal_argument_exception/]
-// TEST[warning:The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.]
 
 The response will tell you that the field and aggregation were not possible, because no rollup jobs were found which contained them:
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -157,20 +157,6 @@ public abstract class ESRestTestCase extends ESTestCase {
 
     private static final Pattern SEMANTIC_VERSION_PATTERN = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)\\D?.*");
 
-    private static final String EXPECTED_ROLLUP_WARNING_MESSAGE =
-        "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.";
-    public static final RequestOptions.Builder ROLLUP_REQUESTS_OPTIONS = RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
-        // Either no warning, because of bwc integration test OR
-        // the expected warning, because on current version
-        if (warnings.isEmpty()) {
-            return false;
-        } else if (warnings.size() == 1 && EXPECTED_ROLLUP_WARNING_MESSAGE.equals(warnings.get(0))) {
-            return false;
-        } else {
-            return true;
-        }
-    });
-
     /**
      * Convert the entity from a {@link Response} into a map of maps.
      * Consumes the underlying HttpEntity, releasing any resources it may be holding.
@@ -1288,9 +1274,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     private void wipeRollupJobs() throws IOException {
         final Response response;
         try {
-            var request = new Request("GET", "/_rollup/job/_all");
-            request.setOptions(ROLLUP_REQUESTS_OPTIONS);
-            response = adminClient().performRequest(request);
+            response = adminClient().performRequest(new Request("GET", "/_rollup/job/_all"));
         } catch (ResponseException e) {
             // If we don't see the rollup endpoint (possibly because of running against an older ES version) we just bail
             if (e.getResponse().getStatusLine().getStatusCode() == RestStatus.NOT_FOUND.getStatus()) {
@@ -1310,7 +1294,6 @@ public abstract class ESRestTestCase extends ESTestCase {
             @SuppressWarnings("unchecked")
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
             Request request = new Request("POST", "/_rollup/job/" + jobId + "/_stop");
-            request.setOptions(ROLLUP_REQUESTS_OPTIONS);
             setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND);
             request.addParameter("wait_for_completion", "true");
             request.addParameter("timeout", "10s");
@@ -1322,7 +1305,6 @@ public abstract class ESRestTestCase extends ESTestCase {
             @SuppressWarnings("unchecked")
             String jobId = (String) ((Map<String, Object>) jobConfig.get("config")).get("id");
             Request request = new Request("DELETE", "/_rollup/job/" + jobId);
-            request.setOptions(ROLLUP_REQUESTS_OPTIONS);
             setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND); // 404s imply someone was racing us to delete this
             logger.debug("deleting rollup job [{}]", jobId);
             adminClient().performRequest(request);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -70,10 +70,6 @@ import java.util.function.Supplier;
 
 public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin {
 
-    public static final String DEPRECATION_MESSAGE =
-        "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.";
-    public static final String DEPRECATION_KEY = "rollup_removal";
-
     // Introduced in ES version 6.3
     public static final int ROLLUP_VERSION_V1 = 1;
     // Introduced in ES Version 6.4

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportDeleteRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportDeleteRollupJobAction.java
@@ -16,8 +16,6 @@ import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.injection.guice.Inject;
@@ -33,16 +31,11 @@ import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.List;
 
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
-
 public class TransportDeleteRollupJobAction extends TransportTasksAction<
     RollupJobTask,
     DeleteRollupJobAction.Request,
     DeleteRollupJobAction.Response,
     DeleteRollupJobAction.Response> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportDeleteRollupJobAction.class);
 
     @Inject
     public TransportDeleteRollupJobAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
@@ -59,7 +52,6 @@ public class TransportDeleteRollupJobAction extends TransportTasksAction<
 
     @Override
     protected void doExecute(Task task, DeleteRollupJobAction.Request request, ActionListener<DeleteRollupJobAction.Response> listener) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         final ClusterState state = clusterService.state();
         final DiscoveryNodes nodes = state.nodes();
 
@@ -101,6 +93,7 @@ public class TransportDeleteRollupJobAction extends TransportTasksAction<
         RollupJobTask jobTask,
         ActionListener<DeleteRollupJobAction.Response> listener
     ) {
+
         assert jobTask.getConfig().getId().equals(request.getId());
         IndexerState state = ((RollupJobStatus) jobTask.getStatus()).getIndexerState();
         if (state.equals(IndexerState.STOPPED)) {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupCapsAction.java
@@ -14,8 +14,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -34,12 +32,7 @@ import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
-
 public class TransportGetRollupCapsAction extends HandledTransportAction<GetRollupCapsAction.Request, GetRollupCapsAction.Response> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportGetRollupCapsAction.class);
 
     private final ClusterService clusterService;
     private final Executor managementExecutor;
@@ -60,7 +53,6 @@ public class TransportGetRollupCapsAction extends HandledTransportAction<GetRoll
 
     @Override
     protected void doExecute(Task task, GetRollupCapsAction.Request request, ActionListener<GetRollupCapsAction.Response> listener) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         // Workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
         managementExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(request.getIndexPattern(), l)));
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
@@ -14,8 +14,6 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -34,14 +32,9 @@ import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
-
 public class TransportGetRollupIndexCapsAction extends HandledTransportAction<
     GetRollupIndexCapsAction.Request,
     GetRollupIndexCapsAction.Response> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportGetRollupCapsAction.class);
 
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver resolver;
@@ -73,7 +66,6 @@ public class TransportGetRollupIndexCapsAction extends HandledTransportAction<
         GetRollupIndexCapsAction.Request request,
         ActionListener<GetRollupIndexCapsAction.Response> listener
     ) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         // Workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
         managementExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(request, l)));
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupJobAction.java
@@ -16,8 +16,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.injection.guice.Inject;
@@ -36,16 +34,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
-
 public class TransportGetRollupJobAction extends TransportTasksAction<
     RollupJobTask,
     GetRollupJobsAction.Request,
     GetRollupJobsAction.Response,
     GetRollupJobsAction.Response> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportGetRollupCapsAction.class);
 
     @Inject
     public TransportGetRollupJobAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
@@ -62,7 +55,6 @@ public class TransportGetRollupJobAction extends TransportTasksAction<
 
     @Override
     protected void doExecute(Task task, GetRollupJobsAction.Request request, ActionListener<GetRollupJobsAction.Response> listener) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         final ClusterState state = clusterService.state();
         final DiscoveryNodes nodes = state.nodes();
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -63,13 +63,10 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.core.ClientHelper.assertNoAuthorizationHeader;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
 
 public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNodeAction<PutRollupJobAction.Request> {
 
     private static final Logger LOGGER = LogManager.getLogger(TransportPutRollupJobAction.class);
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportPutRollupJobAction.class);
     private static final XContentParserConfiguration PARSER_CONFIGURATION = XContentParserConfiguration.EMPTY.withFiltering(
         Set.of("_doc._meta._rollup"),
         null,
@@ -78,6 +75,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
 
     private final PersistentTasksService persistentTasksService;
     private final Client client;
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TransportPutRollupJobAction.class);
 
     @Inject
     public TransportPutRollupJobAction(
@@ -111,7 +109,6 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         ClusterState clusterState,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
         checkForDeprecatedTZ(request);
 
@@ -153,7 +150,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         String timeZone = request.getConfig().getGroupConfig().getDateHistogram().getTimeZone();
         String modernTZ = DateUtils.DEPRECATED_LONG_TIMEZONES.get(timeZone);
         if (modernTZ != null) {
-            DEPRECATION_LOGGER.warn(
+            deprecationLogger.warn(
                 DeprecationCategory.PARSING,
                 "deprecated_timezone",
                 "Creating Rollup job ["

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -27,8 +27,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -75,12 +73,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
 
 public class TransportRollupSearchAction extends TransportAction<SearchRequest, SearchResponse> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportRollupSearchAction.class);
 
     private final Client client;
     private final NamedWriteableRegistry registry;
@@ -121,7 +115,6 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
 
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         String[] indices = resolver.concreteIndexNames(clusterService.state(), request);
         RollupSearchContext rollupSearchContext = separateIndices(indices, clusterService.state().getMetadata().indices());
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
@@ -13,28 +13,20 @@ import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.CancellableTask;
-import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.List;
 
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
-
 public class TransportStartRollupAction extends TransportTasksAction<
     RollupJobTask,
     StartRollupJobAction.Request,
     StartRollupJobAction.Response,
     StartRollupJobAction.Response> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportStartRollupAction.class);
 
     @Inject
     public TransportStartRollupAction(TransportService transportService, ActionFilters actionFilters, ClusterService clusterService) {
@@ -52,12 +44,6 @@ public class TransportStartRollupAction extends TransportTasksAction<
     @Override
     protected List<RollupJobTask> processTasks(StartRollupJobAction.Request request) {
         return TransportTaskHelper.doProcessTasks(request.getId(), taskManager);
-    }
-
-    @Override
-    protected void doExecute(Task task, StartRollupJobAction.Request request, ActionListener<StartRollupJobAction.Response> listener) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
-        super.doExecute(task, request, listener);
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
@@ -14,8 +14,6 @@ import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.injection.guice.Inject;
@@ -31,16 +29,11 @@ import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_KEY;
-import static org.elasticsearch.xpack.rollup.Rollup.DEPRECATION_MESSAGE;
-
 public class TransportStopRollupAction extends TransportTasksAction<
     RollupJobTask,
     StopRollupJobAction.Request,
     StopRollupJobAction.Response,
     StopRollupJobAction.Response> {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(TransportStopRollupAction.class);
 
     private final ThreadPool threadPool;
 
@@ -70,7 +63,6 @@ public class TransportStopRollupAction extends TransportTasksAction<
 
     @Override
     protected void doExecute(Task task, StopRollupJobAction.Request request, ActionListener<StopRollupJobAction.Response> listener) {
-        DEPRECATION_LOGGER.warn(DeprecationCategory.API, DEPRECATION_KEY, DEPRECATION_MESSAGE);
         super.doExecute(task, request, listener);
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/delete_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/delete_job.yml
@@ -1,8 +1,6 @@
 setup:
-  - requires:
-    test_runner_features: [ "allowed_warnings" ]
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -50,16 +48,11 @@ setup:
               }
             ]
           }
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
 
 ---
 "Test basic delete_job":
-  - requires:
-    test_runner_features: ["allowed_warnings"]
+
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -100,15 +93,11 @@ setup:
             job_state: "stopped"
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.delete_job:
         id: foo
   - is_true: acknowledged
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
   - match:
@@ -118,8 +107,6 @@ setup:
 "Test delete job twice":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -160,15 +147,11 @@ setup:
             job_state: "stopped"
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.delete_job:
         id: foo
   - is_true: acknowledged
 
   - do:
-      allowed_warnings:
-        - The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.
       rollup.get_jobs:
         id: foo
   - match:
@@ -178,8 +161,6 @@ setup:
 "Test delete running job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -220,15 +201,11 @@ setup:
             job_state: "stopped"
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.start_job:
         id: foo
   - is_true: started
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: request
       rollup.delete_job:
         id: foo
@@ -240,8 +217,6 @@ setup:
 "Test delete non-existent job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /the task with id \[does_not_exist\] doesn't exist/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_jobs.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_jobs.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -29,8 +29,6 @@ setup:
 "Test basic get_jobs":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -57,8 +55,6 @@ setup:
   - is_true: acknowledged
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -101,8 +97,6 @@ setup:
 "Test get with no jobs":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: "_all"
 
@@ -112,8 +106,6 @@ setup:
 "Test get missing job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_caps.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -46,8 +46,6 @@ setup:
                 my-id: { }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -80,8 +78,6 @@ setup:
 "Verify one job caps":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_caps:
         id: "foo"
 
@@ -105,8 +101,6 @@ setup:
 "Verify two job caps":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -131,8 +125,6 @@ setup:
             ]
           }
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_caps:
         id: "foo"
 
@@ -168,8 +160,6 @@ setup:
 "Verify all caps":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -195,8 +185,6 @@ setup:
           }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -222,8 +210,6 @@ setup:
           }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_caps:
         id: "_all"
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/get_rollup_index_caps.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -47,8 +47,6 @@ setup:
                 my-id: { }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -81,8 +79,6 @@ setup:
 "Verify one job caps by rollup index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "foo_rollup"
 
@@ -106,8 +102,6 @@ setup:
 "Verify two job caps by rollup index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -132,8 +126,6 @@ setup:
             ]
           }
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "foo_rollup"
 
@@ -170,8 +162,6 @@ setup:
 "Verify two different job caps by rollup index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -200,8 +190,6 @@ setup:
         index: "foo_rollup"
 
   - match:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       foo_rollup:
         rollup_jobs:
           - job_id: "foo"
@@ -221,8 +209,6 @@ setup:
 "Verify all job caps by rollup index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -247,8 +233,6 @@ setup:
             ]
           }
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -274,8 +258,6 @@ setup:
           }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "_all"
 
@@ -326,8 +308,6 @@ setup:
 "Verify job caps by rollup index comma delimited list":
 
 - do:
-    allowed_warnings:
-      - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
     headers:
       Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
     rollup.put_job:
@@ -352,8 +332,6 @@ setup:
           ]
         }
 - do:
-    allowed_warnings:
-      - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
     headers:
       Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
     rollup.put_job:
@@ -379,8 +357,6 @@ setup:
         }
 
 - do:
-    allowed_warnings:
-      - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
     rollup.get_rollup_index_caps:
       index: "foo_rollup2,foo_rollup"
 
@@ -431,8 +407,6 @@ setup:
 "Verify index pattern":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -457,8 +431,6 @@ setup:
             ]
           }
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -484,8 +456,6 @@ setup:
           }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_rollup_index_caps:
         index: "*_rollup2"
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/put_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/put_job.yml
@@ -42,8 +42,6 @@ setup:
 ---
 "Test basic put_job":
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -70,8 +68,6 @@ setup:
   - is_true: acknowledged
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: foo
 
@@ -120,8 +116,6 @@ setup:
 "Test put_job with existing name":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -148,8 +142,6 @@ setup:
   - is_true: acknowledged
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Cannot create rollup job \[foo\] because job was previously created \(existing metadata\)/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -181,8 +173,6 @@ setup:
       indices.create:
         index: non-rollup
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Rollup data cannot be added to existing indices that contain non-rollup data/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -213,8 +203,6 @@ setup:
 "Try to include headers":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /unknown field \[headers\]/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -247,8 +235,6 @@ setup:
 "Validation failures":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Could not find a \[numeric\] or \[date,date_nanos\] field with name \[field_doesnt_exist\] in any of the indices matching the index pattern/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -282,8 +268,6 @@ setup:
         index: dummy-rollup-index
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /new rollup jobs are not allowed in clusters that don't have any rollup usage, since rollup has been deprecated/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -313,8 +297,6 @@ setup:
 "Unknown Metric":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Unsupported metric \[does_not_exist\]/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -356,7 +338,6 @@ setup:
   - do:
       allowed_warnings:
         - "index [foo_rollup] matches multiple legacy templates [global, test], composable templates will only match a single template"
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -432,8 +413,6 @@ setup:
       reason: Comma delimited index pattern introduced in 8.2.0
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -460,8 +439,6 @@ setup:
   - is_true: acknowledged
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.get_jobs:
         id: bar
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/rollup_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/rollup_search.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -29,8 +29,6 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.put_job:
         id: foo
         body:  >
@@ -141,8 +139,6 @@ setup:
 "Basic Search":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -170,8 +166,6 @@ setup:
       cluster_features: ["gte_v6.6.0"]
       reason: rest_total_hits_as_int was introduced in 6.6.0
   - do:
-      allowed_warnings:
-        - The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information.
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -197,8 +191,6 @@ setup:
 "Formatted Date Histo":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -225,8 +217,6 @@ setup:
 "Empty aggregation":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         rest_total_hits_as_int: true
         index: "foo_rollup"
@@ -242,8 +232,6 @@ setup:
 "Empty aggregation with new response format":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -261,8 +249,6 @@ setup:
 "Search with Metric":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -296,8 +282,6 @@ setup:
 "Search with Query":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -333,8 +317,6 @@ setup:
 "Search with MatchAll and Second Job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -445,8 +427,6 @@ setup:
 
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -480,8 +460,6 @@ setup:
 "Search with Query and Second Job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -592,8 +570,6 @@ setup:
 
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -629,8 +605,6 @@ setup:
 "Search with Query and Second Job different intervals":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -740,8 +714,6 @@ setup:
             "_rollup.version": 1
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         body:
@@ -777,8 +749,6 @@ setup:
 "Wildcards matching single rollup index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup*"
         body:
@@ -817,8 +787,6 @@ setup:
                 type: integer
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -869,8 +837,6 @@ setup:
         name: rollup_alias
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "rollup_alias"
         body:
@@ -909,8 +875,6 @@ setup:
                 type: integer
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -944,8 +908,6 @@ setup:
         name: rollup_alias
 
   - do:
-       allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
        catch: /RollupSearch currently only supports searching one rollup index at a time\./
        rollup.rollup_search:
          index: "rollup_alias"
@@ -981,8 +943,6 @@ setup:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       warnings:
         - "Creating Rollup job [tz] with timezone [Canada/Mountain], but [Canada/Mountain] has been deprecated by the IANA.  Use [America/Edmonton] instead."
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.put_job:
         id: tz
         body:  >
@@ -1052,8 +1012,6 @@ setup:
             "_rollup.version": 2
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1081,8 +1039,6 @@ setup:
   - match: { aggregations.histo.buckets.2.the_max.value: 3 }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1206,8 +1162,6 @@ setup:
             "_rollup.version": 2
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1236,8 +1190,6 @@ setup:
 
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "tz_rollup"
         body:
@@ -1269,8 +1221,6 @@ setup:
 "Search with typed_keys":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       rollup.rollup_search:
         index: "foo_rollup"
         typed_keys: true
@@ -1304,8 +1254,6 @@ setup:
 "Search error against live index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: bad_request
       rollup.rollup_search:
         index: "foo"
@@ -1322,8 +1270,6 @@ setup:
 "Search error against rollup and live index":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: bad_request
       rollup.rollup_search:
         index: "foo*"
@@ -1339,8 +1285,6 @@ setup:
 "Search error no matching indices":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Must specify at least one concrete index/
       rollup.rollup_search:
         index: "bar*"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/start_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/start_job.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -25,8 +25,6 @@ setup:
                 my-id: { }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -55,8 +53,6 @@ setup:
 "Test start nonexistent job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Task for Rollup Job \[does_not_exist\] not found/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -68,8 +64,6 @@ setup:
 "Test start job twice":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -77,8 +71,6 @@ setup:
   - is_true: started
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/stop_job.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rollup/stop_job.yml
@@ -1,6 +1,6 @@
 setup:
   - skip:
-      features: ["allowed_warnings", "headers"]
+      features: headers
   - do:
       indices.create:
         index: foo
@@ -25,8 +25,6 @@ setup:
                 my-id: { }
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:
@@ -55,8 +53,6 @@ setup:
 "Test stop nonexistent job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       catch: /Task for Rollup Job \[does_not_exist\] not found/
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
@@ -68,8 +64,6 @@ setup:
 "Test stop job twice":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -77,8 +71,6 @@ setup:
   - is_true: started
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -86,8 +78,6 @@ setup:
   - is_true: stopped
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -98,8 +88,6 @@ setup:
 "Test stop non-started job":
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -110,8 +98,6 @@ setup:
 ---
 "Test wait_for_completion default timeout":
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -119,8 +105,6 @@ setup:
   - is_true: started
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:
@@ -131,8 +115,6 @@ setup:
 ---
 "Test wait_for_completion with custom timeout":
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.start_job:
@@ -140,8 +122,6 @@ setup:
   - is_true: started
 
   - do:
-      allowed_warnings:
-        - "The rollup functionality will be removed in in Elasticsearch 9.0. See docs for more information."
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.stop_job:

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -471,7 +471,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
             // create the rollup job
             final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
-            createRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
+
             String intervalType;
             if (clusterHasFeature(RestTestLegacyFeatures.SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM)) {
                 intervalType = "fixed_interval";
@@ -504,7 +504,6 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
             // start the rollup job
             final Request startRollupJobRequest = new Request("POST", "/_rollup/job/rollup-job-test/_start");
-            startRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Map<String, Object> startRollupJobResponse = entityAsMap(client().performRequest(startRollupJobRequest));
             assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -884,7 +883,6 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
         // check that the rollup job is started using the RollUp API
         final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
-        getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         Map<String, Object> getRollupJobResponse = entityAsMap(client().performRequest(getRollupJobRequest));
         Map<?, ?> job = getJob(getRollupJobResponse, rollupJob);
         assertNotNull(job);
@@ -927,7 +925,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
     private void waitForRollUpJob(final String rollupJob, final Matcher<?> expectedStates) throws Exception {
         assertBusy(() -> {
             final Request getRollupJobRequest = new Request("GET", "/_rollup/job/" + rollupJob);
-            getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
+
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 

--- a/x-pack/qa/multi-node/src/javaRestTest/java/org/elasticsearch/multi_node/RollupIT.java
+++ b/x-pack/qa/multi-node/src/javaRestTest/java/org/elasticsearch/multi_node/RollupIT.java
@@ -128,7 +128,6 @@ public class RollupIT extends ESRestTestCase {
 
         // create the rollup job
         final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
-        createRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         int pageSize = randomIntBetween(2, 50);
         // fast cron so test runs quickly
         createRollupJobRequest.setJsonEntity(Strings.format("""
@@ -155,13 +154,11 @@ public class RollupIT extends ESRestTestCase {
                 ]
             }""", pageSize));
 
-        assertWarnings();
         var createRollupJobResponse = responseAsMap(client().performRequest(createRollupJobRequest));
         assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
         // start the rollup job
         final Request startRollupJobRequest = new Request("POST", "_rollup/job/rollup-job-test/_start");
-        startRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         var startRollupJobResponse = responseAsMap(client().performRequest(startRollupJobRequest));
         assertThat(startRollupJobResponse.get("started"), equalTo(Boolean.TRUE));
 
@@ -170,7 +167,6 @@ public class RollupIT extends ESRestTestCase {
         // Wait for the job to finish, by watching how many rollup docs we've indexed
         assertBusy(() -> {
             final Request getRollupJobRequest = new Request("GET", "_rollup/job/rollup-job-test");
-            getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 
@@ -215,7 +211,6 @@ public class RollupIT extends ESRestTestCase {
         var liveBody = responseAsMap(liveResponse);
 
         request = new Request("GET", "results-rollup/_rollup_search");
-        request.setOptions(ROLLUP_REQUESTS_OPTIONS);
         request.setJsonEntity(jsonRequestBody);
         Response rollupResponse = client().performRequest(request);
         var rollupBody = responseAsMap(rollupResponse);
@@ -228,7 +223,6 @@ public class RollupIT extends ESRestTestCase {
 
         request = new Request("GET", "rollup-docs/_rollup_search");
         request.setJsonEntity(jsonRequestBody);
-        request.setOptions(ROLLUP_REQUESTS_OPTIONS);
         Response liveRollupResponse = client().performRequest(request);
         var liveRollupBody = responseAsMap(liveRollupResponse);
 
@@ -247,7 +241,6 @@ public class RollupIT extends ESRestTestCase {
 
         // check that the rollup job is started using the RollUp API
         final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
-        getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
         var getRollupJobResponse = responseAsMap(client().performRequest(getRollupJobRequest));
         Map<?, ?> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
@@ -293,7 +286,6 @@ public class RollupIT extends ESRestTestCase {
     private void waitForRollUpJob(final String rollupJob, String[] expectedStates) throws Exception {
         assertBusy(() -> {
             final Request getRollupJobRequest = new Request("GET", "_rollup/job/" + rollupJob);
-            getRollupJobRequest.setOptions(ROLLUP_REQUESTS_OPTIONS);
             Response getRollupJobResponse = client().performRequest(getRollupJobRequest);
             assertThat(getRollupJobResponse.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 


### PR DESCRIPTION
This reverts commit 3d6e9a2850a5d91c7fee0dbe6153903b909c4937, because the original change is causing xpack rest test failures in other repositories.