### PR TITLE
Fix release tests by checking QSTR function is registered

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -287,8 +287,6 @@ tests:
 - class: org.elasticsearch.validation.DotPrefixClientYamlTestSuiteIT
   method: test {p0=dot_prefix/10_basic/Deprecated index template with a dot prefix index pattern}
   issue: https://github.com/elastic/elasticsearch/issues/113529
-- class: org.elasticsearch.xpack.esql.expression.function.fulltext.QueryStringFunctionTests
-  issue: https://github.com/elastic/elasticsearch/issues/113496
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}
   issue: https://github.com/elastic/elasticsearch/issues/113537

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringFunctionTests.java
@@ -18,16 +18,23 @@ import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.hamcrest.Matcher;
+import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.QSTR_FUNCTION;
 import static org.hamcrest.Matchers.equalTo;
 
 @FunctionName("qstr")
 public class QueryStringFunctionTests extends AbstractFunctionTestCase {
+
+    @BeforeClass
+    public static void checkFunctionEnabled() {
+        assumeTrue("QSTR capability should be enabled ", QSTR_FUNCTION.isEnabled());
+    }
 
     public QueryStringFunctionTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/113496

Checks that QSTR function is registered on the tests so release builds don't error out