### PR TITLE
Backport new `MERGE_ON_RECOVERY_VERSION`

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -115,6 +115,7 @@ public class IndexVersions {
     public static final IndexVersion INDEX_SORTING_ON_NESTED = def(8_512_00_0, Version.LUCENE_9_11_1);
     public static final IndexVersion LENIENT_UPDATEABLE_SYNONYMS = def(8_513_00_0, Version.LUCENE_9_11_1);
     public static final IndexVersion ENABLE_IGNORE_MALFORMED_LOGSDB = def(8_514_00_0, Version.LUCENE_9_11_1);
+    public static final IndexVersion MERGE_ON_RECOVERY_VERSION = def(8_515_00_0, Version.LUCENE_9_11_1);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
Most of #113462 only applies to `main`, but for now we must keep the
index versions aligned in `8.x`. This commit backports the new
`IndexVersion` constant.