### PR TITLE
Add view_index_matadata connector permission for fleet-server account

### DIFF
--- a/docs/reference/rest-api/security/get-service-accounts.asciidoc
+++ b/docs/reference/rest-api/security/get-service-accounts.asciidoc
@@ -250,7 +250,8 @@ GET /_security/service/elastic/fleet-server
             "monitor",
             "create_index",
             "auto_configure",
-            "maintenance"
+            "maintenance",
+            ""view_index_metadata"
           ],
           "allow_restricted_indices": false
         },
@@ -265,7 +266,8 @@ GET /_security/service/elastic/fleet-server
             "monitor",
             "create_index",
             "auto_configure",
-            "maintenance"
+            "maintenance",
+            "view_index_metadata"
           ],
           "allow_restricted_indices": false
         }

--- a/docs/reference/rest-api/security/get-service-accounts.asciidoc
+++ b/docs/reference/rest-api/security/get-service-accounts.asciidoc
@@ -251,7 +251,7 @@ GET /_security/service/elastic/fleet-server
             "create_index",
             "auto_configure",
             "maintenance",
-            ""view_index_metadata"
+            "view_index_metadata"
           ],
           "allow_restricted_indices": false
         },

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -296,7 +296,8 @@ public class ServiceAccountIT extends ESRestTestCase {
                     "monitor",
                     "create_index",
                     "auto_configure",
-                    "maintenance"
+                    "maintenance",
+                    "view_index_metadata"
                   ],
                   "allow_restricted_indices": false
                 },
@@ -311,7 +312,8 @@ public class ServiceAccountIT extends ESRestTestCase {
                     "monitor",
                     "create_index",
                     "auto_configure",
-                    "maintenance"
+                    "maintenance",
+                    "view_index_metadata"
                   ],
                   "allow_restricted_indices": false
                 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -160,12 +160,12 @@ final class ElasticServiceAccounts {
                 // Custom permissions required for running Elastic connectors integration
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".elastic-connectors*")
-                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance", "view_index_metadata")
                     .build(),
                 // Permissions for data indices and access control filters used by Elastic connectors integration
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("content-*", ".search-acl-filter-*")
-                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance", "view_index_metadata")
                     .build(), },
             new RoleDescriptor.ApplicationResourcePrivileges[] {
                 RoleDescriptor.ApplicationResourcePrivileges.builder()


### PR DESCRIPTION
# Changes

See #112556 for details.

Add permissions to fleet-server service account to enable running [elastic/connectors](https://github.com/elastic/connectors) as an integration.

Fleet service service account owns and generates api keys that are used by integrations (components) enrolled in fleet. Connectors are (soon) an integrations that can be deployed in agentless to offer Elastic-managed ingestion story.

When changing from `read,write,manage` to more granular permissions I missed `view_index_metadata`. 

This allows the connector service to call `GET {index}`, without this permission content sync would fail. (I somehow missed that during testing of the last PR...)

## Validation

Tested locally with `view_index_metadata` permission added to `fleet-server` service account.  Performed full content sync  with updated permission model.
