### PR TITLE
Unmute security ITs related to bulk authz failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -236,15 +236,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
   method: "testFold {TestCase=<double> #2}"
   issue: https://github.com/elastic/elasticsearch/issues/113225
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testGetMappings
-  issue: https://github.com/elastic/elasticsearch/issues/113260
 - class: org.elasticsearch.xpack.security.authz.SecurityScrollTests
   method: testSearchAndClearScroll
   issue: https://github.com/elastic/elasticsearch/issues/113285
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testGetIndex
-  issue: https://github.com/elastic/elasticsearch/issues/113311
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test81JavaOptsInJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/113313
@@ -260,9 +254,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_force_delete/Test force deleting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/113327
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testValidateQuery
-  issue: https://github.com/elastic/elasticsearch/issues/113328
 - class: org.elasticsearch.xpack.security.support.SecurityIndexManagerIntegTests
   method: testOnIndexAvailableForSearchIndexAlreadyAvailable
   issue: https://github.com/elastic/elasticsearch/issues/113336
@@ -272,15 +263,9 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=analytics/top_metrics/sort by scaled float field}
   issue: https://github.com/elastic/elasticsearch/issues/113340
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testFieldMappings
-  issue: https://github.com/elastic/elasticsearch/issues/113341
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
   issue: https://github.com/elastic/elasticsearch/issues/113343
-- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
-  method: testSearchAndMSearch
-  issue: https://github.com/elastic/elasticsearch/issues/113345
 - class: org.elasticsearch.action.bulk.IncrementalBulkIT
   method: testBulkLevelBulkFailureAfterFirstIncrementalRequest
   issue: https://github.com/elastic/elasticsearch/issues/113365

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -236,9 +236,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
   method: "testFold {TestCase=<double> #2}"
   issue: https://github.com/elastic/elasticsearch/issues/113225
-- class: org.elasticsearch.xpack.security.authz.SecurityScrollTests
-  method: testSearchAndClearScroll
-  issue: https://github.com/elastic/elasticsearch/issues/113285
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test81JavaOptsInJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/113313
@@ -257,9 +254,6 @@ tests:
 - class: org.elasticsearch.xpack.security.support.SecurityIndexManagerIntegTests
   method: testOnIndexAvailableForSearchIndexAlreadyAvailable
   issue: https://github.com/elastic/elasticsearch/issues/113336
-- class: org.elasticsearch.xpack.security.authz.SecurityScrollTests
-  method: testScrollIsPerUser
-  issue: https://github.com/elastic/elasticsearch/issues/113338
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=analytics/top_metrics/sort by scaled float field}
   issue: https://github.com/elastic/elasticsearch/issues/113340


### PR DESCRIPTION
A [change](https://github.com/elastic/elasticsearch/pull/111865/files#diff-f35477bd1eef27ca0cfd9e94205799a6ff7f64e02a658e456051e400f08db061R1774-R1799) in the `indexRandom` method resulted in test failures due to unexpected switches to system user processing during bulk index creation calls. It has since been [reverted](https://github.com/elastic/elasticsearch/pull/113416), so this PR unmutes the relevant tests. Will monitor for failures.

Resolves: https://github.com/elastic/elasticsearch/issues/113345
Resolves: https://github.com/elastic/elasticsearch/issues/113341
Resolves: https://github.com/elastic/elasticsearch/issues/113338
Resolves: https://github.com/elastic/elasticsearch/issues/113328
Resolves: https://github.com/elastic/elasticsearch/issues/113311
Resolves: https://github.com/elastic/elasticsearch/issues/113285
Resolves: https://github.com/elastic/elasticsearch/issues/113260
Resolves: https://github.com/elastic/elasticsearch/issues/113185