### PR TITLE
[8.x] Extending catch clause in rewriteAndFetch (#112829)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/Rewriteable.java
+++ b/server/src/main/java/org/elasticsearch/index/query/Rewriteable.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.query;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.ParsingException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -108,7 +107,7 @@ public interface Rewriteable<T> {
                 }
             }
             rewriteResponse.onResponse(builder);
-        } catch (IOException | IllegalArgumentException | ParsingException ex) {
+        } catch (Exception ex) {
             rewriteResponse.onFailure(ex);
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Extending catch clause in rewriteAndFetch (#112829)