### PR TITLE
[8.x] [DOCS] Fixes adaptive_allocations examples (#113248)

### DIFF
--- a/docs/reference/inference/service-elasticsearch.asciidoc
+++ b/docs/reference/inference/service-elasticsearch.asciidoc
@@ -179,6 +179,7 @@ PUT _inference/text_embedding/my-e5-model
       "min_number_of_allocations": 3,
       "max_number_of_allocations": 10
     },
+    "num_threads": 1,
     "model_id": ".multilingual-e5-small"
   }
 }

--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -147,7 +147,8 @@ PUT _inference/sparse_embedding/my-elser-model
       "enabled": true,
       "min_number_of_allocations": 3,
       "max_number_of_allocations": 10
-    }
+    },
+    "num_threads": 1
   }
 }
 ------------------------------------------------------------

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -36,7 +36,11 @@ PUT _inference/sparse_embedding/my-elser-endpoint <1>
 {
   "service": "elser", <2>
   "service_settings": {
-    "num_allocations": 1,
+    "adaptive_allocations": { <3>
+      "enabled": true,
+      "min_number_of_allocations": 3,
+      "max_number_of_allocations": 10
+    },
     "num_threads": 1
   }
 }
@@ -46,6 +50,8 @@ PUT _inference/sparse_embedding/my-elser-endpoint <1>
 be used and ELSER creates sparse vectors. The `inference_id` is
 `my-elser-endpoint`.
 <2> The `elser` service is used in this example.
+<3> This setting enables and configures {ml-docs}/ml-nlp-elser.html#elser-adaptive-allocations[adaptive allocations].
+Adaptive allocations make it possible for ELSER to automatically scale up or down resources based on the current load on the process.
 
 [NOTE]
 ====


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [DOCS] Fixes adaptive_allocations examples (#113248)