### PR TITLE
[8.x] Correctly identify parent of copy_to destination field for synthetic source purposes (#113153)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -1269,8 +1269,8 @@ synthetic_source with copy_to and ignored values:
         refresh: true
         body:
           name: "B"
-          k: ["5", "6"]
-          long: ["7", "8"]
+          k: ["55", "66"]
+          long: ["77", "88"]
 
   - do:
       search:
@@ -1289,10 +1289,9 @@ synthetic_source with copy_to and ignored values:
   - match:
       hits.hits.1._source:
         name: "B"
-        k: ["5", "6"]
-        long: ["7", "8"]
-  - match: { hits.hits.1.fields.copy: ["5", "6", "7", "8"] }
-
+        k: ["55", "66"]
+        long: ["77", "88"]
+  - match: { hits.hits.1.fields.copy: ["55", "66", "77", "88"] }
 
 ---
 synthetic_source with copy_to field having values in source:
@@ -1553,3 +1552,402 @@ synthetic_source with copy_to and invalid values for copy:
 
   - match: { error.type: "document_parsing_exception" }
   - contains: { error.reason: "Copy-to currently only works for value-type fields" }
+
+---
+synthetic_source with copy_to pointing inside object:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              name:
+                type: keyword
+              my_values:
+                properties:
+                  k:
+                    type: keyword
+                    ignore_above: 1
+                    copy_to: c.copy
+                  long:
+                    type: long
+                    copy_to: c.copy
+              c:
+                properties:
+                  copy:
+                    type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          name: "A"
+          my_values:
+            k: "hello"
+            long: 100
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          name: "B"
+          my_values:
+            k: ["55", "66"]
+            long: [77, 88]
+
+  - do:
+      index:
+        index: test
+        id: 3
+        refresh: true
+        body:
+          name: "C"
+          my_values:
+            k: "hello"
+            long: 100
+          c:
+            copy: "zap"
+
+  - do:
+      search:
+        index: test
+        sort: name
+        body:
+          docvalue_fields: [ "c.copy" ]
+
+  - match:
+      hits.hits.0._source:
+        name: "A"
+        my_values:
+          k: "hello"
+          long: 100
+  - match:
+      hits.hits.0.fields:
+        c.copy: [ "100", "hello" ]
+
+  - match:
+      hits.hits.1._source:
+        name: "B"
+        my_values:
+          k: ["55", "66"]
+          long: [77, 88]
+  - match:
+      hits.hits.1.fields:
+        c.copy: ["55", "66", "77", "88"]
+
+  - match:
+      hits.hits.2._source:
+        name: "C"
+        my_values:
+          k: "hello"
+          long: 100
+        c:
+          copy: "zap"
+  - match:
+      hits.hits.2.fields:
+          c.copy: [ "100", "hello", "zap" ]
+
+---
+synthetic_source with copy_to pointing to ambiguous field:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              k:
+                type: keyword
+                copy_to: a.b.c
+              a:
+                properties:
+                  b:
+                    properties:
+                      c:
+                        type: keyword
+                  b.c:
+                    type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          k: "hey"
+
+  - do:
+      search:
+        index: test
+        body:
+          docvalue_fields: [ "a.b.c" ]
+
+  - match:
+      hits.hits.0._source:
+        k: "hey"
+  - match:
+      hits.hits.0.fields:
+        a.b.c: [ "hey" ]
+
+---
+synthetic_source with copy_to pointing to ambiguous field and subobjects false:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            subobjects: false
+            properties:
+              k:
+                type: keyword
+                copy_to: a.b.c
+              a:
+                properties:
+                  b:
+                    properties:
+                      c:
+                        type: keyword
+                  b.c:
+                    type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          k: "hey"
+
+  - do:
+      search:
+        index: test
+        body:
+          docvalue_fields: [ "a.b.c" ]
+
+  - match:
+      hits.hits.0._source:
+        k: "hey"
+  - match:
+      hits.hits.0.fields:
+        a.b.c: [ "hey" ]
+
+---
+synthetic_source with copy_to pointing to ambiguous field and subobjects auto:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            subobjects: auto
+            properties:
+              k:
+                type: keyword
+                copy_to: a.b.c
+              a:
+                properties:
+                  b:
+                    properties:
+                      c:
+                        type: keyword
+                  b.c:
+                    type: keyword
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          k: "hey"
+
+  - do:
+      search:
+        index: test
+        body:
+          docvalue_fields: [ "a.b.c" ]
+
+  - match:
+      hits.hits.0._source:
+        k: "hey"
+  - match:
+      hits.hits.0.fields:
+        a.b.c: [ "hey" ]
+
+---
+synthetic_source with copy_to pointing at dynamic field:
+  - requires:
+      test_runner_features: contains
+      cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              k:
+                type: keyword
+                copy_to: c.copy
+              c:
+                properties:
+                  f:
+                    type: float
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          k: ["55", "66"]
+
+  - do:
+      index:
+        index: test
+        id: 3
+        refresh: true
+        body:
+          k: "hello"
+          c:
+            copy: "zap"
+
+  - do:
+      search:
+        index: test
+        body:
+          docvalue_fields: [ "c.copy.keyword" ]
+
+  - match:
+      hits.hits.0._source:
+        k: "hello"
+  - match:
+      hits.hits.0.fields:
+        c.copy.keyword: [ "hello" ]
+
+  - match:
+      hits.hits.1._source:
+        k: ["55", "66"]
+  - match:
+      hits.hits.1.fields:
+        c.copy.keyword: [ "55", "66" ]
+
+  - match:
+      hits.hits.2._source:
+        k: "hello"
+        c:
+          copy: "zap"
+  - match:
+      hits.hits.2.fields:
+        c.copy.keyword: [ "hello", "zap" ]
+
+---
+synthetic_source with copy_to pointing inside dynamic object:
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_copy_to_inside_objects_fix"]
+      reason: requires copy_to support in synthetic source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              k:
+                type: keyword
+                copy_to: c.copy
+
+  - do:
+      index:
+        index: test
+        id: 1
+        refresh: true
+        body:
+          k: "hello"
+
+  - do:
+      index:
+        index: test
+        id: 2
+        refresh: true
+        body:
+          k: ["55", "66"]
+
+  - do:
+      index:
+        index: test
+        id: 3
+        refresh: true
+        body:
+          k: "hello"
+          c:
+            copy: "zap"
+
+  - do:
+      search:
+        index: test
+        body:
+          docvalue_fields: [ "c.copy.keyword" ]
+
+  - match:
+      hits.hits.0._source:
+        k: "hello"
+  - match:
+      hits.hits.0.fields:
+        c.copy.keyword: [ "hello" ]
+
+  - match:
+      hits.hits.1._source:
+        k: ["55", "66"]
+  - match:
+      hits.hits.1.fields:
+        c.copy.keyword: [ "55", "66" ]
+
+  - match:
+      hits.hits.2._source:
+        k: "hello"
+        c:
+          copy: "zap"
+  - match:
+      hits.hits.2.fields:
+        c.copy.keyword: [ "hello", "zap" ]
+

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -123,6 +123,7 @@ public abstract class DocumentParserContext {
     private Field version;
     private final SeqNoFieldMapper.SequenceIDFields seqID;
     private final Set<String> fieldsAppliedFromTemplates;
+
     /**
      * Fields that are copied from values of other fields via copy_to.
      * This per-document state is needed since it is possible
@@ -453,24 +454,14 @@ public abstract class DocumentParserContext {
 
     public void markFieldAsCopyTo(String fieldName) {
         copyToFields.add(fieldName);
-        if (mappingLookup.isSourceSynthetic() && indexSettings().getSkipIgnoredSourceWrite() == false) {
-            /*
-            Mark this field as containing copied data meaning it should not be present
-            in synthetic _source (to be consistent with stored _source).
-            Ignored source values take precedence over standard synthetic source implementation
-            so by adding this nothing entry we "disable" field in synthetic source.
-            Otherwise, it would be constructed f.e. from doc_values which leads to duplicate values
-            in copied field after reindexing.
-
-            Note that this applies to fields that are copied from fields using ignored source themselves
-            and therefore we don't check for canAddIgnoredField().
-            */
-            ignoredFieldValues.add(IgnoredSourceFieldMapper.NameValue.fromContext(this, fieldName, XContentDataHelper.nothing()));
-        }
     }
 
     public boolean isCopyToDestinationField(String name) {
         return copyToFields.contains(name);
+    }
+
+    public Set<String> getCopyToFields() {
+        return copyToFields;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -38,7 +38,8 @@ public class MapperFeatures implements FeatureSpecification {
             SourceFieldMapper.SYNTHETIC_SOURCE_STORED_FIELDS_ADVANCE_FIX,
             Mapper.SYNTHETIC_SOURCE_KEEP_FEATURE,
             SourceFieldMapper.SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT,
-            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX
+            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX,
+            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_INSIDE_OBJECTS_FIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -40,7 +40,7 @@ public class MapperFeatures implements FeatureSpecification {
             Mapper.SYNTHETIC_SOURCE_KEEP_FEATURE,
             SourceFieldMapper.SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT,
             SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX,
-            FlattenedFieldMapper.IGNORE_ABOVE_SUPPORT
+            FlattenedFieldMapper.IGNORE_ABOVE_SUPPORT,
             SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_INSIDE_OBJECTS_FIX
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -48,6 +48,9 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         "mapper.source.synthetic_source_with_copy_to_and_doc_values_false"
     );
     public static final NodeFeature SYNTHETIC_SOURCE_COPY_TO_FIX = new NodeFeature("mapper.source.synthetic_source_copy_to_fix");
+    public static final NodeFeature SYNTHETIC_SOURCE_COPY_TO_INSIDE_OBJECTS_FIX = new NodeFeature(
+        "mapper.source.synthetic_source_copy_to_inside_objects_fix"
+    );
 
     public static final String NAME = "_source";
     public static final String RECOVERY_SOURCE_NAME = "_recovery_source";

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -209,6 +209,9 @@ public interface SourceLoader {
                 if (docValuesLoader != null) {
                     docValuesLoader.advanceToDoc(docId);
                 }
+
+                loader.prepare();
+
                 // TODO accept a requested xcontent type
                 if (loader.hasValue()) {
                     loader.write(b);
@@ -298,6 +301,16 @@ public interface SourceLoader {
          * @param docIdsInLeaf can be null.
          */
         DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException;
+
+        /**
+         Perform any preprocessing needed before producing synthetic source
+         and deduce whether this mapper (and its children, if any) have values to write.
+         The expectation is for this method to be called before {@link SyntheticFieldLoader#hasValue()}
+         and {@link SyntheticFieldLoader#write(XContentBuilder)} are used.
+         */
+        default void prepare() {
+            // Noop
+        }
 
         /**
          * Has this field loaded any values for this document?

--- a/server/src/test/java/org/elasticsearch/index/mapper/XContentDataHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/XContentDataHelperTests.java
@@ -240,64 +240,6 @@ public class XContentDataHelperTests extends ESTestCase {
         assertEquals(expected, map.get("foo"));
     }
 
-    public void testWriteMergedWithVoidValue() throws IOException {
-        var destination = XContentFactory.contentBuilder(XContentType.JSON);
-        destination.startObject();
-
-        XContentDataHelper.writeMerged(destination, "field", List.of(XContentDataHelper.nothing()));
-
-        destination.endObject();
-
-        assertEquals("{}", Strings.toString(destination));
-    }
-
-    public void testWriteMergedWithMultipleVoidValues() throws IOException {
-        var destination = XContentFactory.contentBuilder(XContentType.JSON);
-        destination.startObject();
-
-        XContentDataHelper.writeMerged(
-            destination,
-            "field",
-            List.of(XContentDataHelper.nothing(), XContentDataHelper.nothing(), XContentDataHelper.nothing())
-        );
-
-        destination.endObject();
-
-        assertEquals("{}", Strings.toString(destination));
-    }
-
-    public void testWriteMergedWithMixedVoidValues() throws IOException {
-        var destination = XContentFactory.contentBuilder(XContentType.JSON);
-        destination.startObject();
-
-        var value = XContentFactory.contentBuilder(XContentType.JSON).value(34);
-        XContentDataHelper.writeMerged(
-            destination,
-            "field",
-            List.of(XContentDataHelper.nothing(), XContentDataHelper.encodeXContentBuilder(value), XContentDataHelper.nothing())
-        );
-
-        destination.endObject();
-
-        assertEquals("{\"field\":34}", Strings.toString(destination));
-    }
-
-    public void testWriteMergedWithArraysAndVoidValues() throws IOException {
-        var destination = XContentFactory.contentBuilder(XContentType.JSON);
-        destination.startObject();
-
-        var value = XContentFactory.contentBuilder(XContentType.JSON).value(List.of(3, 4));
-        XContentDataHelper.writeMerged(
-            destination,
-            "field",
-            List.of(XContentDataHelper.nothing(), XContentDataHelper.encodeXContentBuilder(value), XContentDataHelper.nothing())
-        );
-
-        destination.endObject();
-
-        assertEquals("{\"field\":[3,4]}", Strings.toString(destination));
-    }
-
     private Map<String, Object> executeWriteMergedOnRepeated(Object value) throws IOException {
         return executeWriteMergedOnTwoEncodedValues(value, value);
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Correctly identify parent of copy_to destination field for synthetic source purposes (#113153)](https://github.com/elastic/elasticsearch/pull/113153)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)