### PR TITLE
Initial entitlements agent for System.exit

### DIFF
--- a/distribution/tools/entitlements-agent/build.gradle
+++ b/distribution/tools/entitlements-agent/build.gradle
@@ -1,0 +1,48 @@
+import static java.util.stream.Collectors.joining
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+apply plugin: 'elasticsearch.build'
+
+base {
+  archivesName = 'elasticsearch-entitlements-agent'
+}
+
+configurations {
+  entitlementRuntime
+}
+
+dependencies {
+  entitlementRuntime project(":libs:elasticsearch-entitlements-runtime")
+  implementation project(":libs:elasticsearch-entitlements-runtime")
+  implementation 'org.ow2.asm:asm:9.7'
+  testImplementation project(":test:framework")
+}
+
+tasks.named("test").configure {
+  systemProperty "tests.security.manager", "false"
+}
+
+test {
+  dependsOn(jar)
+  def runtimeJars = configurations.entitlementRuntime.files.stream().map(File::toString).collect(joining(File.pathSeparator))
+  jvmArgs "-Dentitlements.runtimeJars=$runtimeJars"
+  jvmArgs "-javaagent:${jar.archiveFile.get().asFile}"
+}
+
+jar {
+  manifest {
+    attributes(
+      'Premain-Class': 'org.elasticsearch.entitlements.agent.Agent'
+      , 'Can-Retransform-Classes': 'true'
+    )
+  }
+}
+

--- a/distribution/tools/entitlements-agent/build.gradle
+++ b/distribution/tools/entitlements-agent/build.gradle
@@ -11,10 +11,6 @@ import static java.util.stream.Collectors.joining
 
 apply plugin: 'elasticsearch.build'
 
-base {
-  archivesName = 'elasticsearch-entitlements-agent'
-}
-
 configurations {
   entitlementRuntime
 }

--- a/distribution/tools/entitlements-agent/build.gradle
+++ b/distribution/tools/entitlements-agent/build.gradle
@@ -1,5 +1,3 @@
-import static java.util.stream.Collectors.joining
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the "Elastic License
@@ -28,8 +26,6 @@ tasks.named("test").configure {
 
 test {
   dependsOn(jar)
-  def runtimeJars = configurations.entitlementRuntime.files.stream().map(File::toString).collect(joining(File.pathSeparator))
-  jvmArgs "-Dentitlements.runtimeJars=$runtimeJars"
   jvmArgs "-javaagent:${jar.archiveFile.get().asFile}"
 }
 

--- a/distribution/tools/entitlements-agent/src/main/java/module-info.java
+++ b/distribution/tools/entitlements-agent/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module elasticsearch.entitlements.agent {
+    requires java.instrument;
+    requires org.elasticsearch.entitlements.runtime;
+    requires org.objectweb.asm;
+}

--- a/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/agent/Agent.java
+++ b/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/agent/Agent.java
@@ -11,11 +11,12 @@ package org.elasticsearch.entitlements.agent;
 
 import org.elasticsearch.entitlements.instrumentation.Instrumenter;
 import org.elasticsearch.entitlements.instrumentation.MethodKey;
+import org.elasticsearch.entitlements.runtime.api.EntitlementChecks;
 import org.elasticsearch.entitlements.runtime.config.SystemMethods;
 
-import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.JarFile;
@@ -26,13 +27,10 @@ public class Agent {
 
     public static void premain(String agentArgs, Instrumentation inst) throws Exception {
         // System.out.println("Starting premain");
-        var jarsString = System.getProperty("entitlements.runtimeJars");
-        if (jarsString != null) {
-            for (var jar : jarsString.split(File.pathSeparator)) {
-                // System.out.println("Adding jar " + jar);
-                inst.appendToBootstrapClassLoaderSearch(new JarFile(jar));
-            }
-        }
+
+        // Add the runtime library (the one with the entitlement checks) to the bootstrap classpath
+        var jar = Paths.get(EntitlementChecks.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile();
+        inst.appendToBootstrapClassLoaderSearch(new JarFile(jar));
 
         // Hardcoded config for now
         Method targetMethod = System.class.getDeclaredMethod("exit", int.class);

--- a/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/agent/Agent.java
+++ b/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/agent/Agent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.agent;
+
+import org.elasticsearch.entitlements.instrumentation.Instrumenter;
+import org.elasticsearch.entitlements.instrumentation.MethodKey;
+import org.elasticsearch.entitlements.runtime.config.SystemMethods;
+
+import java.io.File;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarFile;
+
+import static java.util.stream.Collectors.toSet;
+
+public class Agent {
+
+    public static void premain(String agentArgs, Instrumentation inst) throws Exception {
+        // System.out.println("Starting premain");
+        var jarsString = System.getProperty("entitlements.runtimeJars");
+        if (jarsString != null) {
+            for (var jar : jarsString.split(File.pathSeparator)) {
+                // System.out.println("Adding jar " + jar);
+                inst.appendToBootstrapClassLoaderSearch(new JarFile(jar));
+            }
+        }
+
+        // Hardcoded config for now
+        Method targetMethod = System.class.getDeclaredMethod("exit", int.class);
+        Method instrumentationMethod = SystemMethods.class.getDeclaredMethod("exit", Class.class, System.class, int.class);
+        var methodMap = Map.of(MethodKey.forTargetMethod(targetMethod), instrumentationMethod);
+        var classesToInstrument = List.of(System.class);
+
+        inst.addTransformer(
+            new Transformer(new Instrumenter("", methodMap), classesToInstrument.stream().map(Agent::internalName).collect(toSet())),
+            true
+        );
+        // System.out.println("Starting retransformClasses");
+        inst.retransformClasses(classesToInstrument.toArray(new Class<?>[0]));
+        // System.out.println("Finished initialization");
+    }
+
+    private static String internalName(Class<?> c) {
+        return c.getName().replace('.', '/');
+    }
+
+    // private static final Logger LOGGER = LogManager.getLogger(Agent.class);
+}

--- a/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/agent/Transformer.java
+++ b/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/agent/Transformer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.agent;
+
+import org.elasticsearch.entitlements.instrumentation.Instrumenter;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.security.ProtectionDomain;
+import java.util.Set;
+
+/**
+ * A {@link ClassFileTransformer} that applies {@link Instrumenter} to the appropriate classes.
+ */
+public class Transformer implements ClassFileTransformer {
+    private final Instrumenter instrumenter;
+    private final Set<String> classesToTransform;
+
+    public Transformer(Instrumenter instrumenter, Set<String> classesToTransform) {
+        this.instrumenter = instrumenter;
+        this.classesToTransform = classesToTransform;
+        // TODO: Should warn if any MethodKey doesn't match any methods
+    }
+
+    @Override
+    public byte[] transform(
+        ClassLoader loader,
+        String className,
+        Class<?> classBeingRedefined,
+        ProtectionDomain protectionDomain,
+        byte[] classfileBuffer
+    ) {
+        if (classesToTransform.contains(className)) {
+            // System.out.println("Transforming " + className);
+            return instrumenter.instrumentClass(className, classfileBuffer);
+        } else {
+            // System.out.println("Not transforming " + className);
+            return classfileBuffer;
+        }
+    }
+
+    // private static final Logger LOGGER = LogManager.getLogger(Transformer.class);
+}

--- a/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/instrumentation/Instrumenter.java
+++ b/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/instrumentation/Instrumenter.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.instrumentation;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.ClassWriter.COMPUTE_MAXS;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+
+public class Instrumenter {
+    /**
+     * To avoid class name collisions during testing. Should be an empty string in production.
+     */
+    private final String classNameSuffix;
+    private final Map<MethodKey, Method> instrumentationMethods;
+
+    public Instrumenter(String classNameSuffix, Map<MethodKey, Method> instrumentationMethods) {
+        this.classNameSuffix = classNameSuffix;
+        this.instrumentationMethods = instrumentationMethods;
+    }
+
+    public ClassFileInfo instrumentClassFile(Class<?> clazz) throws IOException {
+        ClassFileInfo initial = getClassFileInfo(clazz);
+        return new ClassFileInfo(initial.fileName(), instrumentClass(Type.getInternalName(clazz), initial.bytecodes()));
+    }
+
+    public static ClassFileInfo getClassFileInfo(Class<?> clazz) throws IOException {
+        String internalName = Type.getInternalName(clazz);
+        String fileName = "/" + internalName + ".class";
+        byte[] originalBytecodes;
+        try (InputStream classStream = clazz.getResourceAsStream(fileName)) {
+            if (classStream == null) {
+                throw new IllegalStateException("Classfile not found in jar: " + fileName);
+            }
+            originalBytecodes = classStream.readAllBytes();
+        }
+        return new ClassFileInfo(fileName, originalBytecodes);
+    }
+
+    public byte[] instrumentClass(String className, byte[] classfileBuffer) {
+        ClassReader reader = new ClassReader(classfileBuffer);
+        ClassWriter writer = new ClassWriter(reader, COMPUTE_FRAMES | COMPUTE_MAXS);
+        ClassVisitor visitor = new EntitlementClassVisitor(Opcodes.ASM9, writer, className);
+        reader.accept(visitor, 0);
+        return writer.toByteArray();
+    }
+
+    class EntitlementClassVisitor extends ClassVisitor {
+        final String className;
+
+        EntitlementClassVisitor(int api, ClassVisitor classVisitor, String className) {
+            super(api, classVisitor);
+            this.className = className;
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            super.visit(version, access, name + classNameSuffix, signature, superName, interfaces);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            var mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+            boolean isStatic = (access & ACC_STATIC) != 0;
+            var voidDescriptor = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getArgumentTypes(descriptor));
+            var key = new MethodKey(className, name, voidDescriptor, isStatic);
+            var instrumentationMethod = instrumentationMethods.get(key);
+            if (instrumentationMethod != null) {
+                // LOGGER.debug("Will instrument method {}", key);
+                return new EntitlementMethodVisitor(Opcodes.ASM9, mv, isStatic, descriptor, instrumentationMethod);
+            } else {
+                // LOGGER.trace("Will not instrument method {}", key);
+            }
+            return mv;
+        }
+    }
+
+    static class EntitlementMethodVisitor extends MethodVisitor {
+        private final boolean instrumentedMethodIsStatic;
+        private final String instrumentedMethodDescriptor;
+        private final Method instrumentationMethod;
+        private boolean hasCallerSensitiveAnnotation = false;
+
+        EntitlementMethodVisitor(
+            int api,
+            MethodVisitor methodVisitor,
+            boolean instrumentedMethodIsStatic,
+            String instrumentedMethodDescriptor,
+            Method instrumentationMethod
+        ) {
+            super(api, methodVisitor);
+            this.instrumentedMethodIsStatic = instrumentedMethodIsStatic;
+            this.instrumentedMethodDescriptor = instrumentedMethodDescriptor;
+            this.instrumentationMethod = instrumentationMethod;
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+            if (visible && descriptor.endsWith("CallerSensitive;")) {
+                hasCallerSensitiveAnnotation = true;
+            }
+            return super.visitAnnotation(descriptor, visible);
+        }
+
+        @Override
+        public void visitCode() {
+            pushCallerClass();
+            forwardIncomingArguments();
+            invokeInstrumentationMethod();
+            super.visitCode();
+        }
+
+        private void pushCallerClass() {
+            if (hasCallerSensitiveAnnotation) {
+                mv.visitMethodInsn(INVOKESTATIC, "jdk/internal/reflect/Reflection", "getCallerClass", "()Ljava/lang/Class;", false);
+            } else {
+                mv.visitFieldInsn(GETSTATIC, "java/lang/StackWalker$Option", "RETAIN_CLASS_REFERENCE", "Ljava/lang/StackWalker$Option;");
+                mv.visitMethodInsn(
+                    INVOKESTATIC,
+                    "java/lang/StackWalker",
+                    "getInstance",
+                    "(Ljava/lang/StackWalker$Option;)Ljava/lang/StackWalker;",
+                    false
+                );
+                mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/StackWalker", "getCallerClass", "()Ljava/lang/Class;", false);
+            }
+        }
+
+        private void forwardIncomingArguments() {
+            int localVarIndex = 0;
+            if (instrumentedMethodIsStatic) {
+                // To keep things consistent between static and virtual methods, we pass a null in here,
+                // analogous to how Field and Method accept nulls for static fields/methods.
+                mv.visitInsn(Opcodes.ACONST_NULL);
+            } else {
+                mv.visitVarInsn(Opcodes.ALOAD, localVarIndex++);
+            }
+            for (Type type : Type.getArgumentTypes(instrumentedMethodDescriptor)) {
+                mv.visitVarInsn(type.getOpcode(Opcodes.ILOAD), localVarIndex);
+                localVarIndex += type.getSize();
+            }
+
+        }
+
+        private void invokeInstrumentationMethod() {
+            mv.visitMethodInsn(
+                INVOKESTATIC,
+                Type.getInternalName(instrumentationMethod.getDeclaringClass()),
+                instrumentationMethod.getName(),
+                Type.getMethodDescriptor(instrumentationMethod),
+                false
+            );
+        }
+    }
+
+    // private static final Logger LOGGER = LogManager.getLogger(Instrumenter.class);
+
+    public record ClassFileInfo(String fileName, byte[] bytecodes) {}
+}

--- a/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/instrumentation/MethodKey.java
+++ b/distribution/tools/entitlements-agent/src/main/java/org/elasticsearch/entitlements/instrumentation/MethodKey.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.instrumentation;
+
+import org.objectweb.asm.Type;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ *
+ * @param className the "internal name" of the class: includes the package info, but with periods replaced by slashes
+ * @param methodName
+ * @param voidDescriptor the method descriptor, but with the return type replaced by {@code V}
+ *                       because the return type isn't consulted in the lookup process anyway
+ * @param isStatic
+ */
+public record MethodKey(String className, String methodName, String voidDescriptor, boolean isStatic) {
+    /**
+     * @return a {@link MethodKey} suitable for looking up the given {@code targetMethod} in the entitlements runtime
+     */
+    public static MethodKey forTargetMethod(Method targetMethod) {
+        Type actualType = Type.getMethodType(Type.getMethodDescriptor(targetMethod));
+        String voidDescriptor = Type.getMethodDescriptor(Type.VOID_TYPE, actualType.getArgumentTypes());
+        return new MethodKey(
+            Type.getInternalName(targetMethod.getDeclaringClass()),
+            targetMethod.getName(),
+            voidDescriptor,
+            Modifier.isStatic(targetMethod.getModifiers())
+        );
+    }
+
+}

--- a/distribution/tools/entitlements-agent/src/test/java/org/elasticsearch/entitlements/agent/AgentTests.java
+++ b/distribution/tools/entitlements-agent/src/test/java/org/elasticsearch/entitlements/agent/AgentTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.agent;
+
+import org.elasticsearch.entitlements.runtime.api.EntitlementChecks;
+import org.elasticsearch.entitlements.runtime.api.NotEntitledException;
+import org.elasticsearch.entitlements.runtime.internals.EntitlementInternals;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutSecurityManager;
+import org.junit.After;
+
+/**
+ * This is an end-to-end test that runs with the javaagent installed.
+ * It should exhaustively test every instrumented method to make sure it passes with the entitlement
+ * and fails without it.
+ * See {@code build.gradle} for how we set the command line arguments for this test.
+ */
+@WithoutSecurityManager
+public class AgentTests extends ESTestCase {
+
+    @After
+    public void deactivate() {
+        // Without this, JUnit can't exit
+        EntitlementInternals.isActive = false;
+    }
+
+    /**
+     * We can't really check that this one passes because it will just exit the JVM.
+     */
+    public void test_exitNotEntitled_throws() {
+        EntitlementChecks.activate();
+        assertThrows(NotEntitledException.class, () -> System.exit(123));
+    }
+
+}

--- a/libs/entitlements-runtime/build.gradle
+++ b/libs/entitlements-runtime/build.gradle
@@ -12,8 +12,6 @@ apply plugin: 'elasticsearch.publish'
 dependencies {
   compileOnly project(':libs:elasticsearch-core')
 
-  testImplementation(project(":test:framework")) {
-    exclude group: 'org.elasticsearch', module: 'elasticsearch-entitlements-runtime'
-  }
+  testImplementation project(":test:framework")
 }
 

--- a/libs/entitlements-runtime/build.gradle
+++ b/libs/entitlements-runtime/build.gradle
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
+
+dependencies {
+  compileOnly project(':libs:elasticsearch-core')
+
+  testImplementation(project(":test:framework")) {
+    exclude group: 'org.elasticsearch', module: 'elasticsearch-entitlements-runtime'
+  }
+}
+

--- a/libs/entitlements-runtime/build.gradle
+++ b/libs/entitlements-runtime/build.gradle
@@ -15,3 +15,7 @@ dependencies {
   testImplementation project(":test:framework")
 }
 
+tasks.named('forbiddenApisMain').configure {
+  replaceSignatureFiles 'jdk-signatures'
+}
+

--- a/libs/entitlements-runtime/src/main/java/module-info.java
+++ b/libs/entitlements-runtime/src/main/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module org.elasticsearch.entitlements.runtime {
+    requires org.elasticsearch.base;
+
+    exports org.elasticsearch.entitlements.runtime.api;
+
+    // TODO: Restrict these to the agent
+    exports org.elasticsearch.entitlements.runtime.config;
+
+    opens org.elasticsearch.entitlements.runtime.config;
+}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/Entitlement.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/Entitlement.java
@@ -1,0 +1,3 @@
+package org.elasticsearch.entitlements.runtime.api;
+
+public sealed interface Entitlement permits FlagEntitlement {}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/Entitlement.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/Entitlement.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
 package org.elasticsearch.entitlements.runtime.api;
 
 public sealed interface Entitlement permits FlagEntitlement {}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/EntitlementChecks.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/EntitlementChecks.java
@@ -64,14 +64,14 @@ public class EntitlementChecks {
     }
 
     public static void checkExitJvmEntitlement(Class<?> callerClass) {
-//        System.out.println("Checking for JVM Exit entitlement on " + callerClass.getSimpleName());
+        // System.out.println("Checking for JVM Exit entitlement on " + callerClass.getSimpleName());
         var requestingModule = requestingModule(callerClass);
         if (isTriviallyAllowed(requestingModule)) {
-//            System.out.println(" - Trivially allowed");
+            // System.out.println(" - Trivially allowed");
             return;
         }
         if (entitledToExit.contains(requestingModule)) {
-//            System.out.println(" - Granted");
+            // System.out.println(" - Granted");
             return;
         }
         throw new NotEntitledException("Missing " + EXIT_JVM + " entitlement for " + requestingModule);

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/EntitlementChecks.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/EntitlementChecks.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.runtime.api;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.newSetFromMap;
+import static org.elasticsearch.entitlements.runtime.api.FlagEntitlement.EXIT_JVM;
+import static org.elasticsearch.entitlements.runtime.internals.EntitlementInternals.isActive;
+
+public class EntitlementChecks {
+    private static final Set<Module> entitledToExit = newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * Causes entitlements to be checked. Before this is called, entitlements are not enforced,
+     * so there's no need for an application to set a lot of permissions which are required only during initialization.
+     */
+    public static void activate() {
+        isActive = true;
+    }
+
+    public static void revokeAll() {
+        entitledToExit.clear();
+    }
+
+    public static boolean grant(Module module, Entitlement e) {
+        return switch (e) {
+            case FlagEntitlement __ -> entitledToExit.add(module);
+        };
+    }
+
+    private static Module requestingModule(Class<?> callerClass) {
+        Module callerModule = callerClass.getModule();
+        if (callerModule.getLayer() != ModuleLayer.boot()) {
+            // fast path
+            return callerModule;
+        }
+        int framesToSkip = 1  // getCallingClass (this method)
+            + 1  // the checkXxx method
+            + 1  // the runtime config method
+            + 1  // the instrumented method
+        ;
+        Optional<Module> module = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+            .walk(
+                s -> s.skip(framesToSkip)
+                    .map(f -> f.getDeclaringClass().getModule())
+                    .filter(m -> m.getLayer() != ModuleLayer.boot())
+                    .findFirst()
+            );
+        return module.orElse(null);
+    }
+
+    private static boolean isTriviallyAllowed(Module requestingModule) {
+        return isActive == false || (requestingModule == null) || requestingModule == EntitlementChecks.class.getModule();
+    }
+
+    public static void checkExitJvmEntitlement(Class<?> callerClass) {
+        System.out.println("Checking for JVM Exit entitlement on " + callerClass.getSimpleName());
+        var requestingModule = requestingModule(callerClass);
+        if (isTriviallyAllowed(requestingModule)) {
+            System.out.println(" - Trivially allowed");
+            return;
+        }
+        if (entitledToExit.contains(requestingModule)) {
+            System.out.println(" - Granted");
+            return;
+        }
+        throw new NotEntitledException("Missing " + EXIT_JVM + " entitlement for " + requestingModule);
+    }
+}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/EntitlementChecks.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/EntitlementChecks.java
@@ -64,14 +64,14 @@ public class EntitlementChecks {
     }
 
     public static void checkExitJvmEntitlement(Class<?> callerClass) {
-        System.out.println("Checking for JVM Exit entitlement on " + callerClass.getSimpleName());
+//        System.out.println("Checking for JVM Exit entitlement on " + callerClass.getSimpleName());
         var requestingModule = requestingModule(callerClass);
         if (isTriviallyAllowed(requestingModule)) {
-            System.out.println(" - Trivially allowed");
+//            System.out.println(" - Trivially allowed");
             return;
         }
         if (entitledToExit.contains(requestingModule)) {
-            System.out.println(" - Granted");
+//            System.out.println(" - Granted");
             return;
         }
         throw new NotEntitledException("Missing " + EXIT_JVM + " entitlement for " + requestingModule);

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/FlagEntitlement.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/FlagEntitlement.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.runtime.api;
+
+/**
+ * A simple kind of entitlement that is either present or absent, with no additional structure.
+ */
+public enum FlagEntitlement implements Entitlement {
+    EXIT_JVM,
+}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/NotEntitledException.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/NotEntitledException.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
 package org.elasticsearch.entitlements.runtime.api;
 
 public class NotEntitledException extends RuntimeException {

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/NotEntitledException.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/api/NotEntitledException.java
@@ -1,0 +1,11 @@
+package org.elasticsearch.entitlements.runtime.api;
+
+public class NotEntitledException extends RuntimeException {
+    public NotEntitledException(String message) {
+        super(message);
+    }
+
+    public NotEntitledException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/config/SystemMethods.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/config/SystemMethods.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.runtime.config;
+
+import org.elasticsearch.entitlements.runtime.api.EntitlementChecks;
+
+public class SystemMethods {
+    public static void exit(Class<?> callerCLass, System system, int status) {
+        EntitlementChecks.checkExitJvmEntitlement(callerCLass);
+    }
+}

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/config/package-info.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/config/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/**
+ * Describes which sensitive methods should perform which permission checks.
+ */
+package org.elasticsearch.entitlements.runtime.config;

--- a/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/internals/EntitlementInternals.java
+++ b/libs/entitlements-runtime/src/main/java/org/elasticsearch/entitlements/runtime/internals/EntitlementInternals.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlements.runtime.internals;
+
+public class EntitlementInternals {
+    public static volatile boolean isActive = false;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -91,6 +91,7 @@ List projects = [
   'distribution:tools:keystore-cli',
   'distribution:tools:geoip-cli',
   'distribution:tools:ansi-console',
+  'distribution:tools:entitlements-agent',
   'server',
   'test:framework',
   'test:fixtures:azure-fixture',


### PR DESCRIPTION
Initial minimal agent for entitlements (the `SecurityManager` replacement) that does nothing but forbid `System.exit`.