### PR TITLE
[8.15] Add blog links to locale deprecation warnings (#113474)

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/30_date_processor.yml
@@ -1,6 +1,6 @@
 setup:
   - requires:
-      test_runner_features: allowed_warnings
+      test_runner_features: allowed_warnings_regex
 ---
 teardown:
   - do:
@@ -100,8 +100,8 @@ teardown:
 "Test date processor with no timezone configured":
 
   - do:
-      allowed_warnings:
-        - 'Date format [dd/MMM/yyyy:H:m:s Z] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[dd/MMM/yyyy:H:m:s Z] contains textual field specifiers that could change in JDK 23.*'
       ingest.put_pipeline:
         id: "my_pipeline"
         # sample formats from beats, featuring mongodb, icinga, apache
@@ -170,8 +170,8 @@ teardown:
   - match: { acknowledged: true }
 
   - do:
-      allowed_warnings:
-        - 'Date format [dd/MMM/yyyy:H:m:s Z] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[dd/MMM/yyyy:H:m:s Z] contains textual field specifiers that could change in JDK 23.*'
       index:
         index: test
         id: "1"
@@ -211,8 +211,8 @@ teardown:
 ---
 "Test week based date parsing":
   - do:
-      allowed_warnings:
-        - 'Date format [YYYY-ww] contains week-date field specifiers that are changing in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[YYYY-ww] contains week-date field specifiers that are changing in JDK 23.*'
       indices.create:
         index: test
         body:
@@ -223,8 +223,8 @@ teardown:
                 format: YYYY-ww
 
   - do:
-      allowed_warnings:
-        - 'Date format [YYYY-ww] contains week-date field specifiers that are changing in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[YYYY-ww] contains week-date field specifiers that are changing in JDK 23.*'
       ingest.put_pipeline:
         id: "my_pipeline"
         body:  >

--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/20_combine_processors.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/20_combine_processors.yml
@@ -1,11 +1,11 @@
 setup:
   - requires:
-      test_runner_features: allowed_warnings
+      test_runner_features: allowed_warnings_regex
 ---
 "Test with date processor":
   - do:
-      allowed_warnings:
-        - 'Date format [dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23.*'
       ingest.put_pipeline:
         id: "_id"
         body:  >
@@ -46,8 +46,8 @@ setup:
   - match: { acknowledged: true }
 
   - do:
-      allowed_warnings:
-        - 'Date format [dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23.*'
       index:
         index: test
         id: "1"
@@ -77,8 +77,8 @@ setup:
 ---
 "Test with date processor and ECS-v1":
   - do:
-      allowed_warnings:
-        - 'Date format [dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23.*'
       ingest.put_pipeline:
         id: "_id"
         body:  >
@@ -108,8 +108,8 @@ setup:
   - match: { acknowledged: true }
 
   - do:
-      allowed_warnings:
-        - 'Date format [dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[dd/MMM/yyyy:HH:mm:ss xx] contains textual field specifiers that could change in JDK 23.*'
       index:
         index: test
         id: "1"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
@@ -1,11 +1,11 @@
 setup:
   - requires:
-      test_runner_features: allowed_warnings
+      test_runner_features: allowed_warnings_regex
 ---
 "Test Index and Search locale dependent mappings / dates":
   - do:
-      allowed_warnings:
-        - 'Date format [E, d MMM yyyy HH:mm:ss Z] contains textual field specifiers that could change in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[E, d MMM yyyy HH:mm:ss Z] contains textual field specifiers that could change in JDK 23.*'
       indices.create:
           index: test_index
           body:

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -404,7 +404,8 @@ public class DateUtils {
             deprecationLogger.warn(
                 DeprecationCategory.PARSING,
                 "cldr_date_formats_" + format,
-                "Date format [{}] contains textual field specifiers that could change in JDK 23",
+                "Date format [{}] contains textual field specifiers that could change in JDK 23."
+                    + " For more information, see https://ela.st/jdk-23-locales",
                 format
             );
         }
@@ -412,7 +413,8 @@ public class DateUtils {
             deprecationLogger.warn(
                 DeprecationCategory.PARSING,
                 "cldr_week_dates_" + format,
-                "Date format [{}] contains week-date field specifiers that are changing in JDK 23",
+                "Date format [{}] contains week-date field specifiers that are changing in JDK 23."
+                    + " For more information, see https://ela.st/jdk-23-locales",
                 format
             );
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -481,7 +481,7 @@ dateFormatLocale
 from employees | where emp_no == 10049 or emp_no == 10050 | sort emp_no 
 | eval birth_month = date_format("MMMM", birth_date) | keep emp_no, birth_date, birth_month;
 ignoreOrder:true
-warningRegex:Date format \[MMMM] contains textual field specifiers that could change in JDK 23
+warningRegex:Date format \[MMMM] contains textual field specifiers that could change in JDK 23.*
 
 emp_no:integer  |  birth_date:datetime       | birth_month:keyword
 10049           |  null                      | null

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
@@ -28,8 +28,8 @@ setup:
 "Date format with default locale":
   - do:
       allowed_warnings_regex:
-        - "No limit defined, adding default limit of \\[.*\\]"
-        - "Date format \\[MMMM] contains textual field specifiers that could change in JDK 23"
+        - 'No limit defined, adding default limit of \[.*]'
+        - 'Date format \[MMMM] contains textual field specifiers that could change in JDK 23.*'
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
@@ -51,7 +51,7 @@ setup:
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
-        - "Date format \\[MMMM] contains textual field specifiers that could change in JDK 23"
+        - "Date format \\[MMMM] contains textual field specifiers that could change in JDK 23.*"
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/13_index_datemath.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/13_index_datemath.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - requires:
-      test_runner_features: allowed_warnings
+      test_runner_features: allowed_warnings_regex
   - skip:
       features: headers
 
@@ -56,8 +56,8 @@ teardown:
           }
 
   - do:
-      allowed_warnings:
-        - 'Date format [YYYY.MM] contains week-date field specifiers that are changing in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[YYYY\.MM] contains week-date field specifiers that are changing in JDK 23.*'
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
       bulk:
         body:
@@ -93,8 +93,8 @@ teardown:
           }
 
   - do:
-      allowed_warnings:
-        - 'Date format [YYYY.MM] contains week-date field specifiers that are changing in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[YYYY\.MM] contains week-date field specifiers that are changing in JDK 23.*'
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
       bulk:
         body:
@@ -121,8 +121,8 @@ teardown:
 ---
 "Test bulk indexing with datemath when only some are allowed":
   - do:
-      allowed_warnings:
-        - 'Date format [YYYY] contains week-date field specifiers that are changing in JDK 23'
+      allowed_warnings_regex:
+        - 'Date format \[YYYY] contains week-date field specifiers that are changing in JDK 23.*'
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
       bulk:
         body:


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Add blog links to locale deprecation warnings (#113474)