### PR TITLE
Adding a mixed cluster yaml rest test runner for the geoip plugin

### DIFF
--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -8,10 +8,13 @@
  */
 
 import org.elasticsearch.gradle.OS
+import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.bwc-test'
 
 esplugin {
   description 'Ingest processor that uses lookup geo data based on IP addresses using the MaxMind geo database'
@@ -88,3 +91,24 @@ tasks.named("dependencyLicenses").configure {
 artifacts {
   restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }
+
+
+def supportedVersion = bwcVersion -> {
+  return bwcVersion.onOrAfter("8.10.0");
+}
+
+BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->
+
+  def yamlRestTest = tasks.register("v${bwcVersion}#yamlRestTest", StandaloneRestIntegTestTask) {
+    usesDefaultDistribution()
+    usesBwcDistribution(bwcVersion)
+    systemProperty("tests.old_cluster_version", bwcVersion)
+    testClassesDirs = sourceSets.yamlRestTest.output.classesDirs
+    classpath = sourceSets.yamlRestTest.runtimeClasspath
+  }
+
+  tasks.register(bwcTaskName(bwcVersion)) {
+    dependsOn yamlRestTest
+  }
+}
+

--- a/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
+++ b/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
@@ -42,7 +42,6 @@ public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
     static final boolean useFixture = Booleans.parseBoolean(System.getProperty("geoip_use_service", "false")) == false;
 
     static GeoIpHttpFixture fixture = new GeoIpHttpFixture(useFixture);
-    static int clusterSize = 1;
 
     private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("reindex")
@@ -73,6 +72,10 @@ public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
         return ESClientYamlSuiteTestCase.createParameters();
     }
 
+    int getClusterSize() {
+        return cluster.getNumNodes();
+    }
+
     @Before
     @SuppressWarnings("unchecked")
     public void waitForDatabases() throws Exception {
@@ -85,7 +88,7 @@ public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
             assertThat(downloadStats.get("databases_count"), equalTo(4));
 
             Map<?, Map<?, ?>> nodes = (Map<?, Map<?, ?>>) response.get("nodes");
-            assertThat(nodes.size(), equalTo(clusterSize));
+            assertThat(nodes.size(), equalTo(getClusterSize()));
             for (Map<?, ?> node : nodes.values()) {
                 List<?> databases = ((List<?>) node.get("databases"));
                 assertThat(databases, notNullValue());

--- a/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpMixedClusterYamlTestSuiteIT.java
+++ b/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpMixedClusterYamlTestSuiteIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.ingest.geoip;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+public class IngestGeoIpMixedClusterYamlTestSuiteIT extends IngestGeoIpClientYamlTestSuiteIT {
+
+    private static ElasticsearchCluster mixedCluster = ElasticsearchCluster.local()
+        .module("reindex")
+        .module("ingest-geoip")
+        .distribution(DistributionType.DEFAULT)
+        .withNode(node -> node.version(getOldVersion()))
+        .withNode(node -> node.version(Version.CURRENT))
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .systemProperty("ingest.geoip.downloader.enabled.default", "true")
+        // sets the plain (geoip.elastic.co) downloader endpoint, which is used in these tests
+        .setting("ingest.geoip.downloader.endpoint", () -> fixture.getAddress(), s -> useFixture)
+        // also sets the enterprise downloader maxmind endpoint, to make sure we do not accidentally hit the real endpoint from tests
+        // note: it's not important that the downloading actually work at this point -- the rest tests (so far) don't exercise
+        // the downloading code because of license reasons -- but if they did, then it would be important that we're hitting a fixture
+        .systemProperty("ingest.geoip.downloader.maxmind.endpoint.default", () -> fixture.getAddress(), s -> useFixture)
+        .build();
+
+    static {
+        clusterSize = mixedCluster.getNumNodes();
+    }
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(fixture).around(mixedCluster);
+
+    static Version getOldVersion() {
+        return Version.fromString(System.getProperty("tests.old_cluster_version"));
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return mixedCluster.getHttpAddresses();
+    }
+
+    public IngestGeoIpMixedClusterYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+}

--- a/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpMixedClusterYamlTestSuiteIT.java
+++ b/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpMixedClusterYamlTestSuiteIT.java
@@ -40,10 +40,6 @@ public class IngestGeoIpMixedClusterYamlTestSuiteIT extends IngestGeoIpClientYam
         .systemProperty("ingest.geoip.downloader.maxmind.endpoint.default", () -> fixture.getAddress(), s -> useFixture)
         .build();
 
-    static {
-        clusterSize = mixedCluster.getNumNodes();
-    }
-
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(fixture).around(mixedCluster);
 
@@ -54,6 +50,11 @@ public class IngestGeoIpMixedClusterYamlTestSuiteIT extends IngestGeoIpClientYam
     @Override
     protected String getTestRestCluster() {
         return mixedCluster.getHttpAddresses();
+    }
+
+    @Override
+    int getClusterSize() {
+        return mixedCluster.getNumNodes();
     }
 
     public IngestGeoIpMixedClusterYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
This adds IngestGeoIpMixedClusterYamlTestSuiteIT for the geoip plugin. It runs the same yaml rest tests as IngestGeoIpClientYamlTestSuiteIT, but in a mixed cluster so that we can have confidence we're not breaking compatibility.