### PR TITLE
[8.x] Account for DelayedBucket before reduction (#113013)

### DIFF
--- a/docs/changelog/113013.yaml
+++ b/docs/changelog/113013.yaml
@@ -1,0 +1,5 @@
+pr: 113013
+summary: Account for `DelayedBucket` before reduction
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
@@ -132,7 +132,11 @@ public abstract class TopBucketBuilder<B extends InternalMultiBucketAggregation.
             DelayedBucket<B> removed = queue.insertWithOverflow(bucket);
             if (removed != null) {
                 nonCompetitive.accept(removed);
+                // release any created sub-buckets
                 removed.nonCompetitive(reduceContext);
+            } else {
+                // add one bucket to the final result
+                reduceContext.consumeBucketsAndMaybeBreak(1);
             }
         }
 
@@ -183,6 +187,8 @@ public abstract class TopBucketBuilder<B extends InternalMultiBucketAggregation.
                 next.add(bucket);
                 return;
             }
+            // add one bucket to the final result
+            reduceContext.consumeBucketsAndMaybeBreak(1);
             buffer.add(bucket);
             if (buffer.size() < size) {
                 return;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -290,6 +290,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                 result = new ArrayList<>();
                 thisReduceOrder = reduceBuckets(bucketsList, getThisReduceOrder(), bucket -> {
                     if (result.size() < getRequiredSize()) {
+                        reduceContext.consumeBucketsAndMaybeBreak(1);
                         result.add(bucket.reduced(AbstractInternalTerms.this::reduceBucket, reduceContext));
                     } else {
                         otherDocCount[0] += bucket.getDocCount();
@@ -311,11 +312,10 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                 result = top.build();
             } else {
                 result = new ArrayList<>();
-                thisReduceOrder = reduceBuckets(
-                    bucketsList,
-                    getThisReduceOrder(),
-                    bucket -> result.add(bucket.reduced(AbstractInternalTerms.this::reduceBucket, reduceContext))
-                );
+                thisReduceOrder = reduceBuckets(bucketsList, getThisReduceOrder(), bucket -> {
+                    reduceContext.consumeBucketsAndMaybeBreak(1);
+                    result.add(bucket.reduced(AbstractInternalTerms.this::reduceBucket, reduceContext));
+                });
             }
             for (B r : result) {
                 if (sumDocCountError == -1) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/DelayedBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/DelayedBucketTests.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DelayedBucketTests extends ESTestCase {
     public void testToString() {
@@ -40,6 +42,23 @@ public class DelayedBucketTests extends ESTestCase {
         assertThat(b.reduced(reduce, context), sameInstance(b.reduced(reduce, context)));
         assertThat(b.reduced(reduce, context).getKeyAsString(), equalTo("test"));
         assertThat(b.reduced(reduce, context).getDocCount(), equalTo(3L));
+        // it only accounts for sub-buckets
+        assertEquals(0, buckets.get());
+    }
+
+    public void testReducedSubAggregation() {
+        AtomicInteger buckets = new AtomicInteger();
+        AggregationReduceContext context = new AggregationReduceContext.ForFinal(null, null, () -> false, null, buckets::addAndGet);
+        BiFunction<List<InternalBucket>, AggregationReduceContext, InternalBucket> reduce = mockReduce(context);
+        DelayedBucket<InternalBucket> b = new DelayedBucket<>(
+            List.of(bucket("test", 1, mockMultiBucketAgg()), bucket("test", 2, mockMultiBucketAgg()))
+        );
+
+        assertThat(b.getDocCount(), equalTo(3L));
+        assertThat(b.reduced(reduce, context), sameInstance(b.reduced(reduce, context)));
+        assertThat(b.reduced(reduce, context).getKeyAsString(), equalTo("test"));
+        assertThat(b.reduced(reduce, context).getDocCount(), equalTo(3L));
+        // it only accounts for sub-buckets
         assertEquals(1, buckets.get());
     }
 
@@ -76,6 +95,19 @@ public class DelayedBucketTests extends ESTestCase {
         BiFunction<List<InternalBucket>, AggregationReduceContext, InternalBucket> reduce = mockReduce(context);
         DelayedBucket<InternalBucket> b = new DelayedBucket<>(List.of(bucket("test", 1)));
         b.reduced(reduce, context);
+        // only account for sub-aggregations
+        assertEquals(0, buckets.get());
+        b.nonCompetitive(context);
+        assertEquals(0, buckets.get());
+    }
+
+    public void testNonCompetitiveReducedSubAggregation() {
+        AtomicInteger buckets = new AtomicInteger();
+        AggregationReduceContext context = new AggregationReduceContext.ForFinal(null, null, () -> false, null, buckets::addAndGet);
+        BiFunction<List<InternalBucket>, AggregationReduceContext, InternalBucket> reduce = mockReduce(context);
+        DelayedBucket<InternalBucket> b = new DelayedBucket<>(List.of(bucket("test", 1, mockMultiBucketAgg())));
+        b.reduced(reduce, context);
+        // only account for sub-aggregations
         assertEquals(1, buckets.get());
         b.nonCompetitive(context);
         assertEquals(0, buckets.get());
@@ -85,10 +117,25 @@ public class DelayedBucketTests extends ESTestCase {
         return new StringTerms.Bucket(new BytesRef(key), docCount, InternalAggregations.EMPTY, false, 0, DocValueFormat.RAW);
     }
 
+    private static InternalBucket bucket(String key, long docCount, InternalAggregations subAggregations) {
+        return new StringTerms.Bucket(new BytesRef(key), docCount, subAggregations, false, 0, DocValueFormat.RAW);
+    }
+
     static BiFunction<List<InternalBucket>, AggregationReduceContext, InternalBucket> mockReduce(AggregationReduceContext context) {
         return (l, c) -> {
             assertThat(c, sameInstance(context));
-            return bucket(l.get(0).getKeyAsString(), l.stream().mapToLong(Bucket::getDocCount).sum());
+            context.consumeBucketsAndMaybeBreak(l.get(0).getAggregations().asList().size());
+            return bucket(l.get(0).getKeyAsString(), l.stream().mapToLong(Bucket::getDocCount).sum(), l.get(0).getAggregations());
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private InternalAggregations mockMultiBucketAgg() {
+        List<InternalBucket> buckets = List.of(bucket("sub", 1));
+        InternalMultiBucketAggregation<?, InternalBucket> mock = (InternalMultiBucketAggregation<?, InternalBucket>) mock(
+            InternalMultiBucketAggregation.class
+        );
+        when(mock.getBuckets()).thenReturn(buckets);
+        return InternalAggregations.from(List.of(mock));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Account for DelayedBucket before reduction (#113013)