### PR TITLE
Add ensureGreen test method for use with adminClient

### DIFF
--- a/docs/changelog/113425.yaml
+++ b/docs/changelog/113425.yaml
@@ -1,0 +1,5 @@
+pr: 113425
+summary: Add `ensureGreen` test method for use with `adminClient`
+area: Infra/Metrics
+type: enhancement
+issues: []

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1721,7 +1721,11 @@ public abstract class ESRestTestCase extends ESTestCase {
      * @param index index to test for
      **/
     public final void ensureGreen(String index) throws IOException {
-        ensureHealth(index, (request) -> {
+        ensureGreen(client(), index);
+    }
+
+    public final void ensureGreen(RestClient client, String index) throws IOException {
+        ensureHealth(client, index, (request) -> {
             request.addParameter("wait_for_status", "green");
             request.addParameter("wait_for_no_relocating_shards", "true");
             final String ensureGreenTimeout = getEnsureGreenTimeout();

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -404,4 +404,9 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
     private static void resumeIndexFollowing(RestClient client, String followerIndex) throws IOException {
         assertOK(client.performRequest(new Request("POST", "/" + followerIndex + "/_ccr/resume_follow")));
     }
+
+    @Override
+    protected final String getEnsureGreenTimeout() {
+        return "70s";
+    }
 }

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -404,14 +404,4 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
     private static void resumeIndexFollowing(RestClient client, String followerIndex) throws IOException {
         assertOK(client.performRequest(new Request("POST", "/" + followerIndex + "/_ccr/resume_follow")));
     }
-
-    private static void ensureGreen(RestClient client, String index) throws IOException {
-        Request request = new Request("GET", "/_cluster/health/" + index);
-        request.addParameter("wait_for_status", "green");
-        request.addParameter("wait_for_no_relocating_shards", "true");
-        request.addParameter("timeout", "70s");
-        request.addParameter("level", "shards");
-        client.performRequest(request);
-    }
-
 }


### PR DESCRIPTION
Current ensureGreen method uses client() directly. Add another version that accepts any RestClient, so can be used with adminClient()