### PR TITLE
Suppress merge-on-recovery for older indices

### DIFF
--- a/docs/changelog/113462.yaml
+++ b/docs/changelog/113462.yaml
@@ -1,0 +1,5 @@
+pr: 113462
+summary: Suppress merge-on-recovery for older indices
+area: CRUD
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -115,6 +115,7 @@ public class IndexVersions {
     public static final IndexVersion INDEX_SORTING_ON_NESTED = def(8_512_00_0, Version.LUCENE_9_11_1);
     public static final IndexVersion LENIENT_UPDATEABLE_SYNONYMS = def(8_513_00_0, Version.LUCENE_9_11_1);
     public static final IndexVersion ENABLE_IGNORE_MALFORMED_LOGSDB = def(8_514_00_0, Version.LUCENE_9_11_1);
+    public static final IndexVersion MERGE_ON_RECOVERY_VERSION = def(8_515_00_0, Version.LUCENE_9_11_1);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -896,7 +896,7 @@ public class IndicesService extends AbstractLifecycleComponent
         indexShard.startRecovery(
             recoveryState,
             recoveryTargetService,
-            postRecoveryMerger.maybeMergeAfterRecovery(shardRouting, recoveryListener),
+            postRecoveryMerger.maybeMergeAfterRecovery(indexService.getMetadata(), shardRouting, recoveryListener),
             repositoriesService,
             (mapping, listener) -> {
                 assert recoveryState.getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS


### PR DESCRIPTION
There may be many older indices in need of merging, but today we do not
throttle this work across shards so an upgrade could lead to an
overwhelming spike in merges. With this commit we make it so that the
automatic merge-on-recovery behaviour only applies to newly-created
indices.