### PR TITLE
[8.x] Detect long-running outbound tasks on network threads (#113250)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -332,8 +332,12 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             if (tlsConfig.isTLSEnabled()) {
                 ch.pipeline().addLast("ssl", new SslHandler(tlsConfig.createServerSSLEngine()));
             }
+            final var threadWatchdogActivityTracker = transport.threadWatchdog.getActivityTrackerForCurrentThread();
             ch.pipeline()
-                .addLast("chunked_writer", new Netty4WriteThrottlingHandler(transport.getThreadPool().getThreadContext()))
+                .addLast(
+                    "chunked_writer",
+                    new Netty4WriteThrottlingHandler(transport.getThreadPool().getThreadContext(), threadWatchdogActivityTracker)
+                )
                 .addLast("byte_buf_sizer", NettyByteBufSizer.INSTANCE);
             if (transport.readTimeoutMillis > 0) {
                 ch.pipeline().addLast("read_timeout", new ReadTimeoutHandler(transport.readTimeoutMillis, TimeUnit.MILLISECONDS));
@@ -409,11 +413,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
             ch.pipeline()
                 .addLast(
                     "pipelining",
-                    new Netty4HttpPipeliningHandler(
-                        transport.pipeliningMaxEvents,
-                        transport,
-                        transport.threadWatchdog.getActivityTrackerForCurrentThread()
-                    )
+                    new Netty4HttpPipeliningHandler(transport.pipeliningMaxEvents, transport, threadWatchdogActivityTracker)
                 );
             transport.serverAcceptedChannel(nettyHttpChannel);
         }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -359,7 +359,10 @@ public class Netty4Transport extends TcpTransport {
         if (NetworkTraceFlag.TRACE_ENABLED) {
             pipeline.addLast("logging", ESLoggingHandler.INSTANCE);
         }
-        pipeline.addLast("chunked_writer", new Netty4WriteThrottlingHandler(getThreadPool().getThreadContext()));
+        pipeline.addLast(
+            "chunked_writer",
+            new Netty4WriteThrottlingHandler(getThreadPool().getThreadContext(), threadWatchdog.getActivityTrackerForCurrentThread())
+        );
         pipeline.addLast(
             "dispatcher",
             new Netty4MessageInboundHandler(

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4WriteThrottlingHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4WriteThrottlingHandlerTests.java
@@ -18,43 +18,52 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.network.ThreadWatchdog;
+import org.elasticsearch.common.network.ThreadWatchdogHelper;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.Transports;
 import org.junit.After;
 import org.junit.Before;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.startsWith;
 
 public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
 
-    private SharedGroupFactory.SharedGroup transportGroup;
+    private ThreadWatchdog threadWatchdog = new ThreadWatchdog();
 
     @Before
-    public void createGroup() {
-        final SharedGroupFactory sharedGroupFactory = new SharedGroupFactory(Settings.EMPTY);
-        transportGroup = sharedGroupFactory.getTransportGroup();
+    public void setFakeThreadName() {
+        // These tests interact with EmbeddedChannel instances directly on the test thread, so we rename it temporarily to satisfy checks
+        // that we're running on a transport thread
+        Thread.currentThread().setName(Transports.TEST_MOCK_TRANSPORT_THREAD_PREFIX + Thread.currentThread().getName());
     }
 
     @After
-    public void stopGroup() {
-        transportGroup.shutdown();
+    public void resetThreadName() {
+        final var threadName = Thread.currentThread().getName();
+        assertThat(threadName, startsWith(Transports.TEST_MOCK_TRANSPORT_THREAD_PREFIX));
+        Thread.currentThread().setName(threadName.substring(Transports.TEST_MOCK_TRANSPORT_THREAD_PREFIX.length()));
     }
 
-    public void testThrottlesLargeMessage() throws ExecutionException, InterruptedException {
+    public void testThrottlesLargeMessage() {
         final List<ByteBuf> seen = new CopyOnWriteArrayList<>();
         final CapturingHandler capturingHandler = new CapturingHandler(seen);
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
             capturingHandler,
-            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY))
+            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY), threadWatchdog.getActivityTrackerForCurrentThread())
         );
         // we assume that the channel outbound buffer is smaller than Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE
         final int writeableBytes = Math.toIntExact(embeddedChannel.bytesBeforeUnwritable());
@@ -66,11 +75,11 @@ public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
         );
         final Object message = wrapAsNettyOrEsBuffer(messageBytes);
         final ChannelPromise promise = embeddedChannel.newPromise();
-        transportGroup.getLowLevelGroup().submit(() -> embeddedChannel.write(message, promise)).get();
+        embeddedChannel.write(message, promise);
         assertThat(seen, hasSize(1));
         assertSliceEquals(seen.get(0), message, 0, Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE);
         assertFalse(promise.isDone());
-        transportGroup.getLowLevelGroup().submit(embeddedChannel::flush).get();
+        embeddedChannel.flush();
         assertTrue(promise.isDone());
         assertThat(seen, hasSize(fullSizeChunks + (extraChunkSize == 0 ? 0 : 1)));
         assertTrue(capturingHandler.didWriteAfterThrottled);
@@ -84,12 +93,12 @@ public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
         }
     }
 
-    public void testThrottleLargeCompositeMessage() throws ExecutionException, InterruptedException {
+    public void testThrottleLargeCompositeMessage() {
         final List<ByteBuf> seen = new CopyOnWriteArrayList<>();
         final CapturingHandler capturingHandler = new CapturingHandler(seen);
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
             capturingHandler,
-            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY))
+            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY), threadWatchdog.getActivityTrackerForCurrentThread())
         );
         // we assume that the channel outbound buffer is smaller than Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE
         final int writeableBytes = Math.toIntExact(embeddedChannel.bytesBeforeUnwritable());
@@ -105,51 +114,51 @@ public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
             new BytesArray(messageBytes, splitOffset, messageBytes.length - splitOffset)
         );
         final ChannelPromise promise = embeddedChannel.newPromise();
-        transportGroup.getLowLevelGroup().submit(() -> embeddedChannel.write(message, promise)).get();
+        embeddedChannel.write(message, promise);
         assertThat(seen, hasSize(oneOf(1, 2)));
         assertSliceEquals(seen.get(0), message, 0, seen.get(0).readableBytes());
         assertFalse(promise.isDone());
-        transportGroup.getLowLevelGroup().submit(embeddedChannel::flush).get();
+        embeddedChannel.flush();
         assertTrue(promise.isDone());
         assertThat(seen, hasSize(oneOf(fullSizeChunks, fullSizeChunks + 1)));
         assertTrue(capturingHandler.didWriteAfterThrottled);
         assertBufferEquals(Unpooled.compositeBuffer().addComponents(true, seen), message);
     }
 
-    public void testPassesSmallMessageDirectly() throws ExecutionException, InterruptedException {
+    public void testPassesSmallMessageDirectly() {
         final List<ByteBuf> seen = new CopyOnWriteArrayList<>();
         final CapturingHandler capturingHandler = new CapturingHandler(seen);
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
             capturingHandler,
-            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY))
+            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY), threadWatchdog.getActivityTrackerForCurrentThread())
         );
         final int writeableBytes = Math.toIntExact(embeddedChannel.bytesBeforeUnwritable());
         assertThat(writeableBytes, lessThan(Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE));
         final byte[] messageBytes = randomByteArrayOfLength(randomIntBetween(0, Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE));
         final Object message = wrapAsNettyOrEsBuffer(messageBytes);
         final ChannelPromise promise = embeddedChannel.newPromise();
-        transportGroup.getLowLevelGroup().submit(() -> embeddedChannel.write(message, promise)).get();
+        embeddedChannel.write(message, promise);
         assertThat(seen, hasSize(1)); // first message should be passed through straight away
         assertBufferEquals(seen.get(0), message);
         assertFalse(promise.isDone());
-        transportGroup.getLowLevelGroup().submit(embeddedChannel::flush).get();
+        embeddedChannel.flush();
         assertTrue(promise.isDone());
         assertThat(seen, hasSize(1));
         assertFalse(capturingHandler.didWriteAfterThrottled);
     }
 
-    public void testThrottlesOnUnwritable() throws ExecutionException, InterruptedException {
+    public void testThrottlesOnUnwritable() {
         final List<ByteBuf> seen = new CopyOnWriteArrayList<>();
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(
             new CapturingHandler(seen),
-            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY))
+            new Netty4WriteThrottlingHandler(new ThreadContext(Settings.EMPTY), threadWatchdog.getActivityTrackerForCurrentThread())
         );
         final int writeableBytes = Math.toIntExact(embeddedChannel.bytesBeforeUnwritable());
         assertThat(writeableBytes, lessThan(Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE));
         final byte[] messageBytes = randomByteArrayOfLength(writeableBytes + randomIntBetween(0, 10));
         final Object message = wrapAsNettyOrEsBuffer(messageBytes);
         final ChannelPromise promise = embeddedChannel.newPromise();
-        transportGroup.getLowLevelGroup().submit(() -> embeddedChannel.write(message, promise)).get();
+        embeddedChannel.write(message, promise);
         assertThat(seen, hasSize(1)); // first message should be passed through straight away
         assertBufferEquals(seen.get(0), message);
         assertFalse(promise.isDone());
@@ -157,11 +166,11 @@ public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
             randomByteArrayOfLength(randomIntBetween(0, Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE))
         );
         final ChannelPromise promiseForQueued = embeddedChannel.newPromise();
-        transportGroup.getLowLevelGroup().submit(() -> embeddedChannel.write(messageToQueue, promiseForQueued)).get();
+        embeddedChannel.write(messageToQueue, promiseForQueued);
         assertThat(seen, hasSize(1));
         assertFalse(promiseForQueued.isDone());
         assertFalse(promise.isDone());
-        transportGroup.getLowLevelGroup().submit(embeddedChannel::flush).get();
+        embeddedChannel.flush();
         assertTrue(promise.isDone());
         assertTrue(promiseForQueued.isDone());
     }
@@ -191,7 +200,7 @@ public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
         return new BytesArray(messageBytes);
     }
 
-    private static class CapturingHandler extends ChannelOutboundHandlerAdapter {
+    private class CapturingHandler extends ChannelOutboundHandlerAdapter {
         private final List<ByteBuf> seen;
 
         private boolean wasThrottled = false;
@@ -204,6 +213,13 @@ public class Netty4WriteThrottlingHandlerTests extends ESTestCase {
 
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            assertThat(
+                ThreadWatchdogHelper.getStuckThreadNames(threadWatchdog),
+                // writes are re-entrant so we might already be considered stuck due to an earlier check
+                anyOf(emptyIterable(), hasItem(Thread.currentThread().getName()))
+            );
+            assertThat(ThreadWatchdogHelper.getStuckThreadNames(threadWatchdog), hasItem(Thread.currentThread().getName()));
+
             assertTrue("should only write to writeable channel", ctx.channel().isWritable());
             assertThat(msg, instanceOf(ByteBuf.class));
             final ByteBuf buf = (ByteBuf) msg;

--- a/server/src/main/java/org/elasticsearch/common/network/ThreadWatchdog.java
+++ b/server/src/main/java/org/elasticsearch/common/network/ThreadWatchdog.java
@@ -131,6 +131,16 @@ public class ThreadWatchdog {
             assert isIdle(prevValue) : "thread [" + trackedThread.getName() + "] was already active";
         }
 
+        public boolean maybeStartActivity() {
+            assert trackedThread == Thread.currentThread() : trackedThread.getName() + " vs " + Thread.currentThread().getName();
+            if (isIdle(get())) {
+                getAndIncrement();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
         public void stopActivity() {
             assert trackedThread == Thread.currentThread() : trackedThread.getName() + " vs " + Thread.currentThread().getName();
             final var prevValue = getAndIncrement();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Detect long-running outbound tasks on network threads (#113250)