### PR TITLE
Add link to NO_COPIES allocation explain message

### DIFF
--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -49,32 +49,32 @@ you might expect otherwise.
 ==== {api-query-parms-title}
 
 `include_disk_info`::
-    (Optional, Boolean) If `true`, returns information about disk usage and
-    shard sizes. Defaults to `false`.
+(Optional, Boolean) If `true`, returns information about disk usage and
+shard sizes. Defaults to `false`.
 
 `include_yes_decisions`::
-    (Optional, Boolean) If `true`, returns 'YES' decisions in explanation.
-    Defaults to `false`.
+(Optional, Boolean) If `true`, returns 'YES' decisions in explanation.
+Defaults to `false`.
 
 [[cluster-allocation-explain-api-request-body]]
 ==== {api-request-body-title}
 
 `current_node`::
-    (Optional, string) Specifies the node ID or the name of the node currently
-    holding the shard to explain. To explain an unassigned shard, omit this
-    parameter.
+(Optional, string) Specifies the node ID or the name of the node currently
+holding the shard to explain. To explain an unassigned shard, omit this
+parameter.
 
 `index`::
-    (Optional, string) Specifies the name of the index that you would like an
-    explanation for.
+(Optional, string) Specifies the name of the index that you would like an
+explanation for.
 
 `primary`::
-    (Optional, Boolean) If `true`, returns explanation for the primary shard
-    for the given shard ID.
+(Optional, Boolean) If `true`, returns explanation for the primary shard
+for the given shard ID.
 
 `shard`::
-    (Optional, integer) Specifies the ID of the shard that you would like an
-    explanation for.
+(Optional, integer) Specifies the ID of the shard that you would like an
+explanation for.
 
 [[cluster-allocation-explain-api-examples]]
 ==== {api-examples-title}
@@ -162,7 +162,7 @@ node.
 ====== Maximum number of retries exceeded
 
 The following response contains an allocation explanation for an unassigned
-primary shard that has reached the maximum number of allocation retry attempts. 
+primary shard that has reached the maximum number of allocation retry attempts.
 
 [source,js]
 ----
@@ -204,9 +204,10 @@ primary shard that has reached the maximum number of allocation retry attempts.
 ----
 // NOTCONSOLE
 
-If decider message indicates a transient allocation issue, use 
-<<cluster-reroute,the cluster reroute API>> to retry allocation. 
+If decider message indicates a transient allocation issue, use
+the <<cluster-reroute,cluster reroute>> API to retry allocation.
 
+[[no-valid-shard-copy]]
 ====== No valid shard copy
 
 The following response contains an allocation explanation for an unassigned
@@ -334,7 +335,7 @@ queued to allocate but currently waiting on other queued shards.
 ----
 // NOTCONSOLE
 
-This is a transient message that might appear when a large amount of shards are allocating. 
+This is a transient message that might appear when a large amount of shards are allocating.
 
 ===== Assigned shard
 
@@ -437,7 +438,7 @@ cluster balance.
 ===== No arguments
 
 If you call the API with no arguments, {es} retrieves an allocation explanation
-for an arbitrary unassigned primary or replica shard, returning any unassigned primary shards first. 
+for an arbitrary unassigned primary or replica shard, returning any unassigned primary shards first.
 
 [source,console]
 ----

--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -49,32 +49,32 @@ you might expect otherwise.
 ==== {api-query-parms-title}
 
 `include_disk_info`::
-(Optional, Boolean) If `true`, returns information about disk usage and
-shard sizes. Defaults to `false`.
+    (Optional, Boolean) If `true`, returns information about disk usage and
+    shard sizes. Defaults to `false`.
 
 `include_yes_decisions`::
-(Optional, Boolean) If `true`, returns 'YES' decisions in explanation.
-Defaults to `false`.
+    (Optional, Boolean) If `true`, returns 'YES' decisions in explanation.
+    Defaults to `false`.
 
 [[cluster-allocation-explain-api-request-body]]
 ==== {api-request-body-title}
 
 `current_node`::
-(Optional, string) Specifies the node ID or the name of the node currently
-holding the shard to explain. To explain an unassigned shard, omit this
-parameter.
+    (Optional, string) Specifies the node ID or the name of the node currently
+    holding the shard to explain. To explain an unassigned shard, omit this
+    parameter.
 
 `index`::
-(Optional, string) Specifies the name of the index that you would like an
-explanation for.
+    (Optional, string) Specifies the name of the index that you would like an
+    explanation for.
 
 `primary`::
-(Optional, Boolean) If `true`, returns explanation for the primary shard
-for the given shard ID.
+    (Optional, Boolean) If `true`, returns explanation for the primary shard
+    for the given shard ID.
 
 `shard`::
-(Optional, integer) Specifies the ID of the shard that you would like an
-explanation for.
+    (Optional, integer) Specifies the ID of the shard that you would like an
+    explanation for.
 
 [[cluster-allocation-explain-api-examples]]
 ==== {api-examples-title}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/Explanations.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/Explanations.java
@@ -32,7 +32,7 @@ public final class Explanations {
         public static final String NO_COPIES = """
             Elasticsearch can't allocate this shard because there are no copies of its data in the cluster. Elasticsearch will allocate \
             this shard when a node holding a good copy of its data joins the cluster. If no such node is available, restore this index \
-            from a recent snapshot.""";
+            from a recent snapshot. For more information, see\s""" + org.elasticsearch.common.ReferenceDocs.ALLOCATION_EXPLAIN_NO_COPIES;
 
         public static final String DELAYED_WITH_ALTERNATIVE = """
             The node containing this shard copy recently left the cluster. Elasticsearch is waiting for it to return. If the node does not \

--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -81,6 +81,7 @@ public enum ReferenceDocs {
     X_OPAQUE_ID,
     FORMING_SINGLE_NODE_CLUSTERS,
     CIRCUIT_BREAKER_ERRORS,
+    ALLOCATION_EXPLAIN_NO_COPIES,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.txt
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.txt
@@ -43,3 +43,4 @@ FLOOD_STAGE_WATERMARK                                           fix-watermark-er
 X_OPAQUE_ID                                                     api-conventions.html#x-opaque-id
 FORMING_SINGLE_NODE_CLUSTERS                                    modules-discovery-bootstrap-cluster.html#modules-discovery-bootstrap-cluster-joining
 CIRCUIT_BREAKER_ERRORS                                          circuit-breaker-errors.html
+ALLOCATION_EXPLAIN_NO_COPIES                                    cluster-allocation-explain.html#no-valid-shard-copy


### PR DESCRIPTION

Adds no_valid_shard_copies [reference link](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-allocation-explain.html#_no_valid_shard_copy) to the NO_COPIES allocation explanations string
