### PR TITLE
[8.x] Make `CloseIndexClusterStateUpdateRequest` a record (#113350)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexClusterStateUpdateRequest.java
@@ -9,35 +9,25 @@
 package org.elasticsearch.action.admin.indices.close;
 
 import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+
+import java.util.Objects;
 
 /**
  * Cluster state update request that allows to close one or more indices
  */
-public class CloseIndexClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<CloseIndexClusterStateUpdateRequest> {
-
-    private long taskId;
-    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
-
-    public CloseIndexClusterStateUpdateRequest(final long taskId) {
-        this.taskId = taskId;
-    }
-
-    public long taskId() {
-        return taskId;
-    }
-
-    public CloseIndexClusterStateUpdateRequest taskId(final long taskId) {
-        this.taskId = taskId;
-        return this;
-    }
-
-    public ActiveShardCount waitForActiveShards() {
-        return waitForActiveShards;
-    }
-
-    public CloseIndexClusterStateUpdateRequest waitForActiveShards(final ActiveShardCount waitForActiveShards) {
-        this.waitForActiveShards = waitForActiveShards;
-        return this;
+public record CloseIndexClusterStateUpdateRequest(
+    TimeValue masterNodeTimeout,
+    TimeValue ackTimeout,
+    long taskId,
+    ActiveShardCount waitForActiveShards,
+    Index[] indices
+) {
+    public CloseIndexClusterStateUpdateRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(ackTimeout);
+        Objects.requireNonNull(waitForActiveShards);
+        Objects.requireNonNull(indices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -120,9 +120,13 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
             return;
         }
 
-        final CloseIndexClusterStateUpdateRequest closeRequest = new CloseIndexClusterStateUpdateRequest(task.getId()).ackTimeout(
-            request.ackTimeout()
-        ).masterNodeTimeout(request.masterNodeTimeout()).waitForActiveShards(request.waitForActiveShards()).indices(concreteIndices);
+        final CloseIndexClusterStateUpdateRequest closeRequest = new CloseIndexClusterStateUpdateRequest(
+            request.masterNodeTimeout(),
+            request.ackTimeout(),
+            task.getId(),
+            request.waitForActiveShards(),
+            concreteIndices
+        );
         indexStateService.closeIndices(closeRequest, listener.delegateResponse((delegatedListener, t) -> {
             logger.debug(() -> "failed to close indices [" + Arrays.toString(concreteIndices) + "]", t);
             delegatedListener.onFailure(t);

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.close.CloseIndexClusterStateUpdate
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexClusterStateUpdateRequest;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
@@ -114,9 +115,13 @@ public final class TransportFreezeIndexAction extends TransportMasterNodeAction<
             return;
         }
 
-        final CloseIndexClusterStateUpdateRequest closeRequest = new CloseIndexClusterStateUpdateRequest(task.getId()).ackTimeout(
-            request.ackTimeout()
-        ).masterNodeTimeout(request.masterNodeTimeout()).indices(concreteIndices);
+        final CloseIndexClusterStateUpdateRequest closeRequest = new CloseIndexClusterStateUpdateRequest(
+            request.masterNodeTimeout(),
+            request.ackTimeout(),
+            task.getId(),
+            ActiveShardCount.DEFAULT,
+            concreteIndices
+        );
 
         indexStateService.closeIndices(closeRequest, new ActionListener<>() {
             @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make `CloseIndexClusterStateUpdateRequest` a record (#113350)