### PR TITLE
[8.x] (Doc+) Avoid search pile up by setting default timeout (#112846)

### DIFF
--- a/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
@@ -66,6 +66,8 @@ searches, consider the following setting changes:
 <<query-dsl-allow-expensive-queries,`search.allow_expensive_queries`>> cluster
 setting.
 
+* Set a default search timeout using the <<search-timeout,`search.default_search_timeout`>> cluster setting. 
+
 [source,console]
 ----
 PUT _settings


### PR DESCRIPTION
Backports the following commits to 8.x:
 - (Doc+) Avoid search pile up by setting default timeout (#112846)