### PR TITLE
[8.x] Improve DateTime error handling and add some bad date tests (#112723)

### DIFF
--- a/docs/changelog/112723.yaml
+++ b/docs/changelog/112723.yaml
@@ -1,0 +1,6 @@
+pr: 112723
+summary: Improve DateTime error handling and add some bad date tests
+area: Search
+type: bug
+issues:
+ - 112190

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -12,13 +12,13 @@ package org.elasticsearch.common.time;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 
+import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjusters;
@@ -220,7 +220,7 @@ public class JavaDateMathParser implements DateMathParser {
 
                 return DateFormatters.from(accessor).withZoneSameLocal(timeZone).toInstant();
             }
-        } catch (IllegalArgumentException | DateTimeParseException e) {
+        } catch (IllegalArgumentException | DateTimeException e) {
             throw new ElasticsearchParseException(
                 "failed to parse date field [{}] with format [{}]: [{}]",
                 e,


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Improve DateTime error handling and add some bad date tests (#112723)