### PR TITLE
Remove skipped tests after backporting

### DIFF
--- a/modules/dot-prefix-validation/build.gradle
+++ b/modules/dot-prefix-validation/build.gradle
@@ -27,13 +27,3 @@ tasks.named('yamlRestTest') {
 tasks.named('yamlRestCompatTest') {
   usesDefaultDistribution()
 }
-
-tasks.named("yamlRestCompatTestTransform").configure(
-  { task ->
-    task.skipTest("tsdb/140_routing_path/multi-value routing path field", "Multi-value routing paths are allowed now. See #112645")
-    task.skipTest(
-      "dot_prefix/10_basic/Deprecated index template with a dot prefix index pattern",
-      "Tentantively disabled until #112092 gets backported to 8.x"
-    )
-  }
-)

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -55,28 +55,6 @@ tasks.named("precommit").configure {
 }
 
 tasks.named("yamlRestCompatTestTransform").configure({task ->
-    task.skipTest("tsdb/140_routing_path/multi-value routing path field", "Multi-value routing paths are allowed now. See #112645")
     task.skipTest("indices.sort/10_basic/Index Sort", "warning does not exist for compatibility")
     task.skipTest("search/330_fetch_fields/Test search rewrite", "warning does not exist for compatibility")
-    task.skipTest("search/540_ignore_above_synthetic_source/ignore_above mapping level setting on arrays", "Temporary mute while backporting to 8.x")
-    task.skipTest("indices.create/20_synthetic_source/subobjects auto", "Tentantively disabled until #112092 gets backported to 8.x")
-    task.skipTest(
-      "index/92_metrics_auto_subobjects/Metrics object indexing with synthetic source",
-      "Tentantively disabled until #112092 gets backported to 8.x"
-    )
-    task.skipTest(
-      "index/92_metrics_auto_subobjects/Root without subobjects with synthetic source",
-      "Tentantively disabled until #112092 gets backported to 8.x"
-    )
-    task.skipTest(
-      "indices.put_index_template/15_composition/Composable index templates that include subobjects: auto at root",
-      "Tentantively disabled until #112092 gets backported to 8.x"
-    )
-    task.skipTest(
-      "indices.put_index_template/15_composition/Composable index templates that include subobjects: auto on arbitrary field",
-      "Tentantively disabled until #112092 gets backported to 8.x"
-    )
-    task.skipTest("index/92_metrics_auto_subobjects/Metrics object indexing", "Tentantively disabled until #112092 gets backported to 8.x")
-    task.skipTest("index/92_metrics_auto_subobjects/Root with metrics", "Tentantively disabled until #112092 gets backported to 8.x")
-    task.skipTest("search/330_fetch_fields/Test with subobjects: auto", "Tentantively disabled until #112092 gets backported to 8.x")
 })


### PR DESCRIPTION
The skip test entries were added in https://github.com/elastic/elasticsearch/pull/113584, no longer needed after backporting it.