### PR TITLE
[8.15] [CI] Remove debian-10 from CI since it is EOL (#113644)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -8,7 +8,6 @@ steps:
           setup:
             image:
               - centos-7
-              - debian-10
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -9,7 +9,6 @@ steps:
           setup:
             image:
               - centos-7
-              - debian-10
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -8,7 +8,6 @@ steps:
           setup:
             image:
               - centos-7
-              - debian-10
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -11,7 +11,6 @@ steps:
           setup:
             image:
               - centos-7
-              - debian-10
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7
@@ -40,7 +39,6 @@ steps:
           setup:
             image:
               - centos-7
-              - debian-10
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7
@@ -69,7 +67,6 @@ steps:
           setup:
             image:
               - centos-7
-              - debian-10
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[CI] Remove debian-10 from CI since it is EOL (#113644)](https://github.com/elastic/elasticsearch/pull/113644)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)