### PR TITLE
Forbid `null` ack timeouts

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/AckedClusterStateUpdateTask.java
@@ -15,6 +15,8 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.TimeValue;
 
+import java.util.Objects;
+
 /**
  * An extension interface to {@link ClusterStateUpdateTask} that allows the caller to be notified after the master has
  * computed, published, accepted, committed, and applied the cluster state update AND only after the rest of the nodes
@@ -54,7 +56,7 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
     ) {
         super(priority, masterNodeTimeout);
         this.listener = (ActionListener<AcknowledgedResponse>) listener;
-        this.ackTimeout = ackTimeout;
+        this.ackTimeout = Objects.requireNonNull(ackTimeout);
     }
 
     /**
@@ -81,10 +83,6 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
         return AcknowledgedResponse.of(acknowledged);
     }
 
-    /**
-     * Called once the acknowledgement timeout defined by
-     * {@link AckedClusterStateUpdateTask#ackTimeout()} has expired
-     */
     public void onAckTimeout() {
         listener.onResponse(newResponse(false));
     }
@@ -94,9 +92,6 @@ public abstract class AckedClusterStateUpdateTask extends ClusterStateUpdateTask
         listener.onFailure(e);
     }
 
-    /**
-     * Acknowledgement timeout, maximum time interval to wait for acknowledgements
-     */
     public final TimeValue ackTimeout() {
         return ackTimeout;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateAckListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateAckListener.java
@@ -20,39 +20,37 @@ import org.elasticsearch.core.TimeValue;
 public interface ClusterStateAckListener {
 
     /**
-     * Called to determine which nodes the acknowledgement is expected from.
+     * Called to determine the nodes from which an acknowledgement is expected.
+     * <p>
+     * This method will be called multiple times to determine the set of acking nodes, so it is crucial for it to return consistent results:
+     * Given the same listener instance and the same node parameter, the method implementation should return the same result.
      *
-     * As this method will be called multiple times to determine the set of acking nodes,
-     * it is crucial for it to return consistent results: Given the same listener instance
-     * and the same node parameter, the method implementation should return the same result.
-     *
-     * @param discoveryNode a node
-     * @return true if the node is expected to send ack back, false otherwise
+     * @return {@code true} if and only if this task will wait for an ack from the given node.
      */
     boolean mustAck(DiscoveryNode discoveryNode);
 
     /**
-     * Called once all the nodes have acknowledged the cluster state update request. Must be
-     * very lightweight execution, since it gets executed on the cluster service thread.
+     * Called once all the selected nodes have acknowledged the cluster state update request. Must be very lightweight execution, since it
+     * is executed on the cluster service thread.
      */
     void onAllNodesAcked();
 
     /**
-     * Called after all the nodes have acknowledged the cluster state update request but at least one of them failed. Must be
-     * very lightweight execution, since it gets executed on the cluster service thread.
+     * Called after all the nodes have acknowledged the cluster state update request but at least one of them failed. Must be very
+     * lightweight execution, since it is executed on the cluster service thread.
      *
-     * @param e optional error that might have been thrown
+     * @param e exception representing the failure.
      */
     void onAckFailure(Exception e);
 
     /**
-     * Called once the acknowledgement timeout defined by
-     * {@link AckedClusterStateUpdateTask#ackTimeout()} has expired
+     * Called if the acknowledgement timeout defined by {@link ClusterStateAckListener#ackTimeout()} expires while still waiting for acks.
      */
     void onAckTimeout();
 
     /**
-     * @return acknowledgement timeout, maximum time interval to wait for acknowledgements
+     * @return acknowledgement timeout, i.e. the maximum time interval to wait for acknowledgements. Return {@link TimeValue#MINUS_ONE} if
+     *         the request should wait indefinitely for acknowledgements.
      */
     TimeValue ackTimeout();
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterServiceTaskQueue.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterServiceTaskQueue.java
@@ -36,6 +36,9 @@ public interface MasterServiceTaskQueue<T extends ClusterStateTaskListener> {
      *                ?master_timeout}, which is typically available from {@link MasterNodeRequest#masterNodeTimeout()}. Tasks that
      *                correspond with internal actions should normally have no timeout since it is usually better to wait patiently in the
      *                queue until processed rather than to fail, especially if the only reasonable reaction to a failure is to retry.
+     *                <p>
+     *                The values {@code null} and {@link MasterNodeRequest#INFINITE_MASTER_NODE_TIMEOUT} (i.e. {@link TimeValue#MINUS_ONE})
+     *                both indicate that the task should never time out.
      */
     void submitTask(String source, T task, @Nullable TimeValue timeout);
 }


### PR DESCRIPTION
We've asserted that `ackTimeout` is non-null for a while now without
issues, so this commit adds code to enforce this invariant.