### PR TITLE
[8.x] Fix release tests by checking QSTR function is registered (#113527)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryStringFunctionTests.java
@@ -18,16 +18,23 @@ import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase
 import org.elasticsearch.xpack.esql.expression.function.FunctionName;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.hamcrest.Matcher;
+import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.QSTR_FUNCTION;
 import static org.hamcrest.Matchers.equalTo;
 
 @FunctionName("qstr")
 public class QueryStringFunctionTests extends AbstractFunctionTestCase {
+
+    @BeforeClass
+    public static void checkFunctionEnabled() {
+        assumeTrue("QSTR capability should be enabled ", QSTR_FUNCTION.isEnabled());
+    }
 
     public QueryStringFunctionTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix release tests by checking QSTR function is registered (#113527)](https://github.com/elastic/elasticsearch/pull/113527)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)