### PR TITLE
Make `IndicesAliasesClusterStateUpdateRequest` a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesClusterStateUpdateRequest.java
@@ -9,32 +9,25 @@
 package org.elasticsearch.action.admin.indices.alias;
 
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse.AliasActionResult;
-import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
 import org.elasticsearch.cluster.metadata.AliasAction;
+import org.elasticsearch.core.TimeValue;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Cluster state update request that allows to add or remove aliases
  */
-public class IndicesAliasesClusterStateUpdateRequest extends ClusterStateUpdateRequest<IndicesAliasesClusterStateUpdateRequest> {
-    private final List<AliasAction> actions;
-
-    private final List<IndicesAliasesResponse.AliasActionResult> actionResults;
-
-    public IndicesAliasesClusterStateUpdateRequest(List<AliasAction> actions, List<AliasActionResult> actionResults) {
-        this.actions = actions;
-        this.actionResults = actionResults;
-    }
-
-    /**
-     * Returns the alias actions to be performed
-     */
-    public List<AliasAction> actions() {
-        return actions;
-    }
-
-    public List<AliasActionResult> getActionResults() {
-        return actionResults;
+public record IndicesAliasesClusterStateUpdateRequest(
+    TimeValue masterNodeTimeout,
+    TimeValue ackTimeout,
+    List<AliasAction> actions,
+    List<AliasActionResult> actionResults
+) {
+    public IndicesAliasesClusterStateUpdateRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(ackTimeout);
+        Objects.requireNonNull(actions);
+        Objects.requireNonNull(actionResults);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -255,9 +255,11 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
         }
         request.aliasActions().clear();
         IndicesAliasesClusterStateUpdateRequest updateRequest = new IndicesAliasesClusterStateUpdateRequest(
+            request.masterNodeTimeout(),
+            request.ackTimeout(),
             unmodifiableList(finalActions),
             unmodifiableList(actionResults)
-        ).ackTimeout(request.ackTimeout()).masterNodeTimeout(request.masterNodeTimeout());
+        );
 
         indexAliasesService.indicesAliases(updateRequest, listener.delegateResponse((l, e) -> {
             logger.debug("failed to perform aliases", e);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -282,7 +282,7 @@ public class MetadataIndexAliasesService {
 
         @Override
         public void onAllNodesAcked() {
-            listener.onResponse(IndicesAliasesResponse.build(request.getActionResults()));
+            listener.onResponse(IndicesAliasesResponse.build(request.actionResults()));
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesServiceTests.java
@@ -693,10 +693,14 @@ public class MetadataIndexAliasesServiceTests extends ESTestCase {
         String index = randomAlphaOfLength(5);
         ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), index);
         IndicesAliasesClusterStateUpdateRequest addAliasRequest = new IndicesAliasesClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             List.of(new AliasAction.Add(index, "test", null, null, null, null, null)),
             List.of(AliasActionResult.buildSuccess(List.of(index), AliasActions.add().aliases("test").indices(index)))
         );
         IndicesAliasesClusterStateUpdateRequest removeAliasRequest = new IndicesAliasesClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             List.of(new AliasAction.Remove(index, "test", true)),
             List.of(AliasActionResult.buildSuccess(List.of(index), AliasActions.remove().aliases("test").indices(index)))
         );


### PR DESCRIPTION
No need to extend `ClusterStateUpdateRequest` here.