### PR TITLE
[8.x] [ESQL] Add finish() elapsed time to aggregation profiling times (#113172)

### DIFF
--- a/docs/changelog/113172.yaml
+++ b/docs/changelog/113172.yaml
@@ -1,0 +1,6 @@
+pr: 113172
+summary: "[ESQL] Add finish() elapsed time to aggregation profiling times"
+area: ES|QL
+type: enhancement
+issues:
+ - 112950

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -220,6 +220,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_IBM_WATSONX_EMBEDDINGS_ADDED = def(8_744_00_0);
     public static final TransportVersion BULK_INCREMENTAL_STATE = def(8_745_00_0);
     public static final TransportVersion FAILURE_STORE_STATUS_IN_INDEX_RESPONSE = def(8_746_00_0);
+    public static final TransportVersion ESQL_AGGREGATION_OPERATOR_STATUS_FINISH_NANOS = def(8_747_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AggregationOperatorStatusTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AggregationOperatorStatusTests.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class AggregationOperatorStatusTests extends AbstractWireSerializingTestCase<AggregationOperator.Status> {
     public static AggregationOperator.Status simple() {
-        return new AggregationOperator.Status(200012, 123);
+        return new AggregationOperator.Status(200012, 400036, 123);
     }
 
     public static String simpleToJson() {
@@ -24,6 +24,8 @@ public class AggregationOperatorStatusTests extends AbstractWireSerializingTestC
             {
               "aggregation_nanos" : 200012,
               "aggregation_time" : "200micros",
+              "aggregation_finish_nanos" : 400036,
+              "aggregation_finish_time" : "400micros",
               "pages_processed" : 123
             }""";
     }
@@ -39,18 +41,20 @@ public class AggregationOperatorStatusTests extends AbstractWireSerializingTestC
 
     @Override
     public AggregationOperator.Status createTestInstance() {
-        return new AggregationOperator.Status(randomNonNegativeLong(), randomNonNegativeInt());
+        return new AggregationOperator.Status(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeInt());
     }
 
     @Override
     protected AggregationOperator.Status mutateInstance(AggregationOperator.Status instance) {
         long aggregationNanos = instance.aggregationNanos();
+        long aggregationFinishNanos = instance.aggregationFinishNanos();
         int pagesProcessed = instance.pagesProcessed();
-        switch (between(0, 1)) {
+        switch (between(0, 2)) {
             case 0 -> aggregationNanos = randomValueOtherThan(aggregationNanos, ESTestCase::randomNonNegativeLong);
-            case 1 -> pagesProcessed = randomValueOtherThan(pagesProcessed, ESTestCase::randomNonNegativeInt);
+            case 1 -> aggregationFinishNanos = randomValueOtherThan(aggregationFinishNanos, ESTestCase::randomNonNegativeLong);
+            case 2 -> pagesProcessed = randomValueOtherThan(pagesProcessed, ESTestCase::randomNonNegativeInt);
             default -> throw new UnsupportedOperationException();
         }
-        return new AggregationOperator.Status(aggregationNanos, pagesProcessed);
+        return new AggregationOperator.Status(aggregationNanos, aggregationFinishNanos, pagesProcessed);
     }
 }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -562,7 +562,9 @@ public class RestEsqlIT extends RestEsqlTestCase {
                 .entry("processing_nanos", greaterThan(0))
                 .entry("processed_queries", List.of("*:*"));
             case "ValuesSourceReaderOperator" -> basicProfile().entry("readers_built", matchesMap().extraOk());
-            case "AggregationOperator" -> matchesMap().entry("pages_processed", greaterThan(0)).entry("aggregation_nanos", greaterThan(0));
+            case "AggregationOperator" -> matchesMap().entry("pages_processed", greaterThan(0))
+                .entry("aggregation_nanos", greaterThan(0))
+                .entry("aggregation_finish_nanos", greaterThan(0));
             case "ExchangeSinkOperator" -> matchesMap().entry("pages_accepted", greaterThan(0));
             case "ExchangeSourceOperator" -> matchesMap().entry("pages_emitted", greaterThan(0)).entry("pages_waiting", 0);
             case "ProjectOperator", "EvalOperator" -> basicProfile();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ESQL] Add finish() elapsed time to aggregation profiling times (#113172)