### PR TITLE
Make `ecs@mappings` more exhaustive

### DIFF
--- a/docs/changelog/113337.yaml
+++ b/docs/changelog/113337.yaml
@@ -1,0 +1,6 @@
+pr: 113337
+summary: Make `ecs@mappings` more exhaustive
+area: Data streams
+type: bug
+issues:
+ - 113124

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -61,6 +61,87 @@
           }
         },
         {
+          "ecs_explicit_keywords": {
+            "mapping": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "path_match": [
+              "*registry.data.bytes"
+            ],
+            "match_mapping_type": "string"
+          }
+        },
+        {
+          "ecs_boolean": {
+            "mapping": {
+              "type": "boolean"
+            },
+            "path_match": [
+              "*.code_signature.exists",
+              "*.code_signature.trusted",
+              "*.code_signature.valid",
+              "*.go_stripped",
+              "*.interactive",
+              "*.same_as_process",
+              "*faas.coldstart",
+              "*volume.removable",
+              "*tls.established",
+              "*container.security_context.privileged",
+              "*tls.resumed",
+              "*process.io.max_bytes_per_process_exceeded",
+              "*volume.writable"
+            ],
+            "match_mapping_type": ["boolean", "string"]
+          }
+        },
+        {
+          "ecs_long": {
+            "mapping": {
+              "type": "long"
+            },
+            "path_match": [
+              "*entropy",
+              "*.size",
+              "*_size",
+              "*.as.number",
+              "*.bytes",
+              "*bytes_skipped*",
+              "*.pid",
+              "*.vpid",
+              "*.port",
+              "*.packets",
+              "*.char_device.major",
+              "*.char_device.minor",
+              "*.chi2",
+              "*.args_count",
+              "*.virtual_address",
+              "*.pgid",
+              "*.thread.id",
+              "*.header.entrypoint",
+              "*.uptime",
+              "*.scanner_stats",
+              "*.indicator.sightings",
+              "*process.io.total_bytes_captured",
+              "*process.tty.columns",
+              "*event.severity",
+              "*log.syslog.severity.code",
+              "*process.parent.exit_code",
+              "*http.response.status_code",
+              "*log.syslog.facility.code",
+              "*process.exit_code",
+              "*log.origin.file.line",
+              "*process.tty.rows",
+              "*event.duration",
+              "*event.sequence",
+              "*dns.answers.ttl",
+              "*log.syslog.priority"
+
+            ],
+            "match_mapping_type": ["long", "string"]
+          }
+        },
+        {
           "ecs_wildcard": {
             "mapping": {
               "type": "wildcard"

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -300,7 +300,7 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
                     + "Fix {} accordingly.",
                 fieldName,
                 expectedType,
-                ingestedValue.getClass().getSimpleName().toLowerCase(),
+                ingestedValue.getClass().getSimpleName().toLowerCase(Locale.ROOT),
                 actualType,
                 ECS_DYNAMIC_TEMPLATES_FILE
             );
@@ -467,7 +467,7 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
 
             // TODO - REMOVE ONCE THE ERROR INTRODUCED WITH https://github.com/elastic/ecs/pull/2370 IS FIXED
             case "string" -> {
-                System.err.println("Field type 'string' is not supported by ECS and should be replaced with 'keyword' or 'text'");
+                logger.error("Field type 'string' is not supported by ECS and should be replaced with 'keyword' or 'text'");
                 return randomAlphaOfLength(20);
             }
 


### PR DESCRIPTION
Closes #113124 

### IMPORTANT NOTE
If we backport this to 8.15, we need to increase [`StackTemplateRegistry`'s version](https://github.com/elastic/elasticsearch/blob/322ed681d95318209fa230021a4f832eadc9e8a2/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java#L51).