### PR TITLE
[8.x] Run snyk dependency checks on 8.x (#113117)

### DIFF
--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -930,7 +930,7 @@ steps:
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
       diskSizeGb: 250
-    if: build.branch == "main" || build.branch == "7.17"
+    if: build.branch == "main" || build.branch == "8.x" || build.branch == "7.17"
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Run snyk dependency checks on 8.x (#113117)