### PR TITLE
[8.x] Apply workaround for known issue to logsdb test data generation (#113214)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
@@ -104,9 +104,12 @@ public interface DataSourceRequest<TResponse extends DataSourceResponse> {
         }
     }
 
-    record LeafMappingParametersGenerator(String fieldName, FieldType fieldType, Set<String> eligibleCopyToFields)
-        implements
-            DataSourceRequest<DataSourceResponse.LeafMappingParametersGenerator> {
+    record LeafMappingParametersGenerator(
+        String fieldName,
+        FieldType fieldType,
+        Set<String> eligibleCopyToFields,
+        DynamicMapping dynamicMapping
+    ) implements DataSourceRequest<DataSourceResponse.LeafMappingParametersGenerator> {
         public DataSourceResponse.LeafMappingParametersGenerator accept(DataSourceHandler handler) {
             return handler.handle(this);
         }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.logsdb.datageneration.datasource;
 
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.logsdb.datageneration.fields.DynamicMapping;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
@@ -48,7 +49,11 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             // We only add copy_to to keywords because we get into trouble with numeric fields that are copied to dynamic fields.
             // If first copied value is numeric, dynamic field is created with numeric field type and then copy of text values fail.
             // Actual value being copied does not influence the core logic of copy_to anyway.
-            if (ESTestCase.randomDouble() <= 0.05) {
+            //
+            // TODO
+            // We don't use copy_to on fields that are inside an object with dynamic: strict
+            // because we'll hit https://github.com/elastic/elasticsearch/issues/113049.
+            if (request.dynamicMapping() != DynamicMapping.FORBIDDEN && ESTestCase.randomDouble() <= 0.05) {
                 var options = request.eligibleCopyToFields()
                     .stream()
                     .filter(f -> f.equals(request.fieldName()) == false)

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/GenericSubObjectFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/GenericSubObjectFieldDataGenerator.java
@@ -62,7 +62,8 @@ public class GenericSubObjectFieldDataGenerator {
                         new DataSourceRequest.LeafMappingParametersGenerator(
                             fieldName,
                             fieldTypeInfo.fieldType(),
-                            context.getEligibleCopyToDestinations()
+                            context.getEligibleCopyToDestinations(),
+                            dynamicMapping
                         )
                     );
                 var generator = fieldTypeInfo.fieldType()

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/PredefinedField.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/PredefinedField.java
@@ -21,7 +21,7 @@ public interface PredefinedField {
 
     FieldDataGenerator generator(DataSource dataSource);
 
-    record WithType(String fieldName, FieldType fieldType) implements PredefinedField {
+    record WithType(String fieldName, FieldType fieldType, DynamicMapping dynamicMapping) implements PredefinedField {
         @Override
         public String name() {
             return fieldName;
@@ -31,7 +31,7 @@ public interface PredefinedField {
         public FieldDataGenerator generator(DataSource dataSource) {
             // copy_to currently not supported for predefined fields, use WithGenerator if needed
             var mappingParametersGenerator = dataSource.get(
-                new DataSourceRequest.LeafMappingParametersGenerator(fieldName, fieldType, Set.of())
+                new DataSourceRequest.LeafMappingParametersGenerator(fieldName, fieldType, Set.of(), dynamicMapping)
             );
             return fieldType().generator(fieldName, dataSource, mappingParametersGenerator);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Apply workaround for known issue to logsdb test data generation (#113214)](https://github.com/elastic/elasticsearch/pull/113214)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)