### PR TITLE
Rename some attributes

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -469,9 +469,9 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         final String replicaNode = internalCluster().startDataOnlyNode(nodeSettings(1, Settings.EMPTY));
         ensureGreen();
 
-        final RecoveryResponse initialRecoveryReponse = indicesAdmin().prepareRecoveries("test").get();
+        final RecoveryResponse initialRecoveryResponse = indicesAdmin().prepareRecoveries("test").get();
         final Set<String> files = new HashSet<>();
-        for (final RecoveryState recoveryState : initialRecoveryReponse.shardRecoveryStates().get("test")) {
+        for (final RecoveryState recoveryState : initialRecoveryResponse.shardRecoveryStates().get("test")) {
             if (recoveryState.getTargetNode().getName().equals(replicaNode)) {
                 for (final RecoveryState.FileDetail file : recoveryState.getIndex().fileDetails()) {
                     files.add(file.name());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/BaseResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/BaseResponseEntity.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 /**
  * A base class for providing InferenceServiceResults from a response. This is a lightweight wrapper
- * to be able to override the `fromReponse` method to avoid using a static reference to the method.
+ * to be able to override the `fromResponse` method to avoid using a static reference to the method.
  */
 public abstract class BaseResponseEntity implements ResponseParser {
     protected abstract InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException;

--- a/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CoordinatedInferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CoordinatedInferenceIngestIT.java
@@ -223,7 +223,7 @@ public class CoordinatedInferenceIngestIT extends InferenceBaseRestTest {
     public Map<String, Object> getModelInference(String modelId, TaskType taskType) throws IOException {
         var endpoint = org.elasticsearch.common.Strings.format("_inference/%s/%s", taskType, modelId);
         var request = new Request("GET", endpoint);
-        var reponse = client().performRequest(request);
-        return entityAsMap(reponse);
+        var response = client().performRequest(request);
+        return entityAsMap(response);
     }
 }


### PR DESCRIPTION
Some  typos were found in the naming of some attributes and corrected them
-  in `RecoveryFromGatewayIT.java·` rename `initialRecoveryReponse` to `initialRecoveryResponse`
- in `CoordinatedInferenceIngestIT.java`  rename  `reponse` to `response` 
- in  `BaseResponseEntity.java`  fix a typo in description