### PR TITLE
[8.x] [ML] Server-Sent Events for Inference response (#112565)

### DIFF
--- a/docs/changelog/112565.yaml
+++ b/docs/changelog/112565.yaml
@@ -1,0 +1,5 @@
+pr: 112565
+summary: Server-Sent Events for Inference response
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/rest/ServerSentEventsRestActionListenerTests.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/rest/ServerSentEventsRestActionListenerTests.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.rest;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.AbstractAsyncResponseConsumer;
+import org.apache.http.nio.util.SimpleInputBuffer;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+public class ServerSentEventsRestActionListenerTests extends ESIntegTestCase {
+    private static final String INFERENCE_ROUTE = "/_inference";
+    private static final String REQUEST_COUNT = "request_count";
+    private static final String WITH_ERROR = "with_error";
+    private static final String ERROR_ROUTE = "/_inference_error";
+    private static final String NO_STREAM_ROUTE = "/_inference_no_stream";
+    private static final Exception expectedException = new IllegalStateException("hello there");
+    private static final String expectedExceptionAsServerSentEvent = """
+        \uFEFF\
+        event: error
+        data: {\
+        "error":{"root_cause":[{"type":"illegal_state_exception","reason":"hello there",\
+        "caused_by":{"type":"illegal_state_exception","reason":"hello there"}}],\
+        "type":"illegal_state_exception","reason":"hello there"},"status":500\
+        }""";
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopyNoNullElements(super.nodePlugins(), StreamingPlugin.class);
+    }
+
+    public static class StreamingPlugin extends Plugin implements ActionPlugin {
+        @Override
+        public Collection<RestHandler> getRestHandlers(
+            Settings settings,
+            NamedWriteableRegistry namedWriteableRegistry,
+            RestController restController,
+            ClusterSettings clusterSettings,
+            IndexScopedSettings indexScopedSettings,
+            SettingsFilter settingsFilter,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<DiscoveryNodes> nodesInCluster,
+            Predicate<NodeFeature> clusterSupportsFeature
+        ) {
+            return List.of(new RestHandler() {
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(RestRequest.Method.POST, INFERENCE_ROUTE));
+                }
+
+                @Override
+                public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) {
+                    var requestCount = request.paramAsInt(REQUEST_COUNT, -1);
+                    assert requestCount >= 0;
+                    var withError = request.paramAsBoolean(WITH_ERROR, false);
+                    var publisher = new RandomPublisher(requestCount, withError);
+                    var inferenceServiceResults = new StreamingInferenceServiceResults(publisher);
+                    var inferenceResponse = new InferenceAction.Response(inferenceServiceResults, inferenceServiceResults.publisher());
+                    new ServerSentEventsRestActionListener(channel).onResponse(inferenceResponse);
+                }
+            }, new RestHandler() {
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(RestRequest.Method.POST, ERROR_ROUTE));
+                }
+
+                @Override
+                public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) {
+                    new ServerSentEventsRestActionListener(channel).onFailure(expectedException);
+                }
+            }, new RestHandler() {
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(RestRequest.Method.POST, NO_STREAM_ROUTE));
+                }
+
+                @Override
+                public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) {
+                    var inferenceResponse = new InferenceAction.Response(new SingleInferenceServiceResults());
+                    new ServerSentEventsRestActionListener(channel).onResponse(inferenceResponse);
+                }
+            });
+        }
+    }
+
+    private static class StreamingInferenceServiceResults implements InferenceServiceResults {
+        private final Flow.Publisher<ChunkedToXContent> publisher;
+
+        private StreamingInferenceServiceResults(Flow.Publisher<ChunkedToXContent> publisher) {
+            this.publisher = publisher;
+        }
+
+        @Override
+        public Flow.Publisher<ChunkedToXContent> publisher() {
+            return publisher;
+        }
+
+        @Override
+        public List<? extends InferenceResults> transformToCoordinationFormat() {
+            return List.of();
+        }
+
+        @Override
+        public List<? extends InferenceResults> transformToLegacyFormat() {
+            return List.of();
+        }
+
+        @Override
+        public Map<String, Object> asMap() {
+            return Map.of();
+        }
+
+        @Override
+        public boolean isStreaming() {
+            return true;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "StreamingInferenceServiceResults";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {}
+
+        @Override
+        public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+            throw new UnsupportedOperationException("Should not be called");
+        }
+    }
+
+    private static class RandomPublisher implements Flow.Publisher<ChunkedToXContent> {
+        private final int requestCount;
+        private final boolean withError;
+
+        private RandomPublisher(int requestCount, boolean withError) {
+            this.requestCount = requestCount;
+            this.withError = withError;
+        }
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super ChunkedToXContent> subscriber) {
+            var resultCount = new AtomicInteger(requestCount);
+            subscriber.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(long n) {
+                    if (resultCount.getAndDecrement() > 0) {
+                        subscriber.onNext(new RandomString());
+                    } else if (withError) {
+                        subscriber.onError(expectedException);
+                    } else {
+                        subscriber.onComplete();
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    resultCount.set(Integer.MIN_VALUE);
+                }
+            });
+        }
+    }
+
+    private static class RandomString implements ChunkedToXContent {
+        @Override
+        public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+            var randomString = randomUnicodeOfLengthBetween(2, 20);
+            return Iterators.concat(
+                ChunkedToXContentHelper.startObject(),
+                ChunkedToXContentHelper.field("delta", randomString),
+                ChunkedToXContentHelper.endObject()
+            );
+        }
+    }
+
+    private static class SingleInferenceServiceResults implements InferenceServiceResults {
+
+        @Override
+        public List<? extends InferenceResults> transformToCoordinationFormat() {
+            return List.of();
+        }
+
+        @Override
+        public List<? extends InferenceResults> transformToLegacyFormat() {
+            return List.of();
+        }
+
+        @Override
+        public Map<String, Object> asMap() {
+            return Map.of();
+        }
+
+        @Override
+        public String getWriteableName() {
+            return "";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {
+
+        }
+
+        @Override
+        public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+            return ChunkedToXContentHelper.field("result", randomUnicodeOfLengthBetween(2, 20));
+        }
+    }
+
+    /**
+     * We can use Elasticsearch's Java SDK to verify that we are sending bytes as we get them and that the response can be processed and
+     * validated before the Response object is returned from the client.
+     */
+    private static class AsyncResponseConsumer extends AbstractAsyncResponseConsumer<HttpResponse> {
+        private final RandomStringCollector collector;
+        private final AtomicReference<HttpResponse> response = new AtomicReference<>();
+
+        private AsyncResponseConsumer(RandomStringCollector collector) {
+            this.collector = collector;
+        }
+
+        @Override
+        protected void onResponseReceived(HttpResponse httpResponse) {
+            response.set(httpResponse);
+        }
+
+        @Override
+        protected void onContentReceived(ContentDecoder contentDecoder, IOControl ioControl) throws IOException {
+            var buffer = new SimpleInputBuffer(4096);
+            var consumed = buffer.consumeContent(contentDecoder);
+            var allBytes = new byte[consumed];
+            buffer.read(allBytes);
+
+            var response = new String(allBytes, StandardCharsets.UTF_8);
+            try {
+                collector.collect(response);
+            } catch (IOException e) {
+                ioControl.shutdown();
+                throw e;
+            }
+        }
+
+        @Override
+        protected void onEntityEnclosed(HttpEntity httpEntity, ContentType contentType) {
+
+        }
+
+        @Override
+        protected HttpResponse buildResult(HttpContext httpContext) {
+            return response.get();
+        }
+
+        @Override
+        protected void releaseResources() {}
+    }
+
+    private static class RandomStringCollector {
+        private static final Pattern jsonPattern = Pattern.compile("^\uFEFFevent: message\ndata: \\{.*}$");
+        private static final Pattern endPattern = Pattern.compile("^\uFEFFevent: message\ndata: \\[DONE\\]$");
+        private final AtomicBoolean hasDoneChunk = new AtomicBoolean(false);
+        private final Deque<String> stringsVerified = new LinkedBlockingDeque<>();
+        private volatile String previousTokens = "";
+
+        private void collect(String str) throws IOException {
+            str = previousTokens + str;
+            String[] events = str.split("\n\n", -1);
+            for (var i = 0; i < events.length - 1; i++) {
+                var line = events[i];
+                if (jsonPattern.matcher(line).matches() || expectedExceptionAsServerSentEvent.equals(line)) {
+                    stringsVerified.offer(line);
+                } else if (endPattern.matcher(line).matches()) {
+                    hasDoneChunk.set(true);
+                } else {
+                    throw new IOException("Line does not match expected JSON message or DONE message. Line: " + line);
+                }
+            }
+
+            previousTokens = events[events.length - 1];
+            if (endPattern.matcher(previousTokens.trim()).matches()) {
+                hasDoneChunk.set(true);
+            }
+        }
+    }
+
+    public void testResponse() {
+        var collector = new RandomStringCollector();
+        var expectedTestCount = randomIntBetween(2, 30);
+        var request = new Request(RestRequest.Method.POST.name(), INFERENCE_ROUTE);
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setHttpAsyncResponseConsumerFactory(() -> new AsyncResponseConsumer(collector))
+                .addParameter(REQUEST_COUNT, String.valueOf(expectedTestCount))
+                .build()
+        );
+
+        var response = callAsync(request);
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(collector.stringsVerified.size(), equalTo(expectedTestCount));
+        assertThat(collector.hasDoneChunk.get(), equalTo(true));
+    }
+
+    private Response callAsync(Request request) {
+        var response = new AtomicReference<Response>();
+        var exception = new AtomicReference<Exception>();
+        var countdown = new CountDownLatch(1);
+        var cancellable = getRestClient().performRequestAsync(request, new ResponseListener() {
+            @Override
+            public void onSuccess(Response r) {
+                response.set(r);
+                countdown.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exception.set(e);
+                countdown.countDown();
+            }
+        });
+
+        try {
+            if (countdown.await(10, TimeUnit.SECONDS) == false) {
+                cancellable.cancel();
+                fail("Failed to finish test in 10 seconds");
+            }
+        } catch (InterruptedException e) {
+            cancellable.cancel();
+            fail(e, "Failed to finish test");
+        }
+
+        assertThat("No exceptions should be thrown.", exception.get(), nullValue());
+        assertThat(response.get(), notNullValue());
+        return response.get();
+    }
+
+    public void testOnFailure() throws IOException {
+        var request = new Request(RestRequest.Method.POST.name(), ERROR_ROUTE);
+
+        try {
+            getRestClient().performRequest(request);
+            fail("Expected an exception to be thrown from the error route");
+        } catch (ResponseException e) {
+            var response = e.getResponse();
+            assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
+            assertThat(
+                EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
+                equalTo(expectedExceptionAsServerSentEvent + "\n\n")
+            );
+        }
+    }
+
+    public void testErrorMidStream() {
+        var collector = new RandomStringCollector();
+        var expectedTestCount = randomIntBetween(2, 30);
+        var request = new Request(RestRequest.Method.POST.name(), INFERENCE_ROUTE);
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setHttpAsyncResponseConsumerFactory(() -> new AsyncResponseConsumer(collector))
+                .addParameter(REQUEST_COUNT, String.valueOf(expectedTestCount))
+                .addParameter(WITH_ERROR, String.valueOf(true))
+                .build()
+        );
+
+        var response = callAsync(request);
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.SC_OK)); // error still starts with 200-OK
+        assertThat(collector.stringsVerified.size(), equalTo(expectedTestCount + 1)); // normal payload count + last error byte
+        assertThat("DONE chunk is not sent on error", collector.hasDoneChunk.get(), equalTo(false));
+        assertThat(collector.stringsVerified.getLast(), equalTo(expectedExceptionAsServerSentEvent));
+    }
+
+    public void testNoStream() throws IOException {
+        var pattern = Pattern.compile("^\uFEFFevent: message\ndata: \\{\"result\":\".*\"}\n\n\uFEFFevent: message\ndata: \\[DONE]\n\n$");
+        var request = new Request(RestRequest.Method.POST.name(), NO_STREAM_ROUTE);
+        var response = getRestClient().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.SC_OK));
+        var responseString = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+        assertThat(
+            "Expected " + responseString + " to match pattern " + pattern.pattern(),
+            pattern.matcher(responseString).matches(),
+            is(true)
+        );
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/ServerSentEventsRestActionListener.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/ServerSentEventsRestActionListener.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.rest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.BytesStream;
+import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
+import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.util.LazyInitializable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.core.Streams;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_CAUSE;
+import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE;
+
+/**
+ * A version of {@link org.elasticsearch.rest.action.RestChunkedToXContentListener} that reads from a {@link Flow.Publisher} and encodes
+ * the response in Server-Sent Events.
+ */
+public class ServerSentEventsRestActionListener implements ActionListener<InferenceAction.Response> {
+    private static final Logger logger = LogManager.getLogger(ServerSentEventsRestActionListener.class);
+    private final StreamingSubscriber subscriber = new StreamingSubscriber();
+    private final AtomicBoolean isLastPart = new AtomicBoolean(false);
+    private final RestChannel channel;
+    private final ToXContent.Params params;
+
+    /**
+     * A listener for the first part of the next entry to become available for transmission.
+     * Chunks are sent one at a time through the completion of this listener.
+     * This listener is initialized in {@link #initializeStream(InferenceAction.Response)} before the first chunk is requested.
+     * When a chunk is ready, this listener is completed with the converted {@link ChunkedRestResponseBodyPart}.
+     * After transmitting the chunk, {@link #requestNextChunk(ActionListener)} will set the next listener and request the next
+     * chunk. This cycle will repeat until this listener completes with the DONE chunk and the stream closes.
+     */
+    private ActionListener<ChunkedRestResponseBodyPart> nextBodyPartListener;
+
+    public ServerSentEventsRestActionListener(RestChannel channel) {
+        this(channel, channel.request());
+    }
+
+    public ServerSentEventsRestActionListener(RestChannel channel, ToXContent.Params params) {
+        this.channel = channel;
+        this.params = params;
+    }
+
+    @Override
+    public void onResponse(InferenceAction.Response response) {
+        try {
+            ensureOpen();
+            if (response.isStreaming()) {
+                initializeStream(response);
+            } else {
+                // if we aren't streaming - if the provider doesn't allow streaming, there will be a single message
+                channel.sendResponse(
+                    RestResponse.chunked(RestStatus.OK, new SingleServerSentEventBodyPart(ServerSentEvents.MESSAGE, response), () -> {})
+                );
+            }
+        } catch (Exception e) {
+            onFailure(e);
+        }
+    }
+
+    protected void ensureOpen() {
+        if (channel.request().getHttpChannel().isOpen() == false) {
+            throw new TaskCancelledException("response channel [" + channel.request().getHttpChannel() + "] closed");
+        }
+    }
+
+    private void initializeStream(InferenceAction.Response response) {
+        nextBodyPartListener = ActionListener.wrap(bodyPart -> {
+            // this is the first response, so we need to send the RestResponse to open the stream
+            // all subsequent bytes will be delivered through the nextBodyPartListener
+            channel.sendResponse(RestResponse.chunked(RestStatus.OK, bodyPart, this::release));
+        }, e -> {
+            assert false : "body part listener's onFailure should never be called";
+            // we shouldn't be here, but just in case we are we should close out the stream
+            isLastPart.set(true);
+            channel.sendResponse(
+                RestResponse.chunked(
+                    ExceptionsHelper.status(e),
+                    new ServerSentEventResponseBodyPart(ServerSentEvents.ERROR, errorChunk(e)),
+                    this::release
+                )
+            );
+        });
+        // subscribe will call onSubscribe, which requests the first chunk
+        response.publisher().subscribe(subscriber);
+    }
+
+    private void release() {
+        if (subscriber.subscription != null) {
+            subscriber.subscription.cancel();
+        }
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        try {
+            isLastPart.set(true);
+            channel.sendResponse(
+                RestResponse.chunked(
+                    ExceptionsHelper.status(e),
+                    new ServerSentEventResponseBodyPart(ServerSentEvents.ERROR, errorChunk(e)),
+                    this::release
+                )
+            );
+        } catch (Exception inner) {
+            inner.addSuppressed(e);
+            logger.error("failed to send failure response", inner);
+        }
+    }
+
+    // taken indirectly from "new Response(channel, e)"
+    // except we need to emit the error as SSE
+    private ChunkedToXContent errorChunk(Throwable t) {
+        var status = ExceptionsHelper.status(t);
+        return params -> Iterators.concat(ChunkedToXContentHelper.startObject(), ChunkedToXContentHelper.singleChunk((b, p) -> {
+            // Render the exception with a simple message
+            if (channel.detailedErrorsEnabled() == false) {
+                String message = "No ElasticsearchException found";
+                var inner = t;
+                for (int counter = 0; counter < 10 && inner != null; counter++) {
+                    if (inner instanceof ElasticsearchException) {
+                        message = inner.getClass().getSimpleName() + "[" + inner.getMessage() + "]";
+                        break;
+                    }
+                    inner = inner.getCause();
+                }
+                return b.field("error", message);
+            }
+
+            var errorParams = p;
+            if (errorParams.paramAsBoolean("error_trace", false) && status != RestStatus.UNAUTHORIZED) {
+                errorParams = new ToXContent.DelegatingMapParams(
+                    Map.of(REST_EXCEPTION_SKIP_STACK_TRACE, "false", REST_EXCEPTION_SKIP_CAUSE, "true"),
+                    params
+                );
+            }
+
+            // Render the exception with all details
+            final ElasticsearchException[] rootCauses = ElasticsearchException.guessRootCauses(t);
+            b.startObject("error");
+            {
+                b.startArray("root_cause");
+                for (ElasticsearchException rootCause : rootCauses) {
+                    b.startObject();
+                    rootCause.toXContent(b, errorParams);
+                    b.endObject();
+                }
+                b.endArray();
+            }
+            ElasticsearchException.generateThrowableXContent(b, errorParams, t);
+            return b.endObject();
+        }), ChunkedToXContentHelper.field("status", status.getStatus()), ChunkedToXContentHelper.endObject());
+    }
+
+    private void requestNextChunk(ActionListener<ChunkedRestResponseBodyPart> listener) {
+        nextBodyPartListener = listener;
+        subscriber.subscription.request(1);
+    }
+
+    /**
+     * This subscriber connects the stream of ChunkedToXContent to the RestResponse's ChunkedRestResponseBodyPart.
+     * The Subscription maintains the flow of chunks via {@link Flow.Subscription#request(long)}. The publisher is
+     * responsible for not blocking the transport thread.
+     * If the RestResponse is closed prematurely, we should call {@link Flow.Subscription#cancel()} to notify the
+     * publisher to stop sending chunks and to clean up any resources.
+     */
+    private class StreamingSubscriber implements Flow.Subscriber<ChunkedToXContent> {
+        private static final Logger logger = LogManager.getLogger(StreamingSubscriber.class);
+        private Flow.Subscription subscription;
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            if (isLastPart.get() == false) {
+                this.subscription = subscription;
+                subscription.request(1);
+            } else {
+                subscription.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(ChunkedToXContent item) {
+            if (isLastPart.get() == false) {
+                nextBodyPartListener().onResponse(new ServerSentEventResponseBodyPart(ServerSentEvents.MESSAGE, item));
+            } else {
+                subscription.cancel();
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            if (isLastPart.compareAndSet(false, true)) {
+                logger.error("A failure occurred in ElasticSearch while streaming the response.", throwable);
+                nextBodyPartListener().onResponse(new ServerSentEventResponseBodyPart(ServerSentEvents.ERROR, errorChunk(throwable)));
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (isLastPart.compareAndSet(false, true)) {
+                nextBodyPartListener().onResponse(new ServerSentEventDoneBodyPart());
+            }
+        }
+
+        private ActionListener<ChunkedRestResponseBodyPart> nextBodyPartListener() {
+            assert nextBodyPartListener != null : "Subscriber should only be called when Subscription#request is called.";
+            var nextListener = nextBodyPartListener;
+            nextBodyPartListener = null;
+            return nextListener;
+        }
+    }
+
+    // from: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
+    private static class ServerSentEventSpec {
+        private static final String MIME_TYPE = "text/event-stream";
+        private static final byte[] BOM = "\uFEFF".getBytes(StandardCharsets.UTF_8);
+        private static final byte[] DATA = "data: ".getBytes(StandardCharsets.UTF_8);
+        private static final byte[] EOL = "\n".getBytes(StandardCharsets.UTF_8);
+    }
+
+    // from: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
+    // we can send "event: " at the start of the message to communicate metadata about what is in "data: "
+    // this should let us send mid-stream errors, though we preferably never have them
+    private enum ServerSentEvents {
+        ERROR("error"),
+        MESSAGE("message");
+
+        private final byte[] eventType;
+
+        ServerSentEvents(String eventType) {
+            this.eventType = ("event: " + eventType).getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Copied from {@link ChunkedRestResponseBodyPart#fromXContent(ChunkedToXContent, ToXContent.Params, RestChannel)},
+     * notable changes:
+     * 1. check if this is the last part, set from the Subscriber's onComplete or onError calls.
+     * 2. write the SSE-specific bytes to the output stream before/after the XContent bytes
+     * 3. if this is not the last chunk, issue a request for a next chunk
+     */
+    private class ServerSentEventResponseBodyPart implements ChunkedRestResponseBodyPart {
+        private static final Logger logger = LogManager.getLogger(ServerSentEventResponseBodyPart.class);
+        private final OutputStream out = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                target.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                target.write(b, off, len);
+            }
+        };
+
+        private final ServerSentEvents event;
+        private final Iterator<? extends ToXContent> serialization;
+        private final LazyInitializable<XContentBuilder, IOException> xContentBuilder;
+        private final AtomicBoolean isStartOfData = new AtomicBoolean(true);
+
+        private BytesStream target;
+
+        private ServerSentEventResponseBodyPart(ServerSentEvents event, ChunkedToXContent item) {
+            this.event = event;
+            this.xContentBuilder = new LazyInitializable<>(
+                () -> channel.newBuilder(channel.request().getXContentType(), null, true, Streams.noCloseStream(out))
+            );
+            this.serialization = channel.request().getRestApiVersion() == RestApiVersion.V_7
+                ? item.toXContentChunkedV7(params)
+                : item.toXContentChunked(params);
+        }
+
+        @Override
+        public boolean isPartComplete() {
+            return serialization.hasNext() == false;
+        }
+
+        @Override
+        public boolean isLastPart() {
+            return isLastPart.get();
+        }
+
+        @Override
+        public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
+            if (isLastPart()) {
+                // this should not have been called
+                assert false : "no continuations";
+                listener.onFailure(new IllegalStateException("no continuations available"));
+            } else {
+                requestNextChunk(listener);
+            }
+        }
+
+        /**
+         * after we are finished with this chunk, the entire payload will look like:
+         * [bom]event: [event type]\n
+         * data: [chunkedXContentJson]\n
+         * \n
+         */
+        @Override
+        public ReleasableBytesReference encodeChunk(int sizeHint, Recycler<BytesRef> recycler) throws IOException {
+            try {
+                final var builder = xContentBuilder.getOrCompute();
+                final var chunkStream = new RecyclerBytesStreamOutput(recycler);
+                assert target == null;
+                target = chunkStream;
+
+                // if this is the first time we are encoding this chunk, write the SSE leading bytes
+                if (isStartOfData.compareAndSet(true, false)) {
+                    target.write(ServerSentEventSpec.BOM);
+                    target.write(event.eventType);
+                    target.write(ServerSentEventSpec.EOL);
+                    target.write(ServerSentEventSpec.DATA);
+                }
+
+                // start or continue writing this chunk
+                while (serialization.hasNext()) {
+                    serialization.next().toXContent(builder, params);
+                    if (chunkStream.size() >= sizeHint) {
+                        break;
+                    }
+                }
+
+                if (serialization.hasNext() == false) {
+                    // SSE wants two newlines between messages
+                    builder.close();
+                    target.write(ServerSentEventSpec.EOL);
+                    target.write(ServerSentEventSpec.EOL);
+                    target.flush();
+                }
+                final var result = new ReleasableBytesReference(chunkStream.bytes(), () -> Releasables.closeExpectNoException(chunkStream));
+                target = null;
+                return result;
+            } catch (Exception e) {
+                logger.error("failure encoding chunk", e);
+                throw e;
+            } finally {
+                if (target != null) {
+                    assert false : "failure encoding chunk";
+                    IOUtils.closeWhileHandlingException(target);
+                    target = null;
+                }
+            }
+        }
+
+        @Override
+        public String getResponseContentTypeString() {
+            return ServerSentEventSpec.MIME_TYPE;
+        }
+    }
+
+    /**
+     * <p>Special ChunkedRestResponseBodyPart that writes the done message, formatted as:
+     * ```
+     * event: message
+     * data: [DONE]
+     * ```
+     * </p>
+     * <p>This will be the last message, sent when {@link Flow.Subscriber#onComplete()} is called.</p>
+     */
+    private static class ServerSentEventDoneBodyPart implements ChunkedRestResponseBodyPart {
+        private static final Logger logger = LogManager.getLogger(ServerSentEventDoneBodyPart.class);
+        private static final byte[] DONE_BYTES = "[DONE]".getBytes(StandardCharsets.UTF_8);
+        private volatile boolean isPartComplete = false;
+
+        @Override
+        public boolean isPartComplete() {
+            return isPartComplete;
+        }
+
+        @Override
+        public boolean isLastPart() {
+            return true;
+        }
+
+        @Override
+        public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
+            assert false : "no continuations";
+            listener.onFailure(new IllegalStateException("no continuations available"));
+        }
+
+        @Override
+        public ReleasableBytesReference encodeChunk(int sizeHint, Recycler<BytesRef> recycler) throws IOException {
+            final var chunkStream = new RecyclerBytesStreamOutput(recycler);
+            try {
+                chunkStream.write(ServerSentEventSpec.BOM);
+                chunkStream.write(ServerSentEvents.MESSAGE.eventType);
+                chunkStream.write(ServerSentEventSpec.EOL);
+                chunkStream.write(ServerSentEventSpec.DATA);
+
+                chunkStream.write(DONE_BYTES);
+
+                chunkStream.write(ServerSentEventSpec.EOL);
+                chunkStream.write(ServerSentEventSpec.EOL);
+                chunkStream.flush();
+                isPartComplete = true;
+                return new ReleasableBytesReference(chunkStream.bytes(), () -> Releasables.closeExpectNoException(chunkStream));
+            } catch (Exception e) {
+                logger.error("failure encoding chunk", e);
+                throw e;
+            } finally {
+                if (isPartComplete == false) {
+                    assert false : "failure encoding chunk";
+                    IOUtils.closeWhileHandlingException(chunkStream);
+                }
+            }
+        }
+
+        @Override
+        public String getResponseContentTypeString() {
+            return ServerSentEventSpec.MIME_TYPE;
+        }
+    }
+
+    /**
+     * Special ChunkedRestResponseBodyPart that writes a single InferenceAction.Response followed by a DONE chunk.
+     * This covers when a provider does not have streaming support but the request asked for it.
+     */
+    private class SingleServerSentEventBodyPart extends ServerSentEventResponseBodyPart {
+        private SingleServerSentEventBodyPart(ServerSentEvents event, InferenceAction.Response item) {
+            super(event, item);
+        }
+
+        @Override
+        public boolean isLastPart() {
+            return false;
+        }
+
+        @Override
+        public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
+            listener.onResponse(new ServerSentEventDoneBodyPart());
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Server-Sent Events for Inference response (#112565)