### PR TITLE
Add extra context to `TransportNodesAction` invocations

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsTransportAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsTransportAction.java
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.List;
 
-public class GeoIpStatsTransportAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse> {
+public class GeoIpStatsTransportAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse, Void> {
 
     private final DatabaseNodeService registry;
     private final GeoIpDownloaderTaskExecutor geoIpDownloaderTaskExecutor;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/TransportNodesCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/TransportNodesCapabilitiesAction.java
@@ -38,7 +38,8 @@ public class TransportNodesCapabilitiesAction extends TransportNodesAction<
     NodesCapabilitiesRequest,
     NodesCapabilitiesResponse,
     TransportNodesCapabilitiesAction.NodeCapabilitiesRequest,
-    NodeCapability> {
+    NodeCapability,
+    Void> {
 
     public static final ActionType<NodesCapabilitiesResponse> TYPE = new ActionType<>("cluster:monitor/nodes/capabilities");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/TransportNodesFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/features/TransportNodesFeaturesAction.java
@@ -33,7 +33,8 @@ public class TransportNodesFeaturesAction extends TransportNodesAction<
     NodesFeaturesRequest,
     NodesFeaturesResponse,
     TransportNodesFeaturesAction.NodeFeaturesRequest,
-    NodeFeatures> {
+    NodeFeatures,
+    Void> {
 
     public static final ActionType<NodesFeaturesResponse> TYPE = new ActionType<>("cluster:monitor/nodes/features");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -38,7 +38,8 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<
     NodesHotThreadsRequest,
     NodesHotThreadsResponse,
     TransportNodesHotThreadsAction.NodeRequest,
-    NodeHotThreads> {
+    NodeHotThreads,
+    Void> {
 
     public static final ActionType<NodesHotThreadsResponse> TYPE = new ActionType<>("cluster:monitor/nodes/hot_threads");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/TransportNodesInfoAction.java
@@ -32,7 +32,8 @@ public class TransportNodesInfoAction extends TransportNodesAction<
     NodesInfoRequest,
     NodesInfoResponse,
     TransportNodesInfoAction.NodeInfoRequest,
-    NodeInfo> {
+    NodeInfo,
+    Void> {
 
     public static final ActionType<NodesInfoResponse> TYPE = new ActionType<>("cluster:monitor/nodes/info");
     private final NodeService nodeService;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -39,7 +39,8 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
     NodesReloadSecureSettingsRequest,
     NodesReloadSecureSettingsResponse,
     NodesReloadSecureSettingsRequest.NodeRequest,
-    NodesReloadSecureSettingsResponse.NodeResponse> {
+    NodesReloadSecureSettingsResponse.NodeResponse,
+    Void> {
 
     public static final ActionType<NodesReloadSecureSettingsResponse> TYPE = new ActionType<>("cluster:admin/nodes/reload_secure_settings");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportPrevalidateShardPathAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportPrevalidateShardPathAction.java
@@ -44,7 +44,8 @@ public class TransportPrevalidateShardPathAction extends TransportNodesAction<
     PrevalidateShardPathRequest,
     PrevalidateShardPathResponse,
     NodePrevalidateShardPathRequest,
-    NodePrevalidateShardPathResponse> {
+    NodePrevalidateShardPathResponse,
+    Void> {
 
     public static final String ACTION_NAME = "internal:admin/indices/prevalidate_shard_path";
     public static final ActionType<PrevalidateShardPathResponse> TYPE = new ActionType<>(ACTION_NAME);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -46,7 +46,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<
     NodesStatsRequest,
     NodesStatsResponse,
     TransportNodesStatsAction.NodeStatsRequest,
-    NodeStats> {
+    NodeStats,
+    Void> {
 
     public static final ActionType<NodesStatsResponse> TYPE = new ActionType<>("cluster:monitor/nodes/stats");
 
@@ -83,6 +84,7 @@ public class TransportNodesStatsAction extends TransportNodesAction<
     protected void newResponseAsync(
         Task task,
         NodesStatsRequest request,
+        Void actionContext,
         List<NodeStats> responses,
         List<FailedNodeException> failures,
         ActionListener<NodesStatsResponse> listener

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/TransportNodesUsageAction.java
@@ -33,7 +33,8 @@ public class TransportNodesUsageAction extends TransportNodesAction<
     NodesUsageRequest,
     NodesUsageResponse,
     TransportNodesUsageAction.NodeUsageRequest,
-    NodeUsage> {
+    NodeUsage,
+    Void> {
 
     public static final ActionType<NodesUsageResponse> TYPE = new ActionType<>("cluster:monitor/nodes/usage");
     private final UsageService restUsageService;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -47,7 +47,8 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
     TransportNodesSnapshotsStatus.Request,
     TransportNodesSnapshotsStatus.NodesSnapshotStatus,
     TransportNodesSnapshotsStatus.NodeRequest,
-    TransportNodesSnapshotsStatus.NodeSnapshotStatus> {
+    TransportNodesSnapshotsStatus.NodeSnapshotStatus,
+    Void> {
 
     public static final String ACTION_NAME = TransportSnapshotsStatusAction.TYPE.name() + "[nodes]";
     public static final ActionType<NodesSnapshotStatus> TYPE = new ActionType<>(ACTION_NAME);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -19,6 +20,8 @@ import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.ClusterSnapshotStats;
 import org.elasticsearch.cluster.ClusterState;
@@ -30,7 +33,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.CancellableSingleObjectCache;
-import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.index.IndexService;
@@ -56,6 +58,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 
@@ -63,7 +66,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
     ClusterStatsRequest,
     ClusterStatsResponse,
     TransportClusterStatsAction.ClusterStatsNodeRequest,
-    ClusterStatsNodeResponse> {
+    ClusterStatsNodeResponse,
+    SubscribableListener<TransportClusterStatsAction.AdditionalStats>> {
 
     public static final ActionType<ClusterStatsResponse> TYPE = new ActionType<>("cluster:monitor/stats");
     private static final CommonStatsFlags SHARD_STATS_FLAGS = new CommonStatsFlags(
@@ -83,6 +87,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
     private final SearchUsageHolder searchUsageHolder;
     private final CCSUsageTelemetry ccsUsageHolder;
 
+    private final Executor clusterStateStatsExecutor;
     private final MetadataStatsCache<MappingStats> mappingStatsCache;
     private final MetadataStatsCache<AnalysisStats> analysisStatsCache;
 
@@ -110,14 +115,32 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         this.repositoriesService = repositoriesService;
         this.searchUsageHolder = usageService.getSearchUsageHolder();
         this.ccsUsageHolder = usageService.getCcsUsageHolder();
+        this.clusterStateStatsExecutor = threadPool.executor(ThreadPool.Names.MANAGEMENT);
         this.mappingStatsCache = new MetadataStatsCache<>(threadPool.getThreadContext(), MappingStats::of);
         this.analysisStatsCache = new MetadataStatsCache<>(threadPool.getThreadContext(), AnalysisStats::of);
+    }
+
+    @Override
+    protected SubscribableListener<AdditionalStats> createActionContext(Task task, ClusterStatsRequest request) {
+        assert task instanceof CancellableTask;
+        final var cancellableTask = (CancellableTask) task;
+        final var additionalStatsListener = new SubscribableListener<AdditionalStats>();
+        AdditionalStats.compute(
+            cancellableTask,
+            clusterStateStatsExecutor,
+            clusterService,
+            mappingStatsCache,
+            analysisStatsCache,
+            additionalStatsListener
+        );
+        return additionalStatsListener;
     }
 
     @Override
     protected void newResponseAsync(
         final Task task,
         final ClusterStatsRequest request,
+        final SubscribableListener<AdditionalStats> additionalStatsListener,
         final List<ClusterStatsNodeResponse> responses,
         final List<FailedNodeException> failures,
         final ActionListener<ClusterStatsResponse> listener
@@ -127,41 +150,19 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                 + "the cluster state that are too slow for a transport thread"
         );
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.MANAGEMENT);
-        assert task instanceof CancellableTask;
-        final CancellableTask cancellableTask = (CancellableTask) task;
-        final ClusterState state = clusterService.state();
-        final Metadata metadata = state.metadata();
-        final ClusterSnapshotStats clusterSnapshotStats = ClusterSnapshotStats.of(
-            state,
-            clusterService.threadPool().absoluteTimeInMillis()
-        );
-
-        final ListenableFuture<MappingStats> mappingStatsStep = new ListenableFuture<>();
-        final ListenableFuture<AnalysisStats> analysisStatsStep = new ListenableFuture<>();
-        mappingStatsCache.get(metadata, cancellableTask::isCancelled, mappingStatsStep);
-        analysisStatsCache.get(metadata, cancellableTask::isCancelled, analysisStatsStep);
-        mappingStatsStep.addListener(
-            listener.delegateFailureAndWrap(
-                (l, mappingStats) -> analysisStatsStep.addListener(
-                    l.delegateFailureAndWrap(
-                        (ll, analysisStats) -> ActionListener.completeWith(
-                            ll,
-                            () -> new ClusterStatsResponse(
-                                System.currentTimeMillis(),
-                                metadata.clusterUUID(),
-                                clusterService.getClusterName(),
-                                responses,
-                                failures,
-                                mappingStats,
-                                analysisStats,
-                                VersionStats.of(metadata, responses),
-                                clusterSnapshotStats
-                            )
-                        )
-                    )
-                )
+        additionalStatsListener.andThenApply(
+            additionalStats -> new ClusterStatsResponse(
+                System.currentTimeMillis(),
+                additionalStats.clusterUUID(),
+                clusterService.getClusterName(),
+                responses,
+                failures,
+                additionalStats.mappingStats(),
+                additionalStats.analysisStats(),
+                VersionStats.of(clusterService.state().metadata(), responses),
+                additionalStats.clusterSnapshotStats()
             )
-        );
+        ).addListener(listener);
     }
 
     @Override
@@ -311,6 +312,69 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         @Override
         protected boolean isFresh(Long currentKey, Long newKey) {
             return newKey <= currentKey;
+        }
+    }
+
+    public static final class AdditionalStats {
+
+        private String clusterUUID;
+        private MappingStats mappingStats;
+        private AnalysisStats analysisStats;
+        private ClusterSnapshotStats clusterSnapshotStats;
+
+        static void compute(
+            CancellableTask task,
+            Executor executor,
+            ClusterService clusterService,
+            MetadataStatsCache<MappingStats> mappingStatsCache,
+            MetadataStatsCache<AnalysisStats> analysisStatsCache,
+            ActionListener<AdditionalStats> listener
+        ) {
+            executor.execute(ActionRunnable.wrap(listener, l -> {
+                task.ensureNotCancelled();
+                final var result = new AdditionalStats();
+                result.compute(
+                    clusterService.state(),
+                    mappingStatsCache,
+                    analysisStatsCache,
+                    task::isCancelled,
+                    clusterService.threadPool().absoluteTimeInMillis(),
+                    l.map(ignored -> result)
+                );
+            }));
+        }
+
+        private void compute(
+            ClusterState clusterState,
+            MetadataStatsCache<MappingStats> mappingStatsCache,
+            MetadataStatsCache<AnalysisStats> analysisStatsCache,
+            BooleanSupplier isCancelledSupplier,
+            long absoluteTimeInMillis,
+            ActionListener<Void> listener
+        ) {
+            try (var listeners = new RefCountingListener(listener)) {
+                final var metadata = clusterState.metadata();
+                clusterUUID = metadata.clusterUUID();
+                mappingStatsCache.get(metadata, isCancelledSupplier, listeners.acquire(s -> mappingStats = s));
+                analysisStatsCache.get(metadata, isCancelledSupplier, listeners.acquire(s -> analysisStats = s));
+                clusterSnapshotStats = ClusterSnapshotStats.of(clusterState, absoluteTimeInMillis);
+            }
+        }
+
+        String clusterUUID() {
+            return clusterUUID;
+        }
+
+        MappingStats mappingStats() {
+            return mappingStats;
+        }
+
+        AnalysisStats analysisStats() {
+            return analysisStats;
+        }
+
+        ClusterSnapshotStats clusterSnapshotStats() {
+            return clusterSnapshotStats;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/TransportFindDanglingIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/find/TransportFindDanglingIndexAction.java
@@ -34,7 +34,8 @@ public class TransportFindDanglingIndexAction extends TransportNodesAction<
     FindDanglingIndexRequest,
     FindDanglingIndexResponse,
     NodeFindDanglingIndexRequest,
-    NodeFindDanglingIndexResponse> {
+    NodeFindDanglingIndexResponse,
+    Void> {
 
     public static final ActionType<FindDanglingIndexResponse> TYPE = new ActionType<>("cluster:admin/indices/dangling/find");
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/TransportListDanglingIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/TransportListDanglingIndicesAction.java
@@ -36,7 +36,8 @@ public class TransportListDanglingIndicesAction extends TransportNodesAction<
     ListDanglingIndicesRequest,
     ListDanglingIndicesResponse,
     NodeListDanglingIndicesRequest,
-    NodeListDanglingIndicesResponse> {
+    NodeListDanglingIndicesResponse,
+    Void> {
 
     public static final ActionType<ListDanglingIndicesResponse> TYPE = new ActionType<>("cluster:admin/indices/dangling/list");
 

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/TransportNodesAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -48,7 +49,8 @@ public abstract class TransportNodesAction<
     NodesRequest extends BaseNodesRequest<NodesRequest>,
     NodesResponse extends BaseNodesResponse<?>,
     NodeRequest extends TransportRequest,
-    NodeResponse extends BaseNodeResponse> extends TransportAction<NodesRequest, NodesResponse> {
+    NodeResponse extends BaseNodeResponse,
+    ActionContext> extends TransportAction<NodesRequest, NodesResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportNodesAction.class);
 
@@ -94,6 +96,7 @@ public abstract class TransportNodesAction<
 
         new CancellableFanOut<DiscoveryNode, NodeResponse, CheckedConsumer<ActionListener<NodesResponse>, Exception>>() {
 
+            final ActionContext actionContext = createActionContext(task, request);
             final ArrayList<NodeResponse> responses = new ArrayList<>(concreteNodes.length);
             final ArrayList<FailedNodeException> exceptions = new ArrayList<>(0);
 
@@ -161,7 +164,7 @@ public abstract class TransportNodesAction<
                 // ref releases all happen-before here so no need to be synchronized
                 return l -> {
                     try (var ignored = Releasables.wrap(Iterators.map(responses.iterator(), r -> r::decRef))) {
-                        newResponseAsync(task, request, responses, exceptions, l);
+                        newResponseAsync(task, request, actionContext, responses, exceptions, l);
                     }
                 };
             }
@@ -180,6 +183,16 @@ public abstract class TransportNodesAction<
     private Writeable.Reader<NodeResponse> nodeResponseReader(DiscoveryNode discoveryNode) {
         // not an inline lambda to avoid capturing CancellableFanOut.this.
         return in -> TransportNodesAction.this.newNodeResponse(in, discoveryNode);
+    }
+
+    /**
+     * Create an (optional) {@link ActionContext}: called when starting to execute this action, and the result passed to
+     * {@link #newResponseAsync} on completion. NB runs on the transport worker thread, must not do anything expensive without dispatching
+     * to a different executor.
+     */
+    @Nullable
+    protected ActionContext createActionContext(Task task, NodesRequest request) {
+        return null;
     }
 
     /**
@@ -206,6 +219,7 @@ public abstract class TransportNodesAction<
     protected void newResponseAsync(
         Task task,
         NodesRequest request,
+        ActionContext actionContext,
         List<NodeResponse> responses,
         List<FailedNodeException> failures,
         ActionListener<NodesResponse> listener

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -58,7 +58,8 @@ public class TransportNodesListGatewayStartedShards extends TransportNodesAction
     TransportNodesListGatewayStartedShards.Request,
     TransportNodesListGatewayStartedShards.NodesGatewayStartedShards,
     TransportNodesListGatewayStartedShards.NodeRequest,
-    TransportNodesListGatewayStartedShards.NodeGatewayStartedShards> {
+    TransportNodesListGatewayStartedShards.NodeGatewayStartedShards,
+    Void> {
 
     private static final Logger logger = LogManager.getLogger(TransportNodesListGatewayStartedShards.class);
 

--- a/server/src/main/java/org/elasticsearch/health/stats/HealthApiStatsTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/health/stats/HealthApiStatsTransportAction.java
@@ -29,7 +29,8 @@ public class HealthApiStatsTransportAction extends TransportNodesAction<
     HealthApiStatsAction.Request,
     HealthApiStatsAction.Response,
     HealthApiStatsAction.Request.Node,
-    HealthApiStatsAction.Response.Node> {
+    HealthApiStatsAction.Response.Node,
+    Void> {
 
     private final HealthApiStats healthApiStats;
 

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -60,7 +60,8 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
     TransportNodesListShardStoreMetadata.Request,
     TransportNodesListShardStoreMetadata.NodesStoreFilesMetadata,
     TransportNodesListShardStoreMetadata.NodeRequest,
-    TransportNodesListShardStoreMetadata.NodeStoreFilesMetadata> {
+    TransportNodesListShardStoreMetadata.NodeStoreFilesMetadata,
+    Void> {
 
     private static final Logger logger = LogManager.getLogger(TransportNodesListShardStoreMetadata.class);
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -138,7 +138,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
      * Simulates node-based task that can be used to block node tasks so they are guaranteed to be registered by task manager
      */
     abstract class AbstractTestNodesAction<NodesRequest extends BaseNodesRequest<NodesRequest>, NodeRequest extends TransportRequest>
-        extends TransportNodesAction<NodesRequest, NodesResponse, NodeRequest, NodeResponse> {
+        extends TransportNodesAction<NodesRequest, NodesResponse, NodeRequest, NodeResponse, Void> {
 
         AbstractTestNodesAction(
             String actionName,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -243,7 +243,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin, NetworkPlugi
         }
     }
 
-    public static class TransportTestTaskAction extends TransportNodesAction<NodesRequest, NodesResponse, NodeRequest, NodeResponse> {
+    public static class TransportTestTaskAction extends TransportNodesAction<NodesRequest, NodesResponse, NodeRequest, NodeResponse, Void> {
 
         @Inject
         public TransportTestTaskAction(ThreadPool threadPool, ClusterService clusterService, TransportService transportService) {

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -78,7 +78,8 @@ public class TransportNodesActionTests extends ESTestCase {
     private TransportService transportService;
 
     public void testRequestIsSentToEachNode() {
-        TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse> action = getTestTransportNodesAction();
+        TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse, Void> action =
+            getTestTransportNodesAction();
         TestNodesRequest request = new TestNodesRequest();
         action.execute(null, request, new PlainActionFuture<>());
         Map<String, List<CapturingTransport.CapturedRequest>> capturedRequests = transport.getCapturedRequestsByTargetNodeAndClear();
@@ -89,7 +90,8 @@ public class TransportNodesActionTests extends ESTestCase {
     }
 
     public void testNodesSelectors() {
-        TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse> action = getTestTransportNodesAction();
+        TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse, Void> action =
+            getTestTransportNodesAction();
         int numSelectors = randomIntBetween(1, 5);
         Set<String> nodeSelectors = new HashSet<>();
         for (int i = 0; i < numSelectors; i++) {
@@ -109,7 +111,7 @@ public class TransportNodesActionTests extends ESTestCase {
     }
 
     public void testCustomResolving() {
-        TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse> action =
+        TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse, Void> action =
             getDataNodesOnlyTransportNodesAction(transportService);
         TestNodesRequest request = new TestNodesRequest(randomBoolean() ? null : generateRandomStringArray(10, 5, false, true));
         action.execute(null, request, new PlainActionFuture<>());
@@ -257,6 +259,63 @@ public class TransportNodesActionTests extends ESTestCase {
         assertTrue(cancellableTask.isCancelled()); // keep task alive
     }
 
+    public void testActionContextReleasedOnCancellation() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        final TransportNodesAction<TestNodesRequest, TestNodesResponse, TestNodeRequest, TestNodeResponse, Object> action =
+            new TransportNodesAction<>(
+                "indices:admin/test",
+                clusterService,
+                transportService,
+                new ActionFilters(Collections.emptySet()),
+                TestNodeRequest::new,
+                THREAD_POOL.executor(ThreadPool.Names.GENERIC)
+            ) {
+                @Override
+                protected TestNodesResponse newResponse(
+                    TestNodesRequest request,
+                    List<TestNodeResponse> testNodeResponses,
+                    List<FailedNodeException> failures
+                ) {
+                    return fail(null, "should not be called");
+                }
+
+                @Override
+                protected TestNodeRequest newNodeRequest(TestNodesRequest request) {
+                    return new TestNodeRequest();
+                }
+
+                @Override
+                protected TestNodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+                    return new TestNodeResponse(in);
+                }
+
+                @Override
+                protected TestNodeResponse nodeOperation(TestNodeRequest request, Task task) {
+                    return new TestNodeResponse();
+                }
+
+                @Override
+                protected Object createActionContext(Task task, TestNodesRequest request) {
+                    return reachabilityChecker.register(new Object());
+                }
+            };
+
+        final CancellableTask cancellableTask = new CancellableTask(randomLong(), "transport", "action", "", null, emptyMap());
+        final PlainActionFuture<TestNodesResponse> listener = new PlainActionFuture<>();
+        action.execute(cancellableTask, new TestNodesRequest(), listener);
+
+        reachabilityChecker.checkReachable();
+        TaskCancelHelper.cancel(cancellableTask, "simulated");
+        reachabilityChecker.ensureUnreachable();
+
+        for (CapturingTransport.CapturedRequest capturedRequest : transport.getCapturedRequestsAndClear()) {
+            transport.handleLocalError(capturedRequest.requestId(), new ElasticsearchException("simulated"));
+        }
+
+        expectThrows(TaskCancelledException.class, () -> listener.actionGet(10, TimeUnit.SECONDS));
+        assertTrue(cancellableTask.isCancelled()); // keep task alive
+    }
+
     @BeforeClass
     public static void startThreadPool() {
         THREAD_POOL = new TestThreadPool(TransportNodesActionTests.class.getSimpleName());
@@ -341,7 +400,8 @@ public class TransportNodesActionTests extends ESTestCase {
         TestNodesRequest,
         TestNodesResponse,
         TestNodeRequest,
-        TestNodeResponse> {
+        TestNodeResponse,
+        Void> {
 
         TestTransportNodesAction(
             ClusterService clusterService,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsAction.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsAction.java
@@ -26,7 +26,8 @@ public class TransportAnalyticsStatsAction extends TransportNodesAction<
     AnalyticsStatsAction.Request,
     AnalyticsStatsAction.Response,
     AnalyticsStatsAction.NodeRequest,
-    AnalyticsStatsAction.NodeResponse> {
+    AnalyticsStatsAction.NodeResponse,
+    Void> {
     private final AnalyticsUsage usage;
 
     @Inject

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/NodesDataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/NodesDataTiersUsageTransportAction.java
@@ -54,7 +54,8 @@ public class NodesDataTiersUsageTransportAction extends TransportNodesAction<
     NodesDataTiersUsageTransportAction.NodesRequest,
     NodesDataTiersUsageTransportAction.NodesResponse,
     NodesDataTiersUsageTransportAction.NodeRequest,
-    NodeDataTiersUsage> {
+    NodeDataTiersUsage,
+    Void> {
 
     public static final ActionType<NodesResponse> TYPE = new ActionType<>("cluster:monitor/nodes/data_tier_usage");
     public static final NodeFeature LOCALLY_PRECALCULATED_STATS_FEATURE = new NodeFeature("usage.data_tiers.precalculate_stats");

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -43,7 +43,8 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     NodesDeprecationCheckRequest,
     NodesDeprecationCheckResponse,
     NodesDeprecationCheckAction.NodeRequest,
-    NodesDeprecationCheckAction.NodeResponse> {
+    NodesDeprecationCheckAction.NodeResponse,
+    Void> {
 
     private final Settings settings;
     private final XPackLicenseState licenseState;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/TransportDeprecationCacheResetAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/TransportDeprecationCacheResetAction.java
@@ -28,7 +28,8 @@ public class TransportDeprecationCacheResetAction extends TransportNodesAction<
     DeprecationCacheResetAction.Request,
     DeprecationCacheResetAction.Response,
     DeprecationCacheResetAction.NodeRequest,
-    DeprecationCacheResetAction.NodeResponse> {
+    DeprecationCacheResetAction.NodeResponse,
+    Void> {
 
     private static final Logger logger = LogManager.getLogger(TransportDeprecationCacheResetAction.class);
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -111,7 +111,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
         }
     }
 
-    public static class TransportAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse> {
+    public static class TransportAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse, Void> {
 
         private final EnrichCache enrichCache;
         private final EnrichCoordinatorProxyAction.Coordinator coordinator;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlStatsAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlStatsAction.java
@@ -28,7 +28,8 @@ public class TransportEqlStatsAction extends TransportNodesAction<
     EqlStatsRequest,
     EqlStatsResponse,
     EqlStatsRequest.NodeStatsRequest,
-    EqlStatsResponse.NodeStatsResponse> {
+    EqlStatsResponse.NodeStatsResponse,
+    Void> {
 
     // the plan executor holds the metrics
     private final PlanExecutor planExecutor;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlStatsAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlStatsAction.java
@@ -31,7 +31,8 @@ public class TransportEsqlStatsAction extends TransportNodesAction<
     EsqlStatsRequest,
     EsqlStatsResponse,
     EsqlStatsRequest.NodeStatsRequest,
-    EsqlStatsResponse.NodeStatsResponse> {
+    EsqlStatsResponse.NodeStatsResponse,
+    Void> {
 
     static final NodeFeature ESQL_STATS_FEATURE = new NodeFeature("esql.stats_node");
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceDiagnosticsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceDiagnosticsAction.java
@@ -28,7 +28,8 @@ public class TransportGetInferenceDiagnosticsAction extends TransportNodesAction
     GetInferenceDiagnosticsAction.Request,
     GetInferenceDiagnosticsAction.Response,
     GetInferenceDiagnosticsAction.NodeRequest,
-    GetInferenceDiagnosticsAction.NodeResponse> {
+    GetInferenceDiagnosticsAction.NodeResponse,
+    Void> {
 
     private final HttpClientManager httpClientManager;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportTrainedModelCacheInfoAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportTrainedModelCacheInfoAction.java
@@ -34,7 +34,8 @@ public class TransportTrainedModelCacheInfoAction extends TransportNodesAction<
     TrainedModelCacheInfoAction.Request,
     TrainedModelCacheInfoAction.Response,
     TransportTrainedModelCacheInfoAction.NodeModelCacheInfoRequest,
-    CacheInfo> {
+    CacheInfo,
+    Void> {
 
     private final ModelLoadingService modelLoadingService;
 

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportClearRepositoriesStatsArchiveAction.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportClearRepositoriesStatsArchiveAction.java
@@ -29,7 +29,8 @@ public final class TransportClearRepositoriesStatsArchiveAction extends Transpor
     ClearRepositoriesMeteringArchiveRequest,
     RepositoriesMeteringResponse,
     TransportClearRepositoriesStatsArchiveAction.ClearRepositoriesStatsArchiveNodeRequest,
-    RepositoriesNodeMeteringResponse> {
+    RepositoriesNodeMeteringResponse,
+    Void> {
 
     private final RepositoriesService repositoriesService;
 

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportRepositoriesStatsAction.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportRepositoriesStatsAction.java
@@ -27,7 +27,8 @@ public final class TransportRepositoriesStatsAction extends TransportNodesAction
     RepositoriesMeteringRequest,
     RepositoriesMeteringResponse,
     TransportRepositoriesStatsAction.RepositoriesNodeStatsRequest,
-    RepositoriesNodeMeteringResponse> {
+    RepositoriesNodeMeteringResponse,
+    Void> {
 
     private final RepositoriesService repositoriesService;
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
@@ -39,7 +39,8 @@ public class TransportSearchableSnapshotCacheStoresAction extends TransportNodes
     TransportSearchableSnapshotCacheStoresAction.Request,
     TransportSearchableSnapshotCacheStoresAction.NodesCacheFilesMetadata,
     TransportSearchableSnapshotCacheStoresAction.NodeRequest,
-    TransportSearchableSnapshotCacheStoresAction.NodeCacheFilesMetadata> {
+    TransportSearchableSnapshotCacheStoresAction.NodeCacheFilesMetadata,
+    Void> {
 
     public static final String ACTION_NAME = "internal:admin/xpack/searchable_snapshots/cache/store";
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -47,7 +47,8 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
     TransportSearchableSnapshotsNodeCachesStatsAction.NodesRequest,
     TransportSearchableSnapshotsNodeCachesStatsAction.NodesCachesStatsResponse,
     TransportSearchableSnapshotsNodeCachesStatsAction.NodeRequest,
-    TransportSearchableSnapshotsNodeCachesStatsAction.NodeCachesStatsResponse> {
+    TransportSearchableSnapshotsNodeCachesStatsAction.NodeCachesStatsResponse,
+    Void> {
 
     public static final String ACTION_NAME = "cluster:admin/xpack/searchable_snapshots/cache/stats";
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportClearSecurityCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportClearSecurityCacheAction.java
@@ -33,7 +33,8 @@ public class TransportClearSecurityCacheAction extends TransportNodesAction<
     ClearSecurityCacheRequest,
     ClearSecurityCacheResponse,
     ClearSecurityCacheRequest.Node,
-    ClearSecurityCacheResponse.Node> {
+    ClearSecurityCacheResponse.Node,
+    Void> {
 
     private final CacheInvalidatorRegistry cacheInvalidatorRegistry;
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportClearPrivilegesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportClearPrivilegesCacheAction.java
@@ -30,7 +30,8 @@ public class TransportClearPrivilegesCacheAction extends TransportNodesAction<
     ClearPrivilegesCacheRequest,
     ClearPrivilegesCacheResponse,
     ClearPrivilegesCacheRequest.Node,
-    ClearPrivilegesCacheResponse.Node> {
+    ClearPrivilegesCacheResponse.Node,
+    Void> {
 
     private final CompositeRolesStore rolesStore;
     private final CacheInvalidatorRegistry cacheInvalidatorRegistry;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/realm/TransportClearRealmCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/realm/TransportClearRealmCacheAction.java
@@ -32,7 +32,8 @@ public class TransportClearRealmCacheAction extends TransportNodesAction<
     ClearRealmCacheRequest,
     ClearRealmCacheResponse,
     ClearRealmCacheRequest.Node,
-    ClearRealmCacheResponse.Node> {
+    ClearRealmCacheResponse.Node,
+    Void> {
 
     private final Realms realms;
     private final AuthenticationService authenticationService;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportClearRolesCacheAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportClearRolesCacheAction.java
@@ -28,7 +28,8 @@ public class TransportClearRolesCacheAction extends TransportNodesAction<
     ClearRolesCacheRequest,
     ClearRolesCacheResponse,
     ClearRolesCacheRequest.Node,
-    ClearRolesCacheResponse.Node> {
+    ClearRolesCacheResponse.Node,
+    Void> {
 
     private final CompositeRolesStore rolesStore;
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountNodesCredentialsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountNodesCredentialsAction.java
@@ -35,7 +35,8 @@ public class TransportGetServiceAccountNodesCredentialsAction extends TransportN
     GetServiceAccountCredentialsNodesRequest,
     GetServiceAccountCredentialsNodesResponse,
     GetServiceAccountCredentialsNodesRequest.Node,
-    GetServiceAccountCredentialsNodesResponse.Node> {
+    GetServiceAccountCredentialsNodesResponse.Node,
+    Void> {
 
     private final FileServiceAccountTokenStore fileServiceAccountTokenStore;
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportAction.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportAction.java
@@ -26,7 +26,8 @@ public class SpatialStatsTransportAction extends TransportNodesAction<
     SpatialStatsAction.Request,
     SpatialStatsAction.Response,
     SpatialStatsAction.NodeRequest,
-    SpatialStatsAction.NodeResponse> {
+    SpatialStatsAction.NodeResponse,
+    Void> {
     private final SpatialUsage usage;
 
     @Inject

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlStatsAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlStatsAction.java
@@ -28,7 +28,8 @@ public class TransportSqlStatsAction extends TransportNodesAction<
     SqlStatsRequest,
     SqlStatsResponse,
     SqlStatsRequest.NodeStatsRequest,
-    SqlStatsResponse.NodeStatsResponse> {
+    SqlStatsResponse.NodeStatsResponse,
+    Void> {
 
     // the plan executor holds the metrics
     private final PlanExecutor planExecutor;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformNodeStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformNodeStatsAction.java
@@ -35,7 +35,8 @@ public class TransportGetTransformNodeStatsAction extends TransportNodesAction<
     NodesStatsRequest,
     NodesStatsResponse,
     NodeStatsRequest,
-    NodeStatsResponse> {
+    NodeStatsResponse,
+    Void> {
 
     private final TransportService transportService;
     private final TransformScheduler scheduler;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsAction.java
@@ -36,7 +36,8 @@ public class TransportWatcherStatsAction extends TransportNodesAction<
     WatcherStatsRequest,
     WatcherStatsResponse,
     WatcherStatsRequest.Node,
-    WatcherStatsResponse.Node> {
+    WatcherStatsResponse.Node,
+    Void> {
 
     private final ExecutionService executionService;
     private final TriggerService triggerService;


### PR DESCRIPTION
Several `TransportNodesAction` implementations do some kind of top-level
computation in addition to fanning out requests to individual nodes.
Today they all have to do this once the node-level fanout is complete,
but in most cases the top-level computation can happen in parallel with
the fanout. This commit adds support for an additional `ActionContext`
object, created when starting to process the request and exposed to
`newResponseAsync()` at the end, to allow this parallelization.

All implementations use `(Void) null` for this param, except for
`TransportClusterStatsAction` which now parallelizes the computation of
the cluster-state-based stats with the node-level fanout.