### PR TITLE
Change log level to info for jwks reload

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
@@ -146,7 +146,7 @@ public class JwkSetLoader implements Releasable {
         assert newContentAndJwksAlgs != null;
         assert contentAndJwksAlgs != null;
         if ((Arrays.equals(contentAndJwksAlgs.sha256, newContentAndJwksAlgs.sha256)) == false) {
-            logger.debug(
+            logger.info(
                 "Reloaded JWK set from sha256=[{}] to sha256=[{}]",
                 MessageDigests.toHexString(contentAndJwksAlgs.sha256),
                 MessageDigests.toHexString(newContentAndJwksAlgs.sha256)


### PR DESCRIPTION
We had an incident in Serverless where the JWKS was updated multiple times within the span of a few minutes and we wanted to confirm when ES clusters reloaded the JWKS. This changes the log level to info, to make it easier to debug such issues. 