### PR TITLE
Expose `Connection` to remote clusters

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/ParentTaskAssigningClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ParentTaskAssigningClient.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.util.concurrent.Executor;
@@ -75,12 +76,18 @@ public class ParentTaskAssigningClient extends FilterClient {
         return new RemoteClusterClient() {
             @Override
             public <Request extends ActionRequest, Response extends TransportResponse> void execute(
+                Transport.Connection connection,
                 RemoteClusterActionType<Response> action,
                 Request request,
                 ActionListener<Response> listener
             ) {
                 request.setParentTask(parentTask);
-                delegate.execute(action, request, listener);
+                delegate.execute(connection, action, request, listener);
+            }
+
+            @Override
+            public <Request extends ActionRequest> void getConnection(Request request, ActionListener<Transport.Connection> listener) {
+                delegate.getConnection(request, listener);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.RemoteClusterActionType;
-import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportResponse;
@@ -30,9 +29,10 @@ public interface RemoteClusterClient {
         Request request,
         ActionListener<Response> listener
     ) {
-        SubscribableListener.<Transport.Connection>newForked(connectionListener -> getConnection(request, connectionListener))
-            .<Response>andThen((responseListener, connection) -> execute(connection, action, request, responseListener))
-            .addListener(listener);
+        getConnection(
+            request,
+            listener.delegateFailureAndWrap((responseListener, connection) -> execute(connection, action, request, responseListener))
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
@@ -13,6 +13,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.RemoteClusterActionType;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportResponse;
 
 /**
@@ -21,16 +24,30 @@ import org.elasticsearch.transport.TransportResponse;
 public interface RemoteClusterClient {
     /**
      * Executes an action, denoted by an {@link ActionType}, on the remote cluster.
-     *
-     * @param action           The action type to execute.
-     * @param request          The action request.
-     * @param listener         A listener for the response
-     * @param <Request>        The request type.
-     * @param <Response>       the response type.
+     */
+    default <Request extends ActionRequest, Response extends TransportResponse> void execute(
+        RemoteClusterActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    ) {
+        SubscribableListener.<Transport.Connection>newForked(connectionListener -> getConnection(request, connectionListener))
+            .<Response>andThen((responseListener, connection) -> execute(connection, action, request, responseListener))
+            .addListener(listener);
+    }
+
+    /**
+     * Executes an action, denoted by an {@link ActionType}, using a connection to the remote cluster obtained using {@link #getConnection}.
      */
     <Request extends ActionRequest, Response extends TransportResponse> void execute(
+        Transport.Connection connection,
         RemoteClusterActionType<Response> action,
         Request request,
         ActionListener<Response> listener
     );
+
+    /**
+     * Obtain a connection to the remote cluster for use with the {@link #execute} override that allows to specify the connection. Useful
+     * for cases where you need to inspect {@link Transport.Connection#getVersion} before deciding the exact remote action to invoke.
+     */
+    <Request extends ActionRequest> void getConnection(@Nullable Request request, ActionListener<Transport.Connection> listener);
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -12,8 +12,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.RemoteClusterActionType;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.RemoteClusterClient;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.core.Nullable;
 
 import java.util.concurrent.Executor;
 
@@ -35,41 +36,48 @@ final class RemoteClusterAwareClient implements RemoteClusterClient {
 
     @Override
     public <Request extends ActionRequest, Response extends TransportResponse> void execute(
+        Transport.Connection connection,
         RemoteClusterActionType<Response> action,
         Request request,
         ActionListener<Response> listener
     ) {
-        maybeEnsureConnected(listener.delegateFailureAndWrap((delegateListener, v) -> {
-            final Transport.Connection connection;
-            try {
-                if (request instanceof RemoteClusterAwareRequest) {
-                    DiscoveryNode preferredTargetNode = ((RemoteClusterAwareRequest) request).getPreferredTargetNode();
-                    connection = remoteClusterService.getConnection(preferredTargetNode, clusterAlias);
-                } else {
-                    connection = remoteClusterService.getConnection(clusterAlias);
-                }
-            } catch (ConnectTransportException e) {
-                if (ensureConnected == false) {
-                    // trigger another connection attempt, but don't wait for it to complete
-                    remoteClusterService.ensureConnected(clusterAlias, ActionListener.noop());
-                }
-                throw e;
-            }
-            service.sendRequest(
-                connection,
-                action.name(),
-                request,
-                TransportRequestOptions.EMPTY,
-                new ActionListenerResponseHandler<>(delegateListener, action.getResponseReader(), responseExecutor)
-            );
-        }));
+        service.sendRequest(
+            connection,
+            action.name(),
+            request,
+            TransportRequestOptions.EMPTY,
+            new ActionListenerResponseHandler<>(listener, action.getResponseReader(), responseExecutor)
+        );
     }
 
-    private void maybeEnsureConnected(ActionListener<Void> ensureConnectedListener) {
-        if (ensureConnected) {
-            ActionListener.run(ensureConnectedListener, l -> remoteClusterService.ensureConnected(clusterAlias, l));
-        } else {
-            ensureConnectedListener.onResponse(null);
-        }
+    @Override
+    public <Request extends ActionRequest> void getConnection(@Nullable Request request, ActionListener<Transport.Connection> listener) {
+        SubscribableListener
+
+            .<Void>newForked(ensureConnectedListener -> {
+                if (ensureConnected) {
+                    remoteClusterService.ensureConnected(clusterAlias, ensureConnectedListener);
+                } else {
+                    ensureConnectedListener.onResponse(null);
+                }
+            })
+
+            .andThenApply(ignored -> {
+                try {
+                    if (request instanceof RemoteClusterAwareRequest remoteClusterAwareRequest) {
+                        return remoteClusterService.getConnection(remoteClusterAwareRequest.getPreferredTargetNode(), clusterAlias);
+                    } else {
+                        return remoteClusterService.getConnection(clusterAlias);
+                    }
+                } catch (ConnectTransportException e) {
+                    if (ensureConnected == false) {
+                        // trigger another connection attempt, but don't wait for it to complete
+                        remoteClusterService.ensureConnected(clusterAlias, ActionListener.noop());
+                    }
+                    throw e;
+                }
+            })
+
+            .addListener(listener);
     }
 }

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.util.concurrent.Executor;
@@ -83,6 +84,24 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
                             assertSame(parentTaskId, request.getParentTask());
                             listener.onFailure(new UnsupportedOperationException("fake remote-cluster client"));
                         }
+
+                        @Override
+                        public <Request extends ActionRequest, Response extends TransportResponse> void execute(
+                            Transport.Connection connection,
+                            RemoteClusterActionType<Response> action,
+                            Request request,
+                            ActionListener<Response> listener
+                        ) {
+                            execute(action, request, listener);
+                        }
+
+                        @Override
+                        public <Request extends ActionRequest> void getConnection(
+                            Request request,
+                            ActionListener<Transport.Connection> listener
+                        ) {
+                            fail("should not be called");
+                        }
                     };
                 }
             };
@@ -100,6 +119,22 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
                     safeAwaitFailure(
                         ClusterStateResponse.class,
                         listener -> remoteClusterClient.execute(
+                            ClusterStateAction.REMOTE_TYPE,
+                            new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                            listener
+                        )
+                    )
+                ).getMessage()
+            );
+
+            assertEquals(
+                "fake remote-cluster client",
+                asInstanceOf(
+                    UnsupportedOperationException.class,
+                    safeAwaitFailure(
+                        ClusterStateResponse.class,
+                        listener -> remoteClusterClient.execute(
+                            null,
                             ClusterStateAction.REMOTE_TYPE,
                             new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
                             listener

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -100,7 +100,7 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
                             Request request,
                             ActionListener<Transport.Connection> listener
                         ) {
-                            fail("should not be called");
+                            listener.onResponse(null);
                         }
                     };
                 }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.search.TransportSearchScrollAction;
-import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -103,13 +103,25 @@ public class RemoteClusterClientTests extends ESTestCase {
                     randomFrom(RemoteClusterService.DisconnectedStrategy.values())
                 );
                 ClusterStateResponse clusterStateResponse = safeAwait(
-                    listener -> client.execute(
-                        ClusterStateAction.REMOTE_TYPE,
-                        new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                    listener -> ActionListener.run(
                         ActionListener.runBefore(
                             listener,
                             () -> assertTrue(Thread.currentThread().getName().contains('[' + TEST_THREAD_POOL_NAME + ']'))
-                        )
+                        ),
+                        clusterStateResponseListener -> {
+                            final var request = new ClusterStateRequest(TEST_REQUEST_TIMEOUT);
+                            if (randomBoolean()) {
+                                client.execute(ClusterStateAction.REMOTE_TYPE, request, clusterStateResponseListener);
+                            } else {
+                                SubscribableListener.<Transport.Connection>newForked(
+                                    l -> client.getConnection(randomFrom(request, null), l)
+                                )
+                                    .<ClusterStateResponse>andThen(
+                                        (l, connection) -> client.execute(connection, ClusterStateAction.REMOTE_TYPE, request, l)
+                                    )
+                                    .addListener(clusterStateResponseListener);
+                            }
+                        }
                     )
                 );
                 assertNotNull(clusterStateResponse);
@@ -169,12 +181,13 @@ public class RemoteClusterClientTests extends ESTestCase {
                 for (int i = 0; i < 10; i++) {
                     RemoteClusterConnection remoteClusterConnection = remoteClusterService.getRemoteClusterConnection("test");
                     assertBusy(remoteClusterConnection::assertNoRunningConnections);
-                    ConnectionManager connectionManager = remoteClusterConnection.getConnectionManager();
-                    Transport.Connection connection = connectionManager.getConnection(remoteNode);
-                    PlainActionFuture<Void> closeFuture = new PlainActionFuture<>();
-                    connection.addCloseListener(closeFuture);
-                    connectionManager.disconnectFromNode(remoteNode);
-                    closeFuture.get();
+
+                    safeAwait(connectionClosedListener -> {
+                        ConnectionManager connectionManager = remoteClusterConnection.getConnectionManager();
+                        Transport.Connection connection = connectionManager.getConnection(remoteNode);
+                        connection.addCloseListener(connectionClosedListener.map(v -> v));
+                        connectionManager.disconnectFromNode(remoteNode);
+                    });
 
                     var client = remoteClusterService.getRemoteClusterClient(
                         "test",
@@ -184,11 +197,21 @@ public class RemoteClusterClientTests extends ESTestCase {
                             RemoteClusterService.DisconnectedStrategy.RECONNECT_UNLESS_SKIP_UNAVAILABLE
                         )
                     );
-                    ClusterStateResponse clusterStateResponse = safeAwait(
-                        listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(TEST_REQUEST_TIMEOUT), listener)
-                    );
-                    assertNotNull(clusterStateResponse);
-                    assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
+
+                    if (randomBoolean()) {
+                        final ClusterStateResponse clusterStateResponse = safeAwait(
+                            listener -> client.execute(
+                                ClusterStateAction.REMOTE_TYPE,
+                                new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                                listener
+                            )
+                        );
+                        assertNotNull(clusterStateResponse);
+                        assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
+                    } else {
+                        final Transport.Connection connection = safeAwait(listener -> client.getConnection(null, listener));
+                        assertFalse(connection.isClosed());
+                    }
                     assertTrue(remoteClusterConnection.isNodeConnected(remoteNode));
                 }
             }
@@ -271,28 +294,42 @@ public class RemoteClusterClientTests extends ESTestCase {
                     assertFalse(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
 
                     // check that we quickly fail
-                    ESTestCase.assertThat(
-                        safeAwaitFailure(
-                            ClusterStateResponse.class,
-                            listener -> client.execute(
-                                ClusterStateAction.REMOTE_TYPE,
-                                new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
-                                listener
-                            )
-                        ),
-                        instanceOf(ConnectTransportException.class)
-                    );
+                    if (randomBoolean()) {
+                        ESTestCase.assertThat(
+                            safeAwaitFailure(
+                                ClusterStateResponse.class,
+                                listener -> client.execute(
+                                    ClusterStateAction.REMOTE_TYPE,
+                                    new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                                    listener
+                                )
+                            ),
+                            instanceOf(ConnectTransportException.class)
+                        );
+                    } else {
+                        ESTestCase.assertThat(
+                            safeAwaitFailure(Transport.Connection.class, listener -> client.getConnection(null, listener)),
+                            instanceOf(ConnectTransportException.class)
+                        );
+                    }
                 } finally {
                     service.clearAllRules();
                     latch.countDown();
                 }
 
-                assertBusy(() -> {
-                    ClusterStateResponse ignored = safeAwait(
-                        listener -> client.execute(ClusterStateAction.REMOTE_TYPE, new ClusterStateRequest(TEST_REQUEST_TIMEOUT), listener)
-                    );
+                assertBusy(
                     // keep retrying on an exception, the goal is to check that we eventually reconnect
-                });
+                    randomFrom(
+                        () -> safeAwait(
+                            listener -> client.execute(
+                                ClusterStateAction.REMOTE_TYPE,
+                                new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                                listener.map(v -> v)
+                            )
+                        ),
+                        () -> safeAwait(listener -> client.getConnection(null, listener.map(v -> v)))
+                    )
+                );
                 assertTrue(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/client/internal/RedirectToLocalClusterRemoteClusterClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/client/internal/RedirectToLocalClusterRemoteClusterClient.java
@@ -11,10 +11,10 @@ package org.elasticsearch.client.internal;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportResponse;
 
 /**
@@ -22,10 +22,10 @@ import org.elasticsearch.transport.TransportResponse;
  */
 public class RedirectToLocalClusterRemoteClusterClient implements RemoteClusterClient {
 
-    private final ElasticsearchClient delegate;
+    private final ElasticsearchClient localNodeClient;
 
-    public RedirectToLocalClusterRemoteClusterClient(ElasticsearchClient delegate) {
-        this.delegate = delegate;
+    public RedirectToLocalClusterRemoteClusterClient(ElasticsearchClient localNodeClient) {
+        this.localNodeClient = localNodeClient;
     }
 
     @SuppressWarnings("unchecked")
@@ -35,6 +35,21 @@ public class RedirectToLocalClusterRemoteClusterClient implements RemoteClusterC
         Request request,
         ActionListener<Response> listener
     ) {
-        delegate.execute(new ActionType<ActionResponse>(action.name()), request, listener.map(r -> (Response) r));
+        localNodeClient.execute(new ActionType<>(action.name()), request, listener.map(r -> (Response) r));
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends TransportResponse> void execute(
+        Transport.Connection connection,
+        RemoteClusterActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    ) {
+        throw new AssertionError("not implemented on RedirectToLocalClusterRemoteClusterClient");
+    }
+
+    @Override
+    public <Request extends ActionRequest> void getConnection(Request request, ActionListener<Transport.Connection> listener) {
+        throw new AssertionError("not implemented on RedirectToLocalClusterRemoteClusterClient");
     }
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -43,6 +43,7 @@ import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.xpack.ccr.action.CcrRequests;
 import org.elasticsearch.xpack.ccr.action.ShardChangesAction;
@@ -424,6 +425,7 @@ public class CcrLicenseChecker {
             return new RemoteClusterClient() {
                 @Override
                 public <Request extends ActionRequest, Response extends TransportResponse> void execute(
+                    Transport.Connection connection,
                     RemoteClusterActionType<Response> action,
                     Request request,
                     ActionListener<Response> listener
@@ -434,8 +436,13 @@ public class CcrLicenseChecker {
                         null,
                         request,
                         listener,
-                        (r, l) -> client.execute(action, r, l)
+                        (r, l) -> client.execute(connection, action, r, l)
                     );
+                }
+
+                @Override
+                public <Request extends ActionRequest> void getConnection(Request request, ActionListener<Transport.Connection> listener) {
+                    client.getConnection(request, listener);
                 }
             };
         }
@@ -466,6 +473,7 @@ public class CcrLicenseChecker {
         return new RemoteClusterClient() {
             @Override
             public <Request extends ActionRequest, Response extends TransportResponse> void execute(
+                Transport.Connection connection,
                 RemoteClusterActionType<Response> action,
                 Request request,
                 ActionListener<Response> listener
@@ -473,8 +481,13 @@ public class CcrLicenseChecker {
                 final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
                 try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                     threadContext.markAsSystemContext();
-                    delegate.execute(action, request, new ContextPreservingActionListener<>(supplier, listener));
+                    delegate.execute(connection, action, request, new ContextPreservingActionListener<>(supplier, listener));
                 }
+            }
+
+            @Override
+            public <Request extends ActionRequest> void getConnection(Request request, ActionListener<Transport.Connection> listener) {
+                delegate.getConnection(request, listener);
             }
         };
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.MockLog.LoggingExpectation;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
+import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -358,13 +359,18 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         String transformId = getTestName();
         TransformConfig transformConfig = TransformConfigTests.randomTransformConfig(transformId);
 
+        doAnswer(withMockConnection()).when(remoteClient1).getConnection(any(), any());
+        doAnswer(withMockConnection()).when(remoteClient2).getConnection(any(), any());
+        doAnswer(withMockConnection()).when(remoteClient3).getConnection(any(), any());
+
         GetCheckpointAction.Response checkpointResponse = new GetCheckpointAction.Response(Map.of("index-1", new long[] { 1L, 2L, 3L }));
         doAnswer(withResponse(checkpointResponse)).when(client).execute(eq(GetCheckpointAction.INSTANCE), any(), any());
 
         GetCheckpointAction.Response remoteCheckpointResponse = new GetCheckpointAction.Response(
             Map.of("index-1", new long[] { 4L, 5L, 6L, 7L, 8L })
         );
-        doAnswer(withResponse(remoteCheckpointResponse)).when(remoteClient1).execute(eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
+        doAnswer(withRemoteResponse(remoteCheckpointResponse)).when(remoteClient1)
+            .execute(any(), eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
 
         RemoteClusterResolver remoteClusterResolver = mock(RemoteClusterResolver.class);
 
@@ -401,18 +407,25 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         String transformId = getTestName();
         TransformConfig transformConfig = TransformConfigTests.randomTransformConfig(transformId);
 
+        doAnswer(withMockConnection()).when(remoteClient1).getConnection(any(), any());
+        doAnswer(withMockConnection()).when(remoteClient2).getConnection(any(), any());
+        doAnswer(withMockConnection()).when(remoteClient3).getConnection(any(), any());
+
         GetCheckpointAction.Response remoteCheckpointResponse1 = new GetCheckpointAction.Response(
             Map.of("index-1", new long[] { 1L, 2L, 3L })
         );
-        doAnswer(withResponse(remoteCheckpointResponse1)).when(remoteClient1).execute(eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
+        doAnswer(withRemoteResponse(remoteCheckpointResponse1)).when(remoteClient1)
+            .execute(any(), eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
 
         GetCheckpointAction.Response remoteCheckpointResponse2 = new GetCheckpointAction.Response(
             Map.of("index-1", new long[] { 4L, 5L, 6L, 7L, 8L })
         );
-        doAnswer(withResponse(remoteCheckpointResponse2)).when(remoteClient2).execute(eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
+        doAnswer(withRemoteResponse(remoteCheckpointResponse2)).when(remoteClient2)
+            .execute(any(), eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
 
         GetCheckpointAction.Response remoteCheckpointResponse3 = new GetCheckpointAction.Response(Map.of("index-1", new long[] { 9L }));
-        doAnswer(withResponse(remoteCheckpointResponse3)).when(remoteClient3).execute(eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
+        doAnswer(withRemoteResponse(remoteCheckpointResponse3)).when(remoteClient3)
+            .execute(any(), eq(GetCheckpointAction.REMOTE_TYPE), any(), any());
 
         RemoteClusterResolver remoteClusterResolver = mock(RemoteClusterResolver.class);
 
@@ -480,6 +493,22 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         return invocationOnMock -> {
             ActionListener<Response> listener = invocationOnMock.getArgument(2);
             listener.onResponse(response);
+            return null;
+        };
+    }
+
+    private static <Response> Answer<Response> withRemoteResponse(Response response) {
+        return invocationOnMock -> {
+            ActionListener<Response> listener = invocationOnMock.getArgument(3);
+            listener.onResponse(response);
+            return null;
+        };
+    }
+
+    private static Answer<Void> withMockConnection() {
+        return invocationOnMock -> {
+            ActionListener<Transport.Connection> listener = invocationOnMock.getArgument(1);
+            listener.onResponse(mock(Transport.Connection.class));
             return null;
         };
     }


### PR DESCRIPTION
Sometimes we might need to invoke different requests on a remote cluster
depending on the version of the transport protocol it understands, but
today we cannot make that distinction (without starting to execute an
action on the remote cluster and failing while serializing the request
at least). This commit allows callers access to the underlying
`Transport.Connection` instance so that we can implement better BwC
logic.