### PR TITLE
[8.x] Also enable LogsdbIndexModeSettingsProvider in case of stateless. (#113624)

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -49,7 +49,7 @@ public class LogsDBPlugin extends Plugin {
     @Override
     public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders(IndexSettingProvider.Parameters parameters) {
         if (DiscoveryNode.isStateless(settings)) {
-            return List.of();
+            return List.of(logsdbIndexModeSettingsProvider);
         }
         return List.of(new SyntheticSourceIndexSettingsProvider(licenseService), logsdbIndexModeSettingsProvider);
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Also enable LogsdbIndexModeSettingsProvider in case of stateless. (#113624)