### PR TITLE
[DOCS] Gives more details to the load data step of the semantic search tutorials

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -161,9 +161,9 @@ GET _tasks/<task_id>
 
 You can also open the Trained Models UI, select the Pipelines tab under ELSER to follow the progress.
 
-Reindexing large datasets can take a long time. You can test this workflow using
-only a subset of the dataset. Do this by cancelling the reindexing process, and
-only generating embeddings for the subset that was reindexed.
+Reindexing large datasets can take a long time.
+You can test this workflow using only a subset of the dataset.
+Do this by cancelling the reindexing process, and only generating embeddings for the subset that was reindexed.
 The following API request will cancel the reindexing task:
 
 [source,console]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -117,15 +117,15 @@ All unique passages, along with their IDs, have been extracted from that data se
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
 IMPORTANT: The `msmarco-passagetest2019-top1000` dataset was not utilized to train the model.
-It is only used in this tutorial as a sample dataset that is easily accessible for demonstration purposes.
+We use this sample dataset in the tutorial because is easily accessible for demonstration purposes.
 You can use a different data set to test the workflow and become familiar with it.
 
-Download the file and upload it to your cluster using the {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer] in the {ml-app} UI.
+Download the file and upload it to your cluster using the {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[File Uploader] in the UI.
 After your data is analyzed, click **Override settings**.
 Under **Edit field names**, assign `id` to the first column and `content` to the second.
 Click **Apply**, then **Import**.
 Name the index `test-data`, and click **Import**.
-Once the upload is complete, you will see an index named `test-data` with 182,469 documents.
+After the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
 [discrete]
 [[reindexing-data-elser]]
@@ -161,8 +161,9 @@ GET _tasks/<task_id>
 
 You can also open the Trained Models UI, select the Pipelines tab under ELSER to follow the progress.
 
-Following this tutorial, you can also cancel the reindexing process if you don't want to wait until the reindexing process is fully complete which might take hours for large data sets.
-You can test the feature even if you reindex only a subset of the data set - a few thousand data points for example - and generate embeddings for the subset.
+Reindexing large datasets can take a long time. You can test this workflow using
+only a subset of the dataset. Do this by cancelling the reindexing process, and
+only generating embeddings for the subset that was reindexed.
 The following API request will cancel the reindexing task:
 
 [source,console]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -120,12 +120,12 @@ IMPORTANT: The `msmarco-passagetest2019-top1000` dataset was not utilized to tra
 It is only used in this tutorial as a sample dataset that is easily accessible for demonstration purposes.
 You can use a different data set to test the workflow and become familiar with it.
 
-Download the file and upload it to your cluster using the
-{kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]
-in the {ml-app} UI.
-Assign the name `id` to the first column and `content` to the second column.
-The index name is `test-data`.
-Once the upload is complete, you can see an index named `test-data` with 182469 documents.
+Download the file and upload it to your cluster using the {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer] in the {ml-app} UI.
+After your data is analyzed, click **Override settings**.
+Under **Edit field names**, assign `id` to the first column and `content` to the second.
+Click **Apply**, then **Import**.
+Name the index `test-data`, and click **Import**.
+Once the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
 [discrete]
 [[reindexing-data-elser]]
@@ -160,6 +160,17 @@ GET _tasks/<task_id>
 // TEST[skip:TBD]
 
 You can also open the Trained Models UI, select the Pipelines tab under ELSER to follow the progress.
+
+Following this tutorial, you can also cancel the reindexing process if you don't want to wait until the reindexing process is fully complete which might take hours for large data sets.
+You can test the feature even if you reindex only a subset of the data set - a few thousand data points for example - and generate embeddings for the subset.
+The following API request will cancel the reindexing task:
+
+[source,console]
+----
+POST _tasks/<task_id>/_cancel
+----
+// TEST[skip:TBD]
+
 
 [discrete]
 [[text-expansion-query]]

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -68,12 +68,12 @@ It consists of 200 queries, each accompanied by a list of relevant text passages
 All unique passages, along with their IDs, have been extracted from that data set and compiled into a
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
-Download the file and upload it to your cluster using the
-{kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]
-in the {ml-app} UI.
-Assign the name `id` to the first column and `content` to the second column.
-The index name is `test-data`.
-Once the upload is complete, you can see an index named `test-data` with 182469 documents.
+Download the file and upload it to your cluster using the {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer] in the {ml-app} UI.
+After your data is analyzed, click **Override settings**.
+Under **Edit field names**, assign `id` to the first column and `content` to the second.
+Click **Apply**, then **Import**.
+Name the index `test-data`, and click **Import**.
+Once the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
 [discrete]
 [[reindexing-data-infer]]
@@ -92,7 +92,9 @@ GET _tasks/<task_id>
 ----
 // TEST[skip:TBD]
 
-You can also cancel the reindexing process if you don't want to wait until the reindexing process is fully complete which might take hours for large data sets:
+Following this tutorial, you can also cancel the reindexing process if you don't want to wait until the reindexing process is fully complete which might take hours for large data sets.
+You can test the feature even if you reindex only a subset of the data set - a few thousand data points for example - and generate embeddings for the subset.
+The following API request will cancel the reindexing task:
 
 [source,console]
 ----

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -73,7 +73,7 @@ After your data is analyzed, click **Override settings**.
 Under **Edit field names**, assign `id` to the first column and `content` to the second.
 Click **Apply**, then **Import**.
 Name the index `test-data`, and click **Import**.
-Once the upload is complete, you will see an index named `test-data` with 182,469 documents.
+After the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
 [discrete]
 [[reindexing-data-infer]]
@@ -92,8 +92,9 @@ GET _tasks/<task_id>
 ----
 // TEST[skip:TBD]
 
-Following this tutorial, you can also cancel the reindexing process if you don't want to wait until the reindexing process is fully complete which might take hours for large data sets.
-You can test the feature even if you reindex only a subset of the data set - a few thousand data points for example - and generate embeddings for the subset.
+Reindexing large datasets can take a long time.
+You can test this workflow using only a subset of the dataset.
+Do this by cancelling the reindexing process, and only generating embeddings for the subset that was reindexed.
 The following API request will cancel the reindexing task:
 
 [source,console]

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -96,11 +96,12 @@ a list of relevant text passages. All unique passages, along with their IDs,
 have been extracted from that data set and compiled into a
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
-Download the file and upload it to your cluster using the
-{kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]
-in the {ml-app} UI. Assign the name `id` to the first column and `content` to
-the second column. The index name is `test-data`. Once the upload is complete,
-you can see an index named `test-data` with 182469 documents.
+Download the file and upload it to your cluster using the {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer] in the {ml-app} UI.
+After your data is analyzed, click **Override settings**.
+Under **Edit field names**, assign `id` to the first column and `content` to the second.
+Click **Apply**, then **Import**.
+Name the index `test-data`, and click **Import**.
+Once the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
 
 [discrete]
@@ -137,8 +138,9 @@ GET _tasks/<task_id>
 ------------------------------------------------------------
 // TEST[skip:TBD]
 
-It is recommended to cancel the reindexing process if you don't want to wait
-until it is fully complete which might take a long time for an inference endpoint with few assigned resources:
+Following this tutorial, it is recommended to cancel the reindexing process if you don't want to wait until it is fully complete which might take a long time for an inference endpoint with few assigned resources.
+You can test the feature even if you reindex only a subset of the data set - a few thousand data points for example - and generate embeddings for the subset.
+The following API request will cancel the reindexing task:
 
 [source,console]
 ------------------------------------------------------------

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -101,7 +101,7 @@ After your data is analyzed, click **Override settings**.
 Under **Edit field names**, assign `id` to the first column and `content` to the second.
 Click **Apply**, then **Import**.
 Name the index `test-data`, and click **Import**.
-Once the upload is complete, you will see an index named `test-data` with 182,469 documents.
+After the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
 
 [discrete]
@@ -138,8 +138,9 @@ GET _tasks/<task_id>
 ------------------------------------------------------------
 // TEST[skip:TBD]
 
-Following this tutorial, it is recommended to cancel the reindexing process if you don't want to wait until it is fully complete which might take a long time for an inference endpoint with few assigned resources.
-You can test the feature even if you reindex only a subset of the data set - a few thousand data points for example - and generate embeddings for the subset.
+Reindexing large datasets can take a long time.
+You can test this workflow using only a subset of the dataset.
+Do this by cancelling the reindexing process, and only generating embeddings for the subset that was reindexed.
 The following API request will cancel the reindexing task:
 
 [source,console]


### PR DESCRIPTION
## Overview

This PR:

* provides more granular details on how to change field names using the DataViz
* clarifies that canceling the reindexing process is only recommended when following the tutorial.

### Preview

[Semantic search with `semantic_text` -- Load data](https://elasticsearch_bk_113088.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-semantic-text.html#semantic-text-load-data)