### PR TITLE
RestServerActionPlugin could  available to external plugins

### DIFF
--- a/docs/changelog/113126.yaml
+++ b/docs/changelog/113126.yaml
@@ -1,0 +1,5 @@
+pr: 113126
+summary: RestServerActionPlugin should be implemented and extended by external plugins
+area: rest server plugin
+type: enhancement
+issues: []

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -309,7 +309,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.persistent;
     exports org.elasticsearch.persistent.decider;
     exports org.elasticsearch.plugins;
-    exports org.elasticsearch.plugins.interceptor to org.elasticsearch.security, org.elasticsearch.serverless.rest;
+    exports org.elasticsearch.plugins.interceptor;
     exports org.elasticsearch.plugins.spi;
     exports org.elasticsearch.repositories;
     exports org.elasticsearch.repositories.blobstore;

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -537,15 +537,6 @@ public class ActionModule extends AbstractModule {
                 var newInstance = function.apply(restPlugin);
                 if (newInstance != null) {
                     logger.debug("Using custom {} from plugin {}", type, plugin.getClass().getName());
-                    if (isInternalPlugin(plugin) == false) {
-                        throw new IllegalArgumentException(
-                            "The "
-                                + plugin.getClass().getName()
-                                + " plugin tried to install a custom "
-                                + type
-                                + ". This functionality is not available to external plugins."
-                        );
-                    }
                     if (result != null) {
                         throw new IllegalArgumentException("Cannot have more than one plugin implementing a " + type);
                     }
@@ -554,14 +545,6 @@ public class ActionModule extends AbstractModule {
             }
         }
         return result;
-    }
-
-    private static boolean isInternalPlugin(ActionPlugin plugin) {
-        final String canonicalName = plugin.getClass().getCanonicalName();
-        if (canonicalName == null) {
-            return false;
-        }
-        return canonicalName.startsWith("org.elasticsearch.xpack.") || canonicalName.startsWith("co.elastic.elasticsearch.");
     }
 
     /**


### PR DESCRIPTION
Based on [pr 112887](https://github.com/elastic/elasticsearch/pull/112887), I think elasticsearch should be more open source, and the rest layer interceptor should be extendable by third-party plugins ;related [pr 98187](https://github.com/elastic/elasticsearch/pull/98187)