### PR TITLE
ES|QL: make CSV date tests more friendly for Java 23

### DIFF
--- a/docs/reference/esql/functions/kibana/definition/date_format.json
+++ b/docs/reference/esql/functions/kibana/definition/date_format.json
@@ -42,7 +42,7 @@
     }
   ],
   "examples" : [
-    "FROM employees\n| KEEP first_name, last_name, hire_date\n| EVAL hired = DATE_FORMAT(\"YYYY-MM-dd\", hire_date)"
+    "FROM employees\n| KEEP first_name, last_name, hire_date\n| EVAL hired = DATE_FORMAT(\"yyyy-MM-dd\", hire_date)"
   ],
   "preview" : false
 }

--- a/docs/reference/esql/functions/kibana/docs/date_format.md
+++ b/docs/reference/esql/functions/kibana/docs/date_format.md
@@ -8,5 +8,5 @@ Returns a string representation of a date, in the provided format.
 ```
 FROM employees
 | KEEP first_name, last_name, hire_date
-| EVAL hired = DATE_FORMAT("YYYY-MM-dd", hire_date)
+| EVAL hired = DATE_FORMAT("yyyy-MM-dd", hire_date)
 ```

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/blog.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/blog.csv-spec
@@ -5,7 +5,7 @@ required_capability: enrich_load
 
   FROM employees
 | WHERE still_hired == true
-| EVAL hired = DATE_FORMAT("YYYY", hire_date)
+| EVAL hired = DATE_FORMAT("yyyy", hire_date)
 | STATS avg_salary = AVG(salary) BY languages
 | EVAL avg_salary = ROUND(avg_salary)
 | EVAL lang_code = TO_STRING(languages)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -45,8 +45,7 @@ emp_no:integer | x:date
 
 
 evalDateFormat
-from employees | sort hire_date | eval x = date_format(hire_date), y = date_format("YYYY-MM-dd", hire_date) | keep emp_no, x, y | limit 5;
-warningRegex:Date format \[YYYY\-MM\-dd\] contains week-date field specifiers that are changing in JDK 23
+from employees | sort hire_date | eval x = date_format(hire_date), y = date_format("yyyy-MM-dd", hire_date) | keep emp_no, x, y | limit 5;
 
 emp_no:integer | x:keyword                     | y:keyword
 10009          | 1985-02-18T00:00:00.000Z      | 1985-02-18            
@@ -957,12 +956,11 @@ docsDateFormat
 // tag::docsDateFormat[]
 FROM employees
 | KEEP first_name, last_name, hire_date
-| EVAL hired = DATE_FORMAT("YYYY-MM-dd", hire_date)
+| EVAL hired = DATE_FORMAT("yyyy-MM-dd", hire_date)
 // end::docsDateFormat[]
 | SORT first_name
 | LIMIT 3
 ;
-warningRegex:Date format \[YYYY\-MM\-dd\] contains week-date field specifiers that are changing in JDK 23
 
 // tag::docsDateFormat-result[]
 first_name:keyword   |   last_name:keyword   | hire_date:date           | hired:keyword
@@ -976,9 +974,8 @@ evalDateFormatString
 required_capability: string_literal_auto_casting
 
 ROW a = 1
-| EVAL df = DATE_FORMAT("YYYY-MM-dd", "1989-06-02T00:00:00.000Z")
+| EVAL df = DATE_FORMAT("yyyy-MM-dd", "1989-06-02T00:00:00.000Z")
 ;
-warningRegex:Date format \[YYYY\-MM\-dd\] contains week-date field specifiers that are changing in JDK 23
 
 a:integer | df:keyword
 1         | 1989-06-02

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1176,14 +1176,13 @@ avg_lang:double | max_lang:integer
 docsStatsGroupByMultipleValues
 // tag::statsGroupByMultipleValues[]
 FROM employees
-| EVAL hired = DATE_FORMAT("YYYY", hire_date)
+| EVAL hired = DATE_FORMAT("yyyy", hire_date)
 | STATS avg_salary = AVG(salary) BY hired, languages.long
 | EVAL avg_salary = ROUND(avg_salary)
 | SORT hired, languages.long
 // end::statsGroupByMultipleValues[]
 | LIMIT 4
 ;
-warningRegex:Date format \[YYYY\] contains week-date field specifiers that are changing in JDK 23
 
 hired:keyword |languages.long:long | avg_salary:double
 1985           |1              |54668.0        


### PR DESCRIPTION
Following [this suggestion](https://github.com/elastic/elasticsearch/pull/113376#issuecomment-2370817089), switching date patterns from week years to calendar years, that have the same behavior in java <=22 and java 23.