### PR TITLE
[8.x] Fix collapse interaction with stored fields (#112761)

### DIFF
--- a/docs/changelog/112761.yaml
+++ b/docs/changelog/112761.yaml
@@ -1,0 +1,6 @@
+pr: 112761
+summary: Fix collapse interaction with stored fields
+area: Search
+type: bug
+issues:
+ - 112646

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/StoredFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/StoredFieldsPhase.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Process stored fields loaded from a HitContext into DocumentFields
@@ -42,7 +43,8 @@ public class StoredFieldsPhase implements FetchSubPhase {
             if (inputs == null) {
                 return List.of();
             }
-            return inputs.stream().map(ft::valueForDisplay).toList();
+            // This is eventually provided to DocumentField, which needs this collection to be mutable
+            return inputs.stream().map(ft::valueForDisplay).collect(Collectors.toList());
         }
 
         boolean hasValue(Map<String, List<Object>> loadedFields) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix collapse interaction with stored fields (#112761)