### PR TITLE
[8.x] Making TransportGetDatabaseConfigurationAction extend TransportNodesAction (#113141)

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/GetDatabaseConfigurationAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/GetDatabaseConfigurationAction.java
@@ -9,13 +9,16 @@
 
 package org.elasticsearch.ingest.geoip.direct;
 
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -28,8 +31,9 @@ import static org.elasticsearch.ingest.geoip.direct.DatabaseConfigurationMetadat
 import static org.elasticsearch.ingest.geoip.direct.DatabaseConfigurationMetadata.MODIFIED_DATE;
 import static org.elasticsearch.ingest.geoip.direct.DatabaseConfigurationMetadata.MODIFIED_DATE_MILLIS;
 import static org.elasticsearch.ingest.geoip.direct.DatabaseConfigurationMetadata.VERSION;
+import static org.elasticsearch.ingest.geoip.direct.GetDatabaseConfigurationAction.Response;
 
-public class GetDatabaseConfigurationAction extends ActionType<GetDatabaseConfigurationAction.Response> {
+public class GetDatabaseConfigurationAction extends ActionType<Response> {
     public static final GetDatabaseConfigurationAction INSTANCE = new GetDatabaseConfigurationAction();
     public static final String NAME = "cluster:admin/ingest/geoip/database/get";
 
@@ -37,16 +41,95 @@ public class GetDatabaseConfigurationAction extends ActionType<GetDatabaseConfig
         super(NAME);
     }
 
-    public static class Request extends AcknowledgedRequest<GetDatabaseConfigurationAction.Request> {
+    public static class Request extends BaseNodesRequest<Request> {
+        private final String[] databaseIds;
+
+        public Request(String... databaseIds) {
+            super((String[]) null);
+            this.databaseIds = databaseIds;
+        }
+
+        public String[] getDatabaseIds() {
+            return databaseIds;
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(databaseIds);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (obj.getClass() != getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Arrays.equals(databaseIds, other.databaseIds);
+        }
+
+    }
+
+    public static class Response extends BaseNodesResponse<NodeResponse> implements ToXContentObject {
+
+        private final List<DatabaseConfigurationMetadata> databases;
+
+        public Response(
+            List<DatabaseConfigurationMetadata> databases,
+            ClusterName clusterName,
+            List<NodeResponse> nodes,
+            List<FailedNodeException> failures
+        ) {
+            super(clusterName, nodes, failures);
+            this.databases = List.copyOf(databases); // defensive copy
+        }
+
+        protected Response(StreamInput in) throws IOException {
+            super(in);
+            this.databases = in.readCollectionAsList(DatabaseConfigurationMetadata::new);
+        }
+
+        @Override
+        protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+            return in.readCollectionAsList(NodeResponse::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
+            out.writeCollection(nodes);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.startArray("databases");
+            for (DatabaseConfigurationMetadata item : databases) {
+                DatabaseConfiguration database = item.database();
+                builder.startObject();
+                builder.field("id", database.id()); // serialize including the id -- this is get response serialization
+                builder.field(VERSION.getPreferredName(), item.version());
+                builder.timeField(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), item.modifiedDate());
+                builder.field(DATABASE.getPreferredName(), database);
+                builder.endObject();
+            }
+            builder.endArray();
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    public static class NodeRequest extends TransportRequest {
 
         private final String[] databaseIds;
 
-        public Request(TimeValue masterNodeTimeout, TimeValue ackTimeout, String... databaseIds) {
-            super(masterNodeTimeout, ackTimeout);
+        public NodeRequest(String... databaseIds) {
+            super();
             this.databaseIds = Objects.requireNonNull(databaseIds, "ids may not be null");
         }
 
-        public Request(StreamInput in) throws IOException {
+        public NodeRequest(StreamInput in) throws IOException {
             super(in);
             databaseIds = in.readStringArray();
         }
@@ -74,48 +157,27 @@ public class GetDatabaseConfigurationAction extends ActionType<GetDatabaseConfig
             if (obj.getClass() != getClass()) {
                 return false;
             }
-            Request other = (Request) obj;
+            NodeRequest other = (NodeRequest) obj;
             return Arrays.equals(databaseIds, other.databaseIds);
         }
     }
 
-    public static class Response extends ActionResponse implements ToXContentObject {
+    public static class NodeResponse extends BaseNodeResponse {
 
         private final List<DatabaseConfigurationMetadata> databases;
 
-        public Response(List<DatabaseConfigurationMetadata> databases) {
+        public NodeResponse(DiscoveryNode node, List<DatabaseConfigurationMetadata> databases) {
+            super(node);
             this.databases = List.copyOf(databases); // defensive copy
         }
 
-        public Response(StreamInput in) throws IOException {
-            this(in.readCollectionAsList(DatabaseConfigurationMetadata::new));
+        public NodeResponse(StreamInput in) throws IOException {
+            super(in);
+            this.databases = in.readCollectionAsList(DatabaseConfigurationMetadata::new);
         }
 
         public List<DatabaseConfigurationMetadata> getDatabases() {
             return this.databases;
-        }
-
-        @Override
-        public String toString() {
-            return Strings.toString(this);
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.startArray("databases");
-            for (DatabaseConfigurationMetadata item : databases) {
-                DatabaseConfiguration database = item.database();
-                builder.startObject();
-                builder.field("id", database.id()); // serialize including the id -- this is get response serialization
-                builder.field(VERSION.getPreferredName(), item.version());
-                builder.timeField(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), item.modifiedDate());
-                builder.field(DATABASE.getPreferredName(), database);
-                builder.endObject();
-            }
-            builder.endArray();
-            builder.endObject();
-            return builder;
         }
 
         @Override
@@ -136,7 +198,7 @@ public class GetDatabaseConfigurationAction extends ActionType<GetDatabaseConfig
             if (obj.getClass() != getClass()) {
                 return false;
             }
-            Response other = (Response) obj;
+            NodeResponse other = (NodeResponse) obj;
             return databases.equals(other.databases);
         }
     }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/RestGetDatabaseConfigurationAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/RestGetDatabaseConfigurationAction.java
@@ -20,8 +20,6 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-import static org.elasticsearch.rest.RestUtils.getAckTimeout;
-import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 
 @ServerlessScope(Scope.INTERNAL)
 public class RestGetDatabaseConfigurationAction extends BaseRestHandler {
@@ -38,11 +36,7 @@ public class RestGetDatabaseConfigurationAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) {
-        final var req = new GetDatabaseConfigurationAction.Request(
-            getMasterNodeTimeout(request),
-            getAckTimeout(request),
-            Strings.splitStringByCommaToArray(request.param("id"))
-        );
+        final var req = new GetDatabaseConfigurationAction.Request(Strings.splitStringByCommaToArray(request.param("id")));
         return channel -> client.execute(GetDatabaseConfigurationAction.INSTANCE, req, new RestToXContentListener<>(channel));
     }
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/TransportGetDatabaseConfigurationAction.java
@@ -11,21 +11,21 @@ package org.elasticsearch.ingest.geoip.direct;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeAction;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.block.ClusterBlockException;
-import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.ingest.geoip.IngestGeoIpMetadata;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -33,9 +33,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class TransportGetDatabaseConfigurationAction extends TransportMasterNodeAction<
+import static org.elasticsearch.ingest.IngestGeoIpFeatures.GET_DATABASE_CONFIGURATION_ACTION_MULTI_NODE;
+
+public class TransportGetDatabaseConfigurationAction extends TransportNodesAction<
     GetDatabaseConfigurationAction.Request,
-    GetDatabaseConfigurationAction.Response> {
+    GetDatabaseConfigurationAction.Response,
+    GetDatabaseConfigurationAction.NodeRequest,
+    GetDatabaseConfigurationAction.NodeResponse,
+    List<DatabaseConfigurationMetadata>> {
+
+    private final FeatureService featureService;
 
     @Inject
     public TransportGetDatabaseConfigurationAction(
@@ -43,28 +50,39 @@ public class TransportGetDatabaseConfigurationAction extends TransportMasterNode
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        FeatureService featureService
     ) {
         super(
             GetDatabaseConfigurationAction.NAME,
-            transportService,
             clusterService,
-            threadPool,
+            transportService,
             actionFilters,
-            GetDatabaseConfigurationAction.Request::new,
-            indexNameExpressionResolver,
-            GetDatabaseConfigurationAction.Response::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE
+            GetDatabaseConfigurationAction.NodeRequest::new,
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
         );
+        this.featureService = featureService;
     }
 
     @Override
-    protected void masterOperation(
-        final Task task,
-        final GetDatabaseConfigurationAction.Request request,
-        final ClusterState state,
-        final ActionListener<GetDatabaseConfigurationAction.Response> listener
+    protected void doExecute(
+        Task task,
+        GetDatabaseConfigurationAction.Request request,
+        ActionListener<GetDatabaseConfigurationAction.Response> listener
     ) {
+        if (featureService.clusterHasFeature(clusterService.state(), GET_DATABASE_CONFIGURATION_ACTION_MULTI_NODE) == false) {
+            /*
+             * TransportGetDatabaseConfigurationAction used to be a TransportMasterNodeAction, and not all nodes in the cluster have been
+             * updated. So we don't want to send node requests to the other nodes because they will blow up. Instead, we just return
+             * the information that we used to return from the master node (it doesn't make any difference that this might not be the master
+             * node, because we're only reading the clsuter state).
+             */
+            newResponseAsync(task, request, createActionContext(task, request), List.of(), List.of(), listener);
+        } else {
+            super.doExecute(task, request, listener);
+        }
+    }
+
+    protected List<DatabaseConfigurationMetadata> createActionContext(Task task, GetDatabaseConfigurationAction.Request request) {
         final Set<String> ids;
         if (request.getDatabaseIds().length == 0) {
             // if we did not ask for a specific name, then return all databases
@@ -79,7 +97,7 @@ public class TransportGetDatabaseConfigurationAction extends TransportMasterNode
             );
         }
 
-        final IngestGeoIpMetadata geoIpMeta = state.metadata().custom(IngestGeoIpMetadata.TYPE, IngestGeoIpMetadata.EMPTY);
+        final IngestGeoIpMetadata geoIpMeta = clusterService.state().metadata().custom(IngestGeoIpMetadata.TYPE, IngestGeoIpMetadata.EMPTY);
         List<DatabaseConfigurationMetadata> results = new ArrayList<>();
 
         for (String id : ids) {
@@ -92,19 +110,54 @@ public class TransportGetDatabaseConfigurationAction extends TransportMasterNode
             } else {
                 DatabaseConfigurationMetadata meta = geoIpMeta.getDatabases().get(id);
                 if (meta == null) {
-                    listener.onFailure(new ResourceNotFoundException("database configuration not found: {}", id));
-                    return;
+                    throw new ResourceNotFoundException("database configuration not found: {}", id);
                 } else {
                     results.add(meta);
                 }
             }
         }
+        return results;
+    }
 
-        listener.onResponse(new GetDatabaseConfigurationAction.Response(results));
+    protected void newResponseAsync(
+        Task task,
+        GetDatabaseConfigurationAction.Request request,
+        List<DatabaseConfigurationMetadata> results,
+        List<GetDatabaseConfigurationAction.NodeResponse> responses,
+        List<FailedNodeException> failures,
+        ActionListener<GetDatabaseConfigurationAction.Response> listener
+    ) {
+        ActionListener.run(
+            listener,
+            l -> ActionListener.respondAndRelease(
+                l,
+                new GetDatabaseConfigurationAction.Response(results, clusterService.getClusterName(), responses, failures)
+            )
+        );
     }
 
     @Override
-    protected ClusterBlockException checkBlock(GetDatabaseConfigurationAction.Request request, ClusterState state) {
-        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    protected GetDatabaseConfigurationAction.Response newResponse(
+        GetDatabaseConfigurationAction.Request request,
+        List<GetDatabaseConfigurationAction.NodeResponse> nodeResponses,
+        List<FailedNodeException> failures
+    ) {
+        throw new UnsupportedOperationException("Use newResponseAsync instead");
     }
+
+    @Override
+    protected GetDatabaseConfigurationAction.NodeRequest newNodeRequest(GetDatabaseConfigurationAction.Request request) {
+        return new GetDatabaseConfigurationAction.NodeRequest(request.getDatabaseIds());
+    }
+
+    @Override
+    protected GetDatabaseConfigurationAction.NodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new GetDatabaseConfigurationAction.NodeResponse(in);
+    }
+
+    @Override
+    protected GetDatabaseConfigurationAction.NodeResponse nodeOperation(GetDatabaseConfigurationAction.NodeRequest request, Task task) {
+        return new GetDatabaseConfigurationAction.NodeResponse(transportService.getLocalNode(), List.of());
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestGeoIpFeatures.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestGeoIpFeatures.java
@@ -17,7 +17,12 @@ import java.util.Set;
 import static org.elasticsearch.ingest.EnterpriseGeoIpTask.GEOIP_DOWNLOADER_DATABASE_CONFIGURATION;
 
 public class IngestGeoIpFeatures implements FeatureSpecification {
+
+    public static final NodeFeature GET_DATABASE_CONFIGURATION_ACTION_MULTI_NODE = new NodeFeature(
+        "get_database_configuration_action.multi_node"
+    );
+
     public Set<NodeFeature> getFeatures() {
-        return Set.of(GEOIP_DOWNLOADER_DATABASE_CONFIGURATION);
+        return Set.of(GEOIP_DOWNLOADER_DATABASE_CONFIGURATION, GET_DATABASE_CONFIGURATION_ACTION_MULTI_NODE);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Making TransportGetDatabaseConfigurationAction extend TransportNodesAction (#113141)