### PR TITLE
ES|QL: Fix warnings for date patterns (Java 23)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -293,12 +293,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}
   issue: https://github.com/elastic/elasticsearch/issues/113537
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/70_locale/Date format with default locale}
-  issue: https://github.com/elastic/elasticsearch/issues/113539
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/70_locale/Date format with Italian locale}
-  issue: https://github.com/elastic/elasticsearch/issues/113540
 - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
   method: testPutE5WithTrainedModelAndInference
   issue: https://github.com/elastic/elasticsearch/issues/113565

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
@@ -29,7 +29,7 @@ setup:
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
-        - "Date format \\[MMMM\\] contains textual field specifiers that could change in JDK 23"
+        - "Date format \\[MMMM\\] contains textual field specifiers that could change in JDK 23.*"
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
@@ -51,7 +51,7 @@ setup:
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
-        - "Date format \\[MMMM\\] contains textual field specifiers that could change in JDK 23"
+        - "Date format \\[MMMM\\] contains textual field specifiers that could change in JDK 23.*"
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/113540
Fixes: https://github.com/elastic/elasticsearch/issues/113539

More generic warning regex for Java 23 date patterns

(already fixed in 8.x, no need to backport)