### PR TITLE
Log exceptions in IndicesLifecycleListener tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesLifecycleListenerSingleNodeTests.java
@@ -128,6 +128,8 @@ public class IndicesLifecycleListenerSingleNodeTests extends ESSingleNodeTestCas
             newRouting = ShardRoutingHelper.moveToStarted(newRouting);
             IndexShardTestCase.updateRoutingEntry(shard, newRouting);
             assertEquals(6, counter.get());
+        } catch (Exception ex) {
+            logger.warn("unexpected exception", ex);
         } finally {
             indicesService.removeIndex(idx, DELETED, "simon says", EsExecutors.DIRECT_EXECUTOR_SERVICE, ActionListener.noop());
         }


### PR DESCRIPTION
Because the finally clause assertions did not finally print any exceptions that might have occurred.

Happened in build scan [qdorbubrxbqh6](https://gradle-enterprise.elastic.co/s/qdorbubrxbqh6/). And can be easily reproduced e.g., by using a custom metadata:

```
metadata = IndexMetadata.builder(metadata).settings(Settings.builder().put(metadata.getSettings()).put(IndexMetadata.INDEX_DATA_PATH_SETTING.getKey(), "/invalid/path")).build();
```