### PR TITLE
Add rolling upgrade and mixed cluster tests for system indices/inference API

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
@@ -137,6 +137,9 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     // YAML
     public static final NodeFeature REST_ELASTIC_PRODUCT_HEADER_PRESENT = new NodeFeature("action.rest.product_header_present");
 
+    // Inference
+    public static final NodeFeature OPEN_AI_EMBEDDINGS_ADDED = new NodeFeature("inference.open_ai_embeddings_added");
+
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
         return Map.ofEntries(
@@ -184,7 +187,8 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
             entry(NEW_DATA_STREAMS_INDEX_NAME_FORMAT, Version.V_7_11_0),
             entry(DISABLE_FIELD_NAMES_FIELD_REMOVED, Version.V_8_0_0),
             entry(ML_NLP_SUPPORTED, Version.V_8_0_0),
-            entry(MAPPINGS_UPGRADE_SERVICE_USES_MAPPINGS_VERSION, Version.V_8_11_0)
+            entry(MAPPINGS_UPGRADE_SERVICE_USES_MAPPINGS_VERSION, Version.V_8_11_0),
+            entry(OPEN_AI_EMBEDDINGS_ADDED, Version.V_8_12_0)
         );
     }
 }

--- a/x-pack/plugin/inference/qa/mixed-cluster/build.gradle
+++ b/x-pack/plugin/inference/qa/mixed-cluster/build.gradle
@@ -18,9 +18,10 @@ dependencies {
   )
 }
 
-// inference is available in 8.11 or later
+// Inference API added in 8.11, but we generate BwC as far back as 8.9.0 to test for mixed clusters
+// with nodes where index descriptors were non-existing/used the older Version-based versioning
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter(Version.fromString("8.11.0"));
+  return bwcVersion.onOrAfter(Version.fromString("8.9.0"));
 }
 
 BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->

--- a/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/OpenAIServiceMixedIT.java
+++ b/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/OpenAIServiceMixedIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -114,8 +115,10 @@ public class OpenAIServiceMixedIT extends BaseMixedTestCase {
     }
 
     public void testMixedClusterNotFullySupportingOpenAiCompletionsRejectsApiCalls() throws IOException {
-        // TODO: oldClusterFeatures
-        assumeTrue("Old nodes must not support OpenAi completion", getOldClusterTestVersion().before(OPEN_AI_EMBEDDINGS_ADDED));
+        assumeFalse(
+            "Old nodes must be before support for OpenAi inference was added",
+            oldClusterHasFeature(RestTestLegacyFeatures.OPEN_AI_EMBEDDINGS_ADDED)
+        );
         final String inferenceId = "mixed-cluster-completions";
 
         var modelConfig = chatCompletionsConfig(getUrl(openAiChatCompletionsServer));

--- a/x-pack/plugin/inference/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/build.gradle
@@ -22,8 +22,9 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(":qa:rolling-upgrade"), "javaRestTest"))
 }
 
-// Inference API added in 8.11
-BuildParams.bwcVersions.withWireCompatible(v -> v.after("8.11.0")) { bwcVersion, baseName ->
+// Inference API added in 8.11, but we generate BwC as far back as 8.9.0 to test for upgrades
+// from a cluster where system index descriptors were non-existing/used the older Version-based versioning
+BuildParams.bwcVersions.withWireCompatible(v -> v.after("8.9.0")) { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/OpenAiServiceUpgradeIT.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/OpenAiServiceUpgradeIT.java
@@ -110,6 +110,25 @@ public class OpenAiServiceUpgradeIT extends InferenceUpgradeTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    public void testOpenAiInferenceCreateAfterUpgradeFromNonSupportedVersion() throws IOException {
+        final String upgradedClusterId = "upgraded-cluster-embeddings";
+        var testTaskType = TaskType.TEXT_EMBEDDING;
+
+        if (isUpgradedCluster()) {
+            String inferenceConfig = embeddingConfigWithModelInServiceSettings(getUrl(openAiEmbeddingsServer));
+            openAiEmbeddingsServer.enqueue(new MockResponse().setResponseCode(200).setBody(embeddingResponse()));
+            put(upgradedClusterId, inferenceConfig, testTaskType);
+
+            var configs = (List<Map<String, Object>>) get(testTaskType, upgradedClusterId).get("endpoints");
+            assertThat(configs, hasSize(1));
+
+            assertEmbeddingInference(upgradedClusterId);
+
+            delete(upgradedClusterId);
+        }
+    }
+
     void assertEmbeddingInference(String inferenceId) throws IOException {
         openAiEmbeddingsServer.enqueue(new MockResponse().setResponseCode(200).setBody(embeddingResponse()));
         var inferenceMap = inference(inferenceId, TaskType.TEXT_EMBEDDING, "some text");

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/OpenAiServiceUpgradeIT.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/OpenAiServiceUpgradeIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -112,6 +113,11 @@ public class OpenAiServiceUpgradeIT extends InferenceUpgradeTestCase {
 
     @SuppressWarnings("unchecked")
     public void testOpenAiInferenceCreateAfterUpgradeFromNonSupportedVersion() throws IOException {
+        assumeFalse(
+            "Old cluster must be before a supported version",
+            oldClusterHasFeature(RestTestLegacyFeatures.OPEN_AI_EMBEDDINGS_ADDED)
+        );
+
         final String upgradedClusterId = "upgraded-cluster-embeddings";
         var testTaskType = TaskType.TEXT_EMBEDDING;
 


### PR DESCRIPTION
Various tests (1 generic, 2 inference-module specific) to try and reproduce https://github.com/elastic/elasticsearch/issues/112694

Note: for these tests to be significant, they need to be ported/merged into 8.x, and run on a older BwC version, e.g.
```
./gradlew :x-pack:plugin:inference:qa:mixed-cluster:v8.9.0#javaRestTest --tests "org.elasticsearch.xpack.inference.qa.mixed.OpenAIServiceMixedIT.testMixedClusterNotFullySupportingOpenAiCompletionsRejectsApiCalls"
```
(I did it locally)