### PR TITLE
Add to SearchUsages queries generated by the vector tiles API

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/VectorTilePlugin.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/VectorTilePlugin.java
@@ -45,6 +45,6 @@ public class VectorTilePlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        return List.of(new RestVectorTileAction());
+        return List.of(new RestVectorTileAction(restController.getSearchUsageHolder()));
     }
 }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -212,7 +212,6 @@ public class RestVectorTileAction extends BaseRestHandler {
         searchRequestBuilder.setRuntimeMappings(runtimeMappings);
         // For Hex aggregation we might need to buffer the bounding box
         final Rectangle boxFilter = request.getGridAgg().bufferTile(request.getBoundingBox(), request.getZ(), request.getGridPrecision());
-
         QueryBuilder qBuilder = QueryBuilders.geoShapeQuery(request.getField(), boxFilter);
         if (request.getQueryBuilder() != null) {
             final BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -108,7 +108,7 @@ public class RestVectorTileAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         // This will allow to cancel the search request if the http channel is closed
         final RestCancellableNodeClient cancellableNodeClient = new RestCancellableNodeClient(client, restRequest.getHttpChannel());
-        final VectorTileRequest request = VectorTileRequest.parseRestRequest(restRequest, searchUsageHolder);
+        final VectorTileRequest request = VectorTileRequest.parseRestRequest(restRequest, searchUsageHolder::updateUsage);
         final SearchRequestBuilder searchRequestBuilder = searchRequestBuilder(cancellableNodeClient, request);
         return channel -> searchRequestBuilder.execute(new RestResponseListener<>(channel) {
 

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuil
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
 
 import java.io.IOException;
@@ -87,7 +88,11 @@ public class RestVectorTileAction extends BaseRestHandler {
     // internal label position runtime field name
     static final String LABEL_POSITION_FIELD_NAME = INTERNAL_AGG_PREFIX + "label_position";
 
-    public RestVectorTileAction() {}
+    private final SearchUsageHolder searchUsageHolder;
+
+    public RestVectorTileAction(SearchUsageHolder searchUsageHolder) {
+        this.searchUsageHolder = searchUsageHolder;
+    }
 
     @Override
     public List<Route> routes() {
@@ -103,7 +108,7 @@ public class RestVectorTileAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         // This will allow to cancel the search request if the http channel is closed
         final RestCancellableNodeClient cancellableNodeClient = new RestCancellableNodeClient(client, restRequest.getHttpChannel());
-        final VectorTileRequest request = VectorTileRequest.parseRestRequest(restRequest);
+        final VectorTileRequest request = VectorTileRequest.parseRestRequest(restRequest, searchUsageHolder);
         final SearchRequestBuilder searchRequestBuilder = searchRequestBuilder(cancellableNodeClient, request);
         return channel -> searchRequestBuilder.execute(new RestResponseListener<>(channel) {
 
@@ -207,6 +212,7 @@ public class RestVectorTileAction extends BaseRestHandler {
         searchRequestBuilder.setRuntimeMappings(runtimeMappings);
         // For Hex aggregation we might need to buffer the bounding box
         final Rectangle boxFilter = request.getGridAgg().bufferTile(request.getBoundingBox(), request.getZ(), request.getGridPrecision());
+
         QueryBuilder qBuilder = QueryBuilders.geoShapeQuery(request.getField(), boxFilter);
         if (request.getQueryBuilder() != null) {
             final BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.usage.SearchUsage;
-import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -133,7 +133,7 @@ class VectorTileRequest {
         }, SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD, ObjectParser.ValueType.VALUE);
     }
 
-    static VectorTileRequest parseRestRequest(RestRequest restRequest, SearchUsageHolder searchUsageHolder) throws IOException {
+    static VectorTileRequest parseRestRequest(RestRequest restRequest, Consumer<SearchUsage> searchUsageConsumer) throws IOException {
         final VectorTileRequest request = new VectorTileRequest(
             Strings.splitStringByCommaToArray(restRequest.param(INDEX_PARAM)),
             restRequest.param(FIELD_PARAM),
@@ -149,7 +149,7 @@ class VectorTileRequest {
         }
         // The API generates a query on the fly that we track here.
         searchUsage.trackQueryUsage(GeoShapeQueryBuilder.NAME);
-        searchUsageHolder.updateUsage(searchUsage);
+        searchUsageConsumer.accept(searchUsage);
         // Following the same strategy of the _search API, some parameters can be defined in the body or as URL parameters.
         // URL parameters takes precedence so we check them here.
         if (restRequest.hasParam(SearchSourceBuilder.SIZE_FIELD.getPreferredName())) {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.geo.SimpleVectorTileFormatter;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.script.Script;
@@ -25,6 +26,8 @@ import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.usage.SearchUsage;
+import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
@@ -75,7 +78,7 @@ class VectorTileRequest {
         public static final int TRACK_TOTAL_HITS_UP_TO = DEFAULT_TRACK_TOTAL_HITS_UP_TO;
     }
 
-    private static final ObjectParser<VectorTileRequest, RestRequest> PARSER;
+    private static final ObjectParser<VectorTileRequest, SearchUsage> PARSER;
 
     static {
         PARSER = new ObjectParser<>("vector-tile");
@@ -89,7 +92,7 @@ class VectorTileRequest {
         }, SearchSourceBuilder.FETCH_FIELDS_FIELD, ObjectParser.ValueType.OBJECT_ARRAY);
         PARSER.declareField(
             VectorTileRequest::setQueryBuilder,
-            (p, c) -> AbstractQueryBuilder.parseTopLevelQuery(p),
+            (p, c) -> AbstractQueryBuilder.parseTopLevelQuery(p, c::trackQueryUsage),
             SearchSourceBuilder.QUERY_FIELD,
             ObjectParser.ValueType.OBJECT
         );
@@ -130,7 +133,7 @@ class VectorTileRequest {
         }, SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD, ObjectParser.ValueType.VALUE);
     }
 
-    static VectorTileRequest parseRestRequest(RestRequest restRequest) throws IOException {
+    static VectorTileRequest parseRestRequest(RestRequest restRequest, SearchUsageHolder searchUsageHolder) throws IOException {
         final VectorTileRequest request = new VectorTileRequest(
             Strings.splitStringByCommaToArray(restRequest.param(INDEX_PARAM)),
             restRequest.param(FIELD_PARAM),
@@ -138,11 +141,15 @@ class VectorTileRequest {
             Integer.parseInt(restRequest.param(X_PARAM)),
             Integer.parseInt(restRequest.param(Y_PARAM))
         );
+        final SearchUsage searchUsage = new SearchUsage();
         if (restRequest.hasContentOrSourceParam()) {
             try (XContentParser contentParser = restRequest.contentOrSourceParamParser()) {
-                PARSER.parse(contentParser, request, restRequest);
+                PARSER.parse(contentParser, request, searchUsage);
             }
         }
+        // The API generates a query on the fly that we track here.
+        searchUsage.trackQueryUsage(GeoShapeQueryBuilder.NAME);
+        searchUsageHolder.updateUsage(searchUsage);
         // Following the same strategy of the _search API, some parameters can be defined in the body or as URL parameters.
         // URL parameters takes precedence so we check them here.
         if (restRequest.hasParam(SearchSourceBuilder.SIZE_FIELD.getPreferredName())) {

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
@@ -231,7 +231,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Invalid geotile_grid precision of " + z + ". Must be between 0 and 29."));
         }
@@ -243,7 +243,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Invalid geotile_grid precision of " + z + ". Must be between 0 and 29."));
         }
@@ -255,7 +255,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -267,7 +267,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -279,7 +279,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -291,7 +291,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -310,7 +310,7 @@ public class VectorTileRequestTests extends ESTestCase {
         consumer.accept(builder);
         builder.endObject();
         final FakeRestRequest request = requestBuilder.withContent(BytesReference.bytes(builder), builder.contentType()).build();
-        final VectorTileRequest vectorTileRequest = VectorTileRequest.parseRestRequest(request);
+        final VectorTileRequest vectorTileRequest = VectorTileRequest.parseRestRequest(request, s -> {});
         assertThat(vectorTileRequest.getIndexes(), Matchers.equalTo(new String[] { index }));
         assertThat(vectorTileRequest.getField(), Matchers.equalTo(field));
         assertThat(vectorTileRequest.getZ(), Matchers.equalTo(z));


### PR DESCRIPTION
It is possible to get the current the type of queries and how many times the queries has been executed in a cluster by executing the following API command:

```
GET /_cluster/stats?filter_path=indices.search.queries
```

This stats are collected when parsing the search request.

This is not true for the vector tiles search API as it has their own parser and it is not registering their usage. Therefore to be consistent with the search API, let's register the queries used via the vector tiles API.
