### PR TITLE
[8.x] Fix ignore_above handling in synthetic source when index level setting is used (#113570)

### DIFF
--- a/docs/changelog/113570.yaml
+++ b/docs/changelog/113570.yaml
@@ -1,0 +1,7 @@
+pr: 113570
+summary: Fix `ignore_above` handling in synthetic source when index level setting
+  is used
+area: Logs
+type: bug
+issues:
+ - 113538

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/540_ignore_above_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/540_ignore_above_synthetic_source.yml
@@ -80,8 +80,7 @@ ignore_above mapping level setting on arrays:
             match_all: {}
 
   - length: { hits.hits: 1 }
-    #TODO: synthetic source field reconstruction bug (TBD: add link to the issue here)
-  #- match: { hits.hits.0._source.keyword: ["foo bar", "the quick brown fox"] }
+  - match: { hits.hits.0._source.keyword: ["foo bar", "the quick brown fox"] }
   - match: { hits.hits.0._source.flattened.value: [ "jumps over", "the quick brown fox" ] }
   - match: { hits.hits.0.fields.keyword.0: "foo bar" }
   - match: { hits.hits.0.fields.flattened.0.value: "jumps over" }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1093,7 +1093,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             });
         }
 
-        if (fieldType().ignoreAbove != ignoreAboveDefault) {
+        if (fieldType().ignoreAbove != Integer.MAX_VALUE) {
             layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(originalName()) {
                 @Override
                 protected void writeValue(Object value, XContentBuilder b) throws IOException {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -201,6 +201,5 @@ tasks.named("precommit").configure {
 
 tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("security/10_forbidden/Test bulk response with invalid credentials", "warning does not exist for compatibility")
-  task.skipTest("wildcard/30_ignore_above_synthetic_source/wildcard field type ignore_above", "Temporary until backported")
 })
 

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -201,5 +201,6 @@ tasks.named("precommit").configure {
 
 tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("security/10_forbidden/Test bulk response with invalid credentials", "warning does not exist for compatibility")
+  task.skipTest("wildcard/30_ignore_above_synthetic_source/wildcard field type ignore_above", "Temporary until backported")
 })
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/wildcard/30_ignore_above_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/wildcard/30_ignore_above_synthetic_source.yml
@@ -49,7 +49,7 @@ wildcard field type ignore_above:
   - length: { hits.hits: 1 }
   - match: { hits.hits.0._source.a_wildcard: "foo bar" }
   - match: { hits.hits.0._source.b_wildcard: "the quick brown" }
-  - match: { hits.hits.0._source.c_wildcard: ["bar", "foo"] }
+  - match: { hits.hits.0._source.c_wildcard: ["bar", "foo", "jumps over the lazy dog"] }
   - match: { hits.hits.0._source.d_wildcard: ["bar", "foo", "the quick"] }
   - match: { hits.hits.0.fields.a_wildcard.0: "foo bar" }
   - match: { hits.hits.0.fields.b_wildcard.0: "the quick brown" }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -994,7 +994,7 @@ public class WildcardFieldMapper extends FieldMapper {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         layers.add(new WildcardSyntheticFieldLoader());
-        if (ignoreAbove != ignoreAboveDefault) {
+        if (ignoreAbove != Integer.MAX_VALUE) {
             layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(originalName()) {
                 @Override
                 protected void writeValue(Object value, XContentBuilder b) throws IOException {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix ignore_above handling in synthetic source when index level setting is used (#113570)