### PR TITLE
Forbid `-` in namespace in reroute processor

### DIFF
--- a/docs/changelog/113218.yaml
+++ b/docs/changelog/113218.yaml
@@ -1,0 +1,6 @@
+pr: 113218
+summary: Forbid - in namespace in reroute processor
+area: Ingest Node
+type: bug
+issues:
+ - 112936

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RerouteProcessor.java
@@ -203,8 +203,7 @@ public final class RerouteProcessor extends AbstractProcessor {
 
         private static final int MAX_LENGTH = 100;
         private static final String REPLACEMENT = "_";
-        private static final Pattern DISALLOWED_IN_DATASET = Pattern.compile("[\\\\/*?\"<>| ,#:-]");
-        private static final Pattern DISALLOWED_IN_NAMESPACE = Pattern.compile("[\\\\/*?\"<>| ,#:]");
+        private static final Pattern DISALLOWED = Pattern.compile("[\\\\/*?\"<>| ,#:-]");
         static final DataStreamValueSource DATASET_VALUE_SOURCE = dataset("{{" + DATA_STREAM_DATASET + "}}");
         static final DataStreamValueSource NAMESPACE_VALUE_SOURCE = namespace("{{" + DATA_STREAM_NAMESPACE + "}}");
 
@@ -213,11 +212,11 @@ public final class RerouteProcessor extends AbstractProcessor {
         private final Function<String, String> sanitizer;
 
         public static DataStreamValueSource dataset(String dataset) {
-            return new DataStreamValueSource(dataset, ds -> sanitizeDataStreamField(ds, DISALLOWED_IN_DATASET));
+            return new DataStreamValueSource(dataset, ds -> sanitizeDataStreamField(ds, DISALLOWED));
         }
 
         public static DataStreamValueSource namespace(String namespace) {
-            return new DataStreamValueSource(namespace, nsp -> sanitizeDataStreamField(nsp, DISALLOWED_IN_NAMESPACE));
+            return new DataStreamValueSource(namespace, nsp -> sanitizeDataStreamField(nsp, DISALLOWED));
         }
 
         private static String sanitizeDataStreamField(String s, Pattern disallowedInDataset) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorTests.java
@@ -106,12 +106,12 @@ public class RerouteProcessorTests extends ESTestCase {
 
     public void testInvalidDataStreamFieldsFromDocument() throws Exception {
         IngestDocument ingestDocument = createIngestDocument("logs-generic-default");
-        ingestDocument.setFieldValue("data_stream.dataset", "foo-bar");
-        ingestDocument.setFieldValue("data_stream.namespace", "baz#qux");
+        ingestDocument.setFieldValue("data_stream.dataset", "foo\\/*?\"<>| ,#:-bar");
+        ingestDocument.setFieldValue("data_stream.namespace", "baz\\/*?\"<>| ,#:-qux");
 
         RerouteProcessor processor = createRerouteProcessor(List.of(), List.of());
         processor.execute(ingestDocument);
-        assertDataSetFields(ingestDocument, "logs", "foo_bar", "baz_qux");
+        assertDataSetFields(ingestDocument, "logs", "foo_____________bar", "baz_____________qux");
     }
 
     public void testDestination() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RerouteProcessorTests.java
@@ -106,12 +106,12 @@ public class RerouteProcessorTests extends ESTestCase {
 
     public void testInvalidDataStreamFieldsFromDocument() throws Exception {
         IngestDocument ingestDocument = createIngestDocument("logs-generic-default");
-        ingestDocument.setFieldValue("data_stream.dataset", "foo\\/*?\"<>| ,#:-bar");
-        ingestDocument.setFieldValue("data_stream.namespace", "baz\\/*?\"<>| ,#:-qux");
+        ingestDocument.setFieldValue("data_stream.dataset", "foo-bar");
+        ingestDocument.setFieldValue("data_stream.namespace", "baz#qux");
 
         RerouteProcessor processor = createRerouteProcessor(List.of(), List.of());
         processor.execute(ingestDocument);
-        assertDataSetFields(ingestDocument, "logs", "foo_____________bar", "baz_____________qux");
+        assertDataSetFields(ingestDocument, "logs", "foo_bar", "baz_qux");
     }
 
     public void testDestination() throws Exception {
@@ -238,7 +238,7 @@ public class RerouteProcessorTests extends ESTestCase {
     }
 
     public void testNamespaceSanitization() {
-        assertNamespaceSanitization("\\/*?\"<>| ,#:-", "____________-");
+        assertNamespaceSanitization("\\/*?\"<>| ,#:-", "_____________");
         assertNamespaceSanitization("foo*bar", "foo_bar");
     }
 


### PR DESCRIPTION
`-` character is not allowed in ECS data_stream.namespace spec.

Fixes #112936 

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
