### PR TITLE
Remove legacy validation of search source in data nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ResolvedIndices;
 import org.elasticsearch.action.search.CanMatchNodeRequest;
 import org.elasticsearch.action.search.CanMatchNodeResponse;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.TransportActions;
@@ -51,7 +50,6 @@ import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
@@ -1257,7 +1255,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (source == null) {
             return;
         }
-        validateSearchSource(source, context.scrollContext() != null);
         SearchShardTarget shardTarget = context.shardTarget();
         SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();
         context.from(source.from());
@@ -1450,49 +1447,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 queries.add(subSearchSourceBuilder.toSearchQuery(context.getSearchExecutionContext()));
             }
             context.queryPhaseRankShardContext(source.rankBuilder().buildQueryPhaseShardContext(queries, context.from()));
-        }
-    }
-
-    /**
-     * Validates the incoming search request on the data node. These checks have been moved to the coordinating node.
-     * Validation is still performed on the data nodes to ensure that in a mixed cluster scenario, when the coordinating node is on an older
-     * version that does not yet perform validation, the shards make up for that.
-     * This method can be entirely removed in the next major version, when all nodes perform the validation when coordinating a search.
-     *
-     * @see SearchRequest#validate()
-     */
-    @UpdateForV9
-    private static void validateSearchSource(SearchSourceBuilder source, boolean hasScroll) {
-        if (source.trackTotalHitsUpTo() != null && source.trackTotalHitsUpTo() != SearchContext.TRACK_TOTAL_HITS_ACCURATE && hasScroll) {
-            throw new IllegalArgumentException("disabling [track_total_hits] is not allowed in a scroll context");
-        }
-        if (CollectionUtils.isEmpty(source.searchAfter()) == false) {
-            if (hasScroll) {
-                throw new IllegalArgumentException("`search_after` cannot be used in a scroll context.");
-            }
-            if (source.from() > 0) {
-                throw new IllegalArgumentException("`from` parameter must be set to 0 when `search_after` is used.");
-            }
-        }
-        if (source.collapse() != null) {
-            if (hasScroll) {
-                throw new IllegalArgumentException("cannot use `collapse` in a scroll context");
-            }
-        }
-        if (source.slice() != null) {
-            if (source.pointInTimeBuilder() == null && (hasScroll == false)) {
-                throw new IllegalArgumentException("[slice] can only be used with [scroll] or [point-in-time] requests");
-            }
-        }
-        if (source.storedFields() != null) {
-            if (source.storedFields().fetchFields() == false) {
-                if (source.fetchSource() != null && source.fetchSource().fetchSource()) {
-                    throw new IllegalArgumentException("[stored_fields] cannot be disabled if [_source] is requested");
-                }
-                if (source.fetchFields() != null) {
-                    throw new IllegalArgumentException("[stored_fields] cannot be disabled when using the [fields] option");
-                }
-            }
         }
     }
 


### PR DESCRIPTION
We moved the validation of incoming search requests from data nodes to coordinating nodes with #105150. The legacy validation performed on the data nodes was left around for bw comp reasons, as there could still be coordinating nodes in the cluster not performing that validation. This is no longer the case in main. This commit removes the validation in favour of validation already performed while coordinating the search request.

Relates to #105150