### PR TITLE
[8.x] Test fix: ensure we don't accidentally generate two identical histograms (#113322)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -33,7 +33,7 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
 
     private LongMetricValue randomLongMetricValue() {
         LongMetric v = new LongMetric();
-        for (int i = 0; i < randomIntBetween(1, 10); i++) {
+        for (int i = 0; i < randomIntBetween(5, 10); i++) {
             v.record(randomIntBetween(0, 1_000_000));
         }
         return v.getValue();
@@ -110,13 +110,13 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
                 }
                 break;
             case 3:
-                took = randomLongMetricValue();
+                took = randomValueOtherThan(took, this::randomLongMetricValue);
                 break;
             case 4:
-                tookMrtTrue = randomLongMetricValue();
+                tookMrtTrue = randomValueOtherThan(tookMrtTrue, this::randomLongMetricValue);
                 break;
             case 5:
-                tookMrtFalse = randomLongMetricValue();
+                tookMrtFalse = randomValueOtherThan(tookMrtFalse, this::randomLongMetricValue);
                 break;
             case 6:
                 skippedRemotes += randomNonNegativeLong();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Test fix: ensure we don't accidentally generate two identical histograms (#113322)