### PR TITLE
[8.x] More unsupported locales in Kerberos tests (#113354)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -166,15 +166,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testPutJob_GivenFarequoteConfig
   issue: https://github.com/elastic/elasticsearch/issues/112382
-- class: org.elasticsearch.xpack.security.authc.kerberos.KerberosTicketValidatorTests
-  method: testWhenKeyTabWithInvalidContentFailsValidation
-  issue: https://github.com/elastic/elasticsearch/issues/112631
-- class: org.elasticsearch.xpack.security.authc.kerberos.KerberosTicketValidatorTests
-  method: testValidKebrerosTicket
-  issue: https://github.com/elastic/elasticsearch/issues/112632
-- class: org.elasticsearch.xpack.security.authc.kerberos.KerberosTicketValidatorTests
-  method: testKerbTicketGeneratedForDifferentServerFailsValidation
-  issue: https://github.com/elastic/elasticsearch/issues/112639
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635

--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -62,7 +62,7 @@ public abstract class KerberosTestCase extends ESTestCase {
      *
      * Note: several unsupported locales were added in CLDR. #109670 included these below.
      */
-    private static Set<String> UNSUPPORTED_LOCALE_LANGUAGES = Set.of(
+    private static final Set<String> UNSUPPORTED_LOCALE_LANGUAGES = Set.of(
         "ar",
         "ja",
         "th",
@@ -88,7 +88,9 @@ public abstract class KerberosTestCase extends ESTestCase {
         "sat",
         "sa",
         "bgc",
-        "raj"
+        "raj",
+        "nqo",
+        "bho"
     );
 
     @BeforeClass


### PR DESCRIPTION
Backports the following commits to 8.x:
 - More unsupported locales in Kerberos tests (#113354)