### PR TITLE
Speedup RecyclerBytesStreamOutput.writeString

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
@@ -177,6 +177,8 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
         }
     }
 
+    // overridden with some code duplication the same way other write methods in this class are overridden to bypass StreamOutput's
+    // intermediary buffers
     @Override
     public void writeString(String str) throws IOException {
         final int currentPageOffset = this.currentPageOffset;
@@ -189,6 +191,7 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
         BytesRef currentPage = pages.get(pageIndex).v();
         int off = currentPage.offset + currentPageOffset;
         byte[] buffer = currentPage.bytes;
+        // mostly duplicated from StreamOutput.writeString to to get more reliable compilation of this very hot loop
         int offset = off + putVInt(buffer, charCount, off);
         for (int i = 0; i < charCount; i++) {
             final int c = str.charAt(i);


### PR DESCRIPTION
This method is quite hot in some use-cases because it's used by most string writing to transport messages. Overriding teh default implementation for cases where we can write straight to the page instead of going through an intermediary buffer speeds up the method by more than 2x, saving lots of cycles, especially on transport threads.
I copied the char to byte conversion code from `StreamOutput` because I couldn't find an implementation that would reliably inline. Given how hot this code is, it's a reasonable tradeoff to duplicate code in my opinion.