### PR TITLE
Remove unused code in persistent task APIs

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/CompletionPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/CompletionPersistentTaskAction.java
@@ -35,28 +35,18 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  * ActionType that is used by executor node to indicate that the persistent action finished or failed on the node and needs to be
  * removed from the cluster state in case of successful completion or restarted on some other node in case of failure.
  */
-public class CompletionPersistentTaskAction extends ActionType<PersistentTaskResponse> {
+public class CompletionPersistentTaskAction {
 
-    public static final CompletionPersistentTaskAction INSTANCE = new CompletionPersistentTaskAction();
-    public static final String NAME = "cluster:admin/persistent/completion";
+    public static final ActionType<PersistentTaskResponse> INSTANCE = new ActionType<>("cluster:admin/persistent/completion");
 
-    private CompletionPersistentTaskAction() {
-        super(NAME);
-    }
+    private CompletionPersistentTaskAction() {/* no instances */}
 
     public static class Request extends MasterNodeRequest<Request> {
 
-        private String taskId;
-
-        private Exception exception;
-
-        private long allocationId = -1;
-
-        private String localAbortReason;
-
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
-        }
+        private final String taskId;
+        private final Exception exception;
+        private final long allocationId;
+        private final String localAbortReason;
 
         public Request(StreamInput in) throws IOException {
             super(in);
@@ -129,7 +119,7 @@ public class CompletionPersistentTaskAction extends ActionType<PersistentTaskRes
             IndexNameExpressionResolver indexNameExpressionResolver
         ) {
             super(
-                CompletionPersistentTaskAction.NAME,
+                INSTANCE.name(),
                 transportService,
                 clusterService,
                 threadPool,

--- a/server/src/main/java/org/elasticsearch/persistent/RemovePersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/RemovePersistentTaskAction.java
@@ -29,22 +29,15 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RemovePersistentTaskAction extends ActionType<PersistentTaskResponse> {
+public class RemovePersistentTaskAction {
 
-    public static final RemovePersistentTaskAction INSTANCE = new RemovePersistentTaskAction();
-    public static final String NAME = "cluster:admin/persistent/remove";
+    public static final ActionType<PersistentTaskResponse> INSTANCE = new ActionType<>("cluster:admin/persistent/remove");
 
-    private RemovePersistentTaskAction() {
-        super(NAME);
-    }
+    private RemovePersistentTaskAction() {/* no instances */}
 
     public static class Request extends MasterNodeRequest<Request> {
 
-        private String taskId;
-
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
-        }
+        private final String taskId;
 
         public Request(StreamInput in) throws IOException {
             super(in);
@@ -53,10 +46,6 @@ public class RemovePersistentTaskAction extends ActionType<PersistentTaskRespons
 
         public Request(String taskId) {
             super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
-            this.taskId = taskId;
-        }
-
-        public void setTaskId(String taskId) {
             this.taskId = taskId;
         }
 
@@ -99,7 +88,7 @@ public class RemovePersistentTaskAction extends ActionType<PersistentTaskRespons
             IndexNameExpressionResolver indexNameExpressionResolver
         ) {
             super(
-                RemovePersistentTaskAction.NAME,
+                INSTANCE.name(),
                 transportService,
                 clusterService,
                 threadPool,

--- a/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
@@ -21,7 +21,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -35,26 +34,16 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 /**
  *  This action can be used to add the record for the persistent action to the cluster state.
  */
-public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse> {
+public class StartPersistentTaskAction {
 
-    public static final StartPersistentTaskAction INSTANCE = new StartPersistentTaskAction();
-    public static final String NAME = "cluster:admin/persistent/start";
+    public static final ActionType<PersistentTaskResponse> INSTANCE = new ActionType<>("cluster:admin/persistent/start");
 
-    private StartPersistentTaskAction() {
-        super(NAME);
-    }
+    private StartPersistentTaskAction() {/* no instances */}
 
     public static class Request extends MasterNodeRequest<Request> {
-
-        private String taskId;
-
-        private String taskName;
-
-        private PersistentTaskParams params;
-
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
-        }
+        private final String taskId;
+        private final String taskName;
+        private final PersistentTaskParams params;
 
         public Request(StreamInput in) throws IOException {
             super(in);
@@ -117,27 +106,13 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
             return taskName;
         }
 
-        public void setTaskName(String taskName) {
-            this.taskName = taskName;
-        }
-
         public String getTaskId() {
             return taskId;
-        }
-
-        public void setTaskId(String taskId) {
-            this.taskId = taskId;
         }
 
         public PersistentTaskParams getParams() {
             return params;
         }
-
-        @Nullable
-        public void setParams(PersistentTaskParams params) {
-            this.params = params;
-        }
-
     }
 
     public static class TransportAction extends TransportMasterNodeAction<Request, PersistentTaskResponse> {
@@ -156,7 +131,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
             IndexNameExpressionResolver indexNameExpressionResolver
         ) {
             super(
-                StartPersistentTaskAction.NAME,
+                INSTANCE.name(),
                 transportService,
                 clusterService,
                 threadPool,

--- a/server/src/main/java/org/elasticsearch/persistent/UpdatePersistentTaskStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/UpdatePersistentTaskStatusAction.java
@@ -31,24 +31,16 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskResponse> {
+public class UpdatePersistentTaskStatusAction {
 
-    public static final UpdatePersistentTaskStatusAction INSTANCE = new UpdatePersistentTaskStatusAction();
-    public static final String NAME = "cluster:admin/persistent/update_status";
+    public static final ActionType<PersistentTaskResponse> INSTANCE = new ActionType<>("cluster:admin/persistent/update_status");
 
-    private UpdatePersistentTaskStatusAction() {
-        super(NAME);
-    }
+    private UpdatePersistentTaskStatusAction() {/* no instances */}
 
     public static class Request extends MasterNodeRequest<Request> {
-
-        private String taskId;
-        private long allocationId = -1L;
-        private PersistentTaskState state;
-
-        public Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT);
-        }
+        private final String taskId;
+        private final long allocationId;
+        private final PersistentTaskState state;
 
         public Request(StreamInput in) throws IOException {
             super(in);
@@ -64,24 +56,12 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
             this.state = state;
         }
 
-        public void setTaskId(String taskId) {
-            this.taskId = taskId;
-        }
-
         public String getTaskId() {
             return taskId;
         }
 
-        public void setAllocationId(long allocationId) {
-            this.allocationId = allocationId;
-        }
-
         public long getAllocationId() {
             return allocationId;
-        }
-
-        public void setState(PersistentTaskState state) {
-            this.state = state;
         }
 
         public PersistentTaskState getState() {
@@ -138,7 +118,7 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
             IndexNameExpressionResolver indexNameExpressionResolver
         ) {
             super(
-                UpdatePersistentTaskStatusAction.NAME,
+                INSTANCE.name(),
                 transportService,
                 clusterService,
                 threadPool,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/SystemPrivilege.java
@@ -39,7 +39,7 @@ public final class SystemPrivilege extends Privilege {
         RetentionLeaseActions.REMOVE.name() + "*", // needed for CCR to remove retention leases
         RetentionLeaseActions.RENEW.name() + "*", // needed for CCR to renew retention leases
         "indices:admin/settings/update", // needed for DiskThresholdMonitor.markIndicesReadOnly
-        CompletionPersistentTaskAction.NAME, // needed for ShardFollowTaskCleaner
+        CompletionPersistentTaskAction.INSTANCE.name(), // needed for ShardFollowTaskCleaner
         "indices:data/write/*", // needed for SystemIndexMigrator
         "indices:data/read/*", // needed for SystemIndexMigrator
         "indices:admin/refresh", // needed for SystemIndexMigrator


### PR DESCRIPTION
Removes unused mutability from request types and unnecessary subclasses
of `ActionType<>`.