### PR TITLE
ILM: Add total_shards_per_node setting to searchable snapshot

### DIFF
--- a/docs/changelog/112972.yaml
+++ b/docs/changelog/112972.yaml
@@ -1,0 +1,6 @@
+pr: 112972
+summary: "ILM: Add `total_shards_per_node` setting to searchable snapshot"
+area: ILM+SLM
+type: enhancement
+issues:
+ - 112261

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -19,7 +19,7 @@ index>> prefixed with `partial-` to the frozen tier. In other phases, the action
 
 In the frozen tier, the action will ignore the setting
 <<total-shards-per-node,`index.routing.allocation.total_shards_per_node`>>, if it was present in the original index,
-to account for the difference in the number of nodes between the frozen and the other tiers.
+to account for the difference in the number of nodes between the frozen and the other tiers. To set <<total-shards-per-node,`index.routing.allocation.total_shards_per_node`>> for searchable snapshots, set the `total_shards_per_node` option in the frozen phase's `searchable_snapshot` action within the ILM policy.
 
 
 WARNING: Don't include the `searchable_snapshot` action in both the hot and cold
@@ -73,6 +73,9 @@ action. For example, if using a `searchable_snapshot` action in the `hot` phase,
 will be performed on the hot nodes. If using a `searchable_snapshot` action in the `cold` phase, the
 force merge will be performed on whatever tier the index is *prior* to the `cold` phase (either
 `hot` or `warm`).
+
+`total_shards_per_node`::
+The maximum number of shards (replicas and primaries) that will be allocated to a single node for the searchable snapshot index. Defaults to unbounded.
 
 [[ilm-searchable-snapshot-ex]]
 ==== Examples

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -221,6 +221,8 @@ public class TransportVersions {
     public static final TransportVersion BULK_INCREMENTAL_STATE = def(8_745_00_0);
     public static final TransportVersion FAILURE_STORE_STATUS_IN_INDEX_RESPONSE = def(8_746_00_0);
     public static final TransportVersion ESQL_AGGREGATION_OPERATOR_STATUS_FINISH_NANOS = def(8_747_00_0);
+    public static final TransportVersion ML_TELEMETRY_MEMORY_ADDED = def(8_748_00_0);
+    public static final TransportVersion ILM_ADD_SEARCHABLE_SNAPSHOT_TOTAL_SHARDS_PER_NODE = def(8_749_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyTests.java
@@ -224,7 +224,11 @@ public class LifecyclePolicyTests extends AbstractXContentSerializingTestCase<Li
                     frozenTime,
                     Collections.singletonMap(
                         SearchableSnapshotAction.NAME,
-                        new SearchableSnapshotAction(randomAlphaOfLength(10), randomBoolean())
+                        new SearchableSnapshotAction(
+                            randomAlphaOfLength(10),
+                            randomBoolean(),
+                            (randomBoolean() ? null : randomIntBetween(1, 100))
+                        )
                     )
                 )
             );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -41,7 +41,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
         StepKey nextStepKey = randomStepKey();
         String restoredIndexPrefix = randomAlphaOfLength(10);
         MountSearchableSnapshotRequest.Storage storage = randomStorageType();
-        return new MountSnapshotStep(stepKey, nextStepKey, client, restoredIndexPrefix, storage);
+        Integer totalShardsPerNode = randomTotalShardsPerNode(true);
+        return new MountSnapshotStep(stepKey, nextStepKey, client, restoredIndexPrefix, storage, totalShardsPerNode);
     }
 
     public static MountSearchableSnapshotRequest.Storage randomStorageType() {
@@ -59,7 +60,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
             instance.getNextStepKey(),
             instance.getClient(),
             instance.getRestoredIndexPrefix(),
-            instance.getStorage()
+            instance.getStorage(),
+            instance.getTotalShardsPerNode()
         );
     }
 
@@ -69,7 +71,8 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
         StepKey nextKey = instance.getNextStepKey();
         String restoredIndexPrefix = instance.getRestoredIndexPrefix();
         MountSearchableSnapshotRequest.Storage storage = instance.getStorage();
-        switch (between(0, 3)) {
+        Integer totalShardsPerNode = instance.getTotalShardsPerNode();
+        switch (between(0, 4)) {
             case 0:
                 key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
                 break;
@@ -88,10 +91,30 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                     throw new AssertionError("unknown storage type: " + storage);
                 }
                 break;
+            case 4:
+                totalShardsPerNode = totalShardsPerNode == null ? 1 : totalShardsPerNode + randomIntBetween(1, 100);
+                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
-        return new MountSnapshotStep(key, nextKey, instance.getClient(), restoredIndexPrefix, storage);
+        return new MountSnapshotStep(key, nextKey, instance.getClient(), restoredIndexPrefix, storage, totalShardsPerNode);
+    }
+
+    public void testCreateWithInvalidTotalShardsPerNode() throws Exception {
+        int invalidTotalShardsPerNode = randomIntBetween(-100, 0);
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new MountSnapshotStep(
+                randomStepKey(),
+                randomStepKey(),
+                client,
+                RESTORED_INDEX_PREFIX,
+                randomStorageType(),
+                invalidTotalShardsPerNode
+            )
+        );
+        assertEquals("[total_shards_per_node] must be >= 1", exception.getMessage());
     }
 
     public void testPerformActionFailure() {
@@ -345,7 +368,50 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 randomStepKey(),
                 client,
                 RESTORED_INDEX_PREFIX,
-                randomStorageType()
+                randomStorageType(),
+                null
+            );
+            performActionAndWait(step, indexMetadata, clusterState, null);
+        }
+    }
+
+    public void testDoNotIgnoreTotalShardsPerNodeIfSet() throws Exception {
+        String indexName = randomAlphaOfLength(10);
+        String policyName = "test-ilm-policy";
+        Map<String, String> ilmCustom = new HashMap<>();
+        String snapshotName = indexName + "-" + policyName;
+        ilmCustom.put("snapshot_name", snapshotName);
+        String repository = "repository";
+        ilmCustom.put("snapshot_repository", repository);
+
+        IndexMetadata.Builder indexMetadataBuilder = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+            .putCustom(LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY, ilmCustom)
+            .numberOfShards(randomIntBetween(1, 5))
+            .numberOfReplicas(randomIntBetween(0, 5));
+        IndexMetadata indexMetadata = indexMetadataBuilder.build();
+
+        ClusterState clusterState = ClusterState.builder(emptyClusterState())
+            .metadata(Metadata.builder().put(indexMetadata, true).build())
+            .build();
+
+        try (var threadPool = createThreadPool()) {
+            final var client = getRestoreSnapshotRequestAssertingClient(
+                threadPool,
+                repository,
+                snapshotName,
+                indexName,
+                RESTORED_INDEX_PREFIX,
+                indexName,
+                new String[] { LifecycleSettings.LIFECYCLE_NAME }
+            );
+            MountSnapshotStep step = new MountSnapshotStep(
+                new StepKey(TimeseriesLifecycleType.FROZEN_PHASE, randomAlphaOfLength(10), randomAlphaOfLength(10)),
+                randomStepKey(),
+                client,
+                RESTORED_INDEX_PREFIX,
+                randomStorageType(),
+                randomTotalShardsPerNode(false)
             );
             performActionAndWait(step, indexMetadata, clusterState, null);
         }
@@ -400,5 +466,11 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
                 listener.onResponse((Response) new RestoreSnapshotResponse((RestoreInfo) null));
             }
         };
+    }
+
+    private Integer randomTotalShardsPerNode(boolean nullable) {
+        Integer randomInt = randomIntBetween(1, 100);
+        Integer randomIntNullable = (randomBoolean() ? null : randomInt);
+        return nullable ? randomIntNullable : randomInt;
     }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createComposableTemplate;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
@@ -919,6 +920,61 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
             triggerStateChange();
             assertThat(explainIndex(client(), restoredIndexName).get("step"), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
+    }
+
+    public void testSearchableSnapshotTotalShardsPerNode() throws Exception {
+        String index = "myindex-" + randomAlphaOfLength(4).toLowerCase(Locale.ROOT);
+        Integer totalShardsPerNode = 2;
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+        createPolicy(
+            client(),
+            policy,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            new Phase(
+                "frozen",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean(), totalShardsPerNode))
+            ),
+            null
+        );
+
+        createIndex(index, Settings.EMPTY);
+        ensureGreen(index);
+        indexDocument(client(), index, true);
+
+        // enable ILM after we indexed a document as otherwise ILM might sometimes run so fast the indexDocument call will fail with
+        // `index_not_found_exception`
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
+
+        // wait for snapshot successfully mounted and ILM execution completed
+        final String searchableSnapMountedIndexName = SearchableSnapshotAction.PARTIAL_RESTORED_INDEX_PREFIX
+            + SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + index;
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to exist...", searchableSnapMountedIndexName);
+            assertTrue(indexExists(searchableSnapMountedIndexName));
+        }, 30, TimeUnit.SECONDS);
+        assertBusy(() -> {
+            triggerStateChange();
+            Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), searchableSnapMountedIndexName);
+            assertThat(stepKeyForIndex.phase(), is("frozen"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
+        }, 30, TimeUnit.SECONDS);
+
+        // validate total_shards_per_node setting
+        Map<String, Object> indexSettings = getIndexSettingsAsMap(searchableSnapMountedIndexName);
+        assertNotNull("expected total_shards_per_node to exist", indexSettings.get(INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()));
+        Integer snapshotTotalShardsPerNode = Integer.valueOf((String) indexSettings.get(INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey()));
+        assertEquals(
+            "expected total_shards_per_node to be " + totalShardsPerNode + ", but got: " + snapshotTotalShardsPerNode,
+            snapshotTotalShardsPerNode,
+            totalShardsPerNode
+        );
     }
 
     /**


### PR DESCRIPTION
Backport for https://github.com/elastic/elasticsearch/commit/80dd56398f855923df0c0117abd098fd3023ce36

Allows setting index total_shards_per_node in the SearchableSnapshot action of ILM to remediate hot spot in shard allocation for searchable snapshot index.

Closes #112261
