### PR TITLE
[8.x] Mute a new test on 8.11 where we did not support spatial points the same (#113119)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_points.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/multivalue_points.csv-spec
@@ -4,6 +4,7 @@
 ####################################################################################################
 
 spatialMultiValuePointsStats
+required_capability: spatial_points_from_source
 
 FROM multivalue_points
 | MV_EXPAND location


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Mute a new test on 8.11 where we did not support spatial points the same (#113119)