### PR TITLE
[8.x] Fix `ignore_above` for flattened fields (#112944)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml
@@ -1,0 +1,121 @@
+---
+flattened ignore_above single-value field:
+  - requires:
+      cluster_features: [ "flattened.ignore_above_support" ]
+      reason: introduce ignore_above support in flattened fields
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+                ignore_above: 5
+              flat:
+                type: flattened
+                ignore_above: 5
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        refresh: true
+        body:
+          keyword: "foo"
+          flat: { "value": "foo", "key": "foo key" }
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        refresh: true
+        body:
+          keyword: "foo bar"
+          flat: { "value": "foo bar",  "key": "foo bar key"}
+
+  - do:
+      search:
+        index: test
+        body:
+          fields:
+            - keyword
+            - flat
+          query:
+            match_all: {}
+
+  - match: { hits.total.value: 2 }
+
+  - match: { hits.hits.0._source.keyword: "foo" }
+  - match: { hits.hits.0._source.flat.value: "foo" }
+  - match: { hits.hits.0._source.flat.key: "foo key" }
+  - match: { hits.hits.1._source.keyword: "foo bar" }
+  - match: { hits.hits.1._source.flat.value: "foo bar" }
+  - match: { hits.hits.1._source.flat.key: "foo bar key" }
+
+  - match: { hits.hits.0.fields.keyword.0: "foo" }
+  - match: { hits.hits.0.fields.flat.0.value: "foo" }
+  - match: { hits.hits.1.fields.keyword.0: null }
+  - match: { hits.hits.1.fields.flat.0.value: null }
+
+---
+flattened ignore_above multi-value field:
+  - requires:
+      cluster_features: [ "flattened.ignore_above_support" ]
+      reason: introduce ignore_above support in flattened fields
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+                ignore_above: 5
+              flat:
+                type: flattened
+                ignore_above: 5
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        refresh: true
+        body:
+          keyword: ["foo","bar"]
+          flat: { "value": ["foo", "bar"], "key": "foo bar array key" }
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        refresh: true
+        body:
+          keyword: ["foobar", "foo", "bar"]
+          flat: { "value": ["foobar", "foo"], "key": ["foo key", "bar key"]}
+
+  - do:
+      search:
+        index: test
+        body:
+          fields:
+            - keyword
+            - flat
+          query:
+            match_all: { }
+
+  - match: { hits.total.value: 2 }
+
+  - match: { hits.hits.0._source.keyword: ["foo", "bar"] }
+  - match: { hits.hits.0._source.flat.value: ["foo", "bar"] }
+  - match: { hits.hits.0._source.flat.key: "foo bar array key" }
+  - match: { hits.hits.1._source.keyword: ["foobar", "foo", "bar"] }
+  - match: { hits.hits.1._source.flat.value: ["foobar", "foo"] }
+  - match: { hits.hits.1._source.flat.key: ["foo key", "bar key"] }
+
+  - match: { hits.hits.0.fields.keyword: [ "foo", "bar" ] }
+  - match: { hits.hits.0.fields.flat.0.value: ["foo", "bar"] }
+  - match: { hits.hits.0.fields.flat.0.key: null }
+  - match: { hits.hits.1.fields.keyword: [ "foo", "bar" ] }
+  - match: { hits.hits.1.fields.flat.0.value: "foo" }
+  - match: { hits.hits.1.fields.flat.0.key: null }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
 import java.util.Set;
@@ -38,7 +39,8 @@ public class MapperFeatures implements FeatureSpecification {
             SourceFieldMapper.SYNTHETIC_SOURCE_STORED_FIELDS_ADVANCE_FIX,
             Mapper.SYNTHETIC_SOURCE_KEEP_FEATURE,
             SourceFieldMapper.SYNTHETIC_SOURCE_WITH_COPY_TO_AND_DOC_VALUES_FALSE_SUPPORT,
-            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX
+            SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_FIX,
+            FlattenedFieldMapper.IGNORE_ABOVE_SUPPORT
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -768,7 +768,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
                         }
                         if (validValues.size() == 1) {
                             // NOTE: for single-value flattened fields do not return an array
-                            return validValues.getFirst();
+                            return validValues.get(0);
                         }
                         return validValues;
                     } else if (entryValue instanceof String valueAsString) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFieldTypeTests.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.RootFlattenedFieldType;
@@ -32,12 +33,12 @@ import java.util.Map;
 
 public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
 
-    private static RootFlattenedFieldType createDefaultFieldType() {
-        return new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false, false);
+    private static RootFlattenedFieldType createDefaultFieldType(int ignoreAbove) {
+        return new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false, false, ignoreAbove);
     }
 
     public void testValueForDisplay() {
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         String fieldValue = "{ \"key\": \"value\" }";
         BytesRef storedValue = new BytesRef(fieldValue);
@@ -45,7 +46,7 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testTermQuery() {
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         Query expected = new TermQuery(new Term("field", "value"));
         assertEquals(expected, ft.termQuery("value", null));
@@ -53,21 +54,45 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
         expected = AutomatonQueries.caseInsensitiveTermQuery(new Term("field", "Value"));
         assertEquals(expected, ft.termQueryCaseInsensitive("Value", null));
 
-        RootFlattenedFieldType unsearchable = new RootFlattenedFieldType("field", false, true, Collections.emptyMap(), false, false);
+        RootFlattenedFieldType unsearchable = new RootFlattenedFieldType(
+            "field",
+            false,
+            true,
+            Collections.emptyMap(),
+            false,
+            false,
+            Integer.MAX_VALUE
+        );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("field", null));
         assertEquals("Cannot search on field [field] since it is not indexed.", e.getMessage());
     }
 
     public void testExistsQuery() {
-        RootFlattenedFieldType ft = new RootFlattenedFieldType("field", true, false, Collections.emptyMap(), false, false);
+        RootFlattenedFieldType ft = new RootFlattenedFieldType(
+            "field",
+            true,
+            false,
+            Collections.emptyMap(),
+            false,
+            false,
+            Integer.MAX_VALUE
+        );
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.NAME, new BytesRef("field"))), ft.existsQuery(null));
 
-        RootFlattenedFieldType withDv = new RootFlattenedFieldType("field", true, true, Collections.emptyMap(), false, false);
+        RootFlattenedFieldType withDv = new RootFlattenedFieldType(
+            "field",
+            true,
+            true,
+            Collections.emptyMap(),
+            false,
+            false,
+            Integer.MAX_VALUE
+        );
         assertEquals(new FieldExistsQuery("field"), withDv.existsQuery(null));
     }
 
     public void testFuzzyQuery() {
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         Query expected = new FuzzyQuery(new Term("field", "value"), 2, 1, 50, true);
         Query actual = ft.fuzzyQuery("value", Fuzziness.fromEdits(2), 1, 50, true, MOCK_CONTEXT);
@@ -88,7 +113,7 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testRangeQuery() {
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         TermRangeQuery expected = new TermRangeQuery("field", new BytesRef("lower"), new BytesRef("upper"), false, false);
         assertEquals(expected, ft.rangeQuery("lower", "upper", false, false, MOCK_CONTEXT));
@@ -107,7 +132,7 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testRegexpQuery() {
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         Query expected = new RegexpQuery(new Term("field", "val.*"));
         Query actual = ft.regexpQuery("val.*", 0, 0, 10, null, MOCK_CONTEXT);
@@ -121,7 +146,7 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testWildcardQuery() {
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         Query expected = new WildcardQuery(new Term("field", new BytesRef("valu*")));
         assertEquals(expected, ft.wildcardQuery("valu*", null, MOCK_CONTEXT));
@@ -135,9 +160,61 @@ public class RootFlattenedFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         Map<String, Object> sourceValue = Map.of("key", "value");
-        RootFlattenedFieldType ft = createDefaultFieldType();
+        RootFlattenedFieldType ft = createDefaultFieldType(Integer.MAX_VALUE);
 
         assertEquals(List.of(sourceValue), fetchSourceValue(ft, sourceValue));
         assertEquals(List.of(), fetchSourceValue(ft, null));
+    }
+
+    public void testFetchSourceValueWithIgnoreAbove() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key", "test ignore above");
+
+        assertEquals(List.of(), fetchSourceValue(createDefaultFieldType(10), sourceValue));
+        assertEquals(List.of(sourceValue), fetchSourceValue(createDefaultFieldType(20), sourceValue));
+    }
+
+    public void testFetchSourceValueWithList() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of("one", "two", "three"));
+
+        assertEquals(List.of(Map.of("key1", List.of("one", "two"))), fetchSourceValue(createDefaultFieldType(3), sourceValue));
+    }
+
+    public void testFetchSourceValueWithMultipleFields() throws IOException {
+        Map<String, Object> sourceValue = Map.of(
+            "key1",
+            "test",
+            "key2",
+            List.of("one", "two", "three"),
+            "key3",
+            "hi",
+            "key4",
+            List.of("the quick brown fox", "jumps over the lazy dog")
+        );
+
+        assertEquals(
+            List.of(Map.of("key2", List.of("one", "two"), "key3", "hi")),
+            fetchSourceValue(createDefaultFieldType(3), sourceValue)
+        );
+    }
+
+    public void testFetchSourceValueWithMixedFieldTypes() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of("one", 1, "two", 2));
+
+        assertEquals(List.of(Map.of("key1", List.of("one", 1, "two", 2))), fetchSourceValue(createDefaultFieldType(3), sourceValue));
+    }
+
+    public void testFetchSourceValueWithNonString() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of(100, 200), "key2", 50L, "key3", new Tuple<>(10, 100));
+
+        assertEquals(
+            List.of(Map.of("key1", List.of(100, 200), "key2", 50L, "key3", new Tuple<>(10, 100))),
+            fetchSourceValue(createDefaultFieldType(3), sourceValue)
+        );
+    }
+
+    public void testFetchSourceValueFilterStringsOnly() throws IOException {
+        Map<String, Object> sourceValue = Map.of("key1", List.of("the quick brown", 1_234_567, "jumps over", 2_456));
+
+        assertEquals(List.of(Map.of("key1", List.of(1_234_567, 2_456))), fetchSourceValue(createDefaultFieldType(8), sourceValue));
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix &#x60;ignore_above&#x60; for flattened fields (#112944)](https://github.com/elastic/elasticsearch/pull/112944)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)