### PR TITLE
Make `UpdateSettingsClusterStateUpdateRequest` a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
@@ -9,17 +9,23 @@
 
 package org.elasticsearch.action.admin.indices.settings.put;
 
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 
-import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Cluster state update request that allows to update settings for some indices
  */
-public class UpdateSettingsClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<UpdateSettingsClusterStateUpdateRequest> {
+public record UpdateSettingsClusterStateUpdateRequest(
+    TimeValue masterNodeTimeout,
+    TimeValue ackTimeout,
+    Settings settings,
+    OnExisting onExisting,
+    OnStaticSetting onStaticSetting,
+    Index... indices
+) {
 
     /**
      * Specifies the behaviour of an update-settings action on existing settings.
@@ -53,79 +59,10 @@ public class UpdateSettingsClusterStateUpdateRequest extends IndicesClusterState
         REOPEN_INDICES
     }
 
-    private Settings settings;
-
-    private boolean preserveExisting = false;
-
-    private boolean reopenShards = false;
-
-    public UpdateSettingsClusterStateUpdateRequest() {}
-
-    @SuppressWarnings("this-escape")
-    public UpdateSettingsClusterStateUpdateRequest(
-        TimeValue masterNodeTimeout,
-        TimeValue ackTimeout,
-        Settings settings,
-        OnExisting onExisting,
-        OnStaticSetting onStaticSetting,
-        Index... indices
-    ) {
-        masterNodeTimeout(masterNodeTimeout);
-        ackTimeout(ackTimeout);
-        settings(settings);
-        setPreserveExisting(onExisting == OnExisting.PRESERVE);
-        reopenShards(onStaticSetting == OnStaticSetting.REOPEN_INDICES);
-        indices(indices);
-    }
-
-    /**
-     * Returns <code>true</code> iff the settings update should only add but not update settings. If the setting already exists
-     * it should not be overwritten by this update. The default is <code>false</code>
-     */
-    public boolean isPreserveExisting() {
-        return preserveExisting;
-    }
-
-    /**
-     * Returns <code>true</code> if non-dynamic setting updates should go through, by automatically unassigning shards in the same cluster
-     * state change as the setting update. The shards will be automatically reassigned after the cluster state update is made. The
-     * default is <code>false</code>.
-     */
-    public boolean reopenShards() {
-        return reopenShards;
-    }
-
-    public UpdateSettingsClusterStateUpdateRequest reopenShards(boolean reopenShards) {
-        this.reopenShards = reopenShards;
-        return this;
-    }
-
-    /**
-     * Iff set to <code>true</code> this settings update will only add settings not already set on an index. Existing settings remain
-     * unchanged.
-     */
-    public UpdateSettingsClusterStateUpdateRequest setPreserveExisting(boolean preserveExisting) {
-        this.preserveExisting = preserveExisting;
-        return this;
-    }
-
-    /**
-     * Returns the {@link Settings} to update
-     */
-    public Settings settings() {
-        return settings;
-    }
-
-    /**
-     * Sets the {@link Settings} to update
-     */
-    public UpdateSettingsClusterStateUpdateRequest settings(Settings settings) {
-        this.settings = settings;
-        return this;
-    }
-
-    @Override
-    public String toString() {
-        return Arrays.toString(indices()) + settings;
+    public UpdateSettingsClusterStateUpdateRequest {
+        Objects.requireNonNull(masterNodeTimeout);
+        Objects.requireNonNull(ackTimeout);
+        Objects.requireNonNull(settings);
+        Objects.requireNonNull(indices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -176,7 +176,7 @@ public class MetadataUpdateSettingsService {
             }
             final Settings closedSettings = settingsForClosedIndices.build();
             final Settings openSettings = settingsForOpenIndices.build();
-            final boolean preserveExisting = request.isPreserveExisting();
+            final boolean preserveExisting = request.onExisting() == UpdateSettingsClusterStateUpdateRequest.OnExisting.PRESERVE;
 
             RoutingTable.Builder routingTableBuilder = null;
             Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
@@ -199,7 +199,7 @@ public class MetadataUpdateSettingsService {
             }
 
             if (skippedSettings.isEmpty() == false && openIndices.isEmpty() == false) {
-                if (request.reopenShards()) {
+                if (request.onStaticSetting() == UpdateSettingsClusterStateUpdateRequest.OnStaticSetting.REOPEN_INDICES) {
                     // We have non-dynamic settings and open indices. We will unassign all of the shards in these indices so that the new
                     // changed settings are applied when the shards are re-assigned.
                     routingTableBuilder = RoutingTable.builder(

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpda
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsClusterStateUpdateRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
@@ -537,11 +538,18 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
      */
     private void setWriteBlock(Index index, boolean readOnlyValue, ActionListener<AcknowledgedResponse> listener) {
         final Settings readOnlySettings = Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), readOnlyValue).build();
-        UpdateSettingsClusterStateUpdateRequest updateSettingsRequest = new UpdateSettingsClusterStateUpdateRequest().indices(
-            new Index[] { index }
-        ).settings(readOnlySettings).setPreserveExisting(false).ackTimeout(TimeValue.ZERO);
 
-        metadataUpdateSettingsService.updateSettings(updateSettingsRequest, listener);
+        metadataUpdateSettingsService.updateSettings(
+            new UpdateSettingsClusterStateUpdateRequest(
+                MasterNodeRequest.INFINITE_MASTER_NODE_TIMEOUT,
+                TimeValue.ZERO,
+                readOnlySettings,
+                UpdateSettingsClusterStateUpdateRequest.OnExisting.OVERWRITE,
+                UpdateSettingsClusterStateUpdateRequest.OnStaticSetting.REJECT,
+                index
+            ),
+            listener
+        );
     }
 
     private void reindex(SystemIndexMigrationInfo migrationInfo, ActionListener<BulkByScrollResponse> listener) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/settings/TransportUpdateSecuritySettingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/settings/TransportUpdateSecuritySettingsAction.java
@@ -119,8 +119,8 @@ public class TransportUpdateSecuritySettingsAction extends TransportMasterNodeAc
     private Optional<UpdateSettingsClusterStateUpdateRequest> createUpdateSettingsRequest(
         String indexName,
         Settings settingsToUpdate,
-        TimeValue timeout,
-        TimeValue masterTimeout,
+        TimeValue ackTimeout,
+        TimeValue masterNodeTimeout,
         ClusterState state
     ) {
         if (settingsToUpdate.isEmpty()) {
@@ -136,10 +136,14 @@ public class TransportUpdateSecuritySettingsAction extends TransportMasterNodeAc
         }
 
         return Optional.of(
-            new UpdateSettingsClusterStateUpdateRequest().indices(new Index[] { writeIndex })
-                .settings(settingsToUpdate)
-                .ackTimeout(timeout)
-                .masterNodeTimeout(masterTimeout)
+            new UpdateSettingsClusterStateUpdateRequest(
+                masterNodeTimeout,
+                ackTimeout,
+                settingsToUpdate,
+                UpdateSettingsClusterStateUpdateRequest.OnExisting.OVERWRITE,
+                UpdateSettingsClusterStateUpdateRequest.OnStaticSetting.REJECT,
+                writeIndex
+            )
         );
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportUpdateWatcherSettingsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportUpdateWatcherSettingsAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -91,9 +90,14 @@ public class TransportUpdateWatcherSettingsAction extends TransportMasterNodeAct
             return;
         }
         final Settings newSettings = Settings.builder().loadFromMap(request.settings()).build();
-        final UpdateSettingsClusterStateUpdateRequest clusterStateUpdateRequest = new UpdateSettingsClusterStateUpdateRequest().indices(
-            new Index[] { watcherIndexMd.getIndex() }
-        ).settings(newSettings).ackTimeout(request.ackTimeout()).masterNodeTimeout(request.masterNodeTimeout());
+        final UpdateSettingsClusterStateUpdateRequest clusterStateUpdateRequest = new UpdateSettingsClusterStateUpdateRequest(
+            request.masterNodeTimeout(),
+            request.ackTimeout(),
+            newSettings,
+            UpdateSettingsClusterStateUpdateRequest.OnExisting.OVERWRITE,
+            UpdateSettingsClusterStateUpdateRequest.OnStaticSetting.REJECT,
+            watcherIndexMd.getIndex()
+        );
 
         updateSettingsService.updateSettings(clusterStateUpdateRequest, new ActionListener<>() {
             @Override


### PR DESCRIPTION
No need to extend `IndicesClusterStateUpdateRequest`, this thing can be
completely immutable.