### PR TITLE
Update refresh.asciidoc for typo and clarification of performed operations

### DIFF
--- a/docs/reference/indices/refresh.asciidoc
+++ b/docs/reference/indices/refresh.asciidoc
@@ -37,13 +37,13 @@ stream, index, or alias.
 [[refresh-api-desc]]
 ==== {api-description-title}
 
-Use the refresh API to explicitly make all operations performed on one or more
+Use the refresh API to explicitly make all write operations performed on one or more
 indices since the last refresh available for search.
 If the request targets a data stream, it refreshes the stream's backing indices.
 
 // tag::refresh-interval-default[]
 By default, Elasticsearch periodically refreshes indices every second, but only on
-indices that have received one search request or more in the last 30 seconds.
+indices that have NOT received one search request or more in the last 30 seconds.
 // end::refresh-interval-default[]
 You can change this default interval
 using the <<index-refresh-interval-setting,`index.refresh_interval`>> setting.


### PR DESCRIPTION
Added two words.  
1.  "write" operations... - not ALL operations performed on an index are "available for search."  (For example, _shrink index resulst are not searchable)   
2. "NOT" received one search... - this typo gives the opposite, incorrect meaning

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
