### PR TITLE
Fix randomization in role descriptor tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -232,9 +232,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
   method: testErrorMidStream
   issue: https://github.com/elastic/elasticsearch/issues/113179
-- class: org.elasticsearch.xpack.core.security.authz.RoleDescriptorTests
-  method: testHasPrivilegesOtherThanIndex
-  issue: https://github.com/elastic/elasticsearch/issues/113202
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {categorize.Categorize SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/113054

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorTests.java
@@ -1341,7 +1341,8 @@ public class RoleDescriptorTests extends ESTestCase {
             || roleDescriptor.hasConfigurableClusterPrivileges()
             || roleDescriptor.hasApplicationPrivileges()
             || roleDescriptor.hasRunAs()
-            || roleDescriptor.hasRemoteIndicesPrivileges();
+            || roleDescriptor.hasRemoteIndicesPrivileges()
+            || roleDescriptor.hasWorkflowsRestriction();
         assertThat(roleDescriptor.hasUnsupportedPrivilegesInsideAPIKeyConnectedRemoteCluster(), equalTo(expected));
     }
 


### PR DESCRIPTION
This commit fixes some randomization in RoleDescriptorTests which was not updated to handle workflow restrictions.

Fixes https://github.com/elastic/elasticsearch/issues/113202