### PR TITLE
[8.x] Fix synthetic source for flattened field when used with ignore_above (#113499)

### DIFF
--- a/docs/changelog/113499.yaml
+++ b/docs/changelog/113499.yaml
@@ -1,0 +1,6 @@
+pr: 113499
+summary: Fix synthetic source for flattened field when used with `ignore_above`
+area: Logs
+type: bug
+issues:
+ - 112044

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -1050,6 +1050,63 @@ flattened field with ignore_above:
 
   - is_false: fields
 
+
+---
+flattened field with ignore_above and arrays:
+  - requires:
+      cluster_features: ["mapper.flattened.ignore_above_with_arrays_support"]
+      reason: requires support of ignore_above synthetic source with arrays
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              field:
+                type: flattened
+                ignore_above: 10
+
+  - do:
+      index:
+        index: test
+        id: 1
+        body: |
+          {
+            "field": [
+              { "key1": { "key2": "key2", "key3": "key3_ignored" }, "key4": "key4_ignored", "key5": { "key6": "key6_ignored" }, "key7": "key7" },
+              { "key1": { "key2": "key12", "key13": "key13_ignored" }, "key4": "key14_ignored", "key15": { "key16": "key16_ignored" }, "key17": [ "key17", "key18" ] }
+            ]
+          }
+
+  - do:
+      get:
+        index: test
+        id: 1
+
+  - match: { _index: "test" }
+  - match: { _id: "1" }
+  - match: { _version: 1 }
+  - match: { found: true }
+  - match:
+      _source:
+        field:
+          key1:
+            key2: [ "key12", "key2" ]
+            key3: "key3_ignored"
+            key13: "key13_ignored"
+          key4: [ "key14_ignored", "key4_ignored" ]
+          key5:
+            key6: "key6_ignored"
+          key7: "key7"
+          key15:
+            key16: "key16_ignored"
+          key17: [ "key17", "key18" ]
+
+  - is_false: fields
+
 ---
 completion:
   - requires:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/540_ignore_above_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/540_ignore_above_synthetic_source.yml
@@ -44,8 +44,8 @@ ignore_above mapping level setting:
 ---
 ignore_above mapping level setting on arrays:
   - requires:
-      cluster_features: [ "mapper.ignore_above_index_level_setting" ]
-      reason: introduce ignore_above index level setting
+      cluster_features: [ "mapper.flattened.ignore_above_with_arrays_support" ]
+      reason: requires support of ignore_above with arrays for flattened fields
   - do:
       indices.create:
         index:  test
@@ -80,9 +80,9 @@ ignore_above mapping level setting on arrays:
             match_all: {}
 
   - length: { hits.hits: 1 }
-  #TODO: synthetic source field reconstruction bug (TBD: add link to the issue here)
+    #TODO: synthetic source field reconstruction bug (TBD: add link to the issue here)
   #- match: { hits.hits.0._source.keyword: ["foo bar", "the quick brown fox"] }
-  - match: { hits.hits.0._source.flattened.value: ["the quick brown fox", "jumps over"] }
+  - match: { hits.hits.0._source.flattened.value: [ "jumps over", "the quick brown fox" ] }
   - match: { hits.hits.0.fields.keyword.0: "foo bar" }
   - match: { hits.hits.0.fields.flattened.0.value: "jumps over" }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -44,7 +44,8 @@ public class MapperFeatures implements FeatureSpecification {
             FlattenedFieldMapper.IGNORE_ABOVE_SUPPORT,
             IndexSettings.IGNORE_ABOVE_INDEX_LEVEL_SETTING,
             SourceFieldMapper.SYNTHETIC_SOURCE_COPY_TO_INSIDE_OBJECTS_FIX,
-            TimeSeriesRoutingHashFieldMapper.TS_ROUTING_HASH_FIELD_PARSES_BYTES_REF
+            TimeSeriesRoutingHashFieldMapper.TS_ROUTING_HASH_FIELD_PARSES_BYTES_REF,
+            FlattenedFieldMapper.IGNORE_ABOVE_WITH_ARRAYS_SUPPORT
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -112,9 +112,11 @@ import static org.elasticsearch.index.IndexSettings.IGNORE_ABOVE_SETTING;
 public final class FlattenedFieldMapper extends FieldMapper {
 
     public static final NodeFeature IGNORE_ABOVE_SUPPORT = new NodeFeature("flattened.ignore_above_support");
+    public static final NodeFeature IGNORE_ABOVE_WITH_ARRAYS_SUPPORT = new NodeFeature("mapper.flattened.ignore_above_with_arrays_support");
 
     public static final String CONTENT_TYPE = "flattened";
     public static final String KEYED_FIELD_SUFFIX = "._keyed";
+    public static final String KEYED_IGNORED_VALUES_FIELD_SUFFIX = "._keyed._ignored";
     public static final String TIME_SERIES_DIMENSIONS_ARRAY_PARAM = "time_series_dimensions";
 
     private static class Defaults {
@@ -835,6 +837,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
         this.fieldParser = new FlattenedFieldParser(
             mappedFieldType.name(),
             mappedFieldType.name() + KEYED_FIELD_SUFFIX,
+            mappedFieldType.name() + KEYED_IGNORED_VALUES_FIELD_SUFFIX,
             mappedFieldType,
             builder.depthLimit.get(),
             builder.ignoreAbove.get(),
@@ -903,7 +906,12 @@ public final class FlattenedFieldMapper extends FieldMapper {
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (fieldType().hasDocValues()) {
-            var loader = new FlattenedSortedSetDocValuesSyntheticFieldLoader(fullPath(), fullPath() + "._keyed", leafName());
+            var loader = new FlattenedSortedSetDocValuesSyntheticFieldLoader(
+                fullPath(),
+                fullPath() + KEYED_FIELD_SUFFIX,
+                ignoreAbove() < Integer.MAX_VALUE ? fullPath() + KEYED_IGNORED_VALUES_FIELD_SUFFIX : null,
+                leafName()
+            );
 
             return new SyntheticSourceSupport.Native(loader);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedSortedSetDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedSortedSetDocValuesSyntheticFieldLoader.java
@@ -13,33 +13,62 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Stream;
 
-public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
-    private DocValuesFieldValues docValues = NO_VALUES;
+class FlattenedSortedSetDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
     private final String fieldFullPath;
     private final String keyedFieldFullPath;
+    private final String keyedIgnoredValuesFieldFullPath;
     private final String leafName;
+
+    private DocValuesFieldValues docValues = NO_VALUES;
+    private List<Object> ignoredValues = List.of();
 
     /**
      * Build a loader for flattened fields from doc values.
      *
-     * @param fieldFullPath           full path to the original field
-     * @param keyedFieldFullPath      full path to the keyed field to load doc values from
-     * @param leafName                the name of the leaf field to use in the rendered {@code _source}
+     * @param fieldFullPath                        full path to the original field
+     * @param keyedFieldFullPath                   full path to the keyed field to load doc values from
+     * @param keyedIgnoredValuesFieldFullPath      full path to the keyed field that stores values that are not present in doc values
+     *                                             due to ignore_above
+     * @param leafName                             the name of the leaf field to use in the rendered {@code _source}
      */
-    public FlattenedSortedSetDocValuesSyntheticFieldLoader(String fieldFullPath, String keyedFieldFullPath, String leafName) {
+    FlattenedSortedSetDocValuesSyntheticFieldLoader(
+        String fieldFullPath,
+        String keyedFieldFullPath,
+        @Nullable String keyedIgnoredValuesFieldFullPath,
+        String leafName
+    ) {
         this.fieldFullPath = fieldFullPath;
         this.keyedFieldFullPath = keyedFieldFullPath;
+        this.keyedIgnoredValuesFieldFullPath = keyedIgnoredValuesFieldFullPath;
         this.leafName = leafName;
     }
 
     @Override
     public String fieldName() {
         return fieldFullPath;
+    }
+
+    @Override
+    public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+        if (keyedIgnoredValuesFieldFullPath == null) {
+            return Stream.empty();
+        }
+
+        return Stream.of(Map.entry(keyedIgnoredValuesFieldFullPath, (values) -> {
+            ignoredValues = new ArrayList<>();
+            ignoredValues.addAll(values);
+        }));
     }
 
     @Override
@@ -56,23 +85,40 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SourceLoade
 
     @Override
     public boolean hasValue() {
-        return docValues.count() > 0;
+        return docValues.count() > 0 || ignoredValues.isEmpty() == false;
     }
 
     @Override
     public void write(XContentBuilder b) throws IOException {
-        if (docValues.count() == 0) {
+        if (docValues.count() == 0 && ignoredValues.isEmpty()) {
             return;
         }
+
+        FlattenedFieldSyntheticWriterHelper.SortedKeyedValues sortedKeyedValues = new DocValuesSortedKeyedValues(docValues);
+        if (ignoredValues.isEmpty() == false) {
+            var ignoredValuesSet = new TreeSet<BytesRef>();
+            for (Object value : ignoredValues) {
+                ignoredValuesSet.add((BytesRef) value);
+            }
+            ignoredValues = List.of();
+            sortedKeyedValues = new DocValuesWithIgnoredSortedKeyedValues(sortedKeyedValues, ignoredValuesSet);
+        }
+        var writer = new FlattenedFieldSyntheticWriterHelper(sortedKeyedValues);
+
         b.startObject(leafName);
-        docValues.write(b);
+        writer.write(b);
         b.endObject();
+    }
+
+    @Override
+    public void reset() {
+        ignoredValues = List.of();
     }
 
     private interface DocValuesFieldValues {
         int count();
 
-        void write(XContentBuilder b) throws IOException;
+        SortedSetDocValues getValues();
     }
 
     private static final DocValuesFieldValues NO_VALUES = new DocValuesFieldValues() {
@@ -82,7 +128,9 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SourceLoade
         }
 
         @Override
-        public void write(XContentBuilder b) {}
+        public SortedSetDocValues getValues() {
+            return null;
+        }
     };
 
     /**
@@ -92,11 +140,9 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SourceLoade
     private static class FlattenedFieldDocValuesLoader implements DocValuesLoader, DocValuesFieldValues {
         private final SortedSetDocValues dv;
         private boolean hasValue;
-        private final FlattenedFieldSyntheticWriterHelper writer;
 
         FlattenedFieldDocValuesLoader(final SortedSetDocValues dv) {
             this.dv = dv;
-            this.writer = new FlattenedFieldSyntheticWriterHelper(dv);
         }
 
         @Override
@@ -110,8 +156,74 @@ public class FlattenedSortedSetDocValuesSyntheticFieldLoader extends SourceLoade
         }
 
         @Override
-        public void write(XContentBuilder b) throws IOException {
-            this.writer.write(b);
+        public SortedSetDocValues getValues() {
+            return dv;
+        }
+    }
+
+    private static class DocValuesWithIgnoredSortedKeyedValues implements FlattenedFieldSyntheticWriterHelper.SortedKeyedValues {
+        private final FlattenedFieldSyntheticWriterHelper.SortedKeyedValues docValues;
+        private final TreeSet<BytesRef> ignoredValues;
+
+        private BytesRef currentFromDocValues;
+
+        private DocValuesWithIgnoredSortedKeyedValues(
+            FlattenedFieldSyntheticWriterHelper.SortedKeyedValues docValues,
+            TreeSet<BytesRef> ignoredValues
+        ) {
+            this.docValues = docValues;
+            this.ignoredValues = ignoredValues;
+        }
+
+        /**
+         * Returns next keyed field value to be included in synthetic source.
+         * This function merges keyed values from doc values and ignored values (due to ignore_above)
+         * that are loaded from stored fields and provided as input.
+         * Sort order of keyed values is preserved during merge so the output is the same as if
+         * it was using only doc values.
+         * @return
+         * @throws IOException
+         */
+        @Override
+        public BytesRef next() throws IOException {
+            if (currentFromDocValues == null) {
+                currentFromDocValues = docValues.next();
+            }
+
+            if (ignoredValues.isEmpty() == false) {
+                BytesRef ignoredCandidate = ignoredValues.first();
+                if (currentFromDocValues == null || ignoredCandidate.compareTo(currentFromDocValues) <= 0) {
+                    ignoredValues.pollFirst();
+                    return ignoredCandidate;
+                }
+            }
+            if (currentFromDocValues == null) {
+                return null;
+            }
+
+            var toReturn = currentFromDocValues;
+            currentFromDocValues = null;
+            return toReturn;
+        }
+    }
+
+    private static class DocValuesSortedKeyedValues implements FlattenedFieldSyntheticWriterHelper.SortedKeyedValues {
+        private final DocValuesFieldValues docValues;
+        private int seen = 0;
+
+        private DocValuesSortedKeyedValues(DocValuesFieldValues docValues) {
+            this.docValues = docValues;
+        }
+
+        @Override
+        public BytesRef next() throws IOException {
+            if (seen < docValues.count()) {
+                seen += 1;
+                var sortedSetDocValues = docValues.getValues();
+                return sortedSetDocValues.lookupOrd(sortedSetDocValues.nextOrd());
+            }
+
+            return null;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
@@ -9,8 +9,11 @@
 
 package org.elasticsearch.index.mapper.flattened;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -41,7 +44,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -712,7 +718,7 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         throw new AssumptionViolatedException("not supported");
     }
 
-    private static void randomMapExample(final TreeMap<Object, Object> example, int depth, int maxDepth) {
+    private static void randomMapExample(final Map<String, Object> example, int depth, int maxDepth) {
         for (int i = 0; i < randomIntBetween(2, 5); i++) {
             int j = depth >= maxDepth ? randomIntBetween(1, 2) : randomIntBetween(1, 3);
             switch (j) {
@@ -728,7 +734,7 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
                     example.put(randomAlphaOfLength(6), randomList);
                 }
                 case 3 -> {
-                    final TreeMap<Object, Object> nested = new TreeMap<>();
+                    final Map<String, Object> nested = new HashMap<>();
                     randomMapExample(nested, depth + 1, maxDepth);
                     example.put(randomAlphaOfLength(10), nested);
                 }
@@ -742,11 +748,73 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
 
         @Override
         public SyntheticSourceExample example(int maxValues) throws IOException {
-            // NOTE: values must be keywords and we use a TreeMap to preserve order (doc values are sorted and the result
-            // is created with keys and nested keys in sorted order).
-            final TreeMap<Object, Object> map = new TreeMap<>();
-            randomMapExample(map, 0, maxValues);
-            return new SyntheticSourceExample(map, map, this::mapping);
+            if (randomBoolean()) {
+                // Create a singleton value
+                var value = randomObject();
+                return new SyntheticSourceExample(value, mergeIntoExpectedMap(List.of(value)), this::mapping);
+            }
+
+            // Create an array of flattened field values
+            var values = new ArrayList<Map<String, Object>>();
+            for (int i = 0; i < maxValues; i++) {
+                values.add(randomObject());
+            }
+            var merged = mergeIntoExpectedMap(values);
+
+            return new SyntheticSourceExample(values, merged, this::mapping);
+        }
+
+        private Map<String, Object> randomObject() {
+            var maxDepth = randomIntBetween(1, 3);
+
+            final Map<String, Object> map = new HashMap<>();
+            randomMapExample(map, 0, maxDepth);
+
+            return map;
+        }
+
+        // Since arrays are moved to leafs in synthetic source, the result is not an array of objects
+        // but one big object containing merged values from all input objects.
+        // This function performs that transformation.
+        private Map<String, Object> mergeIntoExpectedMap(List<Map<String, Object>> inputValues) {
+            // Fields are sorted since they come (mostly) from doc_values.
+            var result = new TreeMap<String, Object>();
+            doMerge(inputValues, result);
+            return result;
+        }
+
+        @SuppressWarnings("unchecked")
+        private void doMerge(List<Map<String, Object>> inputValues, TreeMap<String, Object> result) {
+            for (var iv : inputValues) {
+                for (var field : iv.entrySet()) {
+                    if (field.getValue() instanceof Map<?, ?> inputNestedMap) {
+                        var intermediateResultMap = result.get(field.getKey());
+                        if (intermediateResultMap == null) {
+                            var map = new TreeMap<String, Object>();
+
+                            result.put(field.getKey(), map);
+                            doMerge(List.of((Map<String, Object>) inputNestedMap), map);
+                        } else if (intermediateResultMap instanceof Map<?, ?> m) {
+                            doMerge(List.of((Map<String, Object>) inputNestedMap), (TreeMap<String, Object>) m);
+                        } else {
+                            throw new IllegalStateException("Conflicting entries in merged map");
+                        }
+                    } else {
+                        var valueAtCurrentLevel = result.get(field.getKey());
+                        if (valueAtCurrentLevel == null) {
+                            result.put(field.getKey(), field.getValue());
+                        } else if (valueAtCurrentLevel instanceof List) {
+                            ((List<Object>) valueAtCurrentLevel).add(field.getValue());
+                        } else {
+                            var list = new ArrayList<>();
+                            list.add(valueAtCurrentLevel);
+                            list.add(field.getValue());
+
+                            result.put(field.getKey(), list);
+                        }
+                    }
+                }
+            }
         }
 
         @Override
@@ -762,8 +830,57 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         }
     }
 
+    public void testSyntheticSourceWithOnlyIgnoredValues() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+            b.startObject("field").field("type", "flattened").field("ignore_above", 1).endObject();
+        }));
+
+        var syntheticSource = syntheticSource(mapper, b -> {
+            b.startObject("field");
+            {
+                b.field("key1", "val1");
+                b.startObject("obj1");
+                {
+                    b.field("key2", "val2");
+                    b.field("key3", List.of("val3", "val4"));
+                }
+                b.endObject();
+            }
+            b.endObject();
+        });
+        assertThat(syntheticSource, equalTo("{\"field\":{\"key1\":\"val1\",\"obj1\":{\"key2\":\"val2\",\"key3\":[\"val3\",\"val4\"]}}}"));
+    }
+
     @Override
     protected boolean supportsCopyTo() {
         return false;
+    }
+
+    @Override
+    public void assertStoredFieldsEquals(String info, IndexReader leftReader, IndexReader rightReader) throws IOException {
+        assert leftReader.maxDoc() == rightReader.maxDoc();
+        StoredFields leftStoredFields = leftReader.storedFields();
+        StoredFields rightStoredFields = rightReader.storedFields();
+        for (int i = 0; i < leftReader.maxDoc(); i++) {
+            Document leftDoc = leftStoredFields.document(i);
+            Document rightDoc = rightStoredFields.document(i);
+
+            // Everything is from LuceneTestCase except this part.
+            // LuceneTestCase sorts by name of the field only which results in a difference
+            // between keyed ignored field values that have the same name.
+            Comparator<IndexableField> comp = Comparator.comparing(IndexableField::name).thenComparing(IndexableField::binaryValue);
+            List<IndexableField> leftFields = new ArrayList<>(leftDoc.getFields());
+            List<IndexableField> rightFields = new ArrayList<>(rightDoc.getFields());
+            Collections.sort(leftFields, comp);
+            Collections.sort(rightFields, comp);
+
+            Iterator<IndexableField> leftIterator = leftFields.iterator();
+            Iterator<IndexableField> rightIterator = rightFields.iterator();
+            while (leftIterator.hasNext()) {
+                assertTrue(info, rightIterator.hasNext());
+                assertStoredFieldEquals(info, leftIterator.next(), rightIterator.next());
+            }
+            assertFalse(info, rightIterator.hasNext());
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
@@ -33,7 +33,15 @@ public class FlattenedFieldParserTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        parser = new FlattenedFieldParser("field", "field._keyed", new FakeFieldType("field"), Integer.MAX_VALUE, Integer.MAX_VALUE, null);
+        parser = new FlattenedFieldParser(
+            "field",
+            "field._keyed",
+            "field._keyed._ignored",
+            new FakeFieldType("field"),
+            Integer.MAX_VALUE,
+            Integer.MAX_VALUE,
+            null
+        );
     }
 
     public void testTextValues() throws Exception {
@@ -283,6 +291,7 @@ public class FlattenedFieldParserTests extends ESTestCase {
         FlattenedFieldParser configuredParser = new FlattenedFieldParser(
             "field",
             "field._keyed",
+            "field._keyed._ignored",
             new FakeFieldType("field"),
             2,
             Integer.MAX_VALUE,
@@ -306,6 +315,7 @@ public class FlattenedFieldParserTests extends ESTestCase {
         FlattenedFieldParser configuredParser = new FlattenedFieldParser(
             "field",
             "field._keyed",
+            "field._keyed._ignored",
             new FakeFieldType("field"),
             3,
             Integer.MAX_VALUE,
@@ -323,6 +333,7 @@ public class FlattenedFieldParserTests extends ESTestCase {
         FlattenedFieldParser configuredParser = new FlattenedFieldParser(
             "field",
             "field._keyed",
+            "field._keyed._ignored",
             new FakeFieldType("field"),
             Integer.MAX_VALUE,
             10,
@@ -345,6 +356,7 @@ public class FlattenedFieldParserTests extends ESTestCase {
         FlattenedFieldParser configuredParser = new FlattenedFieldParser(
             "field",
             "field._keyed",
+            "field._keyed._ignored",
             fieldType,
             Integer.MAX_VALUE,
             Integer.MAX_VALUE,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix synthetic source for flattened field when used with ignore_above (#113499)](https://github.com/elastic/elasticsearch/pull/113499)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)