### PR TITLE
ES|QL: Fix failing tests due to date warnings

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -265,20 +265,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authz.SecurityScrollTests
   method: testSearchAndClearScroll
   issue: https://github.com/elastic/elasticsearch/issues/113285
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {date.EvalDateFormatString SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/113293
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {date.EvalDateFormat}
-  issue: https://github.com/elastic/elasticsearch/issues/113294
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {date.DocsDateFormat}
-  issue: https://github.com/elastic/elasticsearch/issues/113295
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {stats.DocsStatsGroupByMultipleValues}
-  issue: https://github.com/elastic/elasticsearch/issues/113296
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/113298
 - class: org.elasticsearch.integration.KibanaUserRoleIntegTests
   method: testGetIndex
   issue: https://github.com/elastic/elasticsearch/issues/113311

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -46,7 +46,7 @@ emp_no:integer | x:date
 
 evalDateFormat
 from employees | sort hire_date | eval x = date_format(hire_date), y = date_format("YYYY-MM-dd", hire_date) | keep emp_no, x, y | limit 5;
-warningRegex:Date format \\[YYYY.MM.dd\\] contains week-date field specifiers that are changing in JDK 23
+warningRegex:Date format \[YYYY\-MM\-dd\] contains week-date field specifiers that are changing in JDK 23
 
 emp_no:integer | x:keyword                     | y:keyword
 10009          | 1985-02-18T00:00:00.000Z      | 1985-02-18            
@@ -962,7 +962,7 @@ FROM employees
 | SORT first_name
 | LIMIT 3
 ;
-warningRegex:Date format \\[YYYY.MM.dd\\] contains week-date field specifiers that are changing in JDK 23
+warningRegex:Date format \[YYYY\-MM\-dd\] contains week-date field specifiers that are changing in JDK 23
 
 // tag::docsDateFormat-result[]
 first_name:keyword   |   last_name:keyword   | hire_date:date           | hired:keyword
@@ -978,7 +978,7 @@ required_capability: string_literal_auto_casting
 ROW a = 1
 | EVAL df = DATE_FORMAT("YYYY-MM-dd", "1989-06-02T00:00:00.000Z")
 ;
-warningRegex:Date format \\[YYYY.MM.dd\\] contains week-date field specifiers that are changing in JDK 23
+warningRegex:Date format \[YYYY\-MM\-dd\] contains week-date field specifiers that are changing in JDK 23
 
 a:integer | df:keyword
 1         | 1989-06-02

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -46,6 +46,7 @@ emp_no:integer | x:date
 
 evalDateFormat
 from employees | sort hire_date | eval x = date_format(hire_date), y = date_format("YYYY-MM-dd", hire_date) | keep emp_no, x, y | limit 5;
+warningRegex:Date format \\[YYYY.MM.dd\\] contains week-date field specifiers that are changing in JDK 23
 
 emp_no:integer | x:keyword                     | y:keyword
 10009          | 1985-02-18T00:00:00.000Z      | 1985-02-18            
@@ -961,6 +962,7 @@ FROM employees
 | SORT first_name
 | LIMIT 3
 ;
+warningRegex:Date format \\[YYYY.MM.dd\\] contains week-date field specifiers that are changing in JDK 23
 
 // tag::docsDateFormat-result[]
 first_name:keyword   |   last_name:keyword   | hire_date:date           | hired:keyword
@@ -976,6 +978,7 @@ required_capability: string_literal_auto_casting
 ROW a = 1
 | EVAL df = DATE_FORMAT("YYYY-MM-dd", "1989-06-02T00:00:00.000Z")
 ;
+warningRegex:Date format \\[YYYY.MM.dd\\] contains week-date field specifiers that are changing in JDK 23
 
 a:integer | df:keyword
 1         | 1989-06-02

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1183,6 +1183,7 @@ FROM employees
 // end::statsGroupByMultipleValues[]
 | LIMIT 4
 ;
+warningRegex:Date format \\[YYYY\\] contains week-date field specifiers that are changing in JDK 23
 
 hired:keyword |languages.long:long | avg_salary:double
 1985           |1              |54668.0        

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1183,7 +1183,7 @@ FROM employees
 // end::statsGroupByMultipleValues[]
 | LIMIT 4
 ;
-warningRegex:Date format \\[YYYY\\] contains week-date field specifiers that are changing in JDK 23
+warningRegex:Date format \[YYYY\] contains week-date field specifiers that are changing in JDK 23
 
 hired:keyword |languages.long:long | avg_salary:double
 1985           |1              |54668.0        


### PR DESCRIPTION
New warnings like 
```
Date format [MMMM] contains textual field specifiers that could change in JDK 23
```

Fixes: #113293
Fixes: #113294
Fixes: #113295
Fixes: #113296
Fixes: #113298
Fixes: #113299
Fixes: #113301