### PR TITLE
[ML] Stream Inference API

### DIFF
--- a/docs/changelog/113158.yaml
+++ b/docs/changelog/113158.yaml
@@ -1,0 +1,5 @@
+pr: 113158
+summary: Adds a new Inference API for streaming responses back to the user.
+area: Machine Learning
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/inference/InferenceService.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceService.java
@@ -188,4 +188,21 @@ public interface InferenceService extends Closeable {
      * @return {@link TransportVersion} specifying the version
      */
     TransportVersion getMinimalSupportedVersion();
+
+    /**
+     * The set of tasks where this service provider supports using the streaming API.
+     * @return set of supported task types. Defaults to empty.
+     */
+    default Set<TaskType> supportedStreamingTasks() {
+        return Set.of();
+    }
+
+    /**
+     * Checks the task type against the set of supported streaming tasks returned by {@link #supportedStreamingTasks()}.
+     * @param taskType the task that supports streaming
+     * @return true if the taskType is supported
+     */
+    default boolean canStream(TaskType taskType) {
+        return supportedStreamingTasks().contains(taskType);
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -92,6 +92,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
         private final Map<String, Object> taskSettings;
         private final InputType inputType;
         private final TimeValue inferenceTimeout;
+        private final boolean stream;
 
         public Request(
             TaskType taskType,
@@ -100,7 +101,8 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             List<String> input,
             Map<String, Object> taskSettings,
             InputType inputType,
-            TimeValue inferenceTimeout
+            TimeValue inferenceTimeout,
+            boolean stream
         ) {
             this.taskType = taskType;
             this.inferenceEntityId = inferenceEntityId;
@@ -109,6 +111,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             this.taskSettings = taskSettings;
             this.inputType = inputType;
             this.inferenceTimeout = inferenceTimeout;
+            this.stream = stream;
         }
 
         public Request(StreamInput in) throws IOException {
@@ -134,6 +137,9 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
                 this.query = null;
                 this.inferenceTimeout = DEFAULT_TIMEOUT;
             }
+
+            // streaming is not supported yet for transport traffic
+            this.stream = false;
         }
 
         public TaskType getTaskType() {
@@ -165,7 +171,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
         }
 
         public boolean isStreaming() {
-            return false;
+            return stream;
         }
 
         @Override
@@ -261,6 +267,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             private Map<String, Object> taskSettings = Map.of();
             private String query;
             private TimeValue timeout = DEFAULT_TIMEOUT;
+            private boolean stream = false;
 
             private Builder() {}
 
@@ -303,8 +310,13 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
                 return setInferenceTimeout(TimeValue.parseTimeValue(inferenceTimeout, TIMEOUT.getPreferredName()));
             }
 
+            public Builder setStream(boolean stream) {
+                this.stream = stream;
+                return this;
+            }
+
             public Request build() {
-                return new Request(taskType, inferenceEntityId, query, input, taskSettings, inputType, timeout);
+                return new Request(taskType, inferenceEntityId, query, input, taskSettings, inputType, timeout, stream);
             }
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -46,7 +46,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             randomList(1, 5, () -> randomAlphaOfLength(8)),
             randomMap(0, 3, () -> new Tuple<>(randomAlphaOfLength(4), randomAlphaOfLength(4))),
             randomFrom(InputType.values()),
-            TimeValue.timeValueMillis(randomLongBetween(1, 2048))
+            TimeValue.timeValueMillis(randomLongBetween(1, 2048)),
+            false
         );
     }
 
@@ -80,7 +81,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             List.of("input"),
             null,
             null,
-            null
+            null,
+            false
         );
         ActionRequestValidationException e = request.validate();
         assertNull(e);
@@ -94,7 +96,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             List.of("input"),
             null,
             null,
-            null
+            null,
+            false
         );
         ActionRequestValidationException e = request.validate();
         assertNull(e);
@@ -108,7 +111,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             null,
             null,
             null,
-            null
+            null,
+            false
         );
         ActionRequestValidationException inputNullError = inputNullRequest.validate();
         assertNotNull(inputNullError);
@@ -123,7 +127,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             List.of(),
             null,
             null,
-            null
+            null,
+            false
         );
         ActionRequestValidationException inputEmptyError = inputEmptyRequest.validate();
         assertNotNull(inputEmptyError);
@@ -138,7 +143,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             List.of("input"),
             null,
             null,
-            null
+            null,
+            false
         );
         ActionRequestValidationException queryNullError = queryNullRequest.validate();
         assertNotNull(queryNullError);
@@ -153,7 +159,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             List.of("input"),
             null,
             null,
-            null
+            null,
+            false
         );
         ActionRequestValidationException queryEmptyError = queryEmptyRequest.validate();
         assertNotNull(queryEmptyError);
@@ -185,7 +192,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                     instance.getInput(),
                     instance.getTaskSettings(),
                     instance.getInputType(),
-                    instance.getInferenceTimeout()
+                    instance.getInferenceTimeout(),
+                    false
                 );
             }
             case 1 -> new InferenceAction.Request(
@@ -195,7 +203,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                 instance.getInput(),
                 instance.getTaskSettings(),
                 instance.getInputType(),
-                instance.getInferenceTimeout()
+                instance.getInferenceTimeout(),
+                false
             );
             case 2 -> {
                 var changedInputs = new ArrayList<String>(instance.getInput());
@@ -207,7 +216,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                     changedInputs,
                     instance.getTaskSettings(),
                     instance.getInputType(),
-                    instance.getInferenceTimeout()
+                    instance.getInferenceTimeout(),
+                    false
                 );
             }
             case 3 -> {
@@ -225,7 +235,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                     instance.getInput(),
                     taskSettings,
                     instance.getInputType(),
-                    instance.getInferenceTimeout()
+                    instance.getInferenceTimeout(),
+                    false
                 );
             }
             case 4 -> {
@@ -237,7 +248,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                     instance.getInput(),
                     instance.getTaskSettings(),
                     nextInputType,
-                    instance.getInferenceTimeout()
+                    instance.getInferenceTimeout(),
+                    false
                 );
             }
             case 5 -> new InferenceAction.Request(
@@ -247,7 +259,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                 instance.getInput(),
                 instance.getTaskSettings(),
                 instance.getInputType(),
-                instance.getInferenceTimeout()
+                instance.getInferenceTimeout(),
+                false
             );
             case 6 -> {
                 var newDuration = Duration.of(
@@ -262,7 +275,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                     instance.getInput(),
                     instance.getTaskSettings(),
                     instance.getInputType(),
-                    TimeValue.timeValueMillis(newDuration.plus(additionalTime).toMillis())
+                    TimeValue.timeValueMillis(newDuration.plus(additionalTime).toMillis()),
+                    false
                 );
             }
             default -> throw new UnsupportedOperationException();
@@ -279,7 +293,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                 instance.getInput().subList(0, 1),
                 instance.getTaskSettings(),
                 InputType.UNSPECIFIED,
-                InferenceAction.Request.DEFAULT_TIMEOUT
+                InferenceAction.Request.DEFAULT_TIMEOUT,
+                false
             );
         } else if (version.before(TransportVersions.V_8_13_0)) {
             return new InferenceAction.Request(
@@ -289,7 +304,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                 instance.getInput(),
                 instance.getTaskSettings(),
                 InputType.UNSPECIFIED,
-                InferenceAction.Request.DEFAULT_TIMEOUT
+                InferenceAction.Request.DEFAULT_TIMEOUT,
+                false
             );
         } else if (version.before(TransportVersions.V_8_13_0)
             && (instance.getInputType() == InputType.UNSPECIFIED
@@ -302,7 +318,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                         instance.getInput(),
                         instance.getTaskSettings(),
                         InputType.INGEST,
-                        InferenceAction.Request.DEFAULT_TIMEOUT
+                        InferenceAction.Request.DEFAULT_TIMEOUT,
+                        false
                     );
                 } else if (version.before(TransportVersions.V_8_13_0)
                     && (instance.getInputType() == InputType.CLUSTERING || instance.getInputType() == InputType.CLASSIFICATION)) {
@@ -313,7 +330,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                             instance.getInput(),
                             instance.getTaskSettings(),
                             InputType.UNSPECIFIED,
-                            InferenceAction.Request.DEFAULT_TIMEOUT
+                            InferenceAction.Request.DEFAULT_TIMEOUT,
+                            false
                         );
                     } else if (version.before(TransportVersions.V_8_14_0)) {
                         return new InferenceAction.Request(
@@ -323,7 +341,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                             instance.getInput(),
                             instance.getTaskSettings(),
                             instance.getInputType(),
-                            InferenceAction.Request.DEFAULT_TIMEOUT
+                            InferenceAction.Request.DEFAULT_TIMEOUT,
+                            false
                         );
                     }
 
@@ -339,7 +358,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                 List.of(),
                 Map.of(),
                 InputType.UNSPECIFIED,
-                InferenceAction.Request.DEFAULT_TIMEOUT
+                InferenceAction.Request.DEFAULT_TIMEOUT,
+                false
             ),
             TransportVersions.V_8_13_0
         );
@@ -353,7 +373,8 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             List.of(),
             Map.of(),
             InputType.INGEST,
-            InferenceAction.Request.DEFAULT_TIMEOUT
+            InferenceAction.Request.DEFAULT_TIMEOUT,
+            false
         );
 
         InferenceAction.Request deserializedInstance = copyWriteable(

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/AsyncInferenceResponseConsumer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/AsyncInferenceResponseConsumer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.ContentDecoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.AbstractAsyncResponseConsumer;
+import org.apache.http.nio.util.SimpleInputBuffer;
+import org.apache.http.protocol.HttpContext;
+import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEvent;
+import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicReference;
+
+class AsyncInferenceResponseConsumer extends AbstractAsyncResponseConsumer<HttpResponse> {
+    private final AtomicReference<HttpResponse> httpResponse = new AtomicReference<>();
+    private final Deque<ServerSentEvent> collector = new ArrayDeque<>();
+    private final ServerSentEventParser sseParser = new ServerSentEventParser();
+    private final SimpleInputBuffer inputBuffer = new SimpleInputBuffer(4096);
+
+    @Override
+    protected void onResponseReceived(HttpResponse httpResponse) {
+        this.httpResponse.set(httpResponse);
+    }
+
+    @Override
+    protected void onContentReceived(ContentDecoder contentDecoder, IOControl ioControl) throws IOException {
+        inputBuffer.consumeContent(contentDecoder);
+    }
+
+    @Override
+    protected void onEntityEnclosed(HttpEntity httpEntity, ContentType contentType) {
+        httpResponse.updateAndGet(response -> {
+            response.setEntity(httpEntity);
+            return response;
+        });
+    }
+
+    @Override
+    protected HttpResponse buildResult(HttpContext httpContext) {
+        var allBytes = new byte[inputBuffer.length()];
+        try {
+            inputBuffer.read(allBytes);
+            sseParser.parse(allBytes).forEach(collector::offer);
+        } catch (IOException e) {
+            failed(e);
+        }
+        return httpResponse.get();
+    }
+
+    @Override
+    protected void releaseResources() {}
+
+    Deque<ServerSentEvent> events() {
+        return collector;
+    }
+}

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -17,8 +17,12 @@ import org.elasticsearch.inference.TaskType;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasSize;
 
 public class InferenceCrudIT extends InferenceBaseRestTest {
@@ -221,5 +225,59 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         }
         deletePipeline(pipelineId);
         deleteIndex(indexName);
+    }
+
+    public void testUnsupportedStream() throws Exception {
+        String modelId = "streaming";
+        putModel(modelId, mockCompletionServiceModelConfig(TaskType.SPARSE_EMBEDDING));
+        var singleModel = getModel(modelId);
+        assertEquals(modelId, singleModel.get("inference_id"));
+        assertEquals(TaskType.SPARSE_EMBEDDING.toString(), singleModel.get("task_type"));
+
+        try {
+            var events = streamInferOnMockService(modelId, TaskType.SPARSE_EMBEDDING, List.of(randomAlphaOfLength(10)));
+            assertThat(events.size(), equalTo(2));
+            events.forEach(event -> {
+                switch (event.name()) {
+                    case EVENT -> assertThat(event.value(), equalToIgnoringCase("error"));
+                    case DATA -> assertThat(
+                        event.value(),
+                        containsString(
+                            "Streaming is not allowed for service [streaming_completion_test_service] and task [sparse_embedding]"
+                        )
+                    );
+                }
+            });
+        } finally {
+            deleteModel(modelId);
+        }
+    }
+
+    public void testSupportedStream() throws Exception {
+        String modelId = "streaming";
+        putModel(modelId, mockCompletionServiceModelConfig(TaskType.COMPLETION));
+        var singleModel = getModel(modelId);
+        assertEquals(modelId, singleModel.get("inference_id"));
+        assertEquals(TaskType.COMPLETION.toString(), singleModel.get("task_type"));
+
+        var input = IntStream.range(0, randomInt(10)).mapToObj(i -> randomAlphaOfLength(10)).toList();
+
+        try {
+            var events = streamInferOnMockService(modelId, TaskType.COMPLETION, input);
+
+            var expectedResponses = Stream.concat(
+                input.stream().map(String::toUpperCase).map(str -> "{\"completion\":[{\"delta\":\"" + str + "\"}]}"),
+                Stream.of("[DONE]")
+            ).iterator();
+            assertThat(events.size(), equalTo((input.size() + 1) * 2));
+            events.forEach(event -> {
+                switch (event.name()) {
+                    case EVENT -> assertThat(event.value(), equalToIgnoringCase("message"));
+                    case DATA -> assertThat(event.value(), equalTo(expectedResponses.next()));
+                }
+            });
+        } finally {
+            deleteModel(modelId);
+        }
     }
 }

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestInferenceServicePlugin.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestInferenceServicePlugin.java
@@ -44,6 +44,11 @@ public class TestInferenceServicePlugin extends Plugin {
                 ServiceSettings.class,
                 TestRerankingServiceExtension.TestServiceSettings.NAME,
                 TestRerankingServiceExtension.TestServiceSettings::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                ServiceSettings.class,
+                TestStreamingCompletionServiceExtension.TestServiceSettings.NAME,
+                TestStreamingCompletionServiceExtension.TestServiceSettings::new
             )
         );
     }

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestStreamingCompletionServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestStreamingCompletionServiceExtension.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.mock;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.inference.ChunkedInferenceServiceResults;
+import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.InferenceServiceExtension;
+import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Flow;
+
+import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResults.COMPLETION;
+
+public class TestStreamingCompletionServiceExtension implements InferenceServiceExtension {
+    @Override
+    public List<Factory> getInferenceServiceFactories() {
+        return List.of(TestInferenceService::new);
+    }
+
+    public static class TestInferenceService extends AbstractTestInferenceService {
+        private static final String NAME = "streaming_completion_test_service";
+        private static final Set<TaskType> supportedStreamingTasks = Set.of(TaskType.COMPLETION);
+
+        public TestInferenceService(InferenceServiceExtension.InferenceServiceFactoryContext context) {}
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+
+        @Override
+        protected ServiceSettings getServiceSettingsFromMap(Map<String, Object> serviceSettingsMap) {
+            return TestServiceSettings.fromMap(serviceSettingsMap);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void parseRequestConfig(
+            String modelId,
+            TaskType taskType,
+            Map<String, Object> config,
+            Set<String> platformArchitectures,
+            ActionListener<Model> parsedModelListener
+        ) {
+            var serviceSettingsMap = (Map<String, Object>) config.remove(ModelConfigurations.SERVICE_SETTINGS);
+            var serviceSettings = TestSparseInferenceServiceExtension.TestServiceSettings.fromMap(serviceSettingsMap);
+            var secretSettings = TestSecretSettings.fromMap(serviceSettingsMap);
+
+            var taskSettingsMap = getTaskSettingsMap(config);
+            var taskSettings = TestTaskSettings.fromMap(taskSettingsMap);
+
+            parsedModelListener.onResponse(new TestServiceModel(modelId, taskType, name(), serviceSettings, taskSettings, secretSettings));
+        }
+
+        @Override
+        public void infer(
+            Model model,
+            String query,
+            List<String> input,
+            Map<String, Object> taskSettings,
+            InputType inputType,
+            TimeValue timeout,
+            ActionListener<InferenceServiceResults> listener
+        ) {
+            switch (model.getConfigurations().getTaskType()) {
+                case COMPLETION -> listener.onResponse(makeResults(input));
+                default -> listener.onFailure(
+                    new ElasticsearchStatusException(
+                        TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            }
+        }
+
+        private StreamingChatCompletionResults makeResults(List<String> input) {
+            var responseIter = input.stream().map(String::toUpperCase).iterator();
+            return new StreamingChatCompletionResults(subscriber -> {
+                subscriber.onSubscribe(new Flow.Subscription() {
+                    @Override
+                    public void request(long n) {
+                        if (responseIter.hasNext()) {
+                            subscriber.onNext(completionChunk(responseIter.next()));
+                        } else {
+                            subscriber.onComplete();
+                        }
+                    }
+
+                    @Override
+                    public void cancel() {}
+                });
+            });
+        }
+
+        private ChunkedToXContent completionChunk(String delta) {
+            return params -> Iterators.concat(
+                ChunkedToXContentHelper.startObject(),
+                ChunkedToXContentHelper.startArray(COMPLETION),
+                ChunkedToXContentHelper.startObject(),
+                ChunkedToXContentHelper.field("delta", delta),
+                ChunkedToXContentHelper.endObject(),
+                ChunkedToXContentHelper.endArray(),
+                ChunkedToXContentHelper.endObject()
+            );
+        }
+
+        @Override
+        public void chunkedInfer(
+            Model model,
+            String query,
+            List<String> input,
+            Map<String, Object> taskSettings,
+            InputType inputType,
+            ChunkingOptions chunkingOptions,
+            TimeValue timeout,
+            ActionListener<List<ChunkedInferenceServiceResults>> listener
+        ) {
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    TaskType.unsupportedTaskTypeErrorMsg(model.getConfigurations().getTaskType(), name()),
+                    RestStatus.BAD_REQUEST
+                )
+            );
+        }
+
+        @Override
+        public Set<TaskType> supportedStreamingTasks() {
+            return supportedStreamingTasks;
+        }
+    }
+
+    public record TestServiceSettings(String modelId) implements ServiceSettings {
+        public static final String NAME = "streaming_completion_test_service_settings";
+
+        public TestServiceSettings(StreamInput in) throws IOException {
+            this(in.readString());
+        }
+
+        public static TestServiceSettings fromMap(Map<String, Object> map) {
+            var modelId = map.remove("model").toString();
+
+            if (modelId == null) {
+                ValidationException validationException = new ValidationException();
+                validationException.addValidationError("missing model id");
+                throw validationException;
+            }
+
+            return new TestServiceSettings(modelId);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return NAME;
+        }
+
+        @Override
+        public TransportVersion getMinimalSupportedVersion() {
+            return TransportVersion.current(); // fine for these tests but will not work for cluster upgrade tests
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(modelId());
+        }
+
+        @Override
+        public ToXContentObject getFilteredXContentObject() {
+            return this;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject().field("model", modelId()).endObject();
+        }
+    }
+}

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/resources/META-INF/services/org.elasticsearch.inference.InferenceServiceExtension
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/resources/META-INF/services/org.elasticsearch.inference.InferenceServiceExtension
@@ -1,3 +1,4 @@
 org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension
 org.elasticsearch.xpack.inference.mock.TestDenseInferenceServiceExtension
 org.elasticsearch.xpack.inference.mock.TestRerankingServiceExtension
+org.elasticsearch.xpack.inference.mock.TestStreamingCompletionServiceExtension

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -73,6 +73,7 @@ import org.elasticsearch.xpack.inference.rest.RestGetInferenceDiagnosticsAction;
 import org.elasticsearch.xpack.inference.rest.RestGetInferenceModelAction;
 import org.elasticsearch.xpack.inference.rest.RestInferenceAction;
 import org.elasticsearch.xpack.inference.rest.RestPutInferenceModelAction;
+import org.elasticsearch.xpack.inference.rest.RestStreamInferenceAction;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchService;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockService;
@@ -167,6 +168,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
     ) {
         return List.of(
             new RestInferenceAction(),
+            new RestStreamInferenceAction(),
             new RestGetInferenceModelAction(),
             new RestPutInferenceModelAction(),
             new RestDeleteInferenceEndpointAction(),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilder.java
@@ -204,7 +204,8 @@ public class SemanticQueryBuilder extends AbstractQueryBuilder<SemanticQueryBuil
                 List.of(query),
                 Map.of(),
                 InputType.SEARCH,
-                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API
+                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API,
+                false
             );
 
             queryRewriteContext.registerAsyncAction(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankFeaturePhaseRankCoordinatorContext.java
@@ -144,7 +144,8 @@ public class TextSimilarityRankFeaturePhaseRankCoordinatorContext extends RankFe
             docFeatures,
             Map.of(),
             InputType.SEARCH,
-            InferenceAction.Request.DEFAULT_TIMEOUT
+            InferenceAction.Request.DEFAULT_TIMEOUT,
+            false
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/BaseInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/BaseInferenceAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.rest;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+
+import java.io.IOException;
+
+import static org.elasticsearch.xpack.inference.rest.Paths.INFERENCE_ID;
+import static org.elasticsearch.xpack.inference.rest.Paths.TASK_TYPE_OR_INFERENCE_ID;
+
+abstract class BaseInferenceAction extends BaseRestHandler {
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String inferenceEntityId;
+        TaskType taskType;
+        if (restRequest.hasParam(INFERENCE_ID)) {
+            inferenceEntityId = restRequest.param(INFERENCE_ID);
+            taskType = TaskType.fromStringOrStatusException(restRequest.param(TASK_TYPE_OR_INFERENCE_ID));
+        } else {
+            inferenceEntityId = restRequest.param(TASK_TYPE_OR_INFERENCE_ID);
+            taskType = TaskType.ANY;
+        }
+
+        InferenceAction.Request.Builder requestBuilder;
+        try (var parser = restRequest.contentParser()) {
+            requestBuilder = InferenceAction.Request.parseRequest(inferenceEntityId, taskType, parser);
+        }
+
+        var inferTimeout = restRequest.paramAsTime(
+            InferenceAction.Request.TIMEOUT.getPreferredName(),
+            InferenceAction.Request.DEFAULT_TIMEOUT
+        );
+        requestBuilder.setInferenceTimeout(inferTimeout);
+        var request = prepareInferenceRequest(requestBuilder);
+        return channel -> client.execute(InferenceAction.INSTANCE, request, listener(channel));
+    }
+
+    protected InferenceAction.Request prepareInferenceRequest(InferenceAction.Request.Builder builder) {
+        return builder.build();
+    }
+
+    protected abstract ActionListener<InferenceAction.Response> listener(RestChannel channel);
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/Paths.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/Paths.java
@@ -15,6 +15,13 @@ public final class Paths {
     static final String TASK_TYPE_INFERENCE_ID_PATH = "_inference/{" + TASK_TYPE_OR_INFERENCE_ID + "}/{" + INFERENCE_ID + "}";
     static final String INFERENCE_DIAGNOSTICS_PATH = "_inference/.diagnostics";
 
+    static final String STREAM_INFERENCE_ID_PATH = "_inference/{" + TASK_TYPE_OR_INFERENCE_ID + "}/_stream";
+    static final String STREAM_TASK_TYPE_INFERENCE_ID_PATH = "_inference/{"
+        + TASK_TYPE_OR_INFERENCE_ID
+        + "}/{"
+        + INFERENCE_ID
+        + "}/_stream";
+
     private Paths() {
 
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestStreamInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestStreamInferenceAction.java
@@ -11,29 +11,33 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
-import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.xpack.inference.rest.Paths.INFERENCE_ID_PATH;
-import static org.elasticsearch.xpack.inference.rest.Paths.TASK_TYPE_INFERENCE_ID_PATH;
+import static org.elasticsearch.xpack.inference.rest.Paths.STREAM_INFERENCE_ID_PATH;
+import static org.elasticsearch.xpack.inference.rest.Paths.STREAM_TASK_TYPE_INFERENCE_ID_PATH;
 
 @ServerlessScope(Scope.PUBLIC)
-public class RestInferenceAction extends BaseInferenceAction {
+public class RestStreamInferenceAction extends BaseInferenceAction {
     @Override
     public String getName() {
-        return "inference_action";
+        return "stream_inference_action";
     }
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, INFERENCE_ID_PATH), new Route(POST, TASK_TYPE_INFERENCE_ID_PATH));
+        return List.of(new Route(POST, STREAM_INFERENCE_ID_PATH), new Route(POST, STREAM_TASK_TYPE_INFERENCE_ID_PATH));
+    }
+
+    @Override
+    protected InferenceAction.Request prepareInferenceRequest(InferenceAction.Request.Builder builder) {
+        return builder.setStream(true).build();
     }
 
     @Override
     protected ActionListener<InferenceAction.Response> listener(RestChannel channel) {
-        return new RestChunkedToXContentListener<>(channel);
+        return new ServerSentEventsRestActionListener(channel);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankTests.java
@@ -92,7 +92,8 @@ public class TextSimilarityRankTests extends ESSingleNodeTestCase {
                         docFeatures,
                         Map.of("inferenceResultCount", inferenceResultCount),
                         InputType.SEARCH,
-                        InferenceAction.Request.DEFAULT_TIMEOUT
+                        InferenceAction.Request.DEFAULT_TIMEOUT,
+                        false
                     );
                 }
             };

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityTestPlugin.java
@@ -312,7 +312,8 @@ public class TextSimilarityTestPlugin extends Plugin implements ActionPlugin {
                             docFeatures,
                             Map.of("throwing", true),
                             InputType.SEARCH,
-                            InferenceAction.Request.DEFAULT_TIMEOUT
+                            InferenceAction.Request.DEFAULT_TIMEOUT,
+                            false
                         );
                     }
                 };

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rest/BaseInferenceActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rest/BaseInferenceActionTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.rest;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+import org.elasticsearch.xpack.core.inference.results.InferenceTextEmbeddingByteResults;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class BaseInferenceActionTests extends RestActionTestCase {
+
+    @Before
+    public void setUpAction() {
+        controller().registerHandler(new BaseInferenceAction() {
+            @Override
+            protected ActionListener<InferenceAction.Response> listener(RestChannel channel) {
+                return new RestChunkedToXContentListener<>(channel);
+            }
+
+            @Override
+            public String getName() {
+                return "base_inference_action";
+            }
+
+            @Override
+            public List<Route> routes() {
+                return List.of(new Route(POST, route("{task_type_or_id}")));
+            }
+        });
+    }
+
+    private static String route(String param) {
+        return "_route/" + param;
+    }
+
+    public void testUsesDefaultTimeout() {
+        SetOnce<Boolean> executeCalled = new SetOnce<>();
+        verifyingClient.setExecuteVerifier(((actionType, actionRequest) -> {
+            assertThat(actionRequest, instanceOf(InferenceAction.Request.class));
+
+            var request = (InferenceAction.Request) actionRequest;
+            assertThat(request.getInferenceTimeout(), is(InferenceAction.Request.DEFAULT_TIMEOUT));
+
+            executeCalled.set(true);
+            return createResponse();
+        }));
+
+        RestRequest inferenceRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath(route("test"))
+            .withContent(new BytesArray("{}"), XContentType.JSON)
+            .build();
+        dispatchRequest(inferenceRequest);
+        assertThat(executeCalled.get(), equalTo(true));
+    }
+
+    public void testUses3SecondTimeoutFromParams() {
+        SetOnce<Boolean> executeCalled = new SetOnce<>();
+        verifyingClient.setExecuteVerifier(((actionType, actionRequest) -> {
+            assertThat(actionRequest, instanceOf(InferenceAction.Request.class));
+
+            var request = (InferenceAction.Request) actionRequest;
+            assertThat(request.getInferenceTimeout(), is(TimeValue.timeValueSeconds(3)));
+
+            executeCalled.set(true);
+            return createResponse();
+        }));
+
+        RestRequest inferenceRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath(route("test"))
+            .withParams(new HashMap<>(Map.of("timeout", "3s")))
+            .withContent(new BytesArray("{}"), XContentType.JSON)
+            .build();
+        dispatchRequest(inferenceRequest);
+        assertThat(executeCalled.get(), equalTo(true));
+    }
+
+    static InferenceAction.Response createResponse() {
+        return new InferenceAction.Response(
+            new InferenceTextEmbeddingByteResults(
+                List.of(new InferenceTextEmbeddingByteResults.InferenceByteEmbedding(new byte[] { (byte) -1 }))
+            )
+        );
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rest/RestStreamInferenceActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rest/RestStreamInferenceActionTests.java
@@ -21,27 +21,27 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestInferenceActionTests extends RestActionTestCase {
+public class RestStreamInferenceActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        controller().registerHandler(new RestInferenceAction());
+        controller().registerHandler(new RestStreamInferenceAction());
     }
 
-    public void testStreamIsFalse() {
+    public void testStreamIsTrue() {
         SetOnce<Boolean> executeCalled = new SetOnce<>();
         verifyingClient.setExecuteVerifier(((actionType, actionRequest) -> {
             assertThat(actionRequest, instanceOf(InferenceAction.Request.class));
 
             var request = (InferenceAction.Request) actionRequest;
-            assertThat(request.isStreaming(), is(false));
+            assertThat(request.isStreaming(), is(true));
 
             executeCalled.set(true);
             return createResponse();
         }));
 
         RestRequest inferenceRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
-            .withPath("_inference/test")
+            .withPath("_inference/test/_stream")
             .withContent(new BytesArray("{}"), XContentType.JSON)
             .build();
         dispatchRequest(inferenceRequest);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCoordinatedInferenceAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCoordinatedInferenceAction.java
@@ -126,7 +126,8 @@ public class TransportCoordinatedInferenceAction extends HandledTransportAction<
                 request.getInputs(),
                 request.getTaskSettings(),
                 inputType,
-                request.getInferenceTimeout()
+                request.getInferenceTimeout(),
+                false
             ),
             listener.delegateFailureAndWrap((l, r) -> l.onResponse(translateInferenceServiceResponse(r.getResults())))
         );


### PR DESCRIPTION
Create `POST _inference/<task>/<id>/_stream` and
`POST _inference/<id>/_stream` API.

REST Streaming API will reuse InferenceAction.
For now, all services and task types will return an HTTP 405 status code and error message.

This is a backport of https://github.com/elastic/elasticsearch/commit/1565c314711908d13fa074c663d1ead6a8b7fc16
