### PR TITLE
[8.15] Fix collapse interaction with stored fields (#112761)

### DIFF
--- a/docs/changelog/112761.yaml
+++ b/docs/changelog/112761.yaml
@@ -1,0 +1,6 @@
+pr: 112761
+summary: Fix collapse interaction with stored fields
+area: Search
+type: bug
+issues:
+ - 112646

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/CollapseSearchResultsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/CollapseSearchResultsIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.query.InnerHitBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Map;
 import java.util.Set;
@@ -81,6 +82,35 @@ public class CollapseSearchResultsIT extends ESIntegTestCase {
             searchResponse -> {
                 assertEquals(collapseField, searchResponse.getHits().getCollapseField());
                 assertEquals(Set.of(new BytesRef("value1"), new BytesRef("value2")), Set.of(searchResponse.getHits().getCollapseValues()));
+            }
+        );
+    }
+
+    public void testCollapseWithStoredFields() {
+        final String indexName = "test_collapse";
+        createIndex(indexName);
+        final String collapseField = "collapse_field";
+        assertAcked(indicesAdmin().preparePutMapping(indexName).setSource("""
+                     {
+                       "dynamic": "strict",
+                       "properties": {
+                         "collapse_field":  { "type": "keyword", "store": true },
+                         "ts":  { "type": "date", "store": true }
+                       }
+                     }
+            """, XContentType.JSON));
+        index(indexName, "id_1_0", Map.of(collapseField, "value1", "ts", 0));
+        index(indexName, "id_1_1", Map.of(collapseField, "value1", "ts", 1));
+        index(indexName, "id_2_0", Map.of(collapseField, "value2", "ts", 2));
+        refresh(indexName);
+
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setQuery(new MatchAllQueryBuilder())
+                .setFetchSource(false)
+                .storedFields("*")
+                .setCollapse(new CollapseBuilder(collapseField)),
+            searchResponse -> {
+                assertEquals(collapseField, searchResponse.getHits().getCollapseField());
             }
         );
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/StoredFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/StoredFieldsPhase.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Process stored fields loaded from a HitContext into DocumentFields
@@ -41,7 +42,8 @@ public class StoredFieldsPhase implements FetchSubPhase {
             if (inputs == null) {
                 return List.of();
             }
-            return inputs.stream().map(ft::valueForDisplay).toList();
+            // This is eventually provided to DocumentField, which needs this collection to be mutable
+            return inputs.stream().map(ft::valueForDisplay).collect(Collectors.toList());
         }
 
         boolean hasValue(Map<String, List<Object>> loadedFields) {


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Fix collapse interaction with stored fields (#112761)