### PR TITLE
[8.x] Remove dynamic templates from otel-plugin that set `index:false` (#113409)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/metrics@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/metrics@mappings.json
@@ -43,50 +43,6 @@
               "default_metric": "value_count"
             }
           }
-        },
-        {
-          "histogram": {
-            "mapping": {
-              "type": "histogram",
-              "ignore_malformed": true
-            }
-          }
-        },
-        {
-          "counter_long": {
-            "mapping": {
-              "type": "long",
-              "time_series_metric": "counter",
-              "ignore_malformed": true
-            }
-          }
-        },
-        {
-          "gauge_long": {
-            "mapping": {
-              "type": "long",
-              "time_series_metric": "gauge",
-              "ignore_malformed": true
-            }
-          }
-        },
-        {
-          "counter_double": {
-            "mapping": {
-              "type": "double",
-              "time_series_metric": "counter",
-              "ignore_malformed": true
-            }
-          }
-        },
-        {
-          "gauge_double": {
-            "mapping": {
-              "type": "double",
-              "time_series_metric": "gauge",
-              "ignore_malformed": true
-            }
-          }
         }
       ],
       "properties": {

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -15,3 +15,33 @@ template:
         type: keyword
         time_series_dimension: true
         ignore_above: 1024
+    dynamic_templates:
+      - histogram:
+          mapping:
+            type: histogram
+            ignore_malformed: true
+      - counter_long:
+          mapping:
+            type: long
+            time_series_metric: counter
+            ignore_malformed: true
+      - gauge_long:
+          mapping:
+            type: long
+            time_series_metric: gauge
+            ignore_malformed: true
+      - counter_double:
+          mapping:
+            type: double
+            time_series_metric: counter
+            ignore_malformed: true
+      - gauge_double:
+          mapping:
+            type: double
+            time_series_metric: gauge
+            ignore_malformed: true
+      - summary:
+          mapping:
+            type: aggregate_metric_double
+            metrics: sum, value_count
+            default_metric: value_count

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-otel@template.yaml
@@ -8,7 +8,6 @@ _meta:
   description: default OpenTelemetry metrics template installed by x-pack
   managed: true
 composed_of:
-  - metrics@mappings
   - metrics@tsdb-settings
   - otel@mappings
   - metrics-otel@mappings
@@ -38,4 +37,3 @@ template:
             ignore_above: 1024
             type: keyword
           match_mapping_type: string
-

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
@@ -178,3 +178,21 @@ IP dimensions:
         expand_wildcards: hidden
   - match: { .$idx0name.mappings.properties.resource.properties.attributes.properties.host\.ip.type: 'ip' }
   - match: { .$idx0name.mappings.properties.attributes.properties.philip.type: "keyword" }
+---
+"Long data type in attributes must be accepted":
+  - do:
+      indices.get_index_template:
+        name: metrics-otel@template
+  - length: {index_templates: 1}
+  - do:
+      bulk:
+        index: metrics-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z","attributes":{"processor.pid": 17}}'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-generic.otel-default
+  - length: { hits.hits: 1 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Remove dynamic templates from otel-plugin that set `index:false` (#113409)