### PR TITLE
[8.x] Add failure store status in index response of data streams (#112816)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1415,7 +1415,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
         IndexRequest indexRequest = new IndexRequest(dataStreamName).opType("create").source("{}", XContentType.JSON);
         Exception e = expectThrows(Exception.class, client().index(indexRequest));
-        assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] is missing"));
+        assertThat(e.getCause().getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] is missing"));
     }
 
     public void testMultipleTimestampValuesInDocument() throws Exception {
@@ -1431,7 +1431,7 @@ public class DataStreamIT extends ESIntegTestCase {
         IndexRequest indexRequest = new IndexRequest(dataStreamName).opType("create")
             .source("{\"@timestamp\": [\"2020-12-12\",\"2022-12-12\"]}", XContentType.JSON);
         Exception e = expectThrows(Exception.class, client().index(indexRequest));
-        assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] encountered multiple values"));
+        assertThat(e.getCause().getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] encountered multiple values"));
     }
 
     public void testMixedAutoCreate() throws Exception {

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/190_failure_store_redirection.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/190_failure_store_redirection.yml
@@ -33,10 +33,12 @@ teardown:
 ---
 "Redirect ingest failure in data stream to failure store":
   - requires:
-      cluster_features: ["gte_v8.15.0"]
-      reason: "data stream failure stores REST structure changed in 8.15+"
-      test_runner_features: [allowed_warnings, contains]
-
+      reason: "Failure store status was added in 8.16+"
+      test_runner_features: [capabilities, allowed_warnings, contains]
+      capabilities:
+        - method: POST
+          path: /{index}/_doc
+          capabilities: [ 'failure_store_status' ]
   - do:
       ingest.put_pipeline:
         id: "failing_pipeline"
@@ -92,6 +94,8 @@ teardown:
         body:
           '@timestamp': '2020-12-12'
           foo: bar
+  - match: { failure_store: used}
+  - match: { _index: '/\.fs-logs-foobar-(\d{4}\.\d{2}\.\d{2}-)?000001/'}
 
   - do:
       indices.get_data_stream:
@@ -144,9 +148,12 @@ teardown:
 ---
 "Redirect shard failure in data stream to failure store":
   - requires:
-      cluster_features: ["gte_v8.14.0"]
-      reason: "data stream failure stores only redirect shard failures in 8.14+"
-      test_runner_features: [allowed_warnings, contains]
+      reason: "Failure store status was added in 8.16+"
+      test_runner_features: [ capabilities, allowed_warnings, contains ]
+      capabilities:
+        - method: POST
+          path: /{index}/_doc
+          capabilities: [ 'failure_store_status' ]
 
   - do:
       allowed_warnings:
@@ -176,6 +183,8 @@ teardown:
         body:
           '@timestamp': '2020-12-12'
           count: 'invalid value'
+  - match: { _index: '/\.fs-logs-foobar-(\d{4}\.\d{2}\.\d{2}-)?000002/'}
+  - match: { failure_store: used}
 
   - do:
       indices.get_data_stream:
@@ -222,14 +231,13 @@ teardown:
 
 ---
 "Ensure failure is redirected to correct failure store after a reroute processor":
-  - skip:
-      known_issues:
-        - cluster_feature: "gte_v8.15.0"
-          fixed_by: "gte_v8.16.0"
-      reason: "Failure store documents contained the original index name rather than the rerouted one before v8.16.0"
   - requires:
-      test_runner_features: [allowed_warnings]
-
+      test_runner_features: [allowed_warnings, capabilities]
+      reason: "Failure store status was added in 8.16+"
+      capabilities:
+        - method: POST
+          path: /{index}/_doc
+          capabilities: [ 'failure_store_status' ]
   - do:
       ingest.put_pipeline:
         id: "failing_pipeline"
@@ -307,6 +315,7 @@ teardown:
         body:
           '@timestamp': '2020-12-12'
           foo: bar
+  - match: { failure_store: used}
 
   - do:
       search:
@@ -422,9 +431,12 @@ teardown:
 ---
 "Failure redirects to original failure store during index change if final pipeline changes target":
   - requires:
-      cluster_features: [ "gte_v8.15.0" ]
-      reason: "data stream failure stores REST structure changed in 8.15+"
-      test_runner_features: [ allowed_warnings, contains ]
+      reason: "Failure store status was added in 8.16+"
+      test_runner_features: [ capabilities, allowed_warnings, contains ]
+      capabilities:
+        - method: POST
+          path: /{index}/_doc
+          capabilities: [ 'failure_store_status' ]
 
   - do:
       ingest.put_pipeline:
@@ -466,6 +478,7 @@ teardown:
         body:
           '@timestamp': '2020-12-12'
           foo: bar
+  - match: { failure_store: used}
 
   - do:
       indices.get_data_stream:
@@ -514,9 +527,12 @@ teardown:
 ---
 "Failure redirects to correct failure store when index loop is detected":
   - requires:
-      cluster_features: [ "gte_v8.15.0" ]
-      reason: "data stream failure stores REST structure changed in 8.15+"
-      test_runner_features: [ allowed_warnings, contains ]
+      reason: "Failure store status was added in 8.16+"
+      test_runner_features: [ capabilities, allowed_warnings, contains ]
+      capabilities:
+        - method: POST
+          path: /{index}/_doc
+          capabilities: [ 'failure_store_status' ]
 
   - do:
       ingest.put_pipeline:
@@ -591,6 +607,8 @@ teardown:
         body:
           '@timestamp': '2020-12-12'
           foo: bar
+  - match: { _index: '/\.fs-destination-data-stream-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { failure_store: used}
 
 
   - do:
@@ -640,9 +658,12 @@ teardown:
 ---
 "Failure redirects to correct failure store when pipeline loop is detected":
   - requires:
-      cluster_features: [ "gte_v8.15.0" ]
-      reason: "data stream failure stores REST structure changed in 8.15+"
-      test_runner_features: [ allowed_warnings, contains ]
+      reason: "Failure store status was added in 8.16+"
+      test_runner_features: [ capabilities, allowed_warnings, contains ]
+      capabilities:
+        - method: POST
+          path: /{index}/_doc
+          capabilities: [ 'failure_store_status' ]
 
   - do:
       ingest.put_pipeline:
@@ -701,6 +722,7 @@ teardown:
         body:
           '@timestamp': '2020-12-12'
           foo: bar
+  - match: { failure_store: used}
 
   - do:
       indices.get_data_stream:
@@ -752,9 +774,7 @@ teardown:
 ---
 "Version conflicts are not redirected to failure store":
   - requires:
-      cluster_features: ["gte_v8.16.0"]
-      reason: "Redirecting version conflicts to the failure store is considered a bug fixed in 8.16"
-      test_runner_features: [allowed_warnings, contains]
+      test_runner_features: [ allowed_warnings]
 
   - do:
       allowed_warnings:
@@ -788,3 +808,92 @@ teardown:
   - match: { items.1.create._index: '/\.ds-logs-foobar-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
   - match: { items.1.create.status: 409 }
   - match: { items.1.create.error.type: version_conflict_engine_exception}
+  - is_false: items.1.create.failure_store
+
+---
+"Test failure store status with bulk request":
+  - requires:
+      test_runner_features: [ allowed_warnings, capabilities ]
+      reason: "Failure store status was added in 8.16+"
+      capabilities:
+        - method: POST
+          path: /_bulk
+          capabilities: [ 'failure_store_status' ]
+        - method: PUT
+          path: /_bulk
+          capabilities: [ 'failure_store_status' ]
+
+  - do:
+      allowed_warnings:
+        - "index template [generic_logs_template] has index patterns [logs-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [generic_logs_template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: generic_logs_template
+        body:
+          index_patterns: logs-*
+          data_stream:
+            failure_store: true
+          template:
+            settings:
+              number_of_shards:   1
+              number_of_replicas: 1
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                count:
+                  type: long
+  - do:
+      allowed_warnings:
+        - "index template [no-fs] has index patterns [no-fs*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [no-fs] will take precedence during new index creation"
+      indices.put_index_template:
+        name: no-fs
+        body:
+          index_patterns: no-fs*
+          data_stream:
+            failure_store: false
+          template:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
+                count:
+                  type: long
+
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "create": { "_index": "logs-foobar", "_id": "1" } }'
+          - '{ "@timestamp": "2022-01-01", "baz": "quick", "a": "brown", "b": "fox" }'
+          - '{ "create": { "_index": "logs-foobar", "_id": "1" } }'
+          - '{ "@timestamp": "2022-01-01", "baz": "lazy", "a": "dog" }'
+          - '{ "create": { "_index": "logs-foobar", "_id": "1" } }'
+          - '{ "@timestamp": "2022-01-01", "count": "invalid" }'
+          - '{ "create": { "_index": "no-fs", "_id": "1" } }'
+          - '{ "@timestamp": "2022-01-01", "count": "invalid" }'
+  - is_true: errors
+  # Successfully indexed to backing index
+  - match: { items.0.create._index: '/\.ds-logs-foobar-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { items.0.create.status: 201 }
+  - is_false: items.1.create.failure_store
+
+  # Rejected but not eligible to go to failure store
+  - match: { items.1.create._index: '/\.ds-logs-foobar-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { items.1.create.status: 409 }
+  - match: { items.1.create.error.type: version_conflict_engine_exception}
+  - is_false: items.1.create.failure_store
+
+  # Successfully indexed to failure store
+  - match: { items.2.create._index: '/\.fs-logs-foobar-(\d{4}\.\d{2}\.\d{2}-)?000002/' }
+  - match: { items.2.create.status: 201 }
+  - match: { items.2.create.failure_store: used }
+
+  # Rejected, eligible to go to failure store, but failure store not enabled
+  - match: { items.3.create._index: '/\.ds-no-fs-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
+  - match: { items.3.create.status: 400 }
+  - match: { items.3.create.error.type: document_parsing_exception }
+  - match: { items.3.create.failure_store: not_enabled }

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.IndexFormatTooNewException;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.LockObtainFailedException;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
@@ -1929,6 +1930,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             org.elasticsearch.ingest.IngestPipelineException::new,
             182,
             TransportVersions.INGEST_PIPELINE_EXCEPTION_ADDED
+        ),
+        INDEX_RESPONSE_WRAPPER_EXCEPTION(
+            IndexDocFailureStoreStatus.ExceptionWithFailureStoreStatus.class,
+            IndexDocFailureStoreStatus.ExceptionWithFailureStoreStatus::new,
+            183,
+            TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -219,6 +219,7 @@ public class TransportVersions {
     public static final TransportVersion SIMULATE_COMPONENT_TEMPLATES_SUBSTITUTIONS = def(8_743_00_0);
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_EMBEDDINGS_ADDED = def(8_744_00_0);
     public static final TransportVersion BULK_INCREMENTAL_STATE = def(8_745_00_0);
+    public static final TransportVersion FAILURE_STORE_STATUS_IN_INDEX_RESPONSE = def(8_746_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.support.WriteResponse;
@@ -247,6 +248,10 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         }
 
         return location.toString();
+    }
+
+    public IndexDocFailureStoreStatus getFailureStoreStatus() {
+        return IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
     }
 
     public void writeThin(StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -63,6 +63,7 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
 
             builder.field(_ID, failure.getId());
             builder.field(STATUS, failure.getStatus().getStatus());
+            failure.getFailureStoreStatus().toXContent(builder, params);
             builder.startObject(ERROR);
             ElasticsearchException.generateThrowableXContent(builder, params, failure.getCause());
             builder.endObject();
@@ -88,6 +89,7 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
         private final long seqNo;
         private final long term;
         private final boolean aborted;
+        private IndexDocFailureStoreStatus failureStoreStatus;
 
         /**
          * For write failures before operation was assigned a sequence number.
@@ -103,7 +105,27 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
                 ExceptionsHelper.status(cause),
                 SequenceNumbers.UNASSIGNED_SEQ_NO,
                 SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-                false
+                false,
+                IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
+            );
+        }
+
+        /**
+         * For write failures before operation was assigned a sequence number.
+         *
+         * use @{link {@link #Failure(String, String, Exception, long, long)}}
+         * to record operation sequence no with failure
+         */
+        public Failure(String index, String id, Exception cause, IndexDocFailureStoreStatus failureStoreStatus) {
+            this(
+                index,
+                id,
+                cause,
+                ExceptionsHelper.status(cause),
+                SequenceNumbers.UNASSIGNED_SEQ_NO,
+                SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+                false,
+                failureStoreStatus
             );
         }
 
@@ -115,20 +137,48 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
                 ExceptionsHelper.status(cause),
                 SequenceNumbers.UNASSIGNED_SEQ_NO,
                 SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-                aborted
+                aborted,
+                IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
             );
         }
 
         public Failure(String index, String id, Exception cause, RestStatus status) {
-            this(index, id, cause, status, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, false);
+            this(
+                index,
+                id,
+                cause,
+                status,
+                SequenceNumbers.UNASSIGNED_SEQ_NO,
+                SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+                false,
+                IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
+            );
         }
 
         /** For write failures after operation was assigned a sequence number. */
         public Failure(String index, String id, Exception cause, long seqNo, long term) {
-            this(index, id, cause, ExceptionsHelper.status(cause), seqNo, term, false);
+            this(
+                index,
+                id,
+                cause,
+                ExceptionsHelper.status(cause),
+                seqNo,
+                term,
+                false,
+                IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
+            );
         }
 
-        private Failure(String index, String id, Exception cause, RestStatus status, long seqNo, long term, boolean aborted) {
+        private Failure(
+            String index,
+            String id,
+            Exception cause,
+            RestStatus status,
+            long seqNo,
+            long term,
+            boolean aborted,
+            IndexDocFailureStoreStatus failureStoreStatus
+        ) {
             this.index = index;
             this.id = id;
             this.cause = cause;
@@ -136,6 +186,7 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
             this.seqNo = seqNo;
             this.term = term;
             this.aborted = aborted;
+            this.failureStoreStatus = failureStoreStatus;
         }
 
         /**
@@ -154,6 +205,11 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
             seqNo = in.readZLong();
             term = in.readVLong();
             aborted = in.readBoolean();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+                failureStoreStatus = IndexDocFailureStoreStatus.read(in);
+            } else {
+                failureStoreStatus = IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
+            }
         }
 
         @Override
@@ -167,6 +223,9 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
             out.writeZLong(seqNo);
             out.writeVLong(term);
             out.writeBoolean(aborted);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+                failureStoreStatus.writeTo(out);
+            }
         }
 
         /**
@@ -231,6 +290,14 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
             return aborted;
         }
 
+        public IndexDocFailureStoreStatus getFailureStoreStatus() {
+            return failureStoreStatus;
+        }
+
+        public void setFailureStoreStatus(IndexDocFailureStoreStatus failureStoreStatus) {
+            this.failureStoreStatus = failureStoreStatus;
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(INDEX_FIELD, index);
@@ -244,6 +311,7 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
             ElasticsearchException.generateThrowableXContent(builder, params, cause);
             builder.endObject();
             builder.field(STATUS_FIELD, status.getStatus());
+            failureStoreStatus.toXContent(builder, params);
             return builder;
         }
 
@@ -339,6 +407,14 @@ public class BulkItemResponse implements Writeable, ToXContentObject {
             return -1;
         }
         return response.getVersion();
+    }
+
+    public IndexDocFailureStoreStatus getFailureStoreStatus() {
+        if (response != null) {
+            return response.getFailureStoreStatus();
+        } else {
+            return failure.getFailureStoreStatus();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.admin.indices.rollover.LazyRolloverAction;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.client.internal.OriginSettingClient;
@@ -240,7 +241,13 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                             if (failureStoreRedirect.index().equals(dataStream) == false) {
                                 continue;
                             }
-                            addFailure(failureStoreRedirect.request(), failureStoreRedirect.id(), failureStoreRedirect.index(), e);
+                            addFailure(
+                                failureStoreRedirect.request(),
+                                failureStoreRedirect.id(),
+                                failureStoreRedirect.index(),
+                                e,
+                                IndexDocFailureStoreStatus.FAILED
+                            );
                             failedRolloverRequests.add(failureStoreRedirect.id());
                         }
                     }
@@ -323,7 +330,10 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 shardRequests.add(bulkItemRequest);
             } catch (ElasticsearchParseException | IllegalArgumentException | RoutingMissingException | ResourceNotFoundException e) {
                 String name = ia != null ? ia.getName() : docWriteRequest.index();
-                addFailureAndDiscardRequest(docWriteRequest, bulkItemRequest.id(), name, e);
+                var failureStoreStatus = isFailureStoreRequest(docWriteRequest)
+                    ? IndexDocFailureStoreStatus.FAILED
+                    : IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
+                addFailureAndDiscardRequest(docWriteRequest, bulkItemRequest.id(), name, e, failureStoreStatus);
             }
         }
         return requestsByShard;
@@ -430,7 +440,10 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
             BulkItemResponse originalFailure = responses.get(slot);
             if (originalFailure.isFailed()) {
                 originalFailure.getFailure().getCause().addSuppressed(exception);
+                originalFailure.getFailure().setFailureStoreStatus(IndexDocFailureStoreStatus.FAILED);
             }
+            // Always replace the item in the responses for thread visibility of any mutations
+            responses.set(slot, originalFailure);
         }
         completeBulkOperation();
     }
@@ -464,10 +477,19 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
 
                         if (bulkItemResponse.isFailed()) {
                             assert bulkItemRequest.id() == bulkItemResponse.getItemId() : "Bulk items were returned out of order";
-                            processFailure(bulkItemRequest, getClusterState(), bulkItemResponse.getFailure().getCause());
+                            IndexDocFailureStoreStatus failureStoreStatus = processFailure(
+                                bulkItemRequest,
+                                getClusterState(),
+                                bulkItemResponse.getFailure().getCause()
+                            );
+                            bulkItemResponse.getFailure().setFailureStoreStatus(failureStoreStatus);
                             addFailure(bulkItemResponse);
                         } else {
                             bulkItemResponse.getResponse().setShardInfo(bulkShardResponse.getShardInfo());
+                            if (isFailureStoreRequest(bulkItemRequest.request())
+                                && bulkItemResponse.getResponse() instanceof IndexResponse ir) {
+                                ir.setFailureStoreStatus(IndexDocFailureStoreStatus.USED);
+                            }
                             responses.set(bulkItemResponse.getItemId(), bulkItemResponse);
                         }
                     }
@@ -498,13 +520,20 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
         for (BulkItemRequest request : bulkShardRequest.items()) {
             final String indexName = request.index();
             DocWriteRequest<?> docWriteRequest = request.request();
-
-            processFailure(request, clusterState, e);
-            addFailure(docWriteRequest, request.id(), indexName, e);
+            IndexDocFailureStoreStatus failureStoreStatus = processFailure(request, clusterState, e);
+            addFailure(docWriteRequest, request.id(), indexName, e, failureStoreStatus);
         }
     }
 
-    private void processFailure(BulkItemRequest bulkItemRequest, ClusterState clusterState, Exception cause) {
+    /**
+     * This method checks the eligibility of the failed document to be redirected to the failure store and updates the metrics.
+     * If the document is eligible it will call {@link BulkOperation#addDocumentToRedirectRequests}. Otherwise, it will return
+     * the appropriate failure store status and count this document as rejected.
+     * @return the status:
+     * - NOT_ENABLED, if the data stream didn't have the data store enabled and
+     * - FAILED if something went wrong in the preparation of the failure store request.
+     */
+    private IndexDocFailureStoreStatus processFailure(BulkItemRequest bulkItemRequest, ClusterState clusterState, Exception cause) {
         var error = ExceptionsHelper.unwrapCause(cause);
         var errorType = ElasticsearchException.getExceptionName(error);
         DocWriteRequest<?> docWriteRequest = bulkItemRequest.request();
@@ -513,25 +542,45 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
         // it has the failure store enabled.
         if (failureStoreCandidate != null) {
             // Do not redirect documents to a failure store that were already headed to one.
-            var isFailureStoreDoc = docWriteRequest instanceof IndexRequest indexRequest && indexRequest.isWriteToFailureStore();
-            if (isFailureStoreDoc == false
+            var isFailureStoreRequest = isFailureStoreRequest(docWriteRequest);
+            if (isFailureStoreRequest == false
                 && failureStoreCandidate.isFailureStoreEnabled()
                 && error instanceof VersionConflictEngineException == false) {
-                // Redirect to failure store.
+                // Prepare the data stream failure store if necessary
                 maybeMarkFailureStoreForRollover(failureStoreCandidate);
-                addDocumentToRedirectRequests(bulkItemRequest, cause, failureStoreCandidate.getName());
-                failureStoreMetrics.incrementFailureStore(bulkItemRequest.index(), errorType, FailureStoreMetrics.ErrorLocation.SHARD);
+
+                // Enqueue the redirect to failure store.
+                boolean added = addDocumentToRedirectRequests(bulkItemRequest, cause, failureStoreCandidate.getName());
+                if (added) {
+                    failureStoreMetrics.incrementFailureStore(bulkItemRequest.index(), errorType, FailureStoreMetrics.ErrorLocation.SHARD);
+                } else {
+                    failureStoreMetrics.incrementRejected(
+                        bulkItemRequest.index(),
+                        errorType,
+                        FailureStoreMetrics.ErrorLocation.SHARD,
+                        isFailureStoreRequest
+                    );
+                    return IndexDocFailureStoreStatus.FAILED;
+                }
             } else {
                 // If we can't redirect to a failure store (because either the data stream doesn't have the failure store enabled
-                // or this request was already targeting a failure store), we increment the rejected counter.
+                // or this request was already targeting a failure store), or this was a version conflict we increment the
+                // rejected counter.
                 failureStoreMetrics.incrementRejected(
                     bulkItemRequest.index(),
                     errorType,
                     FailureStoreMetrics.ErrorLocation.SHARD,
-                    isFailureStoreDoc
+                    isFailureStoreRequest
                 );
+                if (isFailureStoreRequest) {
+                    return IndexDocFailureStoreStatus.FAILED;
+                }
+                if (failureStoreCandidate.isFailureStoreEnabled() == false) {
+                    return IndexDocFailureStoreStatus.NOT_ENABLED;
+                }
             }
         }
+        return IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
     }
 
     /**
@@ -559,8 +608,9 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
      * @param request The bulk item request that failed
      * @param cause The exception for the experienced the failure
      * @param failureStoreReference The data stream that contains the failure store for this item
+     * @return true, if adding the request to the queue was successful, false otherwise.
      */
-    private void addDocumentToRedirectRequests(BulkItemRequest request, Exception cause, String failureStoreReference) {
+    private boolean addDocumentToRedirectRequests(BulkItemRequest request, Exception cause, String failureStoreReference) {
         // Convert the document into a failure document
         IndexRequest failureStoreRequest;
         try {
@@ -585,12 +635,12 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
             );
             // Suppress and do not redirect
             cause.addSuppressed(ioException);
-            return;
+            return false;
         }
 
         // Store for second phase
         BulkItemRequest redirected = new BulkItemRequest(request.id(), failureStoreRequest);
-        failureStoreRedirects.add(redirected);
+        return failureStoreRedirects.add(redirected);
     }
 
     /**
@@ -679,7 +729,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 "[" + DocWriteRequest.REQUIRE_ALIAS + "] request flag is [true] and [" + request.index() + "] is not an alias",
                 request.index()
             );
-            addFailureAndDiscardRequest(request, idx, request.index(), exception);
+            addFailureAndDiscardRequest(request, idx, request.index(), exception, IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN);
             return true;
         }
         return false;
@@ -691,7 +741,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 "[" + DocWriteRequest.REQUIRE_DATA_STREAM + "] request flag is [true] and [" + request.index() + "] is not a data stream",
                 request.index()
             );
-            addFailureAndDiscardRequest(request, idx, request.index(), exception);
+            addFailureAndDiscardRequest(request, idx, request.index(), exception, IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN);
             return true;
         }
         return false;
@@ -700,7 +750,10 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     private boolean addFailureIfIndexIsClosed(DocWriteRequest<?> request, Index concreteIndex, int idx, final Metadata metadata) {
         IndexMetadata indexMetadata = metadata.getIndexSafe(concreteIndex);
         if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
-            addFailureAndDiscardRequest(request, idx, request.index(), new IndexClosedException(concreteIndex));
+            var failureStoreStatus = isFailureStoreRequest(request)
+                ? IndexDocFailureStoreStatus.FAILED
+                : IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
+            addFailureAndDiscardRequest(request, idx, request.index(), new IndexClosedException(concreteIndex), failureStoreStatus);
             return true;
         }
         return false;
@@ -709,18 +762,31 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     private boolean addFailureIfIndexCannotBeCreated(DocWriteRequest<?> request, int idx) {
         IndexNotFoundException cannotCreate = indicesThatCannotBeCreated.get(request.index());
         if (cannotCreate != null) {
-            addFailureAndDiscardRequest(request, idx, request.index(), cannotCreate);
+            var failureStoreStatus = isFailureStoreRequest(request)
+                ? IndexDocFailureStoreStatus.FAILED
+                : IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
+            addFailureAndDiscardRequest(request, idx, request.index(), cannotCreate, failureStoreStatus);
             return true;
         }
         return false;
     }
 
+    private static boolean isFailureStoreRequest(DocWriteRequest<?> request) {
+        return request instanceof IndexRequest ir && ir.isWriteToFailureStore();
+    }
+
     /**
-     * Like {@link BulkOperation#addFailure(DocWriteRequest, int, String, Exception)} but this method will remove the corresponding entry
-     * from the working bulk request so that it never gets processed again during this operation.
+     * Like {@link BulkOperation#addFailure(DocWriteRequest, int, String, Exception, IndexDocFailureStoreStatus)} but this method will
+     * remove the corresponding entry from the working bulk request so that it never gets processed again during this operation.
      */
-    private void addFailureAndDiscardRequest(DocWriteRequest<?> request, int idx, String index, Exception exception) {
-        addFailure(request, idx, index, exception);
+    private void addFailureAndDiscardRequest(
+        DocWriteRequest<?> request,
+        int idx,
+        String index,
+        Exception exception,
+        IndexDocFailureStoreStatus failureStoreStatus
+    ) {
+        addFailure(request, idx, index, exception, failureStoreStatus);
         // make sure the request gets never processed again
         bulkRequest.requests.set(idx, null);
     }
@@ -734,18 +800,26 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
      * @param idx The slot of the bulk entry this request corresponds to
      * @param index The resource that this entry was being written to when it failed
      * @param exception The exception encountered for this entry
+     * @param failureStoreStatus The failure status as it was identified by this entry
      * @see BulkOperation#addFailure(BulkItemResponse) BulkOperation.addFailure if you have a bulk item response object already
      */
-    private void addFailure(DocWriteRequest<?> request, int idx, String index, Exception exception) {
+    private void addFailure(
+        DocWriteRequest<?> request,
+        int idx,
+        String index,
+        Exception exception,
+        IndexDocFailureStoreStatus failureStoreStatus
+    ) {
         BulkItemResponse bulkItemResponse = responses.get(idx);
         if (bulkItemResponse == null) {
-            BulkItemResponse.Failure failure = new BulkItemResponse.Failure(index, request.id(), exception);
+            BulkItemResponse.Failure failure = new BulkItemResponse.Failure(index, request.id(), exception, failureStoreStatus);
             bulkItemResponse = BulkItemResponse.failure(idx, request.opType(), failure);
         } else {
             // Response already recorded. We should only be here if the existing response is a failure and
             // we are encountering a new failure while redirecting.
             assert bulkItemResponse.isFailed() : "Attempting to overwrite successful bulk item result with a failure";
             bulkItemResponse.getFailure().getCause().addSuppressed(exception);
+            bulkItemResponse.getFailure().setFailureStoreStatus(failureStoreStatus);
         }
         // Always replace the item in the responses for thread visibility of any mutations
         responses.set(idx, bulkItemResponse);
@@ -756,8 +830,8 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
      * already, the failure information provided to this call will be added to the existing failure as a suppressed exception.
      *
      * @param bulkItemResponse the item response to add to the overall result array
-     * @see BulkOperation#addFailure(DocWriteRequest, int, String, Exception) BulkOperation.addFailure which conditionally creates the
-     * failure response only when one does not exist already
+     * @see BulkOperation#addFailure(DocWriteRequest, int, String, Exception, IndexDocFailureStoreStatus) BulkOperation.addFailure which
+     * conditionally creates the failure response only when one does not exist already
      */
     private void addFailure(BulkItemResponse bulkItemResponse) {
         assert bulkItemResponse.isFailed() : "Attempting to add a successful bulk item response via the addFailure method";
@@ -767,6 +841,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
             // we are encountering a new failure while redirecting.
             assert existingBulkItemResponse.isFailed() : "Attempting to overwrite successful bulk item result with a failure";
             existingBulkItemResponse.getFailure().getCause().addSuppressed(bulkItemResponse.getFailure().getCause());
+            existingBulkItemResponse.getFailure().setFailureStoreStatus(bulkItemResponse.getFailure().getFailureStoreStatus());
             bulkItemResponse = existingBulkItemResponse;
         }
         // Always replace the item in the responses for thread visibility of any mutations

--- a/server/src/main/java/org/elasticsearch/action/bulk/IndexDocFailureStoreStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IndexDocFailureStoreStatus.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Captures the role of the failure store in this document response. For example,
+ * - USED, means that this document was stored in the failure store
+ * - NOT_ENABLED, means that this document was rejected by elasticsearch, but it could have been stored in
+ * the failure store has it been enabled.
+ * - FAILED, means that this failed document was eligible to be stored in the failure store and the failure store
+ * was enabled but something went wrong.
+ */
+public enum IndexDocFailureStoreStatus implements ToXContentFragment, Writeable {
+    /**
+     * This status represents that we have no information about this response or that the failure store is not applicable.
+     * For example:
+     * - when the doc was successfully indexed in a backing index of a data stream,
+     * - when we are running in a mixed version cluster and the information is not available,
+     * - when the doc was rejected by elasticsearch but failure store was not applicable (i.e. the target was an index).
+     */
+    NOT_APPLICABLE_OR_UNKNOWN(0),
+    /**
+     * This status represents that this document was stored in the failure store successfully.
+     */
+    USED(1),
+    /**
+     * This status represents that this document was rejected, but it could have ended up in the failure store if it was enabled.
+     */
+    NOT_ENABLED(2),
+    /**
+     * This status represents that this document was rejected from the failure store.
+     */
+    FAILED(3);
+
+    private final byte id;
+    private final String label;
+
+    IndexDocFailureStoreStatus(int id) {
+        this.id = (byte) id;
+        this.label = this.toString().toLowerCase(Locale.ROOT);
+    }
+
+    public static IndexDocFailureStoreStatus read(StreamInput in) throws IOException {
+        return fromId(in.readByte());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeByte(id);
+    }
+
+    /**
+     * @return id of the status, mainly used for wire serialisation purposes
+     */
+    public byte getId() {
+        return id;
+    }
+
+    /**
+     * @return the label of this status for display, just lowercase of the enum
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * @param id a candidate id that (hopefully) can be converted to a FailureStoreStatus, used in wire serialisation
+     * @return the failure store status that corresponds to the id.
+     * @throws IllegalArgumentException when the id cannot produce a failure store status
+     */
+    public static IndexDocFailureStoreStatus fromId(byte id) {
+        return switch (id) {
+            case 0 -> NOT_APPLICABLE_OR_UNKNOWN;
+            case 1 -> USED;
+            case 2 -> NOT_ENABLED;
+            case 3 -> FAILED;
+            default -> throw new IllegalArgumentException("Unknown failure store status: [" + id + "]");
+        };
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // We avoid adding the not_applicable status in the response to not increase the size of bulk responses.
+        if (DataStream.isFailureStoreFeatureFlagEnabled() && this.equals(NOT_APPLICABLE_OR_UNKNOWN) == false) {
+            builder.field("failure_store", label);
+        }
+        return builder;
+    }
+
+    /**
+     * Exception wrapper class that adds the failure store status in the XContent response.
+     * Note: We are not using {@link ExceptionWithFailureStoreStatus} because then it unwraps it directly
+     * in the {@link ElasticsearchException} and we cannot add the field.
+     */
+    public static class ExceptionWithFailureStoreStatus extends ElasticsearchException {
+
+        private final IndexDocFailureStoreStatus failureStoreStatus;
+
+        public ExceptionWithFailureStoreStatus(BulkItemResponse.Failure failure) {
+            super(failure.getCause());
+            this.failureStoreStatus = failure.getFailureStoreStatus();
+        }
+
+        public ExceptionWithFailureStoreStatus(StreamInput in) throws IOException {
+            super(in);
+            if (in.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+                failureStoreStatus = IndexDocFailureStoreStatus.fromId(in.readByte());
+            } else {
+                failureStoreStatus = NOT_APPLICABLE_OR_UNKNOWN;
+            }
+        }
+
+        @Override
+        protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+            super.writeTo(out, nestedExceptionsWriter);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+                out.writeByte(failureStoreStatus.getId());
+            }
+        }
+
+        @Override
+        protected XContentBuilder toXContent(XContentBuilder builder, Params params, int nestedLevel) throws IOException {
+            generateThrowableXContent(builder, params, this.getCause(), nestedLevel);
+            failureStoreStatus.toXContent(builder, params);
+            return builder;
+        }
+
+        @Override
+        public RestStatus status() {
+            return ExceptionsHelper.status(getCause());
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -192,7 +192,11 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
                 final Response response = (Response) bulkItemResponse.getResponse();
                 l.onResponse(response);
             } else {
-                l.onFailure(bulkItemResponse.getFailure().getCause());
+                if (IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN.equals(bulkItemResponse.getFailure().getFailureStoreStatus())) {
+                    l.onFailure(bulkItemResponse.getFailure().getCause());
+                } else {
+                    l.onFailure(new IndexDocFailureStoreStatus.ExceptionWithFailureStoreStatus(bulkItemResponse.getFailure()));
+                }
             }
         });
     }
@@ -206,7 +210,6 @@ public class TransportBulkAction extends TransportAbstractBulkAction {
         long relativeStartTimeNanos
     ) {
         trackIndexRequests(bulkRequest);
-
         Map<String, CreateIndexRequest> indicesToAutoCreate = new HashMap<>();
         Set<String> dataStreamsToBeRolledOver = new HashSet<>();
         Set<String> failureStoresToBeRolledOver = new HashSet<>();

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -881,6 +881,9 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         return this;
     }
 
+    /**
+     * Transient flag denoting that the local request should be routed to a failure store. Not persisted across the wire.
+     */
     public boolean isWriteToFailureStore() {
         return writeToFailureStore;
     }

--- a/server/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.index;
 
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,6 +37,7 @@ public class IndexResponse extends DocWriteResponse {
      */
     @Nullable
     protected final List<String> executedPipelines;
+    private IndexDocFailureStoreStatus failureStoreStatus;
 
     public IndexResponse(ShardId shardId, StreamInput in) throws IOException {
         super(shardId, in);
@@ -43,6 +45,11 @@ public class IndexResponse extends DocWriteResponse {
             executedPipelines = in.readOptionalCollectionAsList(StreamInput::readString);
         } else {
             executedPipelines = null;
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+            failureStoreStatus = IndexDocFailureStoreStatus.read(in);
+        } else {
+            failureStoreStatus = IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
         }
     }
 
@@ -53,10 +60,15 @@ public class IndexResponse extends DocWriteResponse {
         } else {
             executedPipelines = null;
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+            failureStoreStatus = IndexDocFailureStoreStatus.read(in);
+        } else {
+            failureStoreStatus = IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
+        }
     }
 
     public IndexResponse(ShardId shardId, String id, long seqNo, long primaryTerm, long version, boolean created) {
-        this(shardId, id, seqNo, primaryTerm, version, created, null);
+        this(shardId, id, seqNo, primaryTerm, version, created, null, IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN);
     }
 
     public IndexResponse(
@@ -68,7 +80,29 @@ public class IndexResponse extends DocWriteResponse {
         boolean created,
         @Nullable List<String> executedPipelines
     ) {
-        this(shardId, id, seqNo, primaryTerm, version, created ? Result.CREATED : Result.UPDATED, executedPipelines);
+        this(
+            shardId,
+            id,
+            seqNo,
+            primaryTerm,
+            version,
+            created ? Result.CREATED : Result.UPDATED,
+            executedPipelines,
+            IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
+        );
+    }
+
+    public IndexResponse(
+        ShardId shardId,
+        String id,
+        long seqNo,
+        long primaryTerm,
+        long version,
+        boolean created,
+        @Nullable List<String> executedPipelines,
+        IndexDocFailureStoreStatus failureStoreStatus
+    ) {
+        this(shardId, id, seqNo, primaryTerm, version, created ? Result.CREATED : Result.UPDATED, executedPipelines, failureStoreStatus);
     }
 
     private IndexResponse(
@@ -78,10 +112,12 @@ public class IndexResponse extends DocWriteResponse {
         long primaryTerm,
         long version,
         Result result,
-        @Nullable List<String> executedPipelines
+        @Nullable List<String> executedPipelines,
+        IndexDocFailureStoreStatus failureStoreStatus
     ) {
         super(shardId, id, seqNo, primaryTerm, version, assertCreatedOrUpdated(result));
         this.executedPipelines = executedPipelines;
+        this.failureStoreStatus = failureStoreStatus;
     }
 
     @Override
@@ -89,6 +125,9 @@ public class IndexResponse extends DocWriteResponse {
         super.writeTo(out);
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
             out.writeOptionalCollection(executedPipelines, StreamOutput::writeString);
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+            failureStoreStatus.writeTo(out);
         }
     }
 
@@ -98,6 +137,9 @@ public class IndexResponse extends DocWriteResponse {
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
             out.writeOptionalCollection(executedPipelines, StreamOutput::writeString);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.FAILURE_STORE_STATUS_IN_INDEX_RESPONSE)) {
+            failureStoreStatus.writeTo(out);
+        }
     }
 
     public XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
@@ -105,6 +147,7 @@ public class IndexResponse extends DocWriteResponse {
         if (executedPipelines != null) {
             updatedBuilder = updatedBuilder.field("executed_pipelines", executedPipelines.toArray());
         }
+        failureStoreStatus.toXContent(builder, params);
         return updatedBuilder;
     }
 
@@ -118,6 +161,15 @@ public class IndexResponse extends DocWriteResponse {
         return result == Result.CREATED ? RestStatus.CREATED : super.status();
     }
 
+    public void setFailureStoreStatus(IndexDocFailureStoreStatus failureStoreStatus) {
+        this.failureStoreStatus = failureStoreStatus;
+    }
+
+    @Override
+    public IndexDocFailureStoreStatus getFailureStoreStatus() {
+        return failureStoreStatus;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
@@ -129,6 +181,7 @@ public class IndexResponse extends DocWriteResponse {
         builder.append(",seqNo=").append(getSeqNo());
         builder.append(",primaryTerm=").append(getPrimaryTerm());
         builder.append(",shards=").append(Strings.toString(getShardInfo()));
+        builder.append(",failure_store=").append(failureStoreStatus.getLabel());
         return builder.append("]").toString();
     }
 
@@ -140,7 +193,16 @@ public class IndexResponse extends DocWriteResponse {
     public static class Builder extends DocWriteResponse.Builder {
         @Override
         public IndexResponse build() {
-            IndexResponse indexResponse = new IndexResponse(shardId, id, seqNo, primaryTerm, version, result, null);
+            IndexResponse indexResponse = new IndexResponse(
+                shardId,
+                id,
+                seqNo,
+                primaryTerm,
+                version,
+                result,
+                null,
+                IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
+            );
             indexResponse.setForcedRefresh(forcedRefresh);
             if (shardInfo != null) {
                 indexResponse.setShardInfo(shardInfo);

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulateIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulateIndexResponse.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -59,7 +60,16 @@ public class SimulateIndexResponse extends IndexResponse {
         @Nullable Exception exception
     ) {
         // We don't actually care about most of the IndexResponse fields:
-        super(new ShardId(index, "", 0), id == null ? "<n/a>" : id, 0, 0, version, true, pipelines);
+        super(
+            new ShardId(index, "", 0),
+            id == null ? "<n/a>" : id,
+            0,
+            0,
+            version,
+            true,
+            pipelines,
+            IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN
+        );
         this.source = source;
         this.sourceXContentType = sourceXContentType;
         setShardInfo(ShardInfo.EMPTY);

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.bulk.IncrementalBulkService;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -59,13 +61,16 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class RestBulkAction extends BaseRestHandler {
 
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in bulk requests is deprecated.";
+    public static final String FAILURE_STORE_STATUS_CAPABILITY = "failure_store_status";
 
     private final boolean allowExplicitIndex;
     private final IncrementalBulkService bulkHandler;
+    private final Set<String> capabilities;
 
     public RestBulkAction(Settings settings, IncrementalBulkService bulkHandler) {
         this.allowExplicitIndex = MULTI_ALLOW_EXPLICIT_INDEX.get(settings);
         this.bulkHandler = bulkHandler;
+        this.capabilities = DataStream.isFailureStoreFeatureFlagEnabled() ? Set.of(FAILURE_STORE_STATUS_CAPABILITY) : Set.of();
     }
 
     @Override
@@ -290,5 +295,10 @@ public class RestBulkAction extends BaseRestHandler {
     @Override
     public boolean allowsUnsafeBuffers() {
         return true;
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return capabilities;
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -26,15 +27,20 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
+import static org.elasticsearch.rest.action.document.RestBulkAction.FAILURE_STORE_STATUS_CAPABILITY;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestIndexAction extends BaseRestHandler {
     static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Specifying types in document "
         + "index requests is deprecated, use the typeless endpoints instead (/{index}/_doc/{id}, /{index}/_doc, "
         + "or /{index}/_create/{id}).";
+    private final Set<String> capabilities = DataStream.isFailureStoreFeatureFlagEnabled()
+        ? Set.of(FAILURE_STORE_STATUS_CAPABILITY)
+        : Set.of();
 
     @Override
     public List<Route> routes() {
@@ -144,4 +150,8 @@ public class RestIndexAction extends BaseRestHandler {
         );
     }
 
+    @Override
+    public Set<String> supportedCapabilities() {
+        return capabilities;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.indices.analyze.TransportReloadAnalyzersAc
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -602,6 +603,9 @@ public class SynonymsManagementAPIService {
         @Override
         public void onFailure(Exception e) {
             Throwable cause = ExceptionsHelper.unwrapCause(e);
+            if (cause instanceof IndexDocFailureStoreStatus.ExceptionWithFailureStoreStatus) {
+                cause = cause.getCause();
+            }
             if (cause instanceof IndexNotFoundException) {
                 delegate.onFailure(new ResourceNotFoundException("synonyms set [" + synonymSetId + "] not found"));
                 return;

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.store.LockObtainFailedException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.TimestampParsingException;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.search.VersionMismatchException;
@@ -837,6 +838,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(180, PersistentTaskNodeNotAssignedException.class);
         ids.put(181, ResourceAlreadyUploadedException.class);
         ids.put(182, IngestPipelineException.class);
+        ids.put(183, IndexDocFailureStoreStatus.ExceptionWithFailureStoreStatus.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
@@ -378,6 +378,8 @@ public class BulkOperationTests extends ESTestCase {
             .findFirst()
             .orElseThrow(() -> new AssertionError("Could not find redirected item"));
         assertThat(failedItem, is(notNullValue()));
+        // Ensure the status in the successful response gets through
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.USED));
     }
 
     /**
@@ -403,6 +405,8 @@ public class BulkOperationTests extends ESTestCase {
             .findFirst()
             .orElseThrow(() -> new AssertionError("Could not find redirected item"));
         assertThat(failedItem.getIndex(), is(notNullValue()));
+        // Ensure the status in the successful response gets through
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.USED));
     }
 
     /**
@@ -441,6 +445,7 @@ public class BulkOperationTests extends ESTestCase {
         assertThat(failedItem.getFailure().getCause().getSuppressed().length, is(not(equalTo(0))));
         assertThat(failedItem.getFailure().getCause().getSuppressed()[0], is(instanceOf(MapperException.class)));
         assertThat(failedItem.getFailure().getCause().getSuppressed()[0].getMessage(), is(equalTo("failure store test failure")));
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
     }
 
     /**
@@ -476,6 +481,7 @@ public class BulkOperationTests extends ESTestCase {
         assertThat(failedItem.getFailure().getCause().getSuppressed().length, is(not(equalTo(0))));
         assertThat(failedItem.getFailure().getCause().getSuppressed()[0], is(instanceOf(IOException.class)));
         assertThat(failedItem.getFailure().getCause().getSuppressed()[0].getMessage(), is(equalTo("Could not serialize json")));
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
     }
 
     /**
@@ -565,6 +571,8 @@ public class BulkOperationTests extends ESTestCase {
             .findFirst()
             .orElseThrow(() -> new AssertionError("Could not find redirected item"));
         assertThat(failedItem, is(notNullValue()));
+        // Ensure the status in the successful response gets through
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.USED));
 
         verify(observer, times(1)).isTimedOut();
         verify(observer, times(1)).waitForNextChange(any());
@@ -617,6 +625,7 @@ public class BulkOperationTests extends ESTestCase {
             failedItem.getFailure().getCause().getSuppressed()[0].getMessage(),
             is(equalTo("blocked by: [FORBIDDEN/5/index read-only (api)];"))
         );
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
 
         verify(observer, times(0)).isTimedOut();
         verify(observer, times(0)).waitForNextChange(any());
@@ -677,6 +686,7 @@ public class BulkOperationTests extends ESTestCase {
             failedItem.getFailure().getCause().getSuppressed()[0].getMessage(),
             is(equalTo("blocked by: [SERVICE_UNAVAILABLE/2/no master];"))
         );
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
 
         verify(observer, times(2)).isTimedOut();
         verify(observer, times(1)).waitForNextChange(any());
@@ -779,6 +789,8 @@ public class BulkOperationTests extends ESTestCase {
             .findFirst()
             .orElseThrow(() -> new AssertionError("Could not find redirected item"));
         assertThat(failedItem, is(notNullValue()));
+        // Ensure the status in the successful response gets through
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.USED));
     }
 
     /**
@@ -826,6 +838,7 @@ public class BulkOperationTests extends ESTestCase {
         assertThat(failedItem.getFailure().getCause().getSuppressed().length, is(not(equalTo(0))));
         assertThat(failedItem.getFailure().getCause().getSuppressed()[0], is(instanceOf(Exception.class)));
         assertThat(failedItem.getFailure().getCause().getSuppressed()[0].getMessage(), is(equalTo("rollover failed")));
+        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
     }
 
     /**
@@ -839,14 +852,12 @@ public class BulkOperationTests extends ESTestCase {
      * Accepts all write operations from the given request object when it is encountered in the mock shard bulk action
      */
     private static BiConsumer<BulkShardRequest, ActionListener<BulkShardResponse>> acceptAllShardWrites() {
-        return (BulkShardRequest request, ActionListener<BulkShardResponse> listener) -> {
-            listener.onResponse(
-                new BulkShardResponse(
-                    request.shardId(),
-                    Arrays.stream(request.items()).map(item -> requestToResponse(request.shardId(), item)).toArray(BulkItemResponse[]::new)
-                )
-            );
-        };
+        return (BulkShardRequest request, ActionListener<BulkShardResponse> listener) -> listener.onResponse(
+            new BulkShardResponse(
+                request.shardId(),
+                Arrays.stream(request.items()).map(item -> requestToResponse(request.shardId(), item)).toArray(BulkItemResponse[]::new)
+            )
+        );
     }
 
     /**
@@ -923,8 +934,11 @@ public class BulkOperationTests extends ESTestCase {
      * Create a shard-level result given a bulk item
      */
     private static BulkItemResponse requestToResponse(ShardId shardId, BulkItemRequest itemRequest) {
+        var failureStatus = itemRequest.request() instanceof IndexRequest ir && ir.isWriteToFailureStore()
+            ? IndexDocFailureStoreStatus.USED
+            : IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN;
         return BulkItemResponse.success(itemRequest.id(), itemRequest.request().opType(), switch (itemRequest.request().opType()) {
-            case INDEX, CREATE -> new IndexResponse(shardId, itemRequest.request().id(), 1, 1, 1, true);
+            case INDEX, CREATE -> new IndexResponse(shardId, itemRequest.request().id(), 1, 1, 1, true, null, failureStatus);
             case UPDATE -> new UpdateResponse(shardId, itemRequest.request().id(), 1, 1, 1, DocWriteResponse.Result.UPDATED);
             case DELETE -> new DeleteResponse(shardId, itemRequest.request().id(), 1, 1, 1, true);
         });

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
@@ -132,7 +133,17 @@ public class IndexRequestTests extends ESTestCase {
         String id = randomAlphaOfLengthBetween(3, 10);
         long version = randomLong();
         boolean created = randomBoolean();
-        IndexResponse indexResponse = new IndexResponse(shardId, id, SequenceNumbers.UNASSIGNED_SEQ_NO, 0, version, created);
+        var failureStatus = randomFrom(Set.of(IndexDocFailureStoreStatus.USED, IndexDocFailureStoreStatus.NOT_APPLICABLE_OR_UNKNOWN));
+        IndexResponse indexResponse = new IndexResponse(
+            shardId,
+            id,
+            SequenceNumbers.UNASSIGNED_SEQ_NO,
+            0,
+            version,
+            created,
+            null,
+            failureStatus
+        );
         int total = randomIntBetween(1, 10);
         int successful = randomIntBetween(1, 10);
         ReplicationResponse.ShardInfo shardInfo = ReplicationResponse.ShardInfo.of(total, successful);
@@ -149,6 +160,7 @@ public class IndexRequestTests extends ESTestCase {
         assertEquals(total, indexResponse.getShardInfo().getTotal());
         assertEquals(successful, indexResponse.getShardInfo().getSuccessful());
         assertEquals(forcedRefresh, indexResponse.forcedRefresh());
+        assertEquals(failureStatus, indexResponse.getFailureStoreStatus());
         Object[] args = new Object[] {
             shardId.getIndexName(),
             id,
@@ -157,10 +169,11 @@ public class IndexRequestTests extends ESTestCase {
             SequenceNumbers.UNASSIGNED_SEQ_NO,
             0,
             total,
-            successful };
+            successful,
+            failureStatus.getLabel() };
         assertEquals(Strings.format("""
             IndexResponse[index=%s,id=%s,version=%s,result=%s,seqNo=%s,primaryTerm=%s,shards=\
-            {"total":%s,"successful":%s,"failed":0}]\
+            {"total":%s,"successful":%s,"failed":0},failure_store=%s]\
             """, args), indexResponse.toString());
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add failure store status in index response of data streams (#112816)](https://github.com/elastic/elasticsearch/pull/112816)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)