### PR TITLE
Rework close and shutdown for the geoip processor

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/ConfigDatabases.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/ConfigDatabases.java
@@ -77,13 +77,13 @@ final class ConfigDatabases implements Closeable {
                 DatabaseReaderLazyLoader loader = new DatabaseReaderLazyLoader(cache, file, null);
                 DatabaseReaderLazyLoader existing = configDatabases.put(databaseFileName, loader);
                 if (existing != null) {
-                    existing.close();
+                    existing.shutdown();
                 }
             } else {
                 logger.info("database file removed [{}], close database...", file);
                 DatabaseReaderLazyLoader existing = configDatabases.remove(databaseFileName);
                 assert existing != null;
-                existing.close();
+                existing.shutdown();
             }
         } catch (Exception e) {
             logger.error(() -> "failed to update database [" + databaseFileName + "]", e);
@@ -116,7 +116,7 @@ final class ConfigDatabases implements Closeable {
     @Override
     public void close() throws IOException {
         for (DatabaseReaderLazyLoader lazyLoader : configDatabases.values()) {
-            lazyLoader.close();
+            lazyLoader.shutdown();
         }
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -36,7 +36,6 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
@@ -86,7 +85,7 @@ import static org.elasticsearch.ingest.geoip.GeoIpTaskState.getGeoIpTaskState;
  * if there is an old instance of this database then that is closed.
  * 4) Cleanup locally loaded databases that are no longer mentioned in {@link GeoIpTaskState}.
  */
-public final class DatabaseNodeService implements IpDatabaseProvider, Closeable {
+public final class DatabaseNodeService implements IpDatabaseProvider {
 
     private static final Logger logger = LogManager.getLogger(DatabaseNodeService.class);
 
@@ -235,8 +234,7 @@ public final class DatabaseNodeService implements IpDatabaseProvider, Closeable 
         return databases.get(key);
     }
 
-    @Override
-    public void close() throws IOException {
+    public void shutdown() throws IOException {
         IOUtils.close(databases.values());
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -13,7 +13,6 @@ import com.maxmind.db.DatabaseRecord;
 import com.maxmind.db.Network;
 import com.maxmind.db.NoCache;
 import com.maxmind.db.Reader;
-import com.maxmind.geoip2.model.AbstractResponse;
 import com.maxmind.geoip2.model.AnonymousIpResponse;
 import com.maxmind.geoip2.model.AsnResponse;
 import com.maxmind.geoip2.model.CityResponse;
@@ -200,10 +199,7 @@ class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
     }
 
     @Nullable
-    private <T extends AbstractResponse> T getResponse(
-        String ipAddress,
-        CheckedBiFunction<Reader, String, Optional<T>, Exception> responseProvider
-    ) {
+    private <T> T getResponse(String ipAddress, CheckedBiFunction<Reader, String, Optional<T>, Exception> responseProvider) {
         return cache.putIfAbsent(ipAddress, databasePath.toString(), ip -> {
             try {
                 return responseProvider.apply(get(), ipAddress).orElse(null);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -187,7 +187,7 @@ class DatabaseReaderLazyLoader implements IpDatabase {
     }
 
     @Override
-    public void release() throws IOException {
+    public void close() throws IOException {
         if (currentUsages.updateAndGet(current -> current > 0 ? current - 1 : current + 1) == -1) {
             doShutdown();
         }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -199,7 +199,10 @@ class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
     }
 
     @Nullable
-    private <T> T getResponse(String ipAddress, CheckedBiFunction<Reader, String, Optional<T>, Exception> responseProvider) {
+    private <RESPONSE> RESPONSE getResponse(
+        String ipAddress,
+        CheckedBiFunction<Reader, String, Optional<RESPONSE>, Exception> responseProvider
+    ) {
         return cache.putIfAbsent(ipAddress, databasePath.toString(), ip -> {
             try {
                 return responseProvider.apply(get(), ipAddress).orElse(null);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -35,7 +35,6 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -50,7 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Facilitates lazy loading of the database reader, so that when the geoip plugin is installed, but not used,
  * no memory is being wasted on the database reader.
  */
-class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
+class DatabaseReaderLazyLoader implements IpDatabase {
 
     private static final boolean LOAD_DATABASE_ON_HEAP = Booleans.parseBoolean(System.getProperty("es.geoip.load_db_on_heap", "false"));
 
@@ -65,7 +64,7 @@ class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
     // cache the database type so that we do not re-read it on every pipeline execution
     final SetOnce<String> databaseType;
 
-    private volatile boolean deleteDatabaseFileOnClose;
+    private volatile boolean deleteDatabaseFileOnShutdown;
     private final AtomicInteger currentUsages = new AtomicInteger(0);
 
     DatabaseReaderLazyLoader(GeoIpCache cache, Path databasePath, String md5) {
@@ -190,7 +189,7 @@ class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
     @Override
     public void release() throws IOException {
         if (currentUsages.updateAndGet(current -> current > 0 ? current - 1 : current + 1) == -1) {
-            doClose();
+            doShutdown();
         }
     }
 
@@ -228,24 +227,23 @@ class DatabaseReaderLazyLoader implements IpDatabase, Closeable {
         return md5;
     }
 
-    public void close(boolean shouldDeleteDatabaseFileOnClose) throws IOException {
-        this.deleteDatabaseFileOnClose = shouldDeleteDatabaseFileOnClose;
-        close();
+    public void shutdown(boolean shouldDeleteDatabaseFileOnShutdown) throws IOException {
+        this.deleteDatabaseFileOnShutdown = shouldDeleteDatabaseFileOnShutdown;
+        shutdown();
     }
 
-    @Override
-    public void close() throws IOException {
+    public void shutdown() throws IOException {
         if (currentUsages.updateAndGet(u -> -1 - u) == -1) {
-            doClose();
+            doShutdown();
         }
     }
 
     // Visible for Testing
-    protected void doClose() throws IOException {
+    protected void doShutdown() throws IOException {
         IOUtils.close(databaseReader.get());
         int numEntriesEvicted = cache.purgeCacheEntriesForDatabase(databasePath);
         logger.info("evicted [{}] entries from cache after reloading database [{}]", numEntriesEvicted, databasePath);
-        if (deleteDatabaseFileOnClose) {
+        if (deleteDatabaseFileOnShutdown) {
             logger.info("deleting [{}]", databasePath);
             Files.delete(databasePath);
         }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -60,7 +60,7 @@ final class GeoIpCache {
     }
 
     @SuppressWarnings("unchecked")
-    <T> T putIfAbsent(String ip, String databasePath, Function<String, T> retrieveFunction) {
+    <RESPONSE> RESPONSE putIfAbsent(String ip, String databasePath, Function<String, RESPONSE> retrieveFunction) {
         // can't use cache.computeIfAbsent due to the elevated permissions for the jackson (run via the cache loader)
         CacheKey cacheKey = new CacheKey(ip, databasePath);
         long cacheStart = relativeNanoTimeProvider.getAsLong();
@@ -87,7 +87,7 @@ final class GeoIpCache {
         if (response == NO_RESULT) {
             return null; // the no-result sentinel is an internal detail, don't expose it
         } else {
-            return (T) response;
+            return (RESPONSE) response;
         }
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -161,7 +161,7 @@ public class IngestGeoIpPlugin extends Plugin
 
     @Override
     public void close() throws IOException {
-        databaseRegistry.get().close();
+        databaseRegistry.get().shutdown();
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabase.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpDatabase.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 /**
  * Provides a uniform interface for interacting with various ip databases.
  */
-public interface IpDatabase {
+public interface IpDatabase extends AutoCloseable {
 
     /**
      * @return the database type as it is detailed in the database file metadata
@@ -76,7 +76,9 @@ public interface IpDatabase {
     /**
      * Releases the current database object. Called after processing a single document. Databases should be closed or returned to a
      * resource pool. No further interactions should be expected.
+     *
      * @throws IOException if the implementation encounters any problem while cleaning up
      */
-    void release() throws IOException;
+    @Override
+    void close() throws IOException;
 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -83,7 +83,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
     @After
     public void closeDatabaseReaders() throws IOException {
-        databaseNodeService.close();
+        databaseNodeService.shutdown();
         databaseNodeService = null;
     }
 

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -666,7 +666,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
         // Check the loader's reference count and attempt to close
         assertThat(loader.current(), equalTo(0));
-        loader.close();
+        loader.shutdown();
         assertTrue(closeCheck.get());
     }
 
@@ -797,11 +797,11 @@ public class GeoIpProcessorTests extends ESTestCase {
         final GeoIpCache cache = new GeoIpCache(1000);
         return new DatabaseReaderLazyLoader(cache, path, null) {
             @Override
-            protected void doClose() throws IOException {
+            protected void doShutdown() throws IOException {
                 if (closed != null) {
                     closed.set(true);
                 }
-                super.doClose();
+                super.doShutdown();
             }
         };
     }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -43,7 +43,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     private static final Set<Property> ALL_PROPERTIES = Set.of(Property.values());
 
     // a temporary directory that mmdb files can be copied to and read from
-    Path tmpDir;
+    private Path tmpDir;
 
     @Before
     public void setup() {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MMDBUtilTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MMDBUtilTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 public class MMDBUtilTests extends ESTestCase {
 
     // a temporary directory that mmdb files can be copied to and read from
-    Path tmpDir;
+    private Path tmpDir;
 
     @Before
     public void setup() {


### PR DESCRIPTION
There's a few tidying cleanups, and then much ado about relatively little. The way `release()` was being used was amenable to being an `AutoClosable`, but `close()` was already in use and meant something else. This refactors `close()` to `shutdown()` and then `release()` to `close()`.