### PR TITLE
Ensure monitoring/_bulk route is fully aggregated

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -374,7 +374,9 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             // combines the HTTP message pieces into a single full HTTP request (with headers and body)
             final HttpObjectAggregator aggregator = new Netty4HttpAggregator(
                 handlingSettings.maxContentLength(),
-                httpPreRequest -> enabled.get() == false || (httpPreRequest.rawPath().endsWith("/_bulk") == false)
+                httpPreRequest -> enabled.get() == false
+                    || ((httpPreRequest.rawPath().endsWith("/_bulk") == false)
+                        || httpPreRequest.rawPath().startsWith("/_xpack/monitoring/_bulk"))
             );
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
             ch.pipeline()


### PR DESCRIPTION
This route still exists in the code even if it is two major version old.
We should still support it properly with our streaming changes.