### PR TITLE
Add missing index settings provider for stateless

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -49,7 +49,7 @@ public class LogsDBPlugin extends Plugin {
     @Override
     public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders(IndexSettingProvider.Parameters parameters) {
         if (DiscoveryNode.isStateless(settings)) {
-            return List.of();
+            return List.of(logsdbIndexModeSettingsProvider);
         }
         return List.of(new SyntheticSourceIndexSettingsProvider(licenseService), logsdbIndexModeSettingsProvider);
     }


### PR DESCRIPTION
We need the index setting provider to be used for stateless too.