### PR TITLE
[8.x] Change default locale of date processors to ENGLISH (#112796)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -98,7 +98,7 @@ public final class DateProcessor extends AbstractProcessor {
     }
 
     private static Locale newLocale(String locale) {
-        return locale == null ? Locale.ROOT : LocaleUtils.parse(locale);
+        return locale == null ? Locale.ENGLISH : LocaleUtils.parse(locale);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Change default locale of date processors to ENGLISH (#112796)