### PR TITLE
adds missing `indexing_pressure` monitoring fields to mb template

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -2466,6 +2466,104 @@
             }
           }
         },
+        "indexing_pressure": {
+          "properties": {
+            "memory": {
+              "properties": {
+                "current": {
+                  "properties": {
+                    "all": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "combined_coordinating_and_primary": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "coordinating": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "primary": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "replica": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                },
+                "limit_in_bytes": {
+                  "type": "long"
+                },
+                "total": {
+                  "properties": {
+                    "all": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "combined_coordinating_and_primary": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "coordinating": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        },
+                        "rejections": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "primary": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        },
+                        "rejections": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "replica": {
+                      "properties": {
+                        "bytes": {
+                          "type": "long"
+                        },
+                        "rejections": {
+                          "type": "long"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "indices_stats": {
           "properties": {
             "_all": {


### PR DESCRIPTION
Adds the missing fields related to `indexing_pressure` to the Metricbeat Monitoring Index Template to align with the Metricbeat Template. Possibly a missing task from: https://github.com/elastic/beats/pull/28479

Closes: https://github.com/elastic/beats/issues/40907