### PR TITLE
Prepare for making `UpdateSettingsClusterStateUpdateRequest` a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
@@ -11,6 +11,8 @@ package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
 
 import java.util.Arrays;
 
@@ -19,11 +21,62 @@ import java.util.Arrays;
  */
 public class UpdateSettingsClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<UpdateSettingsClusterStateUpdateRequest> {
 
+    /**
+     * Specifies the behaviour of an update-settings action on existing settings.
+     */
+    public enum OnExisting {
+        /**
+         * Update all the specified settings, overwriting any settings which already exist. This is the API default.
+         */
+        OVERWRITE,
+
+        /**
+         * Only add new settings, preserving the values of any settings which are already set and ignoring the new values specified in the
+         * request.
+         */
+        PRESERVE
+    }
+
+    /**
+     * Specifies the behaviour of an update-settings action which is trying to adjust a non-dynamic setting.
+     */
+    public enum OnStaticSetting {
+        /**
+         * Reject attempts to update non-dynamic settings on open indices. This is the API default.
+         */
+        REJECT,
+
+        /**
+         * Automatically close and reopen the shards of any open indices when updating a non-dynamic setting, forcing the shard to
+         * reinitialize from scratch.
+         */
+        REOPEN_INDICES
+    }
+
     private Settings settings;
 
     private boolean preserveExisting = false;
 
     private boolean reopenShards = false;
+
+    public UpdateSettingsClusterStateUpdateRequest() {}
+
+    @SuppressWarnings("this-escape")
+    public UpdateSettingsClusterStateUpdateRequest(
+        TimeValue masterNodeTimeout,
+        TimeValue ackTimeout,
+        Settings settings,
+        OnExisting onExisting,
+        OnStaticSetting onStaticSetting,
+        Index... indices
+    ) {
+        masterNodeTimeout(masterNodeTimeout);
+        ackTimeout(ackTimeout);
+        settings(settings);
+        setPreserveExisting(onExisting == OnExisting.PRESERVE);
+        reopenShards(onStaticSetting == OnStaticSetting.REOPEN_INDICES);
+        indices(indices);
+    }
 
     /**
      * Returns <code>true</code> iff the settings update should only add but not update settings. If the setting already exists


### PR DESCRIPTION
A preliminary PR to maintain source compatibility while the serverless
change is still in flight. See #113432 or #113353 for the actual change.