### PR TITLE
[8.x] [ML] Warn for model load failures if they have a status code <500 (#113280)

### DIFF
--- a/docs/changelog/113280.yaml
+++ b/docs/changelog/113280.yaml
@@ -1,0 +1,5 @@
+pr: 113280
+summary: Warn for model load failures if they have a status code <500
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.assignment;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -775,7 +776,11 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
     }
 
     private void handleLoadFailure(TrainedModelDeploymentTask task, Exception ex, ActionListener<Boolean> retryListener) {
-        logger.error(() -> "[" + task.getDeploymentId() + "] model [" + task.getParams().getModelId() + "] failed to load", ex);
+        if (ex instanceof ElasticsearchException esEx && esEx.status().getStatus() < 500) {
+            logger.warn(() -> "[" + task.getDeploymentId() + "] model [" + task.getParams().getModelId() + "] failed to load", ex);
+        } else {
+            logger.error(() -> "[" + task.getDeploymentId() + "] model [" + task.getParams().getModelId() + "] failed to load", ex);
+        }
         if (task.isStopped()) {
             logger.debug(
                 () -> format(


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Warn for model load failures if they have a status code <500 (#113280)