### PR TITLE
Deprecate legacy params from range query (#113286)

### DIFF
--- a/docs/changelog/113286.yaml
+++ b/docs/changelog/113286.yaml
@@ -1,0 +1,10 @@
+pr: 113286
+summary: Deprecate legacy params from range query
+area: Search
+type: deprecation
+issues: []
+deprecation:
+  title: Deprecate legacy params from range query
+  area: REST API
+  details: Range query will not longer accept `to`, `from`, `include_lower`, and `include_upper` parameters.
+  impact: Instead use `gt`, `gte`, `lt` and `lte` parameters.

--- a/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
@@ -165,7 +165,7 @@ Example:
 POST /sales/_search?size=0
 {
   "query": {
-    "constant_score": { "filter": { "range": { "price": { "to": "500" } } } }
+    "constant_score": { "filter": { "range": { "price": { "lte": "500" } } } }
   },
   "aggs": {
     "prices": {
@@ -202,7 +202,7 @@ Example:
 POST /sales/_search?size=0
 {
   "query": {
-    "constant_score": { "filter": { "range": { "price": { "to": "500" } } } }
+    "constant_score": { "filter": { "range": { "price": { "lte": "500" } } } }
   },
   "aggs": {
     "prices": {

--- a/docs/reference/watcher/getting-started.asciidoc
+++ b/docs/reference/watcher/getting-started.asciidoc
@@ -135,7 +135,7 @@ GET .watcher-history*/_search?pretty
     "bool" : {
       "must" : [
         { "match" : { "result.condition.met" : true }},
-        { "range" : { "result.execution_time" : { "from" : "now-10s" }}}
+        { "range" : { "result.execution_time" : { "gte" : "now-10s" }}}
       ]
     }
   }

--- a/docs/reference/watcher/transform/search.asciidoc
+++ b/docs/reference/watcher/transform/search.asciidoc
@@ -119,8 +119,8 @@ time of the watch:
                 {
                   "range" : {
                     "@timestamp" : {
-                      "from" : "{{ctx.trigger.scheduled_time}}||-30s",
-                      "to" : "{{ctx.trigger.triggered_time}}"
+                      "gte" : "{{ctx.trigger.scheduled_time}}||-30s",
+                      "lte" : "{{ctx.trigger.triggered_time}}"
                     }
                   }
                 }
@@ -159,8 +159,8 @@ The following is an example of using templates that refer to provided parameters
                   {
                     "range" : {
                       "@timestamp" : {
-                        "from" : "{{ctx.trigger.scheduled_time}}||-30s",
-                        "to" : "{{ctx.trigger.triggered_time}}"
+                        "gte" : "{{ctx.trigger.scheduled_time}}||-30s",
+                        "lte" : "{{ctx.trigger.triggered_time}}"
                       }
                     }
                   }

--- a/modules/rank-eval/build.gradle
+++ b/modules/rank-eval/build.gradle
@@ -25,3 +25,7 @@ testClusters.configureEach {
   // Modules who's integration is explicitly tested in integration tests
   module ':modules:lang-mustache'
 }
+
+tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
+  task.skipTest("rank_eval/30_failures/Response format", "warning does not exist for compatibility")
+})

--- a/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/30_failures.yml
+++ b/modules/rank-eval/src/yamlRestTest/resources/rest-api-spec/test/rank_eval/30_failures.yml
@@ -21,7 +21,7 @@
             },
             {
                 "id" : "invalid_query",
-                "request": { "query": { "range" : { "bar" : { "from" : "Basel", "time_zone": "+01:00" }}}},
+                "request": { "query": { "range" : { "bar" : { "gte" : "Basel", "time_zone": "+01:00" }}}},
                 "ratings": [{"_index": "foo", "_id": "doc1", "rating": 1}]
             }
           ],

--- a/modules/runtime-fields-common/build.gradle
+++ b/modules/runtime-fields-common/build.gradle
@@ -28,4 +28,5 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("runtime_fields/101_geo_point_from_source/fetch fields from source", "Format changed. Old format was a bug.")
   task.skipTest("runtime_fields/102_geo_point_source_in_query/fetch fields from source", "Format changed. Old format was a bug.")
   task.skipTest("runtime_fields/103_geo_point_calculated_at_index/fetch fields from source", "Format changed. Old format was a bug.")
+  task.skipTestsByFilePattern("**/runtime_fields/110_composite.yml", "warning does not exist for compatibility")
 }

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/110_composite.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/110_composite.yml
@@ -83,8 +83,8 @@ query:
           query:
             range:
               http.clientip:
-                from: 232.0.0.0
-                to: 253.0.0.0
+                gte: 232.0.0.0
+                lte: 253.0.0.0
   - match: { hits.total.value: 4 }
 
 ---

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -244,3 +244,7 @@ tasks.named("precommit").configure {
   dependsOn 'enforceYamlTestConvention'
 }
 
+tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
+  task.skipTest("indices.sort/10_basic/Index Sort", "warning does not exist for compatibility")
+  task.skipTest("search/330_fetch_fields/Test search rewrite", "warning does not exist for compatibility")
+})

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -101,7 +101,7 @@
         index: test
         body:
           sort: ["rank"]
-          query: {"range": { "rank": { "from": 0 } } }
+          query: {"range": { "rank": { "gte": 0 } } }
           track_total_hits: false
           size: 1
 
@@ -142,7 +142,7 @@
         index: test
         body:
           sort: ["rank"]
-          query: {"range": { "rank": { "from": 0 } } }
+          query: {"range": { "rank": { "gte": 0 } } }
           track_total_hits: false
           size: 3
 
@@ -160,6 +160,6 @@
         scroll: 1m
         body:
           sort: ["rank"]
-          query: {"range": { "rank": { "from": 0 } } }
+          query: {"range": { "rank": { "gte": 0 } } }
           track_total_hits: false
           size: 3

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -252,7 +252,7 @@
           query:
             range:
               date:
-                from: "1990-12-29T22:30:00.000Z"
+                gte: "1990-12-29T22:30:00.000Z"
           fields:
             - field: date
               format: "yyyy/MM/dd"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
@@ -123,3 +123,29 @@ setup:
   - match: { hits.total: 1 }
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._id: "4" }
+
+
+---
+"from, to, include_lower, include_upper deprecated":
+  - requires:
+      cluster_features: "gte_v8.16.0"
+      reason: 'from, to, include_lower, include_upper parameters are deprecated since 8.16.0'
+      test_runner_features: warnings
+
+  - do:
+      warnings:
+        - "Deprecated field [from] used, this field is unused and will be removed entirely"
+        - "Deprecated field [to] used, this field is unused and will be removed entirely"
+        - "Deprecated field [include_lower] used, this field is unused and will be removed entirely"
+        - "Deprecated field [include_upper] used, this field is unused and will be removed entirely"
+      search:
+        index: dates
+        body:
+          sort: field
+          query:
+            range:
+              date:
+                from: 1000
+                to: 2023
+                include_lower: false
+                include_upper: false

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -45,10 +45,10 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
 
     public static final ParseField LTE_FIELD = new ParseField("lte");
     public static final ParseField GTE_FIELD = new ParseField("gte");
-    public static final ParseField FROM_FIELD = new ParseField("from");
-    public static final ParseField TO_FIELD = new ParseField("to");
-    private static final ParseField INCLUDE_LOWER_FIELD = new ParseField("include_lower");
-    private static final ParseField INCLUDE_UPPER_FIELD = new ParseField("include_upper");
+    public static final ParseField FROM_FIELD = new ParseField("from").withAllDeprecated();
+    public static final ParseField TO_FIELD = new ParseField("to").withAllDeprecated();
+    private static final ParseField INCLUDE_LOWER_FIELD = new ParseField("include_lower").withAllDeprecated();
+    private static final ParseField INCLUDE_UPPER_FIELD = new ParseField("include_upper").withAllDeprecated();
     public static final ParseField GT_FIELD = new ParseField("gt");
     public static final ParseField LT_FIELD = new ParseField("lt");
     private static final ParseField TIME_ZONE_FIELD = new ParseField("time_zone");

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.hamcrest.Matchers.equalTo;
@@ -109,44 +107,6 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
             );
         }
         return query;
-    }
-
-    @Override
-    protected Map<String, RangeQueryBuilder> getAlternateVersions() {
-        Map<String, RangeQueryBuilder> alternateVersions = new HashMap<>();
-        RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(INT_FIELD_NAME);
-
-        rangeQueryBuilder.includeLower(randomBoolean());
-        rangeQueryBuilder.includeUpper(randomBoolean());
-
-        if (randomBoolean()) {
-            rangeQueryBuilder.from(randomIntBetween(1, 100));
-        }
-
-        if (randomBoolean()) {
-            rangeQueryBuilder.to(randomIntBetween(101, 200));
-        }
-
-        String query = Strings.format(
-            """
-                {
-                    "range":{
-                        "%s": {
-                            "include_lower":%s,
-                            "include_upper":%s,
-                            "from":%s,
-                            "to":%s
-                        }
-                    }
-                }""",
-            INT_FIELD_NAME,
-            rangeQueryBuilder.includeLower(),
-            rangeQueryBuilder.includeUpper(),
-            rangeQueryBuilder.from(),
-            rangeQueryBuilder.to()
-        );
-        alternateVersions.put(query, rangeQueryBuilder);
-        return alternateVersions;
     }
 
     @Override
@@ -420,8 +380,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
             {
               "range" : {
                 "timestamp" : {
-                  "from" : "2015-01-01 00:00:00",
-                  "to" : "now",
+                  "gte" : "2015-01-01 00:00:00",
+                  "lte" : "now",
                   "boost" : 1.0,
                   "_name" : "my_range"
                 }

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -199,3 +199,7 @@ tasks.named("precommit").configure {
   dependsOn 'enforceYamlTestConvention', 'enforceApiSpecsConvention'
 }
 
+tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
+  task.skipTest("security/10_forbidden/Test bulk response with invalid credentials", "warning does not exist for compatibility")
+})
+


### PR DESCRIPTION
Deprecate to, from, include_lower, include_upper range query params. These params have been removed from our documentation in v. 0.90.4 (d6ecdecc19d54b4a37b033a2237a4c76601e9a2d), but did not got through deprecation cycle.

These params to be removed in v9.0.

Related to #81276

Closes #48538