### PR TITLE
Adds text_similarity task type to inference processor documentation

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -455,6 +455,29 @@ include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenizatio
 =======
 =====
 
+[discrete]
+[[inference-processor-text-similarity-opt]]
+==== Text similarity configuration options
+
+`text_similarity`:::
+(Object, optional)
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-similarity]
++
+.Properties of text_similarity inference
+[%collapsible%open]
+=====
+`span_score_combination_function`::::
+(Optional, string)
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-similarity-span-score-func]
+
+`tokenization`::::
+(Optional, object)
+include::{es-ref-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
++
+Refer to <<tokenization-properties>> to review the properties of the
+`tokenization` object.
+=====
+
 
 [discrete]
 [[inference-processor-zero-shot-opt]]


### PR DESCRIPTION
### Overview
This update adds the `text_similarity` task type to the inference processor documentation, detailing its configuration options for comparing text inputs.

### Related issue
https://github.com/elastic/search-docs-team/issues/188

### Preview
[Inference processor](https://elasticsearch_bk_113517.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-processor.html)
