### PR TITLE
Replace IteratorAndCurrent with a DequeAndCurrent

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DequeAndCurrent.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DequeAndCurrent.java
@@ -11,15 +11,16 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 
+import java.util.Deque;
 import java.util.Iterator;
 
-public class IteratorAndCurrent<B extends InternalMultiBucketAggregation.InternalBucket> implements Iterator<B> {
-    private final Iterator<B> iterator;
+public class DequeAndCurrent<B extends InternalMultiBucketAggregation.InternalBucket> implements Iterator<B> {
+    private final Deque<B> deque;
     private B current;
 
-    public IteratorAndCurrent(Iterator<B> iterator) {
-        this.iterator = iterator;
-        this.current = iterator.next();
+    public DequeAndCurrent(Deque<B> deque) {
+        this.deque = deque;
+        this.current = deque.poll();
     }
 
     public B current() {
@@ -28,11 +29,11 @@ public class IteratorAndCurrent<B extends InternalMultiBucketAggregation.Interna
 
     @Override
     public boolean hasNext() {
-        return iterator.hasNext();
+        return deque.isEmpty() == false;
     }
 
     @Override
     public B next() {
-        return current = iterator.next();
+        return current = deque.poll();
     }
 }


### PR DESCRIPTION
While merging buckets on the coordinator node, the most common algorithm is a merge sort as the buckets arrive in order. For doing that, we wrap the buckets with and IteratorAndCurrent object that feeds a priority a bucket at a time.

The only downs side of he current implementation is that we hold a reference of the buckets until  all buckets are merged so I am wondering if we could avoid that. For Internal aggregation that are serialised, we don't keep any strong reference when deserialising them so the bucket could be evicted from the heap as soon as it is merged away. On the other hand this is not true for non-serialised aggregations and maybe building the deque might be slightly more expensive.

I think it might be the trade off as this implementation should be more heap friendly for big clusters.   