### PR TITLE
Handle rejections in `IncrementalBulkIT`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -257,9 +257,6 @@ tests:
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
   issue: https://github.com/elastic/elasticsearch/issues/113343
-- class: org.elasticsearch.action.bulk.IncrementalBulkIT
-  method: testBulkLevelBulkFailureAfterFirstIncrementalRequest
-  issue: https://github.com/elastic/elasticsearch/issues/113365
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJob_TimingStatsDocumentIsDeleted
   issue: https://github.com/elastic/elasticsearch/issues/113370


### PR DESCRIPTION
Submitting a bare runnable to a threadpool risks an exception being
thrown if the queue is full. This commit moves to submitting
`AbstractRunnable` instances that won't be rejected.

Closes #113365