### PR TITLE
Mute a new test on BWC-8.11 where we did not support spatial points the same

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_points.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_points.csv-spec
@@ -4,6 +4,7 @@
 ####################################################################################################
 
 spatialMultiValuePointsStats
+required_capability: spatial_points_from_source
 
 FROM multivalue_points
 | MV_EXPAND location


### PR DESCRIPTION
Some recent tests added run on all recent versions, but BWC against much older versions did not do capabilities checks, and so this test failed.