### PR TITLE
[8.x] Add to SearchUsages queries generated by the vector tiles API (#113449)

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/VectorTilePlugin.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/VectorTilePlugin.java
@@ -45,6 +45,6 @@ public class VectorTilePlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        return List.of(new RestVectorTileAction());
+        return List.of(new RestVectorTileAction(restController.getSearchUsageHolder()));
     }
 }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuil
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
 
 import java.io.IOException;
@@ -87,7 +88,11 @@ public class RestVectorTileAction extends BaseRestHandler {
     // internal label position runtime field name
     static final String LABEL_POSITION_FIELD_NAME = INTERNAL_AGG_PREFIX + "label_position";
 
-    public RestVectorTileAction() {}
+    private final SearchUsageHolder searchUsageHolder;
+
+    public RestVectorTileAction(SearchUsageHolder searchUsageHolder) {
+        this.searchUsageHolder = searchUsageHolder;
+    }
 
     @Override
     public List<Route> routes() {
@@ -103,7 +108,7 @@ public class RestVectorTileAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         // This will allow to cancel the search request if the http channel is closed
         final RestCancellableNodeClient cancellableNodeClient = new RestCancellableNodeClient(client, restRequest.getHttpChannel());
-        final VectorTileRequest request = VectorTileRequest.parseRestRequest(restRequest);
+        final VectorTileRequest request = VectorTileRequest.parseRestRequest(restRequest, searchUsageHolder::updateUsage);
         final SearchRequestBuilder searchRequestBuilder = searchRequestBuilder(cancellableNodeClient, request);
         return channel -> searchRequestBuilder.execute(new RestResponseListener<>(channel) {
 

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
@@ -231,7 +231,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Invalid geotile_grid precision of " + z + ". Must be between 0 and 29."));
         }
@@ -243,7 +243,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Invalid geotile_grid precision of " + z + ". Must be between 0 and 29."));
         }
@@ -255,7 +255,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -267,7 +267,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -279,7 +279,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -291,7 +291,7 @@ public class VectorTileRequestTests extends ESTestCase {
             final FakeRestRequest request = getBasicRequestBuilder(index, field, z, x, y).build();
             final IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> VectorTileRequest.parseRestRequest(request)
+                () -> VectorTileRequest.parseRestRequest(request, s -> {})
             );
             assertThat(ex.getMessage(), Matchers.equalTo("Zoom/X/Y combination is not valid: " + z + "/" + x + "/" + y));
         }
@@ -310,7 +310,7 @@ public class VectorTileRequestTests extends ESTestCase {
         consumer.accept(builder);
         builder.endObject();
         final FakeRestRequest request = requestBuilder.withContent(BytesReference.bytes(builder), builder.contentType()).build();
-        final VectorTileRequest vectorTileRequest = VectorTileRequest.parseRestRequest(request);
+        final VectorTileRequest vectorTileRequest = VectorTileRequest.parseRestRequest(request, s -> {});
         assertThat(vectorTileRequest.getIndexes(), Matchers.equalTo(new String[] { index }));
         assertThat(vectorTileRequest.getField(), Matchers.equalTo(field));
         assertThat(vectorTileRequest.getZ(), Matchers.equalTo(z));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add to SearchUsages queries generated by the vector tiles API (#113449)