### PR TITLE
[8.x] Make `OpenIndexClusterStateUpdateRequest` a record (#113351)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexClusterStateUpdateRequest.java
@@ -9,25 +9,24 @@
 package org.elasticsearch.action.admin.indices.open;
 
 import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+
+import java.util.Objects;
 
 /**
  * Cluster state update request that allows to open one or more indices
  */
-public class OpenIndexClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<OpenIndexClusterStateUpdateRequest> {
-
-    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
-
-    public OpenIndexClusterStateUpdateRequest() {
-
-    }
-
-    public ActiveShardCount waitForActiveShards() {
-        return waitForActiveShards;
-    }
-
-    public OpenIndexClusterStateUpdateRequest waitForActiveShards(ActiveShardCount waitForActiveShards) {
-        this.waitForActiveShards = waitForActiveShards;
-        return this;
+public record OpenIndexClusterStateUpdateRequest(
+    TimeValue masterNodeTimeout,
+    TimeValue ackTimeout,
+    ActiveShardCount waitForActiveShards,
+    Index[] indices
+) {
+    public OpenIndexClusterStateUpdateRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(ackTimeout);
+        Objects.requireNonNull(waitForActiveShards);
+        Objects.requireNonNull(indices);
     }
 }

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
@@ -145,10 +145,12 @@ public final class TransportFreezeIndexAction extends TransportMasterNodeAction<
         submitUnbatchedTask(
             "toggle-frozen-settings",
             new AckedClusterStateUpdateTask(Priority.URGENT, request, listener.delegateFailure((delegate, acknowledgedResponse) -> {
-                OpenIndexClusterStateUpdateRequest updateRequest = new OpenIndexClusterStateUpdateRequest().ackTimeout(request.ackTimeout())
-                    .masterNodeTimeout(request.masterNodeTimeout())
-                    .indices(concreteIndices)
-                    .waitForActiveShards(request.waitForActiveShards());
+                OpenIndexClusterStateUpdateRequest updateRequest = new OpenIndexClusterStateUpdateRequest(
+                    request.masterNodeTimeout(),
+                    request.ackTimeout(),
+                    request.waitForActiveShards(),
+                    concreteIndices
+                );
                 indexStateService.openIndices(
                     updateRequest,
                     delegate.safeMap(


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make `OpenIndexClusterStateUpdateRequest` a record (#113351)