### PR TITLE
Make `PutMappingClusterStateUpdateRequest` a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
@@ -9,33 +9,37 @@
 
 package org.elasticsearch.action.admin.indices.mapping.put;
 
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Cluster state update request that allows to put a mapping
  */
-public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<PutMappingClusterStateUpdateRequest> {
-
-    private final CompressedXContent source;
-    private boolean autoUpdate;
-
-    public PutMappingClusterStateUpdateRequest(String source) throws IOException {
-        this.source = CompressedXContent.fromJSON(source);
+public record PutMappingClusterStateUpdateRequest(
+    TimeValue masterNodeTimeout,
+    TimeValue ackTimeout,
+    CompressedXContent source,
+    boolean autoUpdate,
+    Index[] indices
+) {
+    public PutMappingClusterStateUpdateRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(ackTimeout);
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(indices);
     }
 
-    public CompressedXContent source() {
-        return source;
-    }
-
-    public PutMappingClusterStateUpdateRequest autoUpdate(boolean autoUpdate) {
-        this.autoUpdate = autoUpdate;
-        return this;
-    }
-
-    public boolean autoUpdate() {
-        return autoUpdate;
+    public PutMappingClusterStateUpdateRequest(
+        TimeValue masterNodeTimeout,
+        TimeValue ackTimeout,
+        String source,
+        boolean autoUpdate,
+        Index... indices
+    ) throws IOException {
+        this(masterNodeTimeout, ackTimeout, CompressedXContent.fromJSON(source), autoUpdate, indices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -157,10 +157,13 @@ public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAc
         });
         final PutMappingClusterStateUpdateRequest updateRequest;
         try {
-            updateRequest = new PutMappingClusterStateUpdateRequest(request.source()).indices(concreteIndices)
-                .ackTimeout(request.ackTimeout())
-                .masterNodeTimeout(request.masterNodeTimeout())
-                .autoUpdate(autoUpdate);
+            updateRequest = new PutMappingClusterStateUpdateRequest(
+                request.masterNodeTimeout(),
+                request.ackTimeout(),
+                request.source(),
+                autoUpdate,
+                concreteIndices
+            );
         } catch (IOException e) {
             wrappedListener.onFailure(e);
             return;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingClusterState
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.plugins.Plugin;
@@ -43,9 +42,14 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService.PutMappingExecutor putMappingExecutor = mappingService.new PutMappingExecutor();
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         // TODO - it will be nice to get a random mapping generator
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "text" }}}""");
-        request.indices(new Index[] { indexService.index() });
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            """
+                { "properties": { "field": { "type": "text" }}}""",
+            false,
+            indexService.index()
+        );
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             putMappingExecutor,
@@ -66,8 +70,14 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final MetadataMappingService.PutMappingExecutor putMappingExecutor = mappingService.new PutMappingExecutor();
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "text" }}}""").indices(new Index[] { indexService.index() });
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            """
+                { "properties": { "field": { "type": "text" }}}""",
+            false,
+            indexService.index()
+        );
         final var resultingState1 = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             putMappingExecutor,
@@ -87,9 +97,14 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final MetadataMappingService.PutMappingExecutor putMappingExecutor = mappingService.new PutMappingExecutor();
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "text" }}}""");
-        request.indices(new Index[] { indexService.index() });
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            """
+                { "properties": { "field": { "type": "text" }}}""",
+            false,
+            indexService.index()
+        );
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             putMappingExecutor,
@@ -105,8 +120,13 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final MetadataMappingService.PutMappingExecutor putMappingExecutor = mappingService.new PutMappingExecutor();
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("{ \"properties\": {}}");
-        request.indices(new Index[] { indexService.index() });
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            "{ \"properties\": {}}",
+            false,
+            indexService.index()
+        );
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             putMappingExecutor,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/cluster/metadata/SemanticTextClusterMetadataTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/cluster/metadata/SemanticTextClusterMetadataTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingClusterStateUpdateRequest;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -46,9 +45,14 @@ public class SemanticTextClusterMetadataTests extends ESSingleNodeTestCase {
         final MetadataMappingService.PutMappingExecutor putMappingExecutor = mappingService.new PutMappingExecutor();
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
 
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "semantic_text", "inference_id": "test_model" }}}""");
-        request.indices(new Index[] { indexService.index() });
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            """
+                { "properties": { "field": { "type": "semantic_text", "inference_id": "test_model" }}}""",
+            false,
+            indexService.index()
+        );
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             putMappingExecutor,
@@ -63,25 +67,30 @@ public class SemanticTextClusterMetadataTests extends ESSingleNodeTestCase {
         final MetadataMappingService.PutMappingExecutor putMappingExecutor = mappingService.new PutMappingExecutor();
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
 
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            {
-              "properties": {
-                "semantic": {
-                  "type": "semantic_text",
-                  "inference_id": "test_model"
-                },
-                "copy_origin_1": {
-                  "type": "text",
-                  "copy_to": "semantic"
-                },
-                "copy_origin_2": {
-                  "type": "text",
-                  "copy_to": "semantic"
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
+            """
+                {
+                  "properties": {
+                    "semantic": {
+                      "type": "semantic_text",
+                      "inference_id": "test_model"
+                    },
+                    "copy_origin_1": {
+                      "type": "text",
+                      "copy_to": "semantic"
+                    },
+                    "copy_origin_2": {
+                      "type": "text",
+                      "copy_to": "semantic"
+                    }
+                  }
                 }
-              }
-            }
-            """);
-        request.indices(new Index[] { indexService.index() });
+                """,
+            false,
+            indexService.index()
+        );
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             putMappingExecutor,


### PR DESCRIPTION
No need to extend `IndicesClusterStateUpdateRequest`, this thing can be
completely immutable.