### PR TITLE
[8.x] Add test for source-only snapshot with synthetic source (#113233)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -90,3 +90,53 @@ setup:
   - match: {hits.total:      1    }
   - length: {hits.hits:      1    }
   - match: {hits.hits.0._id: "1" }
+
+---
+"Failed to snapshot indices with synthetic source":
+  - skip:
+      features: ["allowed_warnings"]
+
+  - do:
+      indices.create:
+        index: test_synthetic
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+
+  - do:
+      snapshot.create:
+        repository: test_repo_restore_1
+        snapshot: test_snapshot_2
+        wait_for_completion: true
+        body: |
+          { "indices": "test_synthetic" }
+
+  - match: { snapshot.snapshot: test_snapshot_2 }
+  - match: { snapshot.state : PARTIAL }
+  - match: { snapshot.shards.successful: 0 }
+  - match: { snapshot.shards.failed : 1 }
+  - match: { snapshot.failures.0.index: "test_synthetic" }
+  - match: { snapshot.failures.0.reason : "IllegalStateException[Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source]" }
+  - is_true: snapshot.version
+  - gt: { snapshot.version_id: 0}
+
+  - do:
+      snapshot.create:
+        repository: test_repo_restore_1
+        snapshot: test_snapshot_3
+        wait_for_completion: true
+        body: |
+          { "indices": "test_*" }
+
+  - match: { snapshot.snapshot: test_snapshot_3 }
+  - match: { snapshot.state : PARTIAL }
+  - match: { snapshot.shards.successful: 1 }
+  - match: { snapshot.shards.failed : 1 }
+  - match: { snapshot.failures.0.index: "test_synthetic" }
+  - match: { snapshot.failures.0.reason: "IllegalStateException[Can't snapshot _source only on an index that has incomplete source ie. has _source disabled or filters the source]" }
+  - is_true: snapshot.version
+  - gt: { snapshot.version_id: 0}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add test for source-only snapshot with synthetic source (#113233)