### PR TITLE
[DOCS] FIx a few typos in the documentation

### DIFF
--- a/docs/internal/DistributedArchitectureGuide.md
+++ b/docs/internal/DistributedArchitectureGuide.md
@@ -252,7 +252,7 @@ changes. The cloud service will add more resources to the cluster based on Elast
 Elasticsearch by itself cannot automatically scale.
 
 Autoscaling recommendations are tailored for the user [based on user defined policies][], composed of data
-roles (hot, frozen, etc) and [deciders][]. There's a public [webinar on autoscaling][], as well as the
+roles (hot, frozen, etc.) and [deciders][]. There's a public [webinar on autoscaling][], as well as the
 public [Autoscaling APIs] docs.
 
 Autoscaling's current implementation is based primary on storage requirements, as well as memory capacity
@@ -332,7 +332,7 @@ problems in the cluster. It uses [an algorithm defined here][]. Some examples ar
 [an algorithm defined here]: https://github.com/elastic/elasticsearch/blob/v8.13.2/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java#L158-L176
 
 The `ProactiveStorageDeciderService` maintains a forecast window that [defaults to 30 minutes][]. It only
-runs on data streams (ILM, rollover, etc), not regular indexes. It looks at past [index changes][] that
+runs on data streams (ILM, rollover, etc.), not regular indexes. It looks at past [index changes][] that
 took place within the forecast window to [predict][] resources that will be needed shortly.
 
 [defaults to 30 minutes]: https://github.com/elastic/elasticsearch/blob/v8.13.2/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderService.java#L32

--- a/docs/plugins/development/creating-classic-plugins.asciidoc
+++ b/docs/plugins/development/creating-classic-plugins.asciidoc
@@ -18,7 +18,7 @@ will refuse to start in the presence of plugins with the incorrect
 [discrete]
 ==== Classic plugin file structure
 
-Classis plugins are ZIP files composed of JAR files and
+Classic plugins are ZIP files composed of JAR files and
 <<plugin-descriptor-file-{plugin-type},a metadata file called
 `plugin-descriptor.properties`>>, a Java properties file that describes the
 plugin.

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -3,7 +3,7 @@
 ==== JVM options
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if
-needed this can be overriden by setting the `CLI_JAVA_OPTS` environment variable.
+needed this can be overridden by setting the `CLI_JAVA_OPTS` environment variable.
 For example, the following increases the heap size used by the
 `pass:a[elasticsearch-{tool-name}]` tool to 1GB.
 

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -82,7 +82,7 @@ beta:[]
 
 preview::[]
 
-*Connector Service APIs* are a subset of Connector API endpoints, that represent framework-level operations defined in the https://github.com/elastic/connectors/blob/main/docs/CONNECTOR_PROTOCOL.md[Connector Protocol]. These APIs are not intended for direct connector management by users but are there to support the implementation of services that utilize the Conector Protocol to communicate with {es}.
+*Connector Service APIs* are a subset of Connector API endpoints, that represent framework-level operations defined in the https://github.com/elastic/connectors/blob/main/docs/CONNECTOR_PROTOCOL.md[Connector Protocol]. These APIs are not intended for direct connector management by users but are there to support the implementation of services that utilize the Connector Protocol to communicate with {es}.
 
 [TIP]
 ====

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1990,7 +1990,7 @@ idle for more than the specified timeout.
 
 The server can also set the `Keep-Alive` HTTP response header. The effective
 time-to-live value is the smaller value between this setting and the `Keep-Alive`
-reponse header. Configure this setting to `-1` to let the server dictate the value.
+response header. Configure this setting to `-1` to let the server dictate the value.
 If the header is not set by the server and the setting has value of `-1`,
 the time-to-live is infinite and connections never expire.
 // end::oidc-http-connection-pool-ttl-tag[]

--- a/docs/reference/tab-widgets/troubleshooting/snapshot/corrupt-repository.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/snapshot/corrupt-repository.asciidoc
@@ -71,7 +71,7 @@ GET _snapshot/my-repo
 ----
 // TEST[skip:we're not setting up repos in these tests]
 +
-The reponse will look like this:
+The response will look like this:
 +
 [source,console-result]
 ----


### PR DESCRIPTION
As the title suggests, fixed several typos in the documentation
- `reponse` to `response`
- `Conector` to `Connector`
- `etc` to `etc.`
- `Classis` to `Classic`
- `overriden` to `overridden`

