### PR TITLE
Wait for logs in tests without busy-waiting

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -160,7 +160,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
             other.beforeTest(random());
             final ClusterState first = internalCluster().getInstance(ClusterService.class).state();
             assertThat(first.nodes().getSize(), equalTo(1));
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
         } finally {
             other.close();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -693,7 +693,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
                 }
             }, 30, TimeUnit.SECONDS);
             cancellable.cancel();
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
             logger.info("--> waiting for field-caps tasks to be cancelled");
             assertBusy(() -> {
                 List<TaskInfo> tasks = clusterAdmin().prepareListTasks()

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -181,7 +181,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     fail();
                 }
             });
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -526,7 +526,7 @@ public class MasterServiceTests extends ESTestCase {
                     fail();
                 }
             });
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -4191,7 +4191,7 @@ public class IndexShardTests extends IndexShardTestCase {
             );
             shard.flushOnIdle(0);
             assertFalse(shard.isActive());
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
 
             // While the first flush is happening, index one more doc (to turn the shard's active flag to true),
             // and issue a second flushOnIdle request which should not wait for the ongoing flush
@@ -4206,7 +4206,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 )
             );
             shard.flushOnIdle(0);
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
 
             // A direct call to flush (with waitIfOngoing=false) should not wait and return false immediately
             assertFalse(shard.flush(new FlushRequest().waitIfOngoing(false).force(false)));
@@ -4223,7 +4223,7 @@ public class IndexShardTests extends IndexShardTestCase {
                     "released flush lock"
                 )
             );
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
 
             // The second flushOnIdle (that did not happen) should have turned the active flag to true
             assertTrue(shard.isActive());

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
@@ -146,7 +146,7 @@ public class FsHealthServiceTests extends ESTestCase {
             disruptFileSystemProvider.injectIOException.set(true);
             fsHealthService.new FsHealthMonitor().run();
             assertEquals(env.nodeDataPaths().length, disruptFileSystemProvider.getInjectedPathCount());
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
         } finally {
             PathUtilsForTesting.teardown();
             ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -184,8 +184,8 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
                     // acceptable; we mostly ignore the result of cancellation anyway
                 }
 
-                // assert busy since failure to remove a ban may be logged after cancellation completed
-                assertBusy(mockLog::assertAllExpectationsMatched);
+                // await since failure to remove a ban may be logged after cancellation completed
+                mockLog.awaitAllExpectationsMatched();
             }
 
             assertTrue("child tasks did not finish in time", childTaskLock.tryLock(15, TimeUnit.SECONDS));

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -128,7 +128,7 @@ public class ThreadPoolTests extends ESTestCase {
             final ThreadPool.CachedTimeThread thread = new ThreadPool.CachedTimeThread("[timer]", 200, 100);
             thread.start();
 
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
 
             thread.interrupt();
             thread.join();
@@ -297,7 +297,7 @@ public class ThreadPoolTests extends ESTestCase {
                 }
             };
             threadPool.schedule(runnable, TimeValue.timeValueMillis(randomLongBetween(0, 300)), EsExecutors.DIRECT_EXECUTOR_SERVICE);
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
         } finally {
             assertTrue(terminate(threadPool));
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLog.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLog.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.core.config.Property;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.TimeValue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,10 +24,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -112,10 +116,46 @@ public class MockLog implements Releasable {
         }
     }
 
+    public void awaitAllExpectationsMatched() {
+        awaitAllExpectationsMatched(ESTestCase.SAFE_AWAIT_TIMEOUT);
+    }
+
+    // exposed for testing
+    void awaitAllExpectationsMatched(TimeValue waitTime) {
+        final var deadlineNanos = System.nanoTime() + waitTime.nanos();
+        final var nanosPerMilli = TimeValue.timeValueMillis(1).nanos();
+        try {
+            for (LoggingExpectation expectation : expectations) {
+                final var remainingMillis = (deadlineNanos - System.nanoTime() + nanosPerMilli - 1) / nanosPerMilli; // round up
+                assertThat(remainingMillis, greaterThan(0L));
+                expectation.awaitMatched(remainingMillis);
+            }
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted", interruptedException);
+        }
+    }
+
+    /**
+     * Keeps track of whether the {@link LogEvent} instances it receives match the expected content.
+     */
     public interface LoggingExpectation {
+        /**
+         * Called on every {@link LogEvent} received by the captured appenders.
+         */
         void match(LogEvent event);
 
+        /**
+         * Returns if this expectation is matched, otherwise throws an {@link AssertionError}.
+         */
         void assertMatched();
+
+        /**
+         * Returns if this expectation is matched within the given number of milliseconds, otherwise throws an {@link AssertionError}.
+         */
+        default void awaitMatched(long millis) throws InterruptedException {
+            assertMatched();
+        }
     }
 
     public abstract static class AbstractEventExpectation implements LoggingExpectation {
@@ -123,14 +163,13 @@ public class MockLog implements Releasable {
         protected final String logger;
         protected final Level level;
         protected final String message;
-        volatile boolean saw;
+        protected final CountDownLatch seenLatch = new CountDownLatch(1);
 
         public AbstractEventExpectation(String name, String logger, Level level, String message) {
             this.name = name;
             this.logger = logger;
             this.level = level;
             this.message = message;
-            this.saw = false;
         }
 
         @Override
@@ -138,11 +177,11 @@ public class MockLog implements Releasable {
             if (event.getLevel().equals(level) && event.getLoggerName().equals(logger) && innerMatch(event)) {
                 if (Regex.isSimpleMatchPattern(message)) {
                     if (Regex.simpleMatch(message, event.getMessage().getFormattedMessage())) {
-                        saw = true;
+                        seenLatch.countDown();
                     }
                 } else {
                     if (event.getMessage().getFormattedMessage().contains(message)) {
-                        saw = true;
+                        seenLatch.countDown();
                     }
                 }
             }
@@ -162,7 +201,7 @@ public class MockLog implements Releasable {
 
         @Override
         public void assertMatched() {
-            assertThat("expected not to see " + name + " but did", saw, equalTo(false));
+            assertThat("expected not to see " + name + " but did", seenLatch.getCount(), equalTo(1L));
         }
     }
 
@@ -174,7 +213,12 @@ public class MockLog implements Releasable {
 
         @Override
         public void assertMatched() {
-            assertThat("expected to see " + name + " but did not", saw, equalTo(true));
+            assertThat("expected to see " + name + " but did not", seenLatch.getCount(), equalTo(0L));
+        }
+
+        @Override
+        public void awaitMatched(long millis) throws InterruptedException {
+            assertThat("expected to see " + name + " but did not", seenLatch.await(millis, TimeUnit.MILLISECONDS), equalTo(true));
         }
     }
 
@@ -195,7 +239,17 @@ public class MockLog implements Releasable {
             if (expectSeen) {
                 super.assertMatched();
             } else {
-                assertThat("expected not to see " + name + " yet but did", saw, equalTo(false));
+                assertThat("expected not to see " + name + " yet but did", seenLatch.getCount(), equalTo(1L));
+            }
+        }
+
+        @Override
+        public void awaitMatched(long millis) throws InterruptedException {
+            if (expectSeen) {
+                super.awaitMatched(millis);
+            } else {
+                // do not wait for negative expectation
+                assertThat("expected not to see " + name + " yet but did", seenLatch.getCount(), equalTo(1L));
             }
         }
     }
@@ -229,11 +283,11 @@ public class MockLog implements Releasable {
 
     public static class PatternSeenEventExpectation implements LoggingExpectation {
 
-        protected final String name;
-        protected final String logger;
-        protected final Level level;
-        protected final Pattern pattern;
-        volatile boolean saw;
+        private final String name;
+        private final String logger;
+        private final Level level;
+        private final Pattern pattern;
+        private final CountDownLatch seenLatch = new CountDownLatch(1);
 
         public PatternSeenEventExpectation(String name, String logger, Level level, String pattern) {
             this.name = name;
@@ -246,16 +300,20 @@ public class MockLog implements Releasable {
         public void match(LogEvent event) {
             if (event.getLevel().equals(level) && event.getLoggerName().equals(logger)) {
                 if (pattern.matcher(event.getMessage().getFormattedMessage()).matches()) {
-                    saw = true;
+                    seenLatch.countDown();
                 }
             }
         }
 
         @Override
         public void assertMatched() {
-            assertThat(name, saw, equalTo(true));
+            assertThat(name, seenLatch.getCount(), equalTo(0L));
         }
 
+        @Override
+        public void awaitMatched(long millis) throws InterruptedException {
+            assertThat(name, seenLatch.await(millis, TimeUnit.MILLISECONDS), equalTo(true));
+        }
     }
 
     /**
@@ -279,6 +337,15 @@ public class MockLog implements Releasable {
         public void assertMatched() {
             try {
                 delegate.assertMatched();
+            } finally {
+                assertMatchedCalled = true;
+            }
+        }
+
+        @Override
+        public void awaitMatched(long millis) throws InterruptedException {
+            try {
+                delegate.awaitMatched(millis);
             } finally {
                 assertMatchedCalled = true;
             }
@@ -334,6 +401,19 @@ public class MockLog implements Releasable {
             }
             action.run();
             mockLog.assertAllExpectationsMatched();
+        }
+    }
+
+    /**
+     * Executes an action and waits until the given logging expectations are satisfied.
+     */
+    public static void awaitLogger(Runnable action, Class<?> loggerOwner, MockLog.LoggingExpectation... expectations) {
+        try (var mockLog = MockLog.capture(loggerOwner)) {
+            for (var expectation : expectations) {
+                mockLog.addExpectation(expectation);
+            }
+            action.run();
+            mockLog.awaitAllExpectationsMatched();
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1373,7 +1373,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             serviceA.sendRequest(nodeB, "internal:test", new StringMessageRequest("", 10), noopResponseHandler);
 
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
 
             ////////////////////////////////////////////////////////////////////////
             // tests for included action type "internal:testError" which returns an error
@@ -1420,7 +1420,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             serviceA.sendRequest(nodeB, "internal:testError", new StringMessageRequest(""), noopResponseHandler);
 
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
 
             ////////////////////////////////////////////////////////////////////////
             // tests for excluded action type "internal:testNotSeen"
@@ -1467,7 +1467,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             submitRequest(serviceA, nodeB, "internal:testNotSeen", new StringMessageRequest(""), noopResponseHandler).get();
 
-            assertBusy(mockLog::assertAllExpectationsMatched);
+            mockLog.awaitAllExpectationsMatched();
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/MockLogTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/MockLogTests.java
@@ -9,8 +9,11 @@
 
 package org.elasticsearch.test;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -27,12 +30,70 @@ public class MockLogTests extends ESTestCase {
         logThread.start();
 
         for (int i = 0; i < 1000; i++) {
-            try (var mockLog = MockLog.capture(MockLogTests.class)) {
+            try (var ignored = MockLog.capture(MockLogTests.class)) {
                 Thread.yield();
             }
         }
 
         keepGoing.set(false);
         logThread.join();
+    }
+
+    @TestLogging(reason = "checking log behaviour", value = "org.elasticsearch.test.MockLogTests:INFO")
+    public void testAwaitUnseenEvent() {
+        try (var mockLog = MockLog.capture(MockLogTests.class)) {
+            mockLog.addExpectation(
+                new MockLog.UnseenEventExpectation("unseen", MockLogTests.class.getCanonicalName(), Level.INFO, "unexpected")
+            );
+            Thread.currentThread().interrupt(); // ensures no blocking calls
+            mockLog.awaitAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
+
+            logger.info("unexpected");
+            expectThrows(AssertionError.class, mockLog::awaitAllExpectationsMatched);
+            expectThrows(AssertionError.class, mockLog::assertAllExpectationsMatched);
+
+            assertTrue(Thread.interrupted()); // clear interrupt flag again
+        }
+    }
+
+    @TestLogging(reason = "checking log behaviour", value = "org.elasticsearch.test.MockLogTests:INFO")
+    public void testAwaitSeenEvent() throws InterruptedException {
+        try (var mockLog = MockLog.capture(MockLogTests.class)) {
+            mockLog.addExpectation(new MockLog.SeenEventExpectation("seen", MockLogTests.class.getCanonicalName(), Level.INFO, "expected"));
+
+            expectThrows(AssertionError.class, () -> mockLog.awaitAllExpectationsMatched(TimeValue.timeValueMillis(10)));
+            expectThrows(AssertionError.class, mockLog::assertAllExpectationsMatched);
+
+            final var logThread = new Thread(() -> {
+                logger.info("expected");
+                mockLog.assertAllExpectationsMatched();
+            });
+            logThread.start();
+            mockLog.awaitAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
+            logThread.join();
+        }
+    }
+
+    @TestLogging(reason = "checking log behaviour", value = "org.elasticsearch.test.MockLogTests:INFO")
+    public void testAwaitPatternEvent() throws InterruptedException {
+        try (var mockLog = MockLog.capture(MockLogTests.class)) {
+            mockLog.addExpectation(
+                new MockLog.PatternSeenEventExpectation("seen", MockLogTests.class.getCanonicalName(), Level.INFO, ".*expected.*")
+            );
+
+            expectThrows(AssertionError.class, () -> mockLog.awaitAllExpectationsMatched(TimeValue.timeValueMillis(10)));
+            expectThrows(AssertionError.class, mockLog::assertAllExpectationsMatched);
+
+            final var logThread = new Thread(() -> {
+                logger.info("blah blah expected blah blah");
+                mockLog.assertAllExpectationsMatched();
+            });
+            logThread.start();
+            mockLog.awaitAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
+            logThread.join();
+        }
     }
 }

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -623,7 +623,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
                 assertAcked(indicesAdmin().prepareDelete(indexName).get());
 
-                assertBusy(mockLog::assertAllExpectationsMatched);
+                mockLog.awaitAllExpectationsMatched();
             }
 
             respondToRecoverSnapshotFile.countDown();


### PR DESCRIPTION
Introduces `MockLog#awaitAllExpectationsMatched` to allow tests to wait
until all the expected log messages have been seen without having to use
`assertBusy()`.