### PR TITLE
adjust t-digest compression for MedianAbsoluteDeviationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -129,7 +129,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
     private static MedianAbsoluteDeviationAggregationBuilder randomBuilder() {
         final MedianAbsoluteDeviationAggregationBuilder builder = new MedianAbsoluteDeviationAggregationBuilder("mad");
         if (randomBoolean()) {
-            builder.compression(randomDoubleBetween(25, 1000, false));
+            builder.compression(randomDoubleBetween(30, 1000, false));
         }
         return builder;
     }


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/97680, lets increase a bit the minimum compression to avoid flakiness.

fixes https://github.com/elastic/elasticsearch/issues/107946