### PR TITLE
[8.x] Add initial synthetic source fallback logic (#112994)

### DIFF
--- a/x-pack/plugin/logsdb/build.gradle
+++ b/x-pack/plugin/logsdb/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import org.elasticsearch.gradle.internal.info.BuildParams
+
+evaluationDependsOn(xpackModule('core'))
+
+apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.internal-java-rest-test'
+
+esplugin {
+  name 'logsdb'
+  description 'A plugin for logsdb related functionality'
+  classname 'org.elasticsearch.xpack.logsdb.LogsDBPlugin'
+  extendedPlugins = ['x-pack-core']
+}
+base {
+  archivesName = 'x-pack-logsdb'
+}
+
+dependencies {
+  compileOnly project(path: xpackModule('core'))
+  testImplementation(testArtifact(project(xpackModule('core'))))
+}
+
+tasks.named("javaRestTest").configure {
+  usesDefaultDistribution()
+}

--- a/x-pack/plugin/logsdb/qa/build.gradle
+++ b/x-pack/plugin/logsdb/qa/build.gradle
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+

--- a/x-pack/plugin/logsdb/qa/with-basic/build.gradle
+++ b/x-pack/plugin/logsdb/qa/with-basic/build.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import org.elasticsearch.gradle.internal.info.BuildParams
+
+apply plugin: 'elasticsearch.internal-java-rest-test'
+
+dependencies {
+  javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+}
+
+tasks.named("javaRestTest").configure {
+  // This test cluster is using a BASIC license and FIPS 140 mode is not supported in BASIC
+  BuildParams.withFipsEnabledOnly(it)
+
+  usesDefaultDistribution()
+}

--- a/x-pack/plugin/logsdb/qa/with-basic/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
+++ b/x-pack/plugin/logsdb/qa/with-basic/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.hamcrest.Matchers;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class LogsdbRestIT extends ESRestTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.license.self_generated.type", "basic")
+        .setting("xpack.security.enabled", "false")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    public void testFeatureUsageWithLogsdbIndex() throws IOException {
+        {
+            var response = getAsMap("/_license/feature_usage");
+            @SuppressWarnings("unchecked")
+            List<Map<?, ?>> features = (List<Map<?, ?>>) response.get("features");
+            assertThat(features, Matchers.empty());
+        }
+        {
+            createIndex("test-index", Settings.builder().put("index.mode", "logsdb").build());
+            var response = getAsMap("/_license/feature_usage");
+            @SuppressWarnings("unchecked")
+            List<Map<?, ?>> features = (List<Map<?, ?>>) response.get("features");
+            assertThat(features, Matchers.empty());
+        }
+    }
+
+}

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbRestIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.hamcrest.Matchers;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LogsdbRestIT extends ESRestTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    public void testFeatureUsageWithLogsdbIndex() throws IOException {
+        {
+            var response = getAsMap("/_license/feature_usage");
+            @SuppressWarnings("unchecked")
+            List<Map<?, ?>> features = (List<Map<?, ?>>) response.get("features");
+            assertThat(features, Matchers.empty());
+        }
+        {
+            createIndex("test-index", Settings.builder().put("index.mode", "logsdb").build());
+            var response = getAsMap("/_license/feature_usage");
+            @SuppressWarnings("unchecked")
+            List<Map<?, ?>> features = (List<Map<?, ?>>) response.get("features");
+            logger.info("response's features: {}", features);
+            assertThat(features, Matchers.not(Matchers.empty()));
+            Map<?, ?> feature = features.stream().filter(map -> "mappings".equals(map.get("family"))).findFirst().get();
+            assertThat(feature.get("name"), equalTo("synthetic-source"));
+            assertThat(feature.get("license_level"), equalTo("enterprise"));
+        }
+    }
+
+}

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettingProvider;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.XPackPlugin;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseService.FALLBACK_SETTING;
+
+public class LogsDBPlugin extends Plugin {
+
+    private final Settings settings;
+    private final SyntheticSourceLicenseService licenseService;
+
+    public LogsDBPlugin(Settings settings) {
+        this.settings = settings;
+        this.licenseService = new SyntheticSourceLicenseService(settings);
+    }
+
+    @Override
+    public Collection<?> createComponents(PluginServices services) {
+        licenseService.setLicenseState(XPackPlugin.getSharedLicenseState());
+        var clusterSettings = services.clusterService().getClusterSettings();
+        clusterSettings.addSettingsUpdateConsumer(FALLBACK_SETTING, licenseService::setSyntheticSourceFallback);
+        // Nothing to share here:
+        return super.createComponents(services);
+    }
+
+    @Override
+    public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders(IndexSettingProvider.Parameters parameters) {
+        if (DiscoveryNode.isStateless(settings)) {
+            return List.of();
+        }
+        return List.of(new SyntheticSourceIndexSettingsProvider(licenseService));
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(FALLBACK_SETTING);
+    }
+}

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettingProvider;
+import org.elasticsearch.index.IndexSettings;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * An index setting provider that overwrites the source mode from synthetic to stored if synthetic source isn't allowed to be used.
+ */
+public class SyntheticSourceIndexSettingsProvider implements IndexSettingProvider {
+
+    private static final Logger LOGGER = LogManager.getLogger(SyntheticSourceIndexSettingsProvider.class);
+
+    private final SyntheticSourceLicenseService syntheticSourceLicenseService;
+
+    public SyntheticSourceIndexSettingsProvider(SyntheticSourceLicenseService syntheticSourceLicenseService) {
+        this.syntheticSourceLicenseService = syntheticSourceLicenseService;
+    }
+
+    @Override
+    public Settings getAdditionalIndexSettings(
+        String indexName,
+        String dataStreamName,
+        boolean isTimeSeries,
+        Metadata metadata,
+        Instant resolvedAt,
+        Settings indexTemplateAndCreateRequestSettings,
+        List<CompressedXContent> combinedTemplateMappings
+    ) {
+        if (newIndexHasSyntheticSourceUsage(indexTemplateAndCreateRequestSettings)
+            && syntheticSourceLicenseService.fallbackToStoredSource()) {
+            LOGGER.debug("creation of index [{}] with synthetic source without it being allowed", indexName);
+            // TODO: handle falling back to stored source
+        }
+        return Settings.EMPTY;
+    }
+
+    boolean newIndexHasSyntheticSourceUsage(Settings indexTemplateAndCreateRequestSettings) {
+        // TODO: build tmp MapperService and check whether SourceFieldMapper#isSynthetic() to determine synthetic source usage.
+        // Not using IndexSettings.MODE.get() to avoid validation that may fail at this point.
+        var rawIndexMode = indexTemplateAndCreateRequestSettings.get(IndexSettings.MODE.getKey());
+        IndexMode indexMode = rawIndexMode != null ? Enum.valueOf(IndexMode.class, rawIndexMode.toUpperCase(Locale.ROOT)) : null;
+        return indexMode != null && indexMode.isSyntheticSourceEnabled();
+    }
+}

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
+import org.elasticsearch.license.XPackLicenseState;
+
+/**
+ * Determines based on license and fallback setting whether synthetic source usages should fallback to stored source.
+ */
+public final class SyntheticSourceLicenseService {
+
+    private static final String MAPPINGS_FEATURE_FAMILY = "mappings";
+
+    /**
+     * A setting that determines whether source mode should always be stored source. Regardless of licence.
+     */
+    public static final Setting<Boolean> FALLBACK_SETTING = Setting.boolSetting(
+        "xpack.mapping.synthetic_source_fallback_to_stored_source",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    private static final LicensedFeature.Momentary SYNTHETIC_SOURCE_FEATURE = LicensedFeature.momentary(
+        MAPPINGS_FEATURE_FAMILY,
+        "synthetic-source",
+        License.OperationMode.ENTERPRISE
+    );
+
+    private XPackLicenseState licenseState;
+    private volatile boolean syntheticSourceFallback;
+
+    public SyntheticSourceLicenseService(Settings settings) {
+        syntheticSourceFallback = FALLBACK_SETTING.get(settings);
+    }
+
+    /**
+     * @return whether synthetic source mode should fallback to stored source.
+     */
+    public boolean fallbackToStoredSource() {
+        if (syntheticSourceFallback) {
+            return true;
+        }
+
+        return SYNTHETIC_SOURCE_FEATURE.check(licenseState) == false;
+    }
+
+    void setSyntheticSourceFallback(boolean syntheticSourceFallback) {
+        this.syntheticSourceFallback = syntheticSourceFallback;
+    }
+
+    void setLicenseState(XPackLicenseState licenseState) {
+        this.licenseState = licenseState;
+    }
+}

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseServiceTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseServiceTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SyntheticSourceLicenseServiceTests extends ESTestCase {
+
+    public void testLicenseAllowsSyntheticSource() {
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(any())).thenReturn(true);
+        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        licenseService.setLicenseState(licenseState);
+        assertFalse("synthetic source is allowed, so not fallback to stored source", licenseService.fallbackToStoredSource());
+    }
+
+    public void testDefaultDisallow() {
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(any())).thenReturn(false);
+        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        licenseService.setLicenseState(licenseState);
+        assertTrue("synthetic source is not allowed, so fallback to stored source", licenseService.fallbackToStoredSource());
+    }
+
+    public void testFallback() {
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+        when(licenseState.isAllowed(any())).thenReturn(true);
+        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setSyntheticSourceFallback(true);
+        assertTrue(
+            "synthetic source is allowed, but fallback has been enabled, so fallback to stored source",
+            licenseService.fallbackToStoredSource()
+        );
+    }
+
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add initial synthetic source fallback logic (#112994)