### PR TITLE
[8.x] Add Search Inference ID To Semantic Text Mapping (#113051)

### DIFF
--- a/docs/changelog/113051.yaml
+++ b/docs/changelog/113051.yaml
@@ -1,0 +1,5 @@
+pr: 113051
+summary: Add Search Inference ID To Semantic Text Mapping
+area: Mapping
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -223,6 +223,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_AGGREGATION_OPERATOR_STATUS_FINISH_NANOS = def(8_747_00_0);
     public static final TransportVersion ML_TELEMETRY_MEMORY_ADDED = def(8_748_00_0);
     public static final TransportVersion ILM_ADD_SEARCHABLE_SNAPSHOT_TOTAL_SHARDS_PER_NODE = def(8_749_00_0);
+    public static final TransportVersion SEMANTIC_TEXT_SEARCH_INFERENCE_ID = def(8_750_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/InferenceFieldMetadataTests.java
@@ -61,13 +61,15 @@ public class InferenceFieldMetadataTests extends AbstractXContentTestCase<Infere
     private static InferenceFieldMetadata createTestItem() {
         String name = randomAlphaOfLengthBetween(3, 10);
         String inferenceId = randomIdentifier();
+        String searchInferenceId = randomIdentifier();
         String[] inputFields = generateRandomStringArray(5, 10, false, false);
-        return new InferenceFieldMetadata(name, inferenceId, inputFields);
+        return new InferenceFieldMetadata(name, inferenceId, searchInferenceId, inputFields);
     }
 
     public void testNullCtorArgsThrowException() {
-        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata(null, "inferenceId", new String[0]));
-        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", null, new String[0]));
-        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", "inferenceId", null));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata(null, "inferenceId", "searchInferenceId", new String[0]));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", null, "searchInferenceId", new String[0]));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", "inferenceId", null, new String[0]));
+        assertThrows(NullPointerException.class, () -> new InferenceFieldMetadata("name", "inferenceId", "searchInferenceId", null));
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference;
 
 import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper;
 import org.elasticsearch.xpack.inference.rank.random.RandomRankRetrieverBuilder;
 import org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder;
 
@@ -23,7 +24,8 @@ public class InferenceFeatures implements FeatureSpecification {
     public Set<NodeFeature> getFeatures() {
         return Set.of(
             TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_RETRIEVER_SUPPORTED,
-            RandomRankRetrieverBuilder.RANDOM_RERANKER_RETRIEVER_SUPPORTED
+            RandomRankRetrieverBuilder.RANDOM_RERANKER_RETRIEVER_SUPPORTED,
+            SemanticTextFieldMapper.SEMANTIC_TEXT_SEARCH_INFERENCE_ID
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -79,6 +80,8 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getOrig
  * A {@link FieldMapper} for semantic text fields.
  */
 public class SemanticTextFieldMapper extends FieldMapper implements InferenceFieldMapper {
+    public static final NodeFeature SEMANTIC_TEXT_SEARCH_INFERENCE_ID = new NodeFeature("semantic_text.search_inference_id");
+
     public static final String CONTENT_TYPE = "semantic_text";
 
     private final IndexSettings indexSettings;
@@ -103,6 +106,13 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             }
         });
 
+        private final Parameter<String> searchInferenceId = Parameter.stringParam(
+            "search_inference_id",
+            true,
+            mapper -> ((SemanticTextFieldType) mapper.fieldType()).searchInferenceId,
+            null
+        ).acceptsNull();
+
         private final Parameter<SemanticTextField.ModelSettings> modelSettings = new Parameter<>(
             "model_settings",
             true,
@@ -116,6 +126,17 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         private Function<MapperBuilderContext, ObjectMapper> inferenceFieldBuilder;
+
+        public static Builder from(SemanticTextFieldMapper mapper) {
+            Builder builder = new Builder(
+                mapper.leafName(),
+                mapper.fieldType().indexVersionCreated,
+                mapper.fieldType().getChunksField().bitsetProducer(),
+                mapper.indexSettings
+            );
+            builder.init(mapper);
+            return builder;
+        }
 
         public Builder(
             String name,
@@ -140,6 +161,11 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             return this;
         }
 
+        public Builder setSearchInferenceId(String id) {
+            this.searchInferenceId.setValue(id);
+            return this;
+        }
+
         public Builder setModelSettings(SemanticTextField.ModelSettings value) {
             this.modelSettings.setValue(value);
             return this;
@@ -147,15 +173,17 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
         @Override
         protected Parameter<?>[] getParameters() {
-            return new Parameter<?>[] { inferenceId, modelSettings, meta };
+            return new Parameter<?>[] { inferenceId, searchInferenceId, modelSettings, meta };
         }
 
         @Override
         protected void merge(FieldMapper mergeWith, Conflicts conflicts, MapperMergeContext mapperMergeContext) {
-            super.merge(mergeWith, conflicts, mapperMergeContext);
+            SemanticTextFieldMapper semanticMergeWith = (SemanticTextFieldMapper) mergeWith;
+            semanticMergeWith = copySettings(semanticMergeWith, mapperMergeContext);
+
+            super.merge(semanticMergeWith, conflicts, mapperMergeContext);
             conflicts.check();
-            var semanticMergeWith = (SemanticTextFieldMapper) mergeWith;
-            var context = mapperMergeContext.createChildContext(mergeWith.leafName(), ObjectMapper.Dynamic.FALSE);
+            var context = mapperMergeContext.createChildContext(semanticMergeWith.leafName(), ObjectMapper.Dynamic.FALSE);
             var inferenceField = inferenceFieldBuilder.apply(context.getMapperBuilderContext());
             var mergedInferenceField = inferenceField.merge(semanticMergeWith.fieldType().getInferenceField(), context);
             inferenceFieldBuilder = c -> mergedInferenceField;
@@ -181,6 +209,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                 new SemanticTextFieldType(
                     fullName,
                     inferenceId.getValue(),
+                    searchInferenceId.getValue(),
                     modelSettings.getValue(),
                     inferenceField,
                     indexVersionCreated,
@@ -189,6 +218,25 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                 builderParams(this, context),
                 indexSettings
             );
+        }
+
+        /**
+         * As necessary, copy settings from this builder to the passed-in mapper.
+         * Used to preserve {@link SemanticTextField.ModelSettings} when updating a semantic text mapping to one where the model settings
+         * are not specified.
+         *
+         * @param mapper The mapper
+         * @return A mapper with the copied settings applied
+         */
+        private SemanticTextFieldMapper copySettings(SemanticTextFieldMapper mapper, MapperMergeContext mapperMergeContext) {
+            SemanticTextFieldMapper returnedMapper = mapper;
+            if (mapper.fieldType().getModelSettings() == null) {
+                Builder builder = from(mapper);
+                builder.setModelSettings(modelSettings.getValue());
+                returnedMapper = builder.build(mapperMergeContext.getMapperBuilderContext());
+            }
+
+            return returnedMapper;
         }
     }
 
@@ -211,9 +259,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(leafName(), fieldType().indexVersionCreated, fieldType().getChunksField().bitsetProducer(), indexSettings).init(
-            this
-        );
+        return Builder.from(this);
     }
 
     @Override
@@ -267,7 +313,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             }
         } else {
             Conflicts conflicts = new Conflicts(fullFieldName);
-            canMergeModelSettings(field.inference().modelSettings(), fieldType().getModelSettings(), conflicts);
+            canMergeModelSettings(fieldType().getModelSettings(), field.inference().modelSettings(), conflicts);
             try {
                 conflicts.check();
             } catch (Exception exc) {
@@ -316,7 +362,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         String[] copyFields = sourcePaths.toArray(String[]::new);
         // ensure consistent order
         Arrays.sort(copyFields);
-        return new InferenceFieldMetadata(fullPath(), fieldType().inferenceId, copyFields);
+        return new InferenceFieldMetadata(fullPath(), fieldType().getInferenceId(), fieldType().getSearchInferenceId(), copyFields);
     }
 
     @Override
@@ -335,6 +381,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
     public static class SemanticTextFieldType extends SimpleMappedFieldType {
         private final String inferenceId;
+        private final String searchInferenceId;
         private final SemanticTextField.ModelSettings modelSettings;
         private final ObjectMapper inferenceField;
         private final IndexVersion indexVersionCreated;
@@ -342,6 +389,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         public SemanticTextFieldType(
             String name,
             String inferenceId,
+            String searchInferenceId,
             SemanticTextField.ModelSettings modelSettings,
             ObjectMapper inferenceField,
             IndexVersion indexVersionCreated,
@@ -349,6 +397,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         ) {
             super(name, true, false, false, TextSearchInfo.NONE, meta);
             this.inferenceId = inferenceId;
+            this.searchInferenceId = searchInferenceId;
             this.modelSettings = modelSettings;
             this.inferenceField = inferenceField;
             this.indexVersionCreated = indexVersionCreated;
@@ -361,6 +410,10 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
         public String getInferenceId() {
             return inferenceId;
+        }
+
+        public String getSearchInferenceId() {
+            return searchInferenceId == null ? inferenceId : searchInferenceId;
         }
 
         public SemanticTextField.ModelSettings getModelSettings() {
@@ -428,14 +481,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                     case SPARSE_EMBEDDING -> {
                         if (inferenceResults instanceof TextExpansionResults == false) {
                             throw new IllegalArgumentException(
-                                "Field ["
-                                    + name()
-                                    + "] expected query inference results to be of type ["
-                                    + TextExpansionResults.NAME
-                                    + "],"
-                                    + " got ["
-                                    + inferenceResults.getWriteableName()
-                                    + "]. Has the inference endpoint configuration changed?"
+                                generateQueryInferenceResultsTypeMismatchMessage(inferenceResults, TextExpansionResults.NAME)
                             );
                         }
 
@@ -454,14 +500,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                     case TEXT_EMBEDDING -> {
                         if (inferenceResults instanceof MlTextEmbeddingResults == false) {
                             throw new IllegalArgumentException(
-                                "Field ["
-                                    + name()
-                                    + "] expected query inference results to be of type ["
-                                    + MlTextEmbeddingResults.NAME
-                                    + "],"
-                                    + " got ["
-                                    + inferenceResults.getWriteableName()
-                                    + "]. Has the inference endpoint configuration changed?"
+                                generateQueryInferenceResultsTypeMismatchMessage(inferenceResults, MlTextEmbeddingResults.NAME)
                             );
                         }
 
@@ -469,13 +508,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                         float[] inference = textEmbeddingResults.getInferenceAsFloat();
                         if (inference.length != modelSettings.dimensions()) {
                             throw new IllegalArgumentException(
-                                "Field ["
-                                    + name()
-                                    + "] expected query inference results with "
-                                    + modelSettings.dimensions()
-                                    + " dimensions, got "
-                                    + inference.length
-                                    + " dimensions. Has the inference endpoint configuration changed?"
+                                generateDimensionCountMismatchMessage(inference.length, modelSettings.dimensions())
                             );
                         }
 
@@ -484,7 +517,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                     default -> throw new IllegalStateException(
                         "Field ["
                             + name()
-                            + "] configured to use an inference endpoint with an unsupported task type ["
+                            + "] is configured to use an inference endpoint with an unsupported task type ["
                             + modelSettings.taskType()
                             + "]"
                     );
@@ -492,6 +525,51 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             }
 
             return new NestedQueryBuilder(nestedFieldPath, childQueryBuilder, ScoreMode.Max).boost(boost).queryName(queryName);
+        }
+
+        private String generateQueryInferenceResultsTypeMismatchMessage(InferenceResults inferenceResults, String expectedResultsType) {
+            StringBuilder sb = new StringBuilder(
+                "Field ["
+                    + name()
+                    + "] expected query inference results to be of type ["
+                    + expectedResultsType
+                    + "],"
+                    + " got ["
+                    + inferenceResults.getWriteableName()
+                    + "]."
+            );
+
+            return generateInvalidQueryInferenceResultsMessage(sb);
+        }
+
+        private String generateDimensionCountMismatchMessage(int inferenceDimCount, int expectedDimCount) {
+            StringBuilder sb = new StringBuilder(
+                "Field ["
+                    + name()
+                    + "] expected query inference results with "
+                    + expectedDimCount
+                    + " dimensions, got "
+                    + inferenceDimCount
+                    + " dimensions."
+            );
+
+            return generateInvalidQueryInferenceResultsMessage(sb);
+        }
+
+        private String generateInvalidQueryInferenceResultsMessage(StringBuilder baseMessageBuilder) {
+            if (searchInferenceId != null && searchInferenceId.equals(inferenceId) == false) {
+                baseMessageBuilder.append(
+                    " Is the search inference endpoint ["
+                        + searchInferenceId
+                        + "] compatible with the inference endpoint ["
+                        + inferenceId
+                        + "]?"
+                );
+            } else {
+                baseMessageBuilder.append(" Has the configuration for inference endpoint [" + inferenceId + "] changed?");
+            }
+
+            return baseMessageBuilder.toString();
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilder.java
@@ -284,7 +284,7 @@ public class SemanticQueryBuilder extends AbstractQueryBuilder<SemanticQueryBuil
         String inferenceId = null;
         for (IndexMetadata indexMetadata : indexMetadataCollection) {
             InferenceFieldMetadata inferenceFieldMetadata = indexMetadata.getInferenceFields().get(fieldName);
-            String indexInferenceId = inferenceFieldMetadata != null ? inferenceFieldMetadata.getInferenceId() : null;
+            String indexInferenceId = inferenceFieldMetadata != null ? inferenceFieldMetadata.getSearchInferenceId() : null;
             if (indexInferenceId != null) {
                 if (inferenceId != null && inferenceId.equals(indexInferenceId) == false) {
                     throw new IllegalArgumentException("Field [" + fieldName + "] has multiple inference IDs associated with it");

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
@@ -79,9 +79,11 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
     private static final int QUERY_TOKEN_LENGTH = 4;
     private static final int TEXT_EMBEDDING_DIMENSION_COUNT = 10;
     private static final String INFERENCE_ID = "test_service";
+    private static final String SEARCH_INFERENCE_ID = "search_test_service";
 
     private static InferenceResultType inferenceResultType;
     private static DenseVectorFieldMapper.ElementType denseVectorElementType;
+    private static boolean useSearchInferenceId;
 
     private enum InferenceResultType {
         NONE,
@@ -100,6 +102,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
             DenseVectorFieldMapper.ElementType.BIT,
             () -> randomFrom(DenseVectorFieldMapper.ElementType.values())
         ); // TODO: Support bit elements once KNN bit vector queries are available
+        useSearchInferenceId = randomBoolean();
     }
 
     @Override
@@ -126,11 +129,14 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
 
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
+        String mappingConfig = "type=semantic_text,inference_id=" + INFERENCE_ID;
+        if (useSearchInferenceId) {
+            mappingConfig += ",search_inference_id=" + SEARCH_INFERENCE_ID;
+        }
+
         mapperService.merge(
             "_doc",
-            new CompressedXContent(
-                Strings.toString(PutMappingRequest.simpleMapping(SEMANTIC_TEXT_FIELD, "type=semantic_text,inference_id=" + INFERENCE_ID))
-            ),
+            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping(SEMANTIC_TEXT_FIELD, mappingConfig))),
             MapperService.MergeReason.MAPPING_UPDATE
         );
 
@@ -244,6 +250,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         InferenceAction.Request request = (InferenceAction.Request) args[1];
         assertThat(request.getTaskType(), equalTo(TaskType.ANY));
         assertThat(request.getInputType(), equalTo(InputType.SEARCH));
+        assertThat(request.getInferenceEntityId(), equalTo(useSearchInferenceId ? SEARCH_INFERENCE_ID : INFERENCE_ID));
 
         List<String> input = request.getInput();
         assertThat(input.size(), equalTo(1));

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/40_semantic_text_query.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/40_semantic_text_query.yml
@@ -20,8 +20,40 @@ setup:
 
   - do:
       inference.put:
+        task_type: sparse_embedding
+        inference_id: sparse-inference-id-2
+        body: >
+          {
+            "service": "test_service",
+            "service_settings": {
+              "model": "my_model",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+            }
+          }
+
+  - do:
+      inference.put:
         task_type: text_embedding
         inference_id: dense-inference-id
+        body: >
+          {
+            "service": "text_embedding_test_service",
+            "service_settings": {
+              "model": "my_model",
+              "dimensions": 10,
+              "api_key": "abc64",
+              "similarity": "COSINE"
+            },
+            "task_settings": {
+            }
+          }
+
+  - do:
+      inference.put:
+        task_type: text_embedding
+        inference_id: dense-inference-id-2
         body: >
           {
             "service": "text_embedding_test_service",
@@ -141,6 +173,51 @@ setup:
   - match: { hits.total.value: 1 }
   - match: { hits.hits.0._id: "doc_1" }
   - length: { hits.hits.0._source.inference_field.inference.chunks: 1 }
+
+---
+"Query using a sparse embedding model via a search inference ID":
+  - requires:
+      cluster_features: "semantic_text.search_inference_id"
+      reason: search_inference_id introduced in 8.16.0
+
+  - skip:
+      features: [ "headers", "close_to" ]
+
+  - do:
+      indices.put_mapping:
+        index: test-sparse-index
+        body:
+          properties:
+            inference_field:
+              type: semantic_text
+              inference_id: sparse-inference-id
+              search_inference_id: sparse-inference-id-2
+
+  - do:
+      index:
+        index: test-sparse-index
+        id: doc_1
+        body:
+          inference_field: [ "inference test", "another inference test" ]
+          non_inference_field: "non inference test"
+        refresh: true
+
+  - do:
+      headers:
+        # Force JSON content type so that we use a parser that interprets the floating-point score as a double
+        Content-Type: application/json
+      search:
+        index: test-sparse-index
+        body:
+          query:
+            semantic:
+              field: "inference_field"
+              query: "inference test"
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc_1" }
+  - close_to: { hits.hits.0._score: { value: 3.7837332e17, error: 1e10 } }
+  - length: { hits.hits.0._source.inference_field.inference.chunks: 2 }
 
 ---
 "Query using a dense embedding model":
@@ -275,6 +352,51 @@ setup:
         Content-Type: application/json
       search:
         index: test-dense-byte-index
+        body:
+          query:
+            semantic:
+              field: "inference_field"
+              query: "inference test"
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc_1" }
+  - close_to: { hits.hits.0._score: { value: 1.0, error: 0.0001 } }
+  - length: { hits.hits.0._source.inference_field.inference.chunks: 2 }
+
+---
+"Query using a dense embedding model via a search inference ID":
+  - requires:
+      cluster_features: "semantic_text.search_inference_id"
+      reason: search_inference_id introduced in 8.16.0
+
+  - skip:
+      features: [ "headers", "close_to" ]
+
+  - do:
+      indices.put_mapping:
+        index: test-dense-index
+        body:
+          properties:
+            inference_field:
+              type: semantic_text
+              inference_id: dense-inference-id
+              search_inference_id: dense-inference-id-2
+
+  - do:
+      index:
+        index: test-dense-index
+        id: doc_1
+        body:
+          inference_field: ["inference test", "another inference test"]
+          non_inference_field: "non inference test"
+        refresh: true
+
+  - do:
+      headers:
+        # Force JSON content type so that we use a parser that interprets the floating-point score as a double
+        Content-Type: application/json
+      search:
+        index: test-dense-index
         body:
           query:
             semantic:
@@ -573,6 +695,142 @@ setup:
       catch: missing
       search:
         index: test-index-with-invalid-inference-id
+        body:
+          query:
+            semantic:
+              field: "inference_field"
+              query: "inference test"
+
+  - match: { error.type: "resource_not_found_exception" }
+  - match: { error.reason: "Inference endpoint not found [invalid-inference-id]" }
+
+---
+"Query a field with a search inference ID that uses the wrong task type":
+  - requires:
+      cluster_features: "semantic_text.search_inference_id"
+      reason: search_inference_id introduced in 8.16.0
+
+  - do:
+      indices.put_mapping:
+        index: test-sparse-index
+        body:
+          properties:
+            inference_field:
+              type: semantic_text
+              inference_id: sparse-inference-id
+              search_inference_id: dense-inference-id
+
+  - do:
+      index:
+        index: test-sparse-index
+        id: doc_1
+        body:
+          inference_field: [ "inference test", "another inference test" ]
+          non_inference_field: "non inference test"
+        refresh: true
+
+  - do:
+      catch: bad_request
+      search:
+        index: test-sparse-index
+        body:
+          query:
+            semantic:
+              field: "inference_field"
+              query: "inference test"
+
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "Field [inference_field] expected query inference results to be of type
+                                    [text_expansion_result], got [text_embedding_result]. Is the search inference
+                                    endpoint [dense-inference-id] compatible with the inference endpoint
+                                    [sparse-inference-id]?" }
+
+---
+"Query a field with a search inference ID that uses the wrong dimension count":
+  - requires:
+      cluster_features: "semantic_text.search_inference_id"
+      reason: search_inference_id introduced in 8.16.0
+
+  - do:
+      inference.put:
+        task_type: text_embedding
+        inference_id: dense-inference-id-20-dims
+        body: >
+          {
+            "service": "text_embedding_test_service",
+            "service_settings": {
+              "model": "my_model",
+              "dimensions": 20,
+              "api_key": "abc64",
+              "similarity": "COSINE"
+            },
+            "task_settings": {
+            }
+          }
+
+  - do:
+      indices.put_mapping:
+        index: test-dense-index
+        body:
+          properties:
+            inference_field:
+              type: semantic_text
+              inference_id: dense-inference-id
+              search_inference_id: dense-inference-id-20-dims
+
+  - do:
+      index:
+        index: test-dense-index
+        id: doc_1
+        body:
+          inference_field: ["inference test", "another inference test"]
+          non_inference_field: "non inference test"
+        refresh: true
+
+  - do:
+      catch: bad_request
+      search:
+        index: test-dense-index
+        body:
+          query:
+            semantic:
+              field: "inference_field"
+              query: "inference test"
+
+  - match: { error.caused_by.type: "illegal_argument_exception" }
+  - match: { error.caused_by.reason: "Field [inference_field] expected query inference results with 10 dimensions, got
+                                      20 dimensions. Is the search inference endpoint [dense-inference-id-20-dims]
+                                      compatible with the inference endpoint [dense-inference-id]?" }
+
+---
+"Query a field with an invalid search inference ID":
+  - requires:
+      cluster_features: "semantic_text.search_inference_id"
+      reason: search_inference_id introduced in 8.16.0
+
+  - do:
+      indices.put_mapping:
+        index: test-dense-index
+        body:
+          properties:
+            inference_field:
+              type: semantic_text
+              inference_id: dense-inference-id
+              search_inference_id: invalid-inference-id
+
+  - do:
+      index:
+        index: test-dense-index
+        id: doc_1
+        body:
+          inference_field: [ "inference test", "another inference test" ]
+          non_inference_field: "non inference test"
+        refresh: true
+
+  - do:
+      catch: missing
+      search:
+        index: test-dense-index
         body:
           query:
             semantic:

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/50_semantic_text_query_inference_endpoint_changes.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/50_semantic_text_query_inference_endpoint_changes.yml
@@ -112,8 +112,8 @@ setup:
 
   - match: { error.caused_by.type: "illegal_argument_exception" }
   - match: { error.caused_by.reason: "Field [inference_field] expected query inference results to be of type
-                                      [text_expansion_result], got [text_embedding_result]. Has the inference endpoint
-                                      configuration changed?" }
+                                      [text_expansion_result], got [text_embedding_result]. Has the configuration for
+                                      inference endpoint [sparse-inference-id] changed?" }
 
 ---
 "text_embedding changed to sparse_embedding":
@@ -149,8 +149,8 @@ setup:
 
   - match: { error.caused_by.type: "illegal_argument_exception" }
   - match: { error.caused_by.reason: "Field [inference_field] expected query inference results to be of type
-                                      [text_embedding_result], got [text_expansion_result]. Has the inference endpoint
-                                      configuration changed?" }
+                                      [text_embedding_result], got [text_expansion_result]. Has the configuration for
+                                      inference endpoint [dense-inference-id] changed?" }
 
 ---
 "text_embedding dimension count changed":
@@ -188,4 +188,5 @@ setup:
 
   - match: { error.caused_by.type: "illegal_argument_exception" }
   - match: { error.caused_by.reason: "Field [inference_field] expected query inference results with 10 dimensions, got
-                                      20 dimensions. Has the inference endpoint configuration changed?" }
+                                      20 dimensions. Has the configuration for inference endpoint [dense-inference-id]
+                                      changed?" }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add Search Inference ID To Semantic Text Mapping (#113051)