### PR TITLE
Fix tests with warnings due to date format changes in JDK 23

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -238,15 +238,6 @@ tests:
 - class: org.elasticsearch.logsdb.datageneration.DataGeneratorTests
   method: testDataGeneratorProducesValidMappingAndDocument
   issue: https://github.com/elastic/elasticsearch/issues/112966
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/70_locale/Date format with Italian locale}
-  issue: https://github.com/elastic/elasticsearch/issues/113198
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {date.DateFormatLocale SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/113199
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {date.DateFormatLocale ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/113200
 - class: org.elasticsearch.xpack.core.security.authz.RoleDescriptorTests
   method: testHasPrivilegesOtherThanIndex
   issue: https://github.com/elastic/elasticsearch/issues/113202
@@ -271,12 +262,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
   method: "testFold {TestCase=<double> #2}"
   issue: https://github.com/elastic/elasticsearch/issues/113225
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/70_locale/Date format with default locale}
-  issue: https://github.com/elastic/elasticsearch/issues/113226
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}
-  issue: https://github.com/elastic/elasticsearch/issues/113227
 - class: org.elasticsearch.index.mapper.DoubleRangeFieldMapperTests
   method: testSyntheticSourceKeepAll
   issue: https://github.com/elastic/elasticsearch/issues/113234

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
@@ -1,6 +1,10 @@
 ---
 "Test Index and Search locale dependent mappings / dates":
+  - requires:
+      test_runner_features: ["allowed_warnings"]
   - do:
+      allowed_warnings:
+        - "Date format [E, d MMM yyyy HH:mm:ss Z] contains textual field specifiers that could change in JDK 23"
       indices.create:
           index: test_index
           body:

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -480,6 +480,7 @@ emp_no:integer | year:long    | month:long    | day:long
 dateFormatLocale
 from employees | where emp_no == 10049 or emp_no == 10050 | sort emp_no 
 | eval birth_month = date_format("MMMM", birth_date) | keep emp_no, birth_date, birth_month;
+warningRegex:Date format \[MMMM\] contains textual field specifiers that could change in JDK 23
 ignoreOrder:true
 
 emp_no:integer  |  birth_date:datetime       | birth_month:keyword

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
@@ -29,6 +29,7 @@ setup:
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
+        - "Date format \\[MMMM\\] contains textual field specifiers that could change in JDK 23"
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
@@ -50,6 +51,7 @@ setup:
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
+        - "Date format \\[MMMM\\] contains textual field specifiers that could change in JDK 23"
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'


### PR DESCRIPTION
Adding warnings like

```
Date format [MMMM] contains textual field specifiers that could change in JDK 23
```

to failing tests, due to changes recently introduced about Locale Provider

Fixes: #113226
Fixes: #113227
Fixes: #113198
Fixes: #113199
Fixes: #113200