### PR TITLE
Add Lucene70DocValuesFormat to old-lucene-versions plugin

### DIFF
--- a/x-pack/plugin/old-lucene-versions/src/internalClusterTest/java/org/elasticsearch/xpack/lucene/bwc/AbstractArchiveTestCase.java
+++ b/x-pack/plugin/old-lucene-versions/src/internalClusterTest/java/org/elasticsearch/xpack/lucene/bwc/AbstractArchiveTestCase.java
@@ -97,7 +97,7 @@ public abstract class AbstractArchiveTestCase extends AbstractSnapshotIntegTestC
                                     .getAsVersionId(
                                         "version",
                                         IndexVersion::fromId,
-                                        IndexVersion.fromId(randomBoolean() ? 5000099 : 6000099)
+                                        IndexVersion.fromId(randomFrom(5000099, 6000099, 7000099))
                                     )
                             )
                     )

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/BWCLucene70Codec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/BWCLucene70Codec.java
@@ -47,7 +47,11 @@ public class BWCLucene70Codec extends BWCCodec {
     };
 
     public BWCLucene70Codec() {
-        super("BWCLucene70Codec");
+        this("BWCLucene70Codec");
+    }
+
+    protected BWCLucene70Codec(String name) {
+        super(name);
         storedFieldsFormat = new Lucene50StoredFieldsFormat(Lucene50StoredFieldsFormat.Mode.BEST_SPEED);
     }
 

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/BWCLucene70Codec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/BWCLucene70Codec.java
@@ -22,7 +22,6 @@ import org.apache.lucene.codecs.SegmentInfoFormat;
 import org.apache.lucene.codecs.StoredFieldsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
 import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.xpack.lucene.bwc.codecs.BWCCodec;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene60.Lucene60MetadataOnlyPointsFormat;
 
@@ -33,9 +32,7 @@ public class BWCLucene70Codec extends BWCCodec {
     private final LiveDocsFormat liveDocsFormat = new Lucene50LiveDocsFormat();
     private final CompoundFormat compoundFormat = new Lucene50CompoundFormat();
     private final StoredFieldsFormat storedFieldsFormat;
-    @UpdateForV9
-    // this needs addressing to support 7.x indices in 9.x
-    private final DocValuesFormat defaultDVFormat = null; // DocValuesFormat.forName("Lucene70");
+    private final DocValuesFormat defaultDVFormat = new Lucene70DocValuesFormat();
     private final DocValuesFormat docValuesFormat = new PerFieldDocValuesFormat() {
         @Override
         public DocValuesFormat getDocValuesFormatForField(String field) {

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/IndexedDISI.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/IndexedDISI.java
@@ -1,0 +1,327 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright (C) 2021 Elasticsearch B.V.
+ */
+package org.elasticsearch.xpack.lucene.bwc.codecs.lucene70;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.RoaringDocIdSet;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+/**
+ * Disk-based implementation of a {@link DocIdSetIterator} which can return the index of the current
+ * document, i.e. the ordinal of the current document among the list of documents that this iterator
+ * can return. This is useful to implement sparse doc values by only having to encode values for
+ * documents that actually have a value.
+ *
+ * <p>Implementation-wise, this {@link DocIdSetIterator} is inspired of {@link RoaringDocIdSet
+ * roaring bitmaps} and encodes ranges of {@code 65536} documents independently and picks between 3
+ * encodings depending on the density of the range:
+ *
+ * <ul>
+ *   <li>{@code ALL} if the range contains 65536 documents exactly,
+ *   <li>{@code DENSE} if the range contains 4096 documents or more; in that case documents are
+ *       stored in a bit set,
+ *   <li>{@code SPARSE} otherwise, and the lower 16 bits of the doc IDs are stored in a {@link
+ *       DataInput#readShort() short}.
+ * </ul>
+ *
+ * <p>Only ranges that contain at least one value are encoded.
+ *
+ * <p>This implementation uses 6 bytes per document in the worst-case, which happens in the case
+ * that all ranges contain exactly one document.
+ */
+final class IndexedDISI extends DocIdSetIterator {
+
+    static final int MAX_ARRAY_LENGTH = (1 << 12) - 1;
+
+    private static void flush(int block, FixedBitSet buffer, int cardinality, IndexOutput out) throws IOException {
+        assert block >= 0 && block < 65536;
+        out.writeShort((short) block);
+        assert cardinality > 0 && cardinality <= 65536;
+        out.writeShort((short) (cardinality - 1));
+        if (cardinality > MAX_ARRAY_LENGTH) {
+            if (cardinality != 65536) { // all docs are set
+                for (long word : buffer.getBits()) {
+                    out.writeLong(word);
+                }
+            }
+        } else {
+            BitSetIterator it = new BitSetIterator(buffer, cardinality);
+            for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+                out.writeShort((short) doc);
+            }
+        }
+    }
+
+    static void writeBitSet(DocIdSetIterator it, IndexOutput out) throws IOException {
+        int i = 0;
+        final FixedBitSet buffer = new FixedBitSet(1 << 16);
+        int prevBlock = -1;
+        for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+            final int block = doc >>> 16;
+            if (prevBlock != -1 && block != prevBlock) {
+                flush(prevBlock, buffer, i, out);
+                buffer.clear(0, buffer.length());
+                prevBlock = block;
+                i = 0;
+            }
+            buffer.set(doc & 0xFFFF);
+            i++;
+            prevBlock = block;
+        }
+        if (i > 0) {
+            flush(prevBlock, buffer, i, out);
+            buffer.clear(0, buffer.length());
+        }
+        // NO_MORE_DOCS is stored explicitly
+        buffer.set(DocIdSetIterator.NO_MORE_DOCS & 0xFFFF);
+        flush(DocIdSetIterator.NO_MORE_DOCS >>> 16, buffer, 1, out);
+    }
+
+    /** The slice that stores the {@link DocIdSetIterator}. */
+    private final IndexInput slice;
+
+    private final long cost;
+
+    IndexedDISI(IndexInput in, long offset, long length, long cost) throws IOException {
+        this(in.slice("docs", offset, length), cost);
+    }
+
+    // This constructor allows to pass the slice directly in case it helps reuse
+    // see eg. Lucene70 norms producer's merge instance
+    IndexedDISI(IndexInput slice, long cost) throws IOException {
+        this.slice = slice;
+        this.cost = cost;
+    }
+
+    private int block = -1;
+    private long blockEnd;
+    private int nextBlockIndex = -1;
+    Method method;
+
+    private int doc = -1;
+    private int index = -1;
+
+    // SPARSE variables
+    boolean exists;
+
+    // DENSE variables
+    private long word;
+    private int wordIndex = -1;
+    // number of one bits encountered so far, including those of `word`
+    private int numberOfOnes;
+
+    // ALL variables
+    private int gap;
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        final int targetBlock = target & 0xFFFF0000;
+        if (block < targetBlock) {
+            advanceBlock(targetBlock);
+        }
+        if (block == targetBlock) {
+            if (method.advanceWithinBlock(this, target)) {
+                return doc;
+            }
+            readBlockHeader();
+        }
+        boolean found = method.advanceWithinBlock(this, block);
+        assert found;
+        return doc;
+    }
+
+    public boolean advanceExact(int target) throws IOException {
+        final int targetBlock = target & 0xFFFF0000;
+        if (block < targetBlock) {
+            advanceBlock(targetBlock);
+        }
+        boolean found = block == targetBlock && method.advanceExactWithinBlock(this, target);
+        this.doc = target;
+        return found;
+    }
+
+    private void advanceBlock(int targetBlock) throws IOException {
+        do {
+            slice.seek(blockEnd);
+            readBlockHeader();
+        } while (block < targetBlock);
+    }
+
+    private void readBlockHeader() throws IOException {
+        block = Short.toUnsignedInt(slice.readShort()) << 16;
+        assert block >= 0;
+        final int numValues = 1 + Short.toUnsignedInt(slice.readShort());
+        index = nextBlockIndex;
+        nextBlockIndex = index + numValues;
+        if (numValues <= MAX_ARRAY_LENGTH) {
+            method = Method.SPARSE;
+            blockEnd = slice.getFilePointer() + (numValues << 1);
+        } else if (numValues == 65536) {
+            method = Method.ALL;
+            blockEnd = slice.getFilePointer();
+            gap = block - index - 1;
+        } else {
+            method = Method.DENSE;
+            blockEnd = slice.getFilePointer() + (1 << 13);
+            wordIndex = -1;
+            numberOfOnes = index + 1;
+        }
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    public int index() {
+        return index;
+    }
+
+    @Override
+    public long cost() {
+        return cost;
+    }
+
+    enum Method {
+        SPARSE {
+            @Override
+            boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {
+                final int targetInBlock = target & 0xFFFF;
+                // TODO: binary search
+                for (; disi.index < disi.nextBlockIndex;) {
+                    int doc = Short.toUnsignedInt(disi.slice.readShort());
+                    disi.index++;
+                    if (doc >= targetInBlock) {
+                        disi.doc = disi.block | doc;
+                        disi.exists = true;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            boolean advanceExactWithinBlock(IndexedDISI disi, int target) throws IOException {
+                final int targetInBlock = target & 0xFFFF;
+                // TODO: binary search
+                if (target == disi.doc) {
+                    return disi.exists;
+                }
+                for (; disi.index < disi.nextBlockIndex;) {
+                    int doc = Short.toUnsignedInt(disi.slice.readShort());
+                    disi.index++;
+                    if (doc >= targetInBlock) {
+                        if (doc != targetInBlock) {
+                            disi.index--;
+                            disi.slice.seek(disi.slice.getFilePointer() - Short.BYTES);
+                            break;
+                        }
+                        disi.exists = true;
+                        return true;
+                    }
+                }
+                disi.exists = false;
+                return false;
+            }
+        },
+        DENSE {
+            @Override
+            boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {
+                final int targetInBlock = target & 0xFFFF;
+                final int targetWordIndex = targetInBlock >>> 6;
+                for (int i = disi.wordIndex + 1; i <= targetWordIndex; ++i) {
+                    disi.word = disi.slice.readLong();
+                    disi.numberOfOnes += Long.bitCount(disi.word);
+                }
+                disi.wordIndex = targetWordIndex;
+
+                long leftBits = disi.word >>> target;
+                if (leftBits != 0L) {
+                    disi.doc = target + Long.numberOfTrailingZeros(leftBits);
+                    disi.index = disi.numberOfOnes - Long.bitCount(leftBits);
+                    return true;
+                }
+
+                while (++disi.wordIndex < 1024) {
+                    disi.word = disi.slice.readLong();
+                    if (disi.word != 0) {
+                        disi.index = disi.numberOfOnes;
+                        disi.numberOfOnes += Long.bitCount(disi.word);
+                        disi.doc = disi.block | (disi.wordIndex << 6) | Long.numberOfTrailingZeros(disi.word);
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            boolean advanceExactWithinBlock(IndexedDISI disi, int target) throws IOException {
+                final int targetInBlock = target & 0xFFFF;
+                final int targetWordIndex = targetInBlock >>> 6;
+                for (int i = disi.wordIndex + 1; i <= targetWordIndex; ++i) {
+                    disi.word = disi.slice.readLong();
+                    disi.numberOfOnes += Long.bitCount(disi.word);
+                }
+                disi.wordIndex = targetWordIndex;
+
+                long leftBits = disi.word >>> target;
+                disi.index = disi.numberOfOnes - Long.bitCount(leftBits);
+                return (leftBits & 1L) != 0;
+            }
+        },
+        ALL {
+            @Override
+            boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException {
+                disi.doc = target;
+                disi.index = target - disi.gap;
+                return true;
+            }
+
+            @Override
+            boolean advanceExactWithinBlock(IndexedDISI disi, int target) throws IOException {
+                disi.index = target - disi.gap;
+                return true;
+            }
+        };
+
+        /**
+         * Advance to the first doc from the block that is equal to or greater than {@code target}.
+         * Return true if there is such a doc and false otherwise.
+         */
+        abstract boolean advanceWithinBlock(IndexedDISI disi, int target) throws IOException;
+
+        /**
+         * Advance the iterator exactly to the position corresponding to the given {@code target} and
+         * return whether this document exists.
+         */
+        abstract boolean advanceExactWithinBlock(IndexedDISI disi, int target) throws IOException;
+    }
+}

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70Codec.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70Codec.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.lucene.bwc.codecs.lucene70;
+
+public class Lucene70Codec extends BWCLucene70Codec {
+
+    public Lucene70Codec() {
+        super("Lucene70");
+    }
+}

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesConsumer.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesConsumer.java
@@ -1,0 +1,683 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright (C) 2021 Elasticsearch B.V.
+ */
+package org.elasticsearch.xpack.lucene.bwc.codecs.lucene70;
+
+import org.apache.lucene.backward_codecs.packed.LegacyDirectMonotonicWriter;
+import org.apache.lucene.backward_codecs.packed.LegacyDirectWriter;
+import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.EmptyDocValuesProducer;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.SortedSetSelector;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.ByteBuffersIndexOutput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.MathUtil;
+import org.apache.lucene.util.StringHelper;
+import org.elasticsearch.core.IOUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.Lucene70DocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+import static org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.Lucene70DocValuesFormat.NUMERIC_BLOCK_SHIFT;
+import static org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.Lucene70DocValuesFormat.NUMERIC_BLOCK_SIZE;
+
+/** writer for {@link Lucene70DocValuesFormat} */
+final class Lucene70DocValuesConsumer extends DocValuesConsumer {
+
+    static final long NO_MORE_ORDS = -1;
+
+    IndexOutput data, meta;
+    final int maxDoc;
+
+    /** expert: Creates a new writer */
+    Lucene70DocValuesConsumer(SegmentWriteState state, String dataCodec, String dataExtension, String metaCodec, String metaExtension)
+        throws IOException {
+        boolean success = false;
+        try {
+            String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
+            data = EndiannessReverserUtil.createOutput(state.directory, dataName, state.context);
+            CodecUtil.writeIndexHeader(
+                data,
+                dataCodec,
+                Lucene70DocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
+            meta = EndiannessReverserUtil.createOutput(state.directory, metaName, state.context);
+            CodecUtil.writeIndexHeader(
+                meta,
+                metaCodec,
+                Lucene70DocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            maxDoc = state.segmentInfo.maxDoc();
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        boolean success = false;
+        try {
+            if (meta != null) {
+                meta.writeInt(-1); // write EOF marker
+                CodecUtil.writeFooter(meta); // write checksum
+            }
+            if (data != null) {
+                CodecUtil.writeFooter(data); // write checksum
+            }
+            success = true;
+        } finally {
+            if (success) {
+                IOUtils.close(data, meta);
+            } else {
+                IOUtils.closeWhileHandlingException(data, meta);
+            }
+            meta = data = null;
+        }
+    }
+
+    @Override
+    public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        meta.writeInt(field.number);
+        meta.writeByte(Lucene70DocValuesFormat.NUMERIC);
+
+        writeValues(field, new EmptyDocValuesProducer() {
+            @Override
+            public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+                return DocValues.singleton(valuesProducer.getNumeric(field));
+            }
+        });
+    }
+
+    private static class MinMaxTracker {
+        long min, max, numValues, spaceInBits;
+
+        MinMaxTracker() {
+            reset();
+            spaceInBits = 0;
+        }
+
+        private void reset() {
+            min = Long.MAX_VALUE;
+            max = Long.MIN_VALUE;
+            numValues = 0;
+        }
+
+        /** Accumulate a new value. */
+        void update(long v) {
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+            ++numValues;
+        }
+
+        /** Update the required space. */
+        void finish() {
+            if (max > min) {
+                spaceInBits += LegacyDirectWriter.unsignedBitsRequired(max - min) * numValues;
+            }
+        }
+
+        /** Update space usage and get ready for accumulating values for the next block. */
+        void nextBlock() {
+            finish();
+            reset();
+        }
+    }
+
+    private long[] writeValues(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
+        int numDocsWithValue = 0;
+        MinMaxTracker minMax = new MinMaxTracker();
+        MinMaxTracker blockMinMax = new MinMaxTracker();
+        long gcd = 0;
+        Set<Long> uniqueValues = new HashSet<>();
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            for (int i = 0, count = values.docValueCount(); i < count; ++i) {
+                long v = values.nextValue();
+
+                if (gcd != 1) {
+                    if (v < Long.MIN_VALUE / 2 || v > Long.MAX_VALUE / 2) {
+                        // in that case v - minValue might overflow and make the GCD computation return
+                        // wrong results. Since these extreme values are unlikely, we just discard
+                        // GCD computation for them
+                        gcd = 1;
+                    } else if (minMax.numValues != 0) { // minValue needs to be set first
+                        gcd = MathUtil.gcd(gcd, v - minMax.min);
+                    }
+                }
+
+                minMax.update(v);
+                blockMinMax.update(v);
+                if (blockMinMax.numValues == NUMERIC_BLOCK_SIZE) {
+                    blockMinMax.nextBlock();
+                }
+
+                if (uniqueValues != null && uniqueValues.add(v) && uniqueValues.size() > 256) {
+                    uniqueValues = null;
+                }
+            }
+
+            numDocsWithValue++;
+        }
+
+        minMax.finish();
+        blockMinMax.finish();
+
+        final long numValues = minMax.numValues;
+        long min = minMax.min;
+        final long max = minMax.max;
+        assert blockMinMax.spaceInBits <= minMax.spaceInBits;
+
+        if (numDocsWithValue == 0) {
+            meta.writeLong(-2);
+            meta.writeLong(0L);
+        } else if (numDocsWithValue == maxDoc) {
+            meta.writeLong(-1);
+            meta.writeLong(0L);
+        } else {
+            long offset = data.getFilePointer();
+            meta.writeLong(offset);
+            values = valuesProducer.getSortedNumeric(field);
+            IndexedDISI.writeBitSet(values, data);
+            meta.writeLong(data.getFilePointer() - offset);
+        }
+
+        meta.writeLong(numValues);
+        final int numBitsPerValue;
+        boolean doBlocks = false;
+        Map<Long, Integer> encode = null;
+        if (min >= max) {
+            numBitsPerValue = 0;
+            meta.writeInt(-1);
+        } else {
+            if (uniqueValues != null
+                && uniqueValues.size() > 1
+                && LegacyDirectWriter.unsignedBitsRequired(uniqueValues.size() - 1) < LegacyDirectWriter.unsignedBitsRequired(
+                    (max - min) / gcd
+                )) {
+                numBitsPerValue = LegacyDirectWriter.unsignedBitsRequired(uniqueValues.size() - 1);
+                final Long[] sortedUniqueValues = uniqueValues.toArray(new Long[0]);
+                Arrays.sort(sortedUniqueValues);
+                meta.writeInt(sortedUniqueValues.length);
+                for (Long v : sortedUniqueValues) {
+                    meta.writeLong(v);
+                }
+                encode = new HashMap<>();
+                for (int i = 0; i < sortedUniqueValues.length; ++i) {
+                    encode.put(sortedUniqueValues[i], i);
+                }
+                min = 0;
+                gcd = 1;
+            } else {
+                uniqueValues = null;
+                // we do blocks if that appears to save 10+% storage
+                doBlocks = minMax.spaceInBits > 0 && (double) blockMinMax.spaceInBits / minMax.spaceInBits <= 0.9;
+                if (doBlocks) {
+                    numBitsPerValue = 0xFF;
+                    meta.writeInt(-2 - NUMERIC_BLOCK_SHIFT);
+                } else {
+                    numBitsPerValue = LegacyDirectWriter.unsignedBitsRequired((max - min) / gcd);
+                    if (gcd == 1
+                        && min > 0
+                        && LegacyDirectWriter.unsignedBitsRequired(max) == LegacyDirectWriter.unsignedBitsRequired(max - min)) {
+                        min = 0;
+                    }
+                    meta.writeInt(-1);
+                }
+            }
+        }
+
+        meta.writeByte((byte) numBitsPerValue);
+        meta.writeLong(min);
+        meta.writeLong(gcd);
+        long startOffset = data.getFilePointer();
+        meta.writeLong(startOffset);
+        if (doBlocks) {
+            writeValuesMultipleBlocks(valuesProducer.getSortedNumeric(field), gcd);
+        } else if (numBitsPerValue != 0) {
+            writeValuesSingleBlock(valuesProducer.getSortedNumeric(field), numValues, numBitsPerValue, min, gcd, encode);
+        }
+        meta.writeLong(data.getFilePointer() - startOffset);
+
+        return new long[] { numDocsWithValue, numValues };
+    }
+
+    private void writeValuesSingleBlock(
+        SortedNumericDocValues values,
+        long numValues,
+        int numBitsPerValue,
+        long min,
+        long gcd,
+        Map<Long, Integer> encode
+    ) throws IOException {
+        LegacyDirectWriter writer = LegacyDirectWriter.getInstance(data, numValues, numBitsPerValue);
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            for (int i = 0, count = values.docValueCount(); i < count; ++i) {
+                long v = values.nextValue();
+                if (encode == null) {
+                    writer.add((v - min) / gcd);
+                } else {
+                    writer.add(encode.get(v));
+                }
+            }
+        }
+        writer.finish();
+    }
+
+    private void writeValuesMultipleBlocks(SortedNumericDocValues values, long gcd) throws IOException {
+        final long[] buffer = new long[NUMERIC_BLOCK_SIZE];
+        final ByteBuffersDataOutput encodeBuffer = ByteBuffersDataOutput.newResettableInstance();
+        int upTo = 0;
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            for (int i = 0, count = values.docValueCount(); i < count; ++i) {
+                buffer[upTo++] = values.nextValue();
+                if (upTo == NUMERIC_BLOCK_SIZE) {
+                    writeBlock(buffer, NUMERIC_BLOCK_SIZE, gcd, encodeBuffer);
+                    upTo = 0;
+                }
+            }
+        }
+        if (upTo > 0) {
+            writeBlock(buffer, upTo, gcd, encodeBuffer);
+        }
+    }
+
+    private void writeBlock(long[] values, int length, long gcd, ByteBuffersDataOutput buffer) throws IOException {
+        assert length > 0;
+        long min = values[0];
+        long max = values[0];
+        for (int i = 1; i < length; ++i) {
+            final long v = values[i];
+            assert Math.floorMod(values[i] - min, gcd) == 0;
+            min = Math.min(min, v);
+            max = Math.max(max, v);
+        }
+        if (min == max) {
+            data.writeByte((byte) 0);
+            data.writeLong(min);
+        } else {
+            final int bitsPerValue = LegacyDirectWriter.unsignedBitsRequired(max - min);
+            buffer.reset();
+            assert buffer.size() == 0;
+            final LegacyDirectWriter w = LegacyDirectWriter.getInstance(buffer, length, bitsPerValue);
+            for (int i = 0; i < length; ++i) {
+                w.add((values[i] - min) / gcd);
+            }
+            w.finish();
+            data.writeByte((byte) bitsPerValue);
+            data.writeLong(min);
+            data.writeInt(Math.toIntExact(buffer.size()));
+            buffer.copyTo(data);
+        }
+    }
+
+    @Override
+    public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        meta.writeInt(field.number);
+        meta.writeByte(Lucene70DocValuesFormat.BINARY);
+
+        BinaryDocValues values = valuesProducer.getBinary(field);
+        long start = data.getFilePointer();
+        meta.writeLong(start);
+        int numDocsWithField = 0;
+        int minLength = Integer.MAX_VALUE;
+        int maxLength = 0;
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            numDocsWithField++;
+            BytesRef v = values.binaryValue();
+            int length = v.length;
+            data.writeBytes(v.bytes, v.offset, v.length);
+            minLength = Math.min(length, minLength);
+            maxLength = Math.max(length, maxLength);
+        }
+        assert numDocsWithField <= maxDoc;
+        meta.writeLong(data.getFilePointer() - start);
+
+        if (numDocsWithField == 0) {
+            meta.writeLong(-2);
+            meta.writeLong(0L);
+        } else if (numDocsWithField == maxDoc) {
+            meta.writeLong(-1);
+            meta.writeLong(0L);
+        } else {
+            long offset = data.getFilePointer();
+            meta.writeLong(offset);
+            values = valuesProducer.getBinary(field);
+            IndexedDISI.writeBitSet(values, data);
+            meta.writeLong(data.getFilePointer() - offset);
+        }
+
+        meta.writeInt(numDocsWithField);
+        meta.writeInt(minLength);
+        meta.writeInt(maxLength);
+        if (maxLength > minLength) {
+            start = data.getFilePointer();
+            meta.writeLong(start);
+            meta.writeVInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+
+            final LegacyDirectMonotonicWriter writer = LegacyDirectMonotonicWriter.getInstance(
+                meta,
+                data,
+                numDocsWithField + 1,
+                DIRECT_MONOTONIC_BLOCK_SHIFT
+            );
+            long addr = 0;
+            writer.add(addr);
+            values = valuesProducer.getBinary(field);
+            for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                addr += values.binaryValue().length;
+                writer.add(addr);
+            }
+            writer.finish();
+            meta.writeLong(data.getFilePointer() - start);
+        }
+    }
+
+    @Override
+    public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        meta.writeInt(field.number);
+        meta.writeByte(Lucene70DocValuesFormat.SORTED);
+        doAddSortedField(field, valuesProducer);
+    }
+
+    private void doAddSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        SortedDocValues values = valuesProducer.getSorted(field);
+        int numDocsWithField = 0;
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            numDocsWithField++;
+        }
+
+        if (numDocsWithField == 0) {
+            meta.writeLong(-2);
+            meta.writeLong(0L);
+        } else if (numDocsWithField == maxDoc) {
+            meta.writeLong(-1);
+            meta.writeLong(0L);
+        } else {
+            long offset = data.getFilePointer();
+            meta.writeLong(offset);
+            values = valuesProducer.getSorted(field);
+            IndexedDISI.writeBitSet(values, data);
+            meta.writeLong(data.getFilePointer() - offset);
+        }
+
+        meta.writeInt(numDocsWithField);
+        if (values.getValueCount() <= 1) {
+            meta.writeByte((byte) 0);
+            meta.writeLong(0L);
+            meta.writeLong(0L);
+        } else {
+            int numberOfBitsPerOrd = LegacyDirectWriter.unsignedBitsRequired(values.getValueCount() - 1);
+            meta.writeByte((byte) numberOfBitsPerOrd);
+            long start = data.getFilePointer();
+            meta.writeLong(start);
+            LegacyDirectWriter writer = LegacyDirectWriter.getInstance(data, numDocsWithField, numberOfBitsPerOrd);
+            values = valuesProducer.getSorted(field);
+            for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                writer.add(values.ordValue());
+            }
+            writer.finish();
+            meta.writeLong(data.getFilePointer() - start);
+        }
+
+        addTermsDict(DocValues.singleton(valuesProducer.getSorted(field)));
+    }
+
+    private void addTermsDict(SortedSetDocValues values) throws IOException {
+        final long size = values.getValueCount();
+        meta.writeVLong(size);
+        meta.writeInt(Lucene70DocValuesFormat.TERMS_DICT_BLOCK_SHIFT);
+
+        ByteBuffersDataOutput addressBuffer = new ByteBuffersDataOutput();
+        ByteBuffersIndexOutput addressIndexOut = new ByteBuffersIndexOutput(addressBuffer, "temp", "temp");
+        meta.writeInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+        long numBlocks = (size + Lucene70DocValuesFormat.TERMS_DICT_BLOCK_MASK) >>> Lucene70DocValuesFormat.TERMS_DICT_BLOCK_SHIFT;
+        LegacyDirectMonotonicWriter writer = LegacyDirectMonotonicWriter.getInstance(
+            meta,
+            addressIndexOut,
+            numBlocks,
+            DIRECT_MONOTONIC_BLOCK_SHIFT
+        );
+
+        BytesRefBuilder previous = new BytesRefBuilder();
+        long ord = 0;
+        long start = data.getFilePointer();
+        int maxLength = 0;
+        TermsEnum iterator = values.termsEnum();
+        for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
+            if ((ord & Lucene70DocValuesFormat.TERMS_DICT_BLOCK_MASK) == 0) {
+                writer.add(data.getFilePointer() - start);
+                data.writeVInt(term.length);
+                data.writeBytes(term.bytes, term.offset, term.length);
+            } else {
+                final int prefixLength = StringHelper.bytesDifference(previous.get(), term);
+                final int suffixLength = term.length - prefixLength;
+                assert suffixLength > 0; // terms are unique
+
+                data.writeByte((byte) (Math.min(prefixLength, 15) | (Math.min(15, suffixLength - 1) << 4)));
+                if (prefixLength >= 15) {
+                    data.writeVInt(prefixLength - 15);
+                }
+                if (suffixLength >= 16) {
+                    data.writeVInt(suffixLength - 16);
+                }
+                data.writeBytes(term.bytes, term.offset + prefixLength, term.length - prefixLength);
+            }
+            maxLength = Math.max(maxLength, term.length);
+            previous.copyBytes(term);
+            ++ord;
+        }
+        writer.finish();
+        meta.writeInt(maxLength);
+        meta.writeLong(start);
+        meta.writeLong(data.getFilePointer() - start);
+        start = data.getFilePointer();
+        addressBuffer.copyTo(data);
+        meta.writeLong(start);
+        meta.writeLong(data.getFilePointer() - start);
+
+        // Now write the reverse terms index
+        writeTermsIndex(values);
+    }
+
+    private void writeTermsIndex(SortedSetDocValues values) throws IOException {
+        final long size = values.getValueCount();
+        meta.writeInt(Lucene70DocValuesFormat.TERMS_DICT_REVERSE_INDEX_SHIFT);
+        long start = data.getFilePointer();
+
+        long numBlocks = 1L + ((size + Lucene70DocValuesFormat.TERMS_DICT_REVERSE_INDEX_MASK)
+            >>> Lucene70DocValuesFormat.TERMS_DICT_REVERSE_INDEX_SHIFT);
+        ByteBuffersDataOutput addressBuffer = new ByteBuffersDataOutput();
+        ByteBuffersIndexOutput addressIndexOut = new ByteBuffersIndexOutput(addressBuffer, "temp", "temp");
+        LegacyDirectMonotonicWriter writer = LegacyDirectMonotonicWriter.getInstance(
+            meta,
+            addressIndexOut,
+            numBlocks,
+            DIRECT_MONOTONIC_BLOCK_SHIFT
+        );
+
+        TermsEnum iterator = values.termsEnum();
+        BytesRefBuilder previous = new BytesRefBuilder();
+        long offset = 0;
+        long ord = 0;
+        for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
+            if ((ord & Lucene70DocValuesFormat.TERMS_DICT_REVERSE_INDEX_MASK) == 0) {
+                writer.add(offset);
+                final int sortKeyLength;
+                if (ord == 0) {
+                    // no previous term: no bytes to write
+                    sortKeyLength = 0;
+                } else {
+                    sortKeyLength = StringHelper.sortKeyLength(previous.get(), term);
+                }
+                offset += sortKeyLength;
+                data.writeBytes(term.bytes, term.offset, sortKeyLength);
+            } else if ((ord
+                & Lucene70DocValuesFormat.TERMS_DICT_REVERSE_INDEX_MASK) == Lucene70DocValuesFormat.TERMS_DICT_REVERSE_INDEX_MASK) {
+                    previous.copyBytes(term);
+                }
+            ++ord;
+        }
+        writer.add(offset);
+        writer.finish();
+        meta.writeLong(start);
+        meta.writeLong(data.getFilePointer() - start);
+        start = data.getFilePointer();
+        addressBuffer.copyTo(data);
+        meta.writeLong(start);
+        meta.writeLong(data.getFilePointer() - start);
+    }
+
+    @Override
+    public void addSortedNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        meta.writeInt(field.number);
+        meta.writeByte(Lucene70DocValuesFormat.SORTED_NUMERIC);
+
+        long[] stats = writeValues(field, valuesProducer);
+        int numDocsWithField = Math.toIntExact(stats[0]);
+        long numValues = stats[1];
+        assert numValues >= numDocsWithField;
+
+        meta.writeInt(numDocsWithField);
+        if (numValues > numDocsWithField) {
+            long start = data.getFilePointer();
+            meta.writeLong(start);
+            meta.writeVInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+
+            final LegacyDirectMonotonicWriter addressesWriter = LegacyDirectMonotonicWriter.getInstance(
+                meta,
+                data,
+                numDocsWithField + 1L,
+                DIRECT_MONOTONIC_BLOCK_SHIFT
+            );
+            long addr = 0;
+            addressesWriter.add(addr);
+            SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
+            for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+                addr += values.docValueCount();
+                addressesWriter.add(addr);
+            }
+            addressesWriter.finish();
+            meta.writeLong(data.getFilePointer() - start);
+        }
+    }
+
+    @Override
+    public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        meta.writeInt(field.number);
+        meta.writeByte(Lucene70DocValuesFormat.SORTED_SET);
+
+        SortedSetDocValues values = valuesProducer.getSortedSet(field);
+        int numDocsWithField = 0;
+        long numOrds = 0;
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            numDocsWithField++;
+            numOrds += values.docValueCount();  // chegar: note this change
+        }
+
+        if (numDocsWithField == numOrds) {
+            meta.writeByte((byte) 0);
+            doAddSortedField(field, new EmptyDocValuesProducer() {
+                @Override
+                public SortedDocValues getSorted(FieldInfo field) throws IOException {
+                    return SortedSetSelector.wrap(valuesProducer.getSortedSet(field), SortedSetSelector.Type.MIN);
+                }
+            });
+            return;
+        }
+        meta.writeByte((byte) 1);
+
+        assert numDocsWithField != 0;
+        if (numDocsWithField == maxDoc) {
+            meta.writeLong(-1);
+            meta.writeLong(0L);
+        } else {
+            long offset = data.getFilePointer();
+            meta.writeLong(offset);
+            values = valuesProducer.getSortedSet(field);
+            IndexedDISI.writeBitSet(values, data);
+            meta.writeLong(data.getFilePointer() - offset);
+        }
+
+        int numberOfBitsPerOrd = LegacyDirectWriter.unsignedBitsRequired(values.getValueCount() - 1);
+        meta.writeByte((byte) numberOfBitsPerOrd);
+        long start = data.getFilePointer();
+        meta.writeLong(start);
+        LegacyDirectWriter writer = LegacyDirectWriter.getInstance(data, numOrds, numberOfBitsPerOrd);
+        values = valuesProducer.getSortedSet(field);
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            for (int i = 0; i < values.docValueCount(); i++) { // chegar: note this change
+                writer.add(values.nextOrd());
+            }
+        }
+        writer.finish();
+        meta.writeLong(data.getFilePointer() - start);
+
+        meta.writeInt(numDocsWithField);
+        start = data.getFilePointer();
+        meta.writeLong(start);
+        meta.writeVInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+
+        final LegacyDirectMonotonicWriter addressesWriter = LegacyDirectMonotonicWriter.getInstance(
+            meta,
+            data,
+            numDocsWithField + 1,
+            DIRECT_MONOTONIC_BLOCK_SHIFT
+        );
+        long addr = 0;
+        addressesWriter.add(addr);
+        values = valuesProducer.getSortedSet(field);
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            values.nextOrd();
+            addr += values.docValueCount();  // chegar: note this change
+            addressesWriter.add(addr);
+        }
+        addressesWriter.finish();
+        meta.writeLong(data.getFilePointer() - start);
+
+        addTermsDict(values);
+    }
+}

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesConsumer.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesConsumer.java
@@ -60,8 +60,6 @@ import static org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.Lucene70DocValu
 /** writer for {@link Lucene70DocValuesFormat} */
 final class Lucene70DocValuesConsumer extends DocValuesConsumer {
 
-    static final long NO_MORE_ORDS = -1;
-
     IndexOutput data, meta;
     final int maxDoc;
 
@@ -615,7 +613,7 @@ final class Lucene70DocValuesConsumer extends DocValuesConsumer {
         long numOrds = 0;
         for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
             numDocsWithField++;
-            numOrds += values.docValueCount();  // chegar: note this change
+            numOrds += values.docValueCount();
         }
 
         if (numDocsWithField == numOrds) {
@@ -649,7 +647,7 @@ final class Lucene70DocValuesConsumer extends DocValuesConsumer {
         LegacyDirectWriter writer = LegacyDirectWriter.getInstance(data, numOrds, numberOfBitsPerOrd);
         values = valuesProducer.getSortedSet(field);
         for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-            for (int i = 0; i < values.docValueCount(); i++) { // chegar: note this change
+            for (int i = 0; i < values.docValueCount(); i++) {
                 writer.add(values.nextOrd());
             }
         }
@@ -672,7 +670,7 @@ final class Lucene70DocValuesConsumer extends DocValuesConsumer {
         values = valuesProducer.getSortedSet(field);
         for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
             values.nextOrd();
-            addr += values.docValueCount();  // chegar: note this change
+            addr += values.docValueCount();
             addressesWriter.add(addr);
         }
         addressesWriter.finish();

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesFormat.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesFormat.java
@@ -1,0 +1,171 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright (C) 2021 Elasticsearch B.V.
+ */
+package org.elasticsearch.xpack.lucene.bwc.codecs.lucene70;
+
+import org.apache.lucene.backward_codecs.packed.LegacyDirectWriter;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.SmallFloat;
+
+import java.io.IOException;
+
+/**
+ * Lucene 7.0 DocValues format.
+ *
+ * <p>Documents that have a value for the field are encoded in a way that it is always possible to
+ * know the ordinal of the current document in the set of documents that have a value. For instance,
+ * say the set of documents that have a value for the field is <code>{1, 5, 6, 11}</code>. When the
+ * iterator is on <code>6</code>, it knows that this is the 3rd item of the set. This way, values
+ * can be stored densely and accessed based on their index at search time. If all documents in a
+ * segment have a value for the field, the index is the same as the doc ID, so this case is encoded
+ * implicitly and is very fast at query time. On the other hand if some documents are missing a
+ * value for the field then the set of documents that have a value is encoded into blocks. All doc
+ * IDs that share the same upper 16 bits are encoded into the same block with the following
+ * strategies:
+ *
+ * <ul>
+ *   <li>SPARSE: This strategy is used when a block contains at most 4095 documents. The lower 16
+ *       bits of doc IDs are stored as {@link DataOutput#writeShort(short) shorts} while the upper
+ *       16 bits are given by the block ID.
+ *   <li>DENSE: This strategy is used when a block contains between 4096 and 65535 documents. The
+ *       lower bits of doc IDs are stored in a bit set. Advancing is performed using {@link
+ *       Long#numberOfTrailingZeros(long) ntz} operations while the index is computed by
+ *       accumulating the {@link Long#bitCount(long) bit counts} of the visited longs.
+ *   <li>ALL: This strategy is used when a block contains exactly 65536 documents, meaning that the
+ *       block is full. In that case doc IDs do not need to be stored explicitly. This is typically
+ *       faster than both SPARSE and DENSE which is a reason why it is preferable to have all
+ *       documents that have a value for a field using contiguous doc IDs, for instance by using
+ *       {@link IndexWriterConfig#setIndexSort(org.apache.lucene.search.Sort) index sorting}.
+ * </ul>
+ *
+ * <p>Then the five per-document value types (Numeric,Binary,Sorted,SortedSet,SortedNumeric) are
+ * encoded using the following strategies:
+ *
+ * <p>{@link DocValuesType#NUMERIC NUMERIC}:
+ *
+ * <ul>
+ *   <li>Delta-compressed: per-document integers written as deltas from the minimum value,
+ *       compressed with bitpacking. For more information, see {@link LegacyDirectWriter}.
+ *   <li>Table-compressed: when the number of unique values is very small (&lt; 256), and when there
+ *       are unused "gaps" in the range of values used (such as {@link SmallFloat}), a lookup table
+ *       is written instead. Each per-document entry is instead the ordinal to this table, and those
+ *       ordinals are compressed with bitpacking ({@link LegacyDirectWriter}).
+ *   <li>GCD-compressed: when all numbers share a common divisor, such as dates, the greatest common
+ *       denominator (GCD) is computed, and quotients are stored using Delta-compressed Numerics.
+ *   <li>Monotonic-compressed: when all numbers are monotonically increasing offsets, they are
+ *       written as blocks of bitpacked integers, encoding the deviation from the expected delta.
+ *   <li>Const-compressed: when there is only one possible value, no per-document data is needed and
+ *       this value is encoded alone.
+ * </ul>
+ *
+ * <p>{@link DocValuesType#BINARY BINARY}:
+ *
+ * <ul>
+ *   <li>Fixed-width Binary: one large concatenated byte[] is written, along with the fixed length.
+ *       Each document's value can be addressed directly with multiplication ({@code docID *
+ *       length}).
+ *   <li>Variable-width Binary: one large concatenated byte[] is written, along with end addresses
+ *       for each document. The addresses are written as Monotonic-compressed numerics.
+ *   <li>Prefix-compressed Binary: values are written in chunks of 16, with the first value written
+ *       completely and other values sharing prefixes. chunk addresses are written as
+ *       Monotonic-compressed numerics. A reverse lookup index is written from a portion of every
+ *       1024th term.
+ * </ul>
+ *
+ * <p>{@link DocValuesType#SORTED SORTED}:
+ *
+ * <ul>
+ *   <li>Sorted: a mapping of ordinals to deduplicated terms is written as Prefix-compressed Binary,
+ *       along with the per-document ordinals written using one of the numeric strategies above.
+ * </ul>
+ *
+ * <p>{@link DocValuesType#SORTED_SET SORTED_SET}:
+ *
+ * <ul>
+ *   <li>Single: if all documents have 0 or 1 value, then data are written like SORTED.
+ *   <li>SortedSet: a mapping of ordinals to deduplicated terms is written as Binary, an ordinal
+ *       list and per-document index into this list are written using the numeric strategies above.
+ * </ul>
+ *
+ * <p>{@link DocValuesType#SORTED_NUMERIC SORTED_NUMERIC}:
+ *
+ * <ul>
+ *   <li>Single: if all documents have 0 or 1 value, then data are written like NUMERIC.
+ *   <li>SortedNumeric: a value list and per-document index into this list are written using the
+ *       numeric strategies above.
+ * </ul>
+ *
+ * <p>Files:
+ *
+ * <ol>
+ *   <li><code>.dvd</code>: DocValues data
+ *   <li><code>.dvm</code>: DocValues metadata
+ * </ol>
+ */
+public final class Lucene70DocValuesFormat extends DocValuesFormat {
+
+    /** Sole Constructor */
+    public Lucene70DocValuesFormat() {
+        super("Lucene70");
+    }
+
+    @Override
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        return new Lucene70DocValuesConsumer(state, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION);
+    }
+
+    @Override
+    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new Lucene70DocValuesProducer(state, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION);
+    }
+
+    static final String DATA_CODEC = "Lucene70DocValuesData";
+    static final String DATA_EXTENSION = "dvd";
+    static final String META_CODEC = "Lucene70DocValuesMetadata";
+    static final String META_EXTENSION = "dvm";
+    static final int VERSION_START = 0;
+    static final int VERSION_CURRENT = VERSION_START;
+
+    // indicates docvalues type
+    static final byte NUMERIC = 0;
+    static final byte BINARY = 1;
+    static final byte SORTED = 2;
+    static final byte SORTED_SET = 3;
+    static final byte SORTED_NUMERIC = 4;
+
+    static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+
+    static final int NUMERIC_BLOCK_SHIFT = 14;
+    static final int NUMERIC_BLOCK_SIZE = 1 << NUMERIC_BLOCK_SHIFT;
+
+    static final int TERMS_DICT_BLOCK_SHIFT = 4;
+    static final int TERMS_DICT_BLOCK_SIZE = 1 << TERMS_DICT_BLOCK_SHIFT;
+    static final int TERMS_DICT_BLOCK_MASK = TERMS_DICT_BLOCK_SIZE - 1;
+
+    static final int TERMS_DICT_REVERSE_INDEX_SHIFT = 10;
+    static final int TERMS_DICT_REVERSE_INDEX_SIZE = 1 << TERMS_DICT_REVERSE_INDEX_SHIFT;
+    static final int TERMS_DICT_REVERSE_INDEX_MASK = TERMS_DICT_REVERSE_INDEX_SIZE - 1;
+}

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesProducer.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesProducer.java
@@ -1,0 +1,1461 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright (C) 2021 Elasticsearch B.V.
+ */
+package org.elasticsearch.xpack.lucene.bwc.codecs.lucene70;
+
+import org.apache.lucene.backward_codecs.packed.LegacyDirectMonotonicReader;
+import org.apache.lucene.backward_codecs.packed.LegacyDirectReader;
+import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BaseTermsEnum;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.ImpactsEnum;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.index.TermsEnum.SeekStatus;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.elasticsearch.core.IOUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** reader for {@link Lucene70DocValuesFormat} */
+final class Lucene70DocValuesProducer extends DocValuesProducer {
+    private final Map<String, NumericEntry> numerics = new HashMap<>();
+    private final Map<String, BinaryEntry> binaries = new HashMap<>();
+    private final Map<String, SortedEntry> sorted = new HashMap<>();
+    private final Map<String, SortedSetEntry> sortedSets = new HashMap<>();
+    private final Map<String, SortedNumericEntry> sortedNumerics = new HashMap<>();
+    private final IndexInput data;
+    private final int maxDoc;
+
+    static final long NO_MORE_ORDS = -1;
+
+    /** expert: instantiates a new reader */
+    Lucene70DocValuesProducer(SegmentReadState state, String dataCodec, String dataExtension, String metaCodec, String metaExtension)
+        throws IOException {
+        String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
+        this.maxDoc = state.segmentInfo.maxDoc();
+
+        int version = -1;
+
+        // read in the entries from the metadata file.
+        try (ChecksumIndexInput in = EndiannessReverserUtil.openChecksumInput(state.directory, metaName, state.context)) {
+            Throwable priorE = null;
+            try {
+                version = CodecUtil.checkIndexHeader(
+                    in,
+                    metaCodec,
+                    Lucene70DocValuesFormat.VERSION_START,
+                    Lucene70DocValuesFormat.VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                readFields(in, state.fieldInfos);
+            } catch (Throwable exception) {
+                priorE = exception;
+            } finally {
+                CodecUtil.checkFooter(in, priorE);
+            }
+        }
+
+        String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
+        this.data = EndiannessReverserUtil.openInput(state.directory, dataName, state.context);
+        boolean success = false;
+        try {
+            final int version2 = CodecUtil.checkIndexHeader(
+                data,
+                dataCodec,
+                Lucene70DocValuesFormat.VERSION_START,
+                Lucene70DocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            if (version != version2) {
+                throw new CorruptIndexException("Format versions mismatch: meta=" + version + ", data=" + version2, data);
+            }
+
+            // NOTE: data file is too costly to verify checksum against all the bytes on open,
+            // but for now we at least verify proper structure of the checksum footer: which looks
+            // for FOOTER_MAGIC + algorithmID. This is cheap and can detect some forms of corruption
+            // such as file truncation.
+            CodecUtil.retrieveChecksum(data);
+
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this.data);
+            }
+        }
+    }
+
+    private void readFields(ChecksumIndexInput meta, FieldInfos infos) throws IOException {
+        for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
+            FieldInfo info = infos.fieldInfo(fieldNumber);
+            if (info == null) {
+                throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
+            }
+            byte type = meta.readByte();
+            if (type == Lucene70DocValuesFormat.NUMERIC) {
+                numerics.put(info.name, readNumeric(meta));
+            } else if (type == Lucene70DocValuesFormat.BINARY) {
+                binaries.put(info.name, readBinary(meta));
+            } else if (type == Lucene70DocValuesFormat.SORTED) {
+                sorted.put(info.name, readSorted(meta));
+            } else if (type == Lucene70DocValuesFormat.SORTED_SET) {
+                sortedSets.put(info.name, readSortedSet(meta));
+            } else if (type == Lucene70DocValuesFormat.SORTED_NUMERIC) {
+                sortedNumerics.put(info.name, readSortedNumeric(meta));
+            } else {
+                throw new CorruptIndexException("invalid type: " + type, meta);
+            }
+        }
+    }
+
+    private NumericEntry readNumeric(ChecksumIndexInput meta) throws IOException {
+        NumericEntry entry = new NumericEntry();
+        readNumeric(meta, entry);
+        return entry;
+    }
+
+    private void readNumeric(ChecksumIndexInput meta, NumericEntry entry) throws IOException {
+        entry.docsWithFieldOffset = meta.readLong();
+        entry.docsWithFieldLength = meta.readLong();
+        entry.numValues = meta.readLong();
+        int tableSize = meta.readInt();
+        if (tableSize > 256) {
+            throw new CorruptIndexException("invalid table size: " + tableSize, meta);
+        }
+        if (tableSize >= 0) {
+            entry.table = new long[tableSize];
+            for (int i = 0; i < tableSize; ++i) {
+                entry.table[i] = meta.readLong();
+            }
+        }
+        if (tableSize < -1) {
+            entry.blockShift = -2 - tableSize;
+        } else {
+            entry.blockShift = -1;
+        }
+        entry.bitsPerValue = meta.readByte();
+        entry.minValue = meta.readLong();
+        entry.gcd = meta.readLong();
+        entry.valuesOffset = meta.readLong();
+        entry.valuesLength = meta.readLong();
+    }
+
+    private BinaryEntry readBinary(ChecksumIndexInput meta) throws IOException {
+        BinaryEntry entry = new BinaryEntry();
+        entry.dataOffset = meta.readLong();
+        entry.dataLength = meta.readLong();
+        entry.docsWithFieldOffset = meta.readLong();
+        entry.docsWithFieldLength = meta.readLong();
+        entry.numDocsWithField = meta.readInt();
+        entry.minLength = meta.readInt();
+        entry.maxLength = meta.readInt();
+        if (entry.minLength < entry.maxLength) {
+            entry.addressesOffset = meta.readLong();
+            final int blockShift = meta.readVInt();
+            entry.addressesMeta = LegacyDirectMonotonicReader.loadMeta(meta, entry.numDocsWithField + 1L, blockShift);
+            entry.addressesLength = meta.readLong();
+        }
+        return entry;
+    }
+
+    private SortedEntry readSorted(ChecksumIndexInput meta) throws IOException {
+        SortedEntry entry = new SortedEntry();
+        entry.docsWithFieldOffset = meta.readLong();
+        entry.docsWithFieldLength = meta.readLong();
+        entry.numDocsWithField = meta.readInt();
+        entry.bitsPerValue = meta.readByte();
+        entry.ordsOffset = meta.readLong();
+        entry.ordsLength = meta.readLong();
+        readTermDict(meta, entry);
+        return entry;
+    }
+
+    private SortedSetEntry readSortedSet(ChecksumIndexInput meta) throws IOException {
+        SortedSetEntry entry = new SortedSetEntry();
+        byte multiValued = meta.readByte();
+        switch (multiValued) {
+            case 0: // singlevalued
+                entry.singleValueEntry = readSorted(meta);
+                return entry;
+            case 1: // multivalued
+                break;
+            default:
+                throw new CorruptIndexException("Invalid multiValued flag: " + multiValued, meta);
+        }
+        entry.docsWithFieldOffset = meta.readLong();
+        entry.docsWithFieldLength = meta.readLong();
+        entry.bitsPerValue = meta.readByte();
+        entry.ordsOffset = meta.readLong();
+        entry.ordsLength = meta.readLong();
+        entry.numDocsWithField = meta.readInt();
+        entry.addressesOffset = meta.readLong();
+        final int blockShift = meta.readVInt();
+        entry.addressesMeta = LegacyDirectMonotonicReader.loadMeta(meta, entry.numDocsWithField + 1, blockShift);
+        entry.addressesLength = meta.readLong();
+        readTermDict(meta, entry);
+        return entry;
+    }
+
+    private static void readTermDict(ChecksumIndexInput meta, TermsDictEntry entry) throws IOException {
+        entry.termsDictSize = meta.readVLong();
+        entry.termsDictBlockShift = meta.readInt();
+        final int blockShift = meta.readInt();
+        final long addressesSize = (entry.termsDictSize + (1L << entry.termsDictBlockShift) - 1) >>> entry.termsDictBlockShift;
+        entry.termsAddressesMeta = LegacyDirectMonotonicReader.loadMeta(meta, addressesSize, blockShift);
+        entry.maxTermLength = meta.readInt();
+        entry.termsDataOffset = meta.readLong();
+        entry.termsDataLength = meta.readLong();
+        entry.termsAddressesOffset = meta.readLong();
+        entry.termsAddressesLength = meta.readLong();
+        entry.termsDictIndexShift = meta.readInt();
+        final long indexSize = (entry.termsDictSize + (1L << entry.termsDictIndexShift) - 1) >>> entry.termsDictIndexShift;
+        entry.termsIndexAddressesMeta = LegacyDirectMonotonicReader.loadMeta(meta, 1 + indexSize, blockShift);
+        entry.termsIndexOffset = meta.readLong();
+        entry.termsIndexLength = meta.readLong();
+        entry.termsIndexAddressesOffset = meta.readLong();
+        entry.termsIndexAddressesLength = meta.readLong();
+    }
+
+    private SortedNumericEntry readSortedNumeric(ChecksumIndexInput meta) throws IOException {
+        SortedNumericEntry entry = new SortedNumericEntry();
+        readNumeric(meta, entry);
+        entry.numDocsWithField = meta.readInt();
+        if (entry.numDocsWithField != entry.numValues) {
+            entry.addressesOffset = meta.readLong();
+            final int blockShift = meta.readVInt();
+            entry.addressesMeta = LegacyDirectMonotonicReader.loadMeta(meta, entry.numDocsWithField + 1, blockShift);
+            entry.addressesLength = meta.readLong();
+        }
+        return entry;
+    }
+
+    @Override
+    public void close() throws IOException {
+        data.close();
+    }
+
+    private static class NumericEntry {
+        long[] table;
+        int blockShift;
+        byte bitsPerValue;
+        long docsWithFieldOffset;
+        long docsWithFieldLength;
+        long numValues;
+        long minValue;
+        long gcd;
+        long valuesOffset;
+        long valuesLength;
+    }
+
+    private static class BinaryEntry {
+        long dataOffset;
+        long dataLength;
+        long docsWithFieldOffset;
+        long docsWithFieldLength;
+        int numDocsWithField;
+        int minLength;
+        int maxLength;
+        long addressesOffset;
+        long addressesLength;
+        LegacyDirectMonotonicReader.Meta addressesMeta;
+    }
+
+    private static class TermsDictEntry {
+        long termsDictSize;
+        int termsDictBlockShift;
+        LegacyDirectMonotonicReader.Meta termsAddressesMeta;
+        int maxTermLength;
+        long termsDataOffset;
+        long termsDataLength;
+        long termsAddressesOffset;
+        long termsAddressesLength;
+        int termsDictIndexShift;
+        LegacyDirectMonotonicReader.Meta termsIndexAddressesMeta;
+        long termsIndexOffset;
+        long termsIndexLength;
+        long termsIndexAddressesOffset;
+        long termsIndexAddressesLength;
+    }
+
+    private static class SortedEntry extends TermsDictEntry {
+        long docsWithFieldOffset;
+        long docsWithFieldLength;
+        int numDocsWithField;
+        byte bitsPerValue;
+        long ordsOffset;
+        long ordsLength;
+    }
+
+    private static class SortedSetEntry extends TermsDictEntry {
+        SortedEntry singleValueEntry;
+        long docsWithFieldOffset;
+        long docsWithFieldLength;
+        int numDocsWithField;
+        byte bitsPerValue;
+        long ordsOffset;
+        long ordsLength;
+        LegacyDirectMonotonicReader.Meta addressesMeta;
+        long addressesOffset;
+        long addressesLength;
+    }
+
+    private static class SortedNumericEntry extends NumericEntry {
+        int numDocsWithField;
+        LegacyDirectMonotonicReader.Meta addressesMeta;
+        long addressesOffset;
+        long addressesLength;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(FieldInfo field) throws IOException {
+        NumericEntry entry = numerics.get(field.name);
+        return getNumeric(entry);
+    }
+
+    private abstract static class DenseNumericDocValues extends NumericDocValues {
+
+        final int maxDoc;
+        int doc = -1;
+
+        DenseNumericDocValues(int maxDoc) {
+            this.maxDoc = maxDoc;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            if (target >= maxDoc) {
+                return doc = NO_MORE_DOCS;
+            }
+            return doc = target;
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+            doc = target;
+            return true;
+        }
+
+        @Override
+        public long cost() {
+            return maxDoc;
+        }
+    }
+
+    private abstract static class SparseNumericDocValues extends NumericDocValues {
+
+        final IndexedDISI disi;
+
+        SparseNumericDocValues(IndexedDISI disi) {
+            this.disi = disi;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return disi.advance(target);
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            return disi.advanceExact(target);
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return disi.nextDoc();
+        }
+
+        @Override
+        public int docID() {
+            return disi.docID();
+        }
+
+        @Override
+        public long cost() {
+            return disi.cost();
+        }
+    }
+
+    private NumericDocValues getNumeric(NumericEntry entry) throws IOException {
+        if (entry.docsWithFieldOffset == -2) {
+            // empty
+            return DocValues.emptyNumeric();
+        } else if (entry.docsWithFieldOffset == -1) {
+            // dense
+            if (entry.bitsPerValue == 0) {
+                return new DenseNumericDocValues(maxDoc) {
+                    @Override
+                    public long longValue() throws IOException {
+                        return entry.minValue;
+                    }
+                };
+            } else {
+                final RandomAccessInput slice = data.randomAccessSlice(entry.valuesOffset, entry.valuesLength);
+                if (entry.blockShift >= 0) {
+                    // dense but split into blocks of different bits per value
+                    final int shift = entry.blockShift;
+                    final long mul = entry.gcd;
+                    final int mask = (1 << shift) - 1;
+                    return new DenseNumericDocValues(maxDoc) {
+                        int block = -1;
+                        long delta;
+                        long offset;
+                        long blockEndOffset;
+                        LongValues values;
+
+                        @Override
+                        public long longValue() throws IOException {
+                            final int block = doc >>> shift;
+                            if (this.block != block) {
+                                int bitsPerValue;
+                                do {
+                                    offset = blockEndOffset;
+                                    bitsPerValue = slice.readByte(offset++);
+                                    delta = slice.readLong(offset);
+                                    offset += Long.BYTES;
+                                    if (bitsPerValue == 0) {
+                                        blockEndOffset = offset;
+                                    } else {
+                                        final int length = slice.readInt(offset);
+                                        offset += Integer.BYTES;
+                                        blockEndOffset = offset + length;
+                                    }
+                                    this.block++;
+                                } while (this.block != block);
+                                values = bitsPerValue == 0
+                                    ? LongValues.ZEROES
+                                    : LegacyDirectReader.getInstance(slice, bitsPerValue, offset);
+                            }
+                            return mul * values.get(doc & mask) + delta;
+                        }
+                    };
+                } else {
+                    final LongValues values = LegacyDirectReader.getInstance(slice, entry.bitsPerValue);
+                    if (entry.table != null) {
+                        final long[] table = entry.table;
+                        return new DenseNumericDocValues(maxDoc) {
+                            @Override
+                            public long longValue() throws IOException {
+                                return table[(int) values.get(doc)];
+                            }
+                        };
+                    } else {
+                        final long mul = entry.gcd;
+                        final long delta = entry.minValue;
+                        return new DenseNumericDocValues(maxDoc) {
+                            @Override
+                            public long longValue() throws IOException {
+                                return mul * values.get(doc) + delta;
+                            }
+                        };
+                    }
+                }
+            }
+        } else {
+            // sparse
+            final IndexedDISI disi = new IndexedDISI(data, entry.docsWithFieldOffset, entry.docsWithFieldLength, entry.numValues);
+            if (entry.bitsPerValue == 0) {
+                return new SparseNumericDocValues(disi) {
+                    @Override
+                    public long longValue() throws IOException {
+                        return entry.minValue;
+                    }
+                };
+            } else {
+                final RandomAccessInput slice = data.randomAccessSlice(entry.valuesOffset, entry.valuesLength);
+                if (entry.blockShift >= 0) {
+                    // sparse and split into blocks of different bits per value
+                    final int shift = entry.blockShift;
+                    final long mul = entry.gcd;
+                    final int mask = (1 << shift) - 1;
+                    return new SparseNumericDocValues(disi) {
+                        int block = -1;
+                        long delta;
+                        long offset;
+                        long blockEndOffset;
+                        LongValues values;
+
+                        @Override
+                        public long longValue() throws IOException {
+                            final int index = disi.index();
+                            final int block = index >>> shift;
+                            if (this.block != block) {
+                                int bitsPerValue;
+                                do {
+                                    offset = blockEndOffset;
+                                    bitsPerValue = slice.readByte(offset++);
+                                    delta = slice.readLong(offset);
+                                    offset += Long.BYTES;
+                                    if (bitsPerValue == 0) {
+                                        blockEndOffset = offset;
+                                    } else {
+                                        final int length = slice.readInt(offset);
+                                        offset += Integer.BYTES;
+                                        blockEndOffset = offset + length;
+                                    }
+                                    this.block++;
+                                } while (this.block != block);
+                                values = bitsPerValue == 0
+                                    ? LongValues.ZEROES
+                                    : LegacyDirectReader.getInstance(slice, bitsPerValue, offset);
+                            }
+                            return mul * values.get(index & mask) + delta;
+                        }
+                    };
+                } else {
+                    final LongValues values = LegacyDirectReader.getInstance(slice, entry.bitsPerValue);
+                    if (entry.table != null) {
+                        final long[] table = entry.table;
+                        return new SparseNumericDocValues(disi) {
+                            @Override
+                            public long longValue() throws IOException {
+                                return table[(int) values.get(disi.index())];
+                            }
+                        };
+                    } else {
+                        final long mul = entry.gcd;
+                        final long delta = entry.minValue;
+                        return new SparseNumericDocValues(disi) {
+                            @Override
+                            public long longValue() throws IOException {
+                                return mul * values.get(disi.index()) + delta;
+                            }
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    private LongValues getNumericValues(NumericEntry entry) throws IOException {
+        if (entry.bitsPerValue == 0) {
+            return new LongValues() {
+                @Override
+                public long get(long index) {
+                    return entry.minValue;
+                }
+            };
+        } else {
+            final RandomAccessInput slice = data.randomAccessSlice(entry.valuesOffset, entry.valuesLength);
+            if (entry.blockShift >= 0) {
+                final int shift = entry.blockShift;
+                final long mul = entry.gcd;
+                final long mask = (1L << shift) - 1;
+                return new LongValues() {
+                    long block = -1;
+                    long delta;
+                    long offset;
+                    long blockEndOffset;
+                    LongValues values;
+
+                    @Override
+                    public long get(long index) {
+                        final long block = index >>> shift;
+                        if (this.block != block) {
+                            assert block > this.block : "Reading backwards is illegal: " + this.block + " < " + block;
+                            int bitsPerValue;
+                            do {
+                                offset = blockEndOffset;
+                                try {
+                                    bitsPerValue = slice.readByte(offset++);
+                                    delta = slice.readLong(offset);
+                                    offset += Long.BYTES;
+                                    if (bitsPerValue == 0) {
+                                        blockEndOffset = offset;
+                                    } else {
+                                        final int length = slice.readInt(offset);
+                                        offset += Integer.BYTES;
+                                        blockEndOffset = offset + length;
+                                    }
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                                this.block++;
+                            } while (this.block != block);
+                            values = bitsPerValue == 0 ? LongValues.ZEROES : LegacyDirectReader.getInstance(slice, bitsPerValue, offset);
+                        }
+                        return mul * values.get(index & mask) + delta;
+                    }
+                };
+            } else {
+                final LongValues values = LegacyDirectReader.getInstance(slice, entry.bitsPerValue);
+                if (entry.table != null) {
+                    final long[] table = entry.table;
+                    return new LongValues() {
+                        @Override
+                        public long get(long index) {
+                            return table[(int) values.get(index)];
+                        }
+                    };
+                } else if (entry.gcd != 1) {
+                    final long gcd = entry.gcd;
+                    final long minValue = entry.minValue;
+                    return new LongValues() {
+                        @Override
+                        public long get(long index) {
+                            return values.get(index) * gcd + minValue;
+                        }
+                    };
+                } else if (entry.minValue != 0) {
+                    final long minValue = entry.minValue;
+                    return new LongValues() {
+                        @Override
+                        public long get(long index) {
+                            return values.get(index) + minValue;
+                        }
+                    };
+                } else {
+                    return values;
+                }
+            }
+        }
+    }
+
+    private abstract static class DenseBinaryDocValues extends BinaryDocValues {
+
+        final int maxDoc;
+        int doc = -1;
+
+        DenseBinaryDocValues(int maxDoc) {
+            this.maxDoc = maxDoc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public long cost() {
+            return maxDoc;
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            if (target >= maxDoc) {
+                return doc = NO_MORE_DOCS;
+            }
+            return doc = target;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            doc = target;
+            return true;
+        }
+    }
+
+    private abstract static class SparseBinaryDocValues extends BinaryDocValues {
+
+        final IndexedDISI disi;
+
+        SparseBinaryDocValues(IndexedDISI disi) {
+            this.disi = disi;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return disi.nextDoc();
+        }
+
+        @Override
+        public int docID() {
+            return disi.docID();
+        }
+
+        @Override
+        public long cost() {
+            return disi.cost();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return disi.advance(target);
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            return disi.advanceExact(target);
+        }
+    }
+
+    @Override
+    public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+        BinaryEntry entry = binaries.get(field.name);
+        if (entry.docsWithFieldOffset == -2) {
+            return DocValues.emptyBinary();
+        }
+
+        final IndexInput bytesSlice = data.slice("fixed-binary", entry.dataOffset, entry.dataLength);
+
+        if (entry.docsWithFieldOffset == -1) {
+            // dense
+            if (entry.minLength == entry.maxLength) {
+                // fixed length
+                final int length = entry.maxLength;
+                return new DenseBinaryDocValues(maxDoc) {
+                    final BytesRef bytes = new BytesRef(new byte[length], 0, length);
+
+                    @Override
+                    public BytesRef binaryValue() throws IOException {
+                        bytesSlice.seek((long) doc * length);
+                        bytesSlice.readBytes(bytes.bytes, 0, length);
+                        return bytes;
+                    }
+                };
+            } else {
+                // variable length
+                final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+                final LongValues addresses = LegacyDirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
+                return new DenseBinaryDocValues(maxDoc) {
+                    final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
+
+                    @Override
+                    public BytesRef binaryValue() throws IOException {
+                        long startOffset = addresses.get(doc);
+                        bytes.length = (int) (addresses.get(doc + 1L) - startOffset);
+                        bytesSlice.seek(startOffset);
+                        bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
+                        return bytes;
+                    }
+                };
+            }
+        } else {
+            // sparse
+            final IndexedDISI disi = new IndexedDISI(data, entry.docsWithFieldOffset, entry.docsWithFieldLength, entry.numDocsWithField);
+            if (entry.minLength == entry.maxLength) {
+                // fixed length
+                final int length = entry.maxLength;
+                return new SparseBinaryDocValues(disi) {
+                    final BytesRef bytes = new BytesRef(new byte[length], 0, length);
+
+                    @Override
+                    public BytesRef binaryValue() throws IOException {
+                        bytesSlice.seek((long) disi.index() * length);
+                        bytesSlice.readBytes(bytes.bytes, 0, length);
+                        return bytes;
+                    }
+                };
+            } else {
+                // variable length
+                final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+                final LongValues addresses = LegacyDirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
+                return new SparseBinaryDocValues(disi) {
+                    final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
+
+                    @Override
+                    public BytesRef binaryValue() throws IOException {
+                        final int index = disi.index();
+                        long startOffset = addresses.get(index);
+                        bytes.length = (int) (addresses.get(index + 1L) - startOffset);
+                        bytesSlice.seek(startOffset);
+                        bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
+                        return bytes;
+                    }
+                };
+            }
+        }
+    }
+
+    @Override
+    public SortedDocValues getSorted(FieldInfo field) throws IOException {
+        SortedEntry entry = sorted.get(field.name);
+        return getSorted(entry);
+    }
+
+    private SortedDocValues getSorted(SortedEntry entry) throws IOException {
+        if (entry.docsWithFieldOffset == -2) {
+            return DocValues.emptySorted();
+        }
+
+        final LongValues ords;
+        if (entry.bitsPerValue == 0) {
+            ords = new LongValues() {
+                @Override
+                public long get(long index) {
+                    return 0L;
+                }
+            };
+        } else {
+            final RandomAccessInput slice = data.randomAccessSlice(entry.ordsOffset, entry.ordsLength);
+            ords = LegacyDirectReader.getInstance(slice, entry.bitsPerValue);
+        }
+
+        if (entry.docsWithFieldOffset == -1) {
+            // dense
+            return new BaseSortedDocValues(entry, data) {
+
+                int doc = -1;
+
+                @Override
+                public int nextDoc() throws IOException {
+                    return advance(doc + 1);
+                }
+
+                @Override
+                public int docID() {
+                    return doc;
+                }
+
+                @Override
+                public long cost() {
+                    return maxDoc;
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    if (target >= maxDoc) {
+                        return doc = NO_MORE_DOCS;
+                    }
+                    return doc = target;
+                }
+
+                @Override
+                public boolean advanceExact(int target) {
+                    doc = target;
+                    return true;
+                }
+
+                @Override
+                public int ordValue() {
+                    return (int) ords.get(doc);
+                }
+            };
+        } else {
+            // sparse
+            final IndexedDISI disi = new IndexedDISI(data, entry.docsWithFieldOffset, entry.docsWithFieldLength, entry.numDocsWithField);
+            return new BaseSortedDocValues(entry, data) {
+
+                @Override
+                public int nextDoc() throws IOException {
+                    return disi.nextDoc();
+                }
+
+                @Override
+                public int docID() {
+                    return disi.docID();
+                }
+
+                @Override
+                public long cost() {
+                    return disi.cost();
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    return disi.advance(target);
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    return disi.advanceExact(target);
+                }
+
+                @Override
+                public int ordValue() {
+                    return (int) ords.get(disi.index());
+                }
+            };
+        }
+    }
+
+    private abstract static class BaseSortedDocValues extends SortedDocValues {
+
+        final SortedEntry entry;
+        final IndexInput data;
+        final TermsEnum termsEnum;
+
+        BaseSortedDocValues(SortedEntry entry, IndexInput data) throws IOException {
+            this.entry = entry;
+            this.data = data;
+            this.termsEnum = termsEnum();
+        }
+
+        @Override
+        public int getValueCount() {
+            return Math.toIntExact(entry.termsDictSize);
+        }
+
+        @Override
+        public BytesRef lookupOrd(int ord) throws IOException {
+            termsEnum.seekExact(ord);
+            return termsEnum.term();
+        }
+
+        @Override
+        public int lookupTerm(BytesRef key) throws IOException {
+            SeekStatus status = termsEnum.seekCeil(key);
+            switch (status) {
+                case FOUND:
+                    return Math.toIntExact(termsEnum.ord());
+                case NOT_FOUND:
+                case END:
+                default:
+                    return Math.toIntExact(-1L - termsEnum.ord());
+            }
+        }
+
+        @Override
+        public TermsEnum termsEnum() throws IOException {
+            return new TermsDict(entry, data);
+        }
+    }
+
+    private abstract static class BaseSortedSetDocValues extends SortedSetDocValues {
+
+        final SortedSetEntry entry;
+        final IndexInput data;
+        final TermsEnum termsEnum;
+
+        BaseSortedSetDocValues(SortedSetEntry entry, IndexInput data) throws IOException {
+            this.entry = entry;
+            this.data = data;
+            this.termsEnum = termsEnum();
+        }
+
+        @Override
+        public long getValueCount() {
+            return entry.termsDictSize;
+        }
+
+        @Override
+        public BytesRef lookupOrd(long ord) throws IOException {
+            termsEnum.seekExact(ord);
+            return termsEnum.term();
+        }
+
+        @Override
+        public long lookupTerm(BytesRef key) throws IOException {
+            SeekStatus status = termsEnum.seekCeil(key);
+            switch (status) {
+                case FOUND:
+                    return termsEnum.ord();
+                case NOT_FOUND:
+                case END:
+                default:
+                    return -1L - termsEnum.ord();
+            }
+        }
+
+        @Override
+        public TermsEnum termsEnum() throws IOException {
+            return new TermsDict(entry, data);
+        }
+    }
+
+    private static class TermsDict extends BaseTermsEnum {
+
+        final TermsDictEntry entry;
+        final LongValues blockAddresses;
+        final IndexInput bytes;
+        final long blockMask;
+        final LongValues indexAddresses;
+        final IndexInput indexBytes;
+        final BytesRef term;
+        long ord = -1;
+
+        TermsDict(TermsDictEntry entry, IndexInput data) throws IOException {
+            this.entry = entry;
+            RandomAccessInput addressesSlice = data.randomAccessSlice(entry.termsAddressesOffset, entry.termsAddressesLength);
+            blockAddresses = LegacyDirectMonotonicReader.getInstance(entry.termsAddressesMeta, addressesSlice);
+            bytes = data.slice("terms", entry.termsDataOffset, entry.termsDataLength);
+            blockMask = (1L << entry.termsDictBlockShift) - 1;
+            RandomAccessInput indexAddressesSlice = data.randomAccessSlice(
+                entry.termsIndexAddressesOffset,
+                entry.termsIndexAddressesLength
+            );
+            indexAddresses = LegacyDirectMonotonicReader.getInstance(entry.termsIndexAddressesMeta, indexAddressesSlice);
+            indexBytes = data.slice("terms-index", entry.termsIndexOffset, entry.termsIndexLength);
+            term = new BytesRef(entry.maxTermLength);
+        }
+
+        @Override
+        public BytesRef next() throws IOException {
+            if (++ord >= entry.termsDictSize) {
+                return null;
+            }
+            if ((ord & blockMask) == 0L) {
+                term.length = bytes.readVInt();
+                bytes.readBytes(term.bytes, 0, term.length);
+            } else {
+                final int token = Byte.toUnsignedInt(bytes.readByte());
+                int prefixLength = token & 0x0F;
+                int suffixLength = 1 + (token >>> 4);
+                if (prefixLength == 15) {
+                    prefixLength += bytes.readVInt();
+                }
+                if (suffixLength == 16) {
+                    suffixLength += bytes.readVInt();
+                }
+                term.length = prefixLength + suffixLength;
+                bytes.readBytes(term.bytes, prefixLength, suffixLength);
+            }
+            return term;
+        }
+
+        @Override
+        public void seekExact(long ord) throws IOException {
+            if (ord < 0 || ord >= entry.termsDictSize) {
+                throw new IndexOutOfBoundsException();
+            }
+            final long blockIndex = ord >>> entry.termsDictBlockShift;
+            final long blockAddress = blockAddresses.get(blockIndex);
+            bytes.seek(blockAddress);
+            this.ord = (blockIndex << entry.termsDictBlockShift) - 1;
+            do {
+                next();
+            } while (this.ord < ord);
+        }
+
+        private BytesRef getTermFromIndex(long index) throws IOException {
+            assert index >= 0 && index <= (entry.termsDictSize - 1) >>> entry.termsDictIndexShift;
+            final long start = indexAddresses.get(index);
+            term.length = (int) (indexAddresses.get(index + 1) - start);
+            indexBytes.seek(start);
+            indexBytes.readBytes(term.bytes, 0, term.length);
+            return term;
+        }
+
+        private long seekTermsIndex(BytesRef text) throws IOException {
+            long lo = 0L;
+            long hi = (entry.termsDictSize - 1) >>> entry.termsDictIndexShift;
+            while (lo <= hi) {
+                final long mid = (lo + hi) >>> 1;
+                getTermFromIndex(mid);
+                final int cmp = term.compareTo(text);
+                if (cmp <= 0) {
+                    lo = mid + 1;
+                } else {
+                    hi = mid - 1;
+                }
+            }
+
+            assert hi < 0 || getTermFromIndex(hi).compareTo(text) <= 0;
+            assert hi == ((entry.termsDictSize - 1) >>> entry.termsDictIndexShift) || getTermFromIndex(hi + 1).compareTo(text) > 0;
+
+            return hi;
+        }
+
+        private BytesRef getFirstTermFromBlock(long block) throws IOException {
+            assert block >= 0 && block <= (entry.termsDictSize - 1) >>> entry.termsDictBlockShift;
+            final long blockAddress = blockAddresses.get(block);
+            bytes.seek(blockAddress);
+            term.length = bytes.readVInt();
+            bytes.readBytes(term.bytes, 0, term.length);
+            return term;
+        }
+
+        private long seekBlock(BytesRef text) throws IOException {
+            long index = seekTermsIndex(text);
+            if (index == -1L) {
+                return -1L;
+            }
+
+            long ordLo = index << entry.termsDictIndexShift;
+            long ordHi = Math.min(entry.termsDictSize, ordLo + (1L << entry.termsDictIndexShift)) - 1L;
+
+            long blockLo = ordLo >>> entry.termsDictBlockShift;
+            long blockHi = ordHi >>> entry.termsDictBlockShift;
+
+            while (blockLo <= blockHi) {
+                final long blockMid = (blockLo + blockHi) >>> 1;
+                getFirstTermFromBlock(blockMid);
+                final int cmp = term.compareTo(text);
+                if (cmp <= 0) {
+                    blockLo = blockMid + 1;
+                } else {
+                    blockHi = blockMid - 1;
+                }
+            }
+
+            assert blockHi < 0 || getFirstTermFromBlock(blockHi).compareTo(text) <= 0;
+            assert blockHi == ((entry.termsDictSize - 1) >>> entry.termsDictBlockShift)
+                || getFirstTermFromBlock(blockHi + 1).compareTo(text) > 0;
+
+            return blockHi;
+        }
+
+        @Override
+        public SeekStatus seekCeil(BytesRef text) throws IOException {
+            final long block = seekBlock(text);
+            if (block == -1) {
+                // before the first term
+                seekExact(0L);
+                return SeekStatus.NOT_FOUND;
+            }
+            final long blockAddress = blockAddresses.get(block);
+            this.ord = block << entry.termsDictBlockShift;
+            bytes.seek(blockAddress);
+            term.length = bytes.readVInt();
+            bytes.readBytes(term.bytes, 0, term.length);
+            while (true) {
+                int cmp = term.compareTo(text);
+                if (cmp == 0) {
+                    return SeekStatus.FOUND;
+                } else if (cmp > 0) {
+                    return SeekStatus.NOT_FOUND;
+                }
+                if (next() == null) {
+                    return SeekStatus.END;
+                }
+            }
+        }
+
+        @Override
+        public BytesRef term() throws IOException {
+            return term;
+        }
+
+        @Override
+        public long ord() throws IOException {
+            return ord;
+        }
+
+        @Override
+        public long totalTermFreq() throws IOException {
+            return -1L;
+        }
+
+        @Override
+        public PostingsEnum postings(PostingsEnum reuse, int flags) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ImpactsEnum impacts(int flags) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int docFreq() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+        SortedNumericEntry entry = sortedNumerics.get(field.name);
+        if (entry.numValues == entry.numDocsWithField) {
+            return DocValues.singleton(getNumeric(entry));
+        }
+
+        final RandomAccessInput addressesInput = data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+        final LongValues addresses = LegacyDirectMonotonicReader.getInstance(entry.addressesMeta, addressesInput);
+
+        final LongValues values = getNumericValues(entry);
+
+        if (entry.docsWithFieldOffset == -1) {
+            // dense
+            return new SortedNumericDocValues() {
+
+                int doc = -1;
+                long start, end;
+                int count;
+
+                @Override
+                public int nextDoc() throws IOException {
+                    return advance(doc + 1);
+                }
+
+                @Override
+                public int docID() {
+                    return doc;
+                }
+
+                @Override
+                public long cost() {
+                    return maxDoc;
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    if (target >= maxDoc) {
+                        return doc = NO_MORE_DOCS;
+                    }
+                    start = addresses.get(target);
+                    end = addresses.get(target + 1L);
+                    count = (int) (end - start);
+                    return doc = target;
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    start = addresses.get(target);
+                    end = addresses.get(target + 1L);
+                    count = (int) (end - start);
+                    doc = target;
+                    return true;
+                }
+
+                @Override
+                public long nextValue() throws IOException {
+                    return values.get(start++);
+                }
+
+                @Override
+                public int docValueCount() {
+                    return count;
+                }
+            };
+        } else {
+            // sparse
+            final IndexedDISI disi = new IndexedDISI(data, entry.docsWithFieldOffset, entry.docsWithFieldLength, entry.numDocsWithField);
+            return new SortedNumericDocValues() {
+
+                boolean set;
+                long start, end;
+                int count;
+
+                @Override
+                public int nextDoc() throws IOException {
+                    set = false;
+                    return disi.nextDoc();
+                }
+
+                @Override
+                public int docID() {
+                    return disi.docID();
+                }
+
+                @Override
+                public long cost() {
+                    return disi.cost();
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    set = false;
+                    return disi.advance(target);
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    set = false;
+                    return disi.advanceExact(target);
+                }
+
+                @Override
+                public long nextValue() throws IOException {
+                    set();
+                    return values.get(start++);
+                }
+
+                @Override
+                public int docValueCount() {
+                    set();
+                    return count;
+                }
+
+                private void set() {
+                    if (set == false) {
+                        final int index = disi.index();
+                        start = addresses.get(index);
+                        end = addresses.get(index + 1L);
+                        count = (int) (end - start);
+                        set = true;
+                    }
+                }
+            };
+        }
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+        SortedSetEntry entry = sortedSets.get(field.name);
+        if (entry.singleValueEntry != null) {
+            return DocValues.singleton(getSorted(entry.singleValueEntry));
+        }
+
+        final RandomAccessInput slice = data.randomAccessSlice(entry.ordsOffset, entry.ordsLength);
+        final LongValues ords = LegacyDirectReader.getInstance(slice, entry.bitsPerValue);
+
+        final RandomAccessInput addressesInput = data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+        final LongValues addresses = LegacyDirectMonotonicReader.getInstance(entry.addressesMeta, addressesInput);
+
+        if (entry.docsWithFieldOffset == -1) {
+            // dense
+            return new BaseSortedSetDocValues(entry, data) {
+
+                int doc = -1;
+                long start, end;
+                int count;
+
+                @Override
+                public int nextDoc() throws IOException {
+                    return advance(doc + 1);
+                }
+
+                @Override
+                public int docID() {
+                    return doc;
+                }
+
+                @Override
+                public long cost() {
+                    return maxDoc;
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    if (target >= maxDoc) {
+                        return doc = NO_MORE_DOCS;
+                    }
+                    start = addresses.get(target);
+                    end = addresses.get(target + 1L);
+                    count = (int) (end - start);
+                    return doc = target;
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    start = addresses.get(target);
+                    end = addresses.get(target + 1L);
+                    count = (int) (end - start);
+                    doc = target;
+                    return true;
+                }
+
+                @Override
+                public long nextOrd() throws IOException {
+                    if (start == end) {
+                        return NO_MORE_ORDS;
+                    }
+                    return ords.get(start++);
+                }
+
+                @Override
+                public int docValueCount() {
+                    return count;
+                }
+            };
+        } else {
+            // sparse
+            final IndexedDISI disi = new IndexedDISI(data, entry.docsWithFieldOffset, entry.docsWithFieldLength, entry.numDocsWithField);
+            return new BaseSortedSetDocValues(entry, data) {
+
+                boolean set;
+                long start;
+                long end = 0;
+                int count;
+
+                @Override
+                public int nextDoc() throws IOException {
+                    set = false;
+                    return disi.nextDoc();
+                }
+
+                @Override
+                public int docID() {
+                    return disi.docID();
+                }
+
+                @Override
+                public long cost() {
+                    return disi.cost();
+                }
+
+                @Override
+                public int advance(int target) throws IOException {
+                    set = false;
+                    return disi.advance(target);
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    set = false;
+                    return disi.advanceExact(target);
+                }
+
+                private boolean set() {
+                    if (set == false) {
+                        final int index = disi.index();
+                        start = addresses.get(index);
+                        end = addresses.get(index + 1L);
+                        count = (int) (end - start);
+                        set = true;
+                        return true;
+                    }
+                    return false;
+                }
+
+                @Override
+                public long nextOrd() throws IOException {
+                    if (set()) {
+                        return ords.get(start++);
+                    } else if (start == end) {
+                        return NO_MORE_ORDS;
+                    } else {
+                        return ords.get(start++);
+                    }
+                }
+
+                @Override
+                public int docValueCount() {
+                    set();
+                    return count;
+                }
+            };
+        }
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        CodecUtil.checksumEntireFile(data);
+    }
+
+    @Override
+    public DocValuesSkipper getSkipper(FieldInfo field) {
+        return null;
+    }
+}

--- a/x-pack/plugin/old-lucene-versions/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/x-pack/plugin/old-lucene-versions/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -6,5 +6,6 @@
 #
 
 org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.BWCLucene70Codec
+org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.Lucene70Codec
 org.elasticsearch.xpack.lucene.bwc.codecs.lucene62.Lucene62Codec
 org.elasticsearch.xpack.lucene.bwc.codecs.lucene60.Lucene60Codec

--- a/x-pack/plugin/old-lucene-versions/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
+++ b/x-pack/plugin/old-lucene-versions/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
@@ -14,3 +14,4 @@
 #  limitations under the License.
 
 org.elasticsearch.xpack.lucene.bwc.codecs.lucene54.Lucene54DocValuesFormat
+org.elasticsearch.xpack.lucene.bwc.codecs.lucene70.Lucene70DocValuesFormat

--- a/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesFormatTests.java
+++ b/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/Lucene70DocValuesFormatTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.lucene.bwc.codecs.lucene70;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.tests.index.LegacyBaseDocValuesFormatTestCase;
+import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.test.GraalVMThreadsFilter;
+
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
+public class Lucene70DocValuesFormatTests extends LegacyBaseDocValuesFormatTestCase {
+
+    private final Codec codec = TestUtil.alwaysDocValuesFormat(new Lucene70DocValuesFormat());
+
+    @Override
+    protected Codec getCodec() {
+        return codec;
+    }
+}


### PR DESCRIPTION
Add Lucene70DocValuesFormat to old-lucene-versions plugin.

Lucene 10 has remove the old `Lucene70DocValuesFormat` from its `backward_codecs`, so we can no longer lookup the doc values format by name (`DocValuesFormat.forName("Lucene70")`). Instead we make a copy and reference it statically.

The code is for the most part a direct copy, with the following changes:
1. package and import updates
2. Elasticsearch's spotless
3. A couple of changes in Lucene70DocValuesConsumer, where we no longer iterate `SortedSetDocValues` until NO_MORE_DOCS, but rather use a counted loop with `docValueCount`. As per what is done elsewhere in lucene 10. 

The`Lucene70DocValuesFormatTests` has been, similar to how we test other formats in this plugin.