### PR TITLE
[8.x] [ML] Remove the cluster state listener when the adaptive allocations service stops (#113524)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerService.java
@@ -259,12 +259,17 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
     }
 
     public synchronized void stop() {
+        clusterService.removeListener(this);
         stopScheduling();
         metrics.close();
     }
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
+        if (event.metadataChanged() == false) {
+            return;
+        }
+
         updateAutoscalers(event.state());
         if (scalers.isEmpty() == false) {
             startScheduling();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Remove the cluster state listener when the adaptive allocations service stops (#113524)