### PR TITLE
Fix tests with warnings due to date format changes in JDK 23 (#113253)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -480,6 +480,7 @@ emp_no:integer | year:long    | month:long    | day:long
 dateFormatLocale
 from employees | where emp_no == 10049 or emp_no == 10050 | sort emp_no 
 | eval birth_month = date_format("MMMM", birth_date) | keep emp_no, birth_date, birth_month;
+warningRegex:Date format \[MMMM\] contains textual field specifiers that could change in JDK 23
 ignoreOrder:true
 warningRegex:Date format \[MMMM] contains textual field specifiers that could change in JDK 23
 


### PR DESCRIPTION
Adding warnings like

```
Date format [MMMM] contains textual field specifiers that could change in JDK 23
```

to failing tests, due to changes recently introduced about Locale Provider

Backport of https://github.com/elastic/elasticsearch/pull/113253