### PR TITLE
[8.x] Fix `testFollowIndexAndCloseNode` (#113618)

### DIFF
--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -157,6 +158,7 @@ public class FollowerFailOverIT extends CcrIntegTestCase {
         followRequest.getParameters().setMaxWriteRequestOperationCount(randomIntBetween(32, 2048));
         followRequest.getParameters().setMaxWriteRequestSize(new ByteSizeValue(randomIntBetween(1, 4096), ByteSizeUnit.KB));
         followRequest.getParameters().setMaxOutstandingWriteRequests(randomIntBetween(1, 10));
+        followRequest.waitForActiveShards(ActiveShardCount.ALL);
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
         disableDelayedAllocation("index2");
         logger.info("--> follow request {}", Strings.toString(followRequest));


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix `testFollowIndexAndCloseNode` (#113618)