### PR TITLE
Unmute test affected by #113099

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -281,12 +281,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testOutOfOrderData
   issue: https://github.com/elastic/elasticsearch/issues/113477
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/100_analytics_usage/Basic test for usage stats on analytics indices}
-  issue: https://github.com/elastic/elasticsearch/issues/113497
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry)}
-  issue: https://github.com/elastic/elasticsearch/issues/113502
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testCreateJobsWithIndexNameOption
   issue: https://github.com/elastic/elasticsearch/issues/113528


### PR DESCRIPTION
Those test were failing for a missing backport with the following error:

```
stack_trace":"java.io.IOException: Can't read unknown type [111]\n\tat org.elasticsearch.server@9.0.0-SNAPSHOT
```

The backport is done so we can just unmute them.

fixes https://github.com/elastic/elasticsearch/issues/113502
fixes https://github.com/elastic/elasticsearch/issues/113497