### PR TITLE
[8.x] Workaround packaging tests failures on debian10 (#113550)

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -39,7 +39,7 @@ if [ -f "/etc/os-release" ] ; then
         # Work around incorrect lintian version
         #  https://github.com/elastic/elasticsearch/issues/48573
         if [ $VERSION_ID == 10 ] ; then
-            sudo apt-get update -y
+            sudo apt-get update -y || true
             sudo apt-get install -y --allow-downgrades lintian=2.15.0
         fi
     fi


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Workaround packaging tests failures on debian10 (#113550)