### PR TITLE
[8.15] [DOCS] Fix GeoIP database rest-api-spec doc URLs (#113082)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
@@ -1,7 +1,7 @@
 {
   "ingest.delete_geoip_database":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/TODO.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-geoip-database-api.html",
       "description":"Deletes a geoip database configuration"
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_geoip_database.json
@@ -1,7 +1,7 @@
 {
   "ingest.get_geoip_database":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/TODO.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-geoip-database-api.html",
       "description":"Returns geoip database configuration."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -1,7 +1,7 @@
 {
   "ingest.put_geoip_database":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/TODO.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/put-geoip-database-api.html",
       "description":"Puts the configuration for a geoip database to be downloaded"
     },
     "stability":"stable",


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [DOCS] Fix GeoIP database rest-api-spec doc URLs (#113082)