### PR TITLE
[8.x] Make `AddIndexBlockClusterStateUpdateRequest` a record (#113349)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockClusterStateUpdateRequest.java
@@ -8,32 +8,26 @@
  */
 package org.elasticsearch.action.admin.indices.readonly;
 
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+
+import java.util.Objects;
 
 /**
  * Cluster state update request that allows to add a block to one or more indices
  */
-public class AddIndexBlockClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<AddIndexBlockClusterStateUpdateRequest> {
-
-    private final APIBlock block;
-    private long taskId;
-
-    public AddIndexBlockClusterStateUpdateRequest(final APIBlock block, final long taskId) {
-        this.block = block;
-        this.taskId = taskId;
-    }
-
-    public long taskId() {
-        return taskId;
-    }
-
-    public APIBlock getBlock() {
-        return block;
-    }
-
-    public AddIndexBlockClusterStateUpdateRequest taskId(final long taskId) {
-        this.taskId = taskId;
-        return this;
+public record AddIndexBlockClusterStateUpdateRequest(
+    TimeValue masterNodeTimeout,
+    TimeValue ackTimeout,
+    APIBlock block,
+    long taskId,
+    Index[] indices
+) {
+    public AddIndexBlockClusterStateUpdateRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(ackTimeout);
+        Objects.requireNonNull(block);
+        Objects.requireNonNull(indices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportAddIndexBlockAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportAddIndexBlockAction.java
@@ -102,13 +102,18 @@ public class TransportAddIndexBlockAction extends TransportMasterNodeAction<AddI
             return;
         }
 
-        final AddIndexBlockClusterStateUpdateRequest addBlockRequest = new AddIndexBlockClusterStateUpdateRequest(
-            request.getBlock(),
-            task.getId()
-        ).ackTimeout(request.ackTimeout()).masterNodeTimeout(request.masterNodeTimeout()).indices(concreteIndices);
-        indexStateService.addIndexBlock(addBlockRequest, listener.delegateResponse((delegatedListener, t) -> {
-            logger.debug(() -> "failed to mark indices as readonly [" + Arrays.toString(concreteIndices) + "]", t);
-            delegatedListener.onFailure(t);
-        }));
+        indexStateService.addIndexBlock(
+            new AddIndexBlockClusterStateUpdateRequest(
+                request.masterNodeTimeout(),
+                request.ackTimeout(),
+                request.getBlock(),
+                task.getId(),
+                concreteIndices
+            ),
+            listener.delegateResponse((delegatedListener, t) -> {
+                logger.debug(() -> "failed to mark indices as readonly [" + Arrays.toString(concreteIndices) + "]", t);
+                delegatedListener.onFailure(t);
+            })
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -470,7 +470,7 @@ public class MetadataIndexStateService {
         }
 
         addBlocksQueue.submitTask(
-            "add-index-block-[" + request.getBlock().name + "]-" + Arrays.toString(concreteIndices),
+            "add-index-block-[" + request.block().name + "]-" + Arrays.toString(concreteIndices),
             new AddBlocksTask(request, listener),
             request.masterNodeTimeout()
         );
@@ -480,7 +480,7 @@ public class MetadataIndexStateService {
 
         @Override
         public Tuple<ClusterState, Map<Index, ClusterBlock>> executeTask(AddBlocksTask task, ClusterState clusterState) {
-            return addIndexBlock(task.request.indices(), clusterState, task.request.getBlock());
+            return addIndexBlock(task.request.indices(), clusterState, task.request.block());
         }
 
         @Override
@@ -497,7 +497,7 @@ public class MetadataIndexStateService {
                                 .delegateFailure(
                                     (delegate2, verifyResults) -> finalizeBlocksQueue.submitTask(
                                         "finalize-index-block-["
-                                            + task.request.getBlock().name
+                                            + task.request.block().name
                                             + "]-["
                                             + blockedIndices.keySet().stream().map(Index::getName).collect(Collectors.joining(", "))
                                             + "]",
@@ -529,7 +529,7 @@ public class MetadataIndexStateService {
                 clusterState,
                 task.blockedIndices,
                 task.verifyResults,
-                task.request.getBlock()
+                task.request.block()
             );
             assert finalizeResult.v2().size() == task.verifyResults.size();
             return finalizeResult;
@@ -797,9 +797,7 @@ public class MetadataIndexStateService {
                 block,
                 parentTaskId
             );
-            if (request.ackTimeout() != null) {
-                shardRequest.timeout(request.ackTimeout());
-            }
+            shardRequest.timeout(request.ackTimeout());
             client.executeLocally(TransportVerifyShardIndexBlockAction.TYPE, shardRequest, listener);
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make `AddIndexBlockClusterStateUpdateRequest` a record (#113349)