### PR TITLE
Allow configuring `ignore_dynamic_beyond_limit` in Serverless

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -125,7 +125,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         "index.mapping.total_fields.ignore_dynamic_beyond_limit",
         false,
         Property.Dynamic,
-        Property.IndexScope
+        Property.IndexScope,
+        Property.ServerlessPublic
     );
     public static final Setting<Long> INDEX_MAPPING_DEPTH_LIMIT_SETTING = Setting.longSetting(
         "index.mapping.depth.limit",


### PR DESCRIPTION
This setting is already set for the Serverless templates, however, it's not marked as available on Serverless, so it's ending up ignored. This allows the setting.
