### PR TITLE
Improve `safeAwaitFailure`

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureRepositoryMissingCredentialsIT.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureRepositoryMissingCredentialsIT.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.repositories.azure;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.put.TransportPutRepositoryAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -41,17 +40,13 @@ public class AzureRepositoryMissingCredentialsIT extends ESIntegTestCase {
 
     public void testMissingCredentialsException() {
         assertThat(
-            asInstanceOf(
+            safeAwaitAndUnwrapFailure(
                 RepositoryVerificationException.class,
-                ExceptionsHelper.unwrapCause(
-                    safeAwaitFailure(
-                        AcknowledgedResponse.class,
-                        l -> client().execute(
-                            TransportPutRepositoryAction.TYPE,
-                            new PutRepositoryRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "test-repo").type("azure"),
-                            l
-                        )
-                    )
+                AcknowledgedResponse.class,
+                l -> client().execute(
+                    TransportPutRepositoryAction.TYPE,
+                    new PutRepositoryRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, "test-repo").type("azure"),
+                    l
                 )
             ).getCause().getMessage(),
             allOf(

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.cluster.shards;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
@@ -145,17 +144,13 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
             enableIndexBlock("test-blocks", SETTING_BLOCKS_METADATA);
             assertBlocked(
                 null,
-                asInstanceOf(
+                safeAwaitAndUnwrapFailure(
                     ClusterBlockException.class,
-                    ExceptionsHelper.unwrapCause(
-                        safeAwaitFailure(
-                            ClusterSearchShardsResponse.class,
-                            l -> client().execute(
-                                TransportClusterSearchShardsAction.TYPE,
-                                new ClusterSearchShardsRequest(TEST_REQUEST_TIMEOUT, "test-blocks"),
-                                l
-                            )
-                        )
+                    ClusterSearchShardsResponse.class,
+                    l -> client().execute(
+                        TransportClusterSearchShardsAction.TYPE,
+                        new ClusterSearchShardsRequest(TEST_REQUEST_TIMEOUT, "test-blocks"),
+                        l
                     )
                 )
             );

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestProcessorNotInstalledOnAllNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestProcessorNotInstalledOnAllNodesIT.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.ingest;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -61,17 +60,13 @@ public class IngestProcessorNotInstalledOnAllNodesIT extends ESIntegTestCase {
         ensureStableCluster(2, node2);
 
         assertThat(
-            asInstanceOf(
+            safeAwaitAndUnwrapFailure(
                 ElasticsearchParseException.class,
-                ExceptionsHelper.unwrapCause(
-                    safeAwaitFailure(
-                        AcknowledgedResponse.class,
-                        l -> client().execute(
-                            PutPipelineTransportAction.TYPE,
-                            IngestPipelineTestUtils.putJsonPipelineRequest("id", pipelineSource),
-                            l
-                        )
-                    )
+                AcknowledgedResponse.class,
+                l -> client().execute(
+                    PutPipelineTransportAction.TYPE,
+                    IngestPipelineTestUtils.putJsonPipelineRequest("id", pipelineSource),
+                    l
                 )
             ).getMessage(),
             containsString("Processor type [test] is not installed on node")
@@ -84,17 +79,13 @@ public class IngestProcessorNotInstalledOnAllNodesIT extends ESIntegTestCase {
         internalCluster().startNode();
 
         assertThat(
-            asInstanceOf(
+            safeAwaitAndUnwrapFailure(
                 ElasticsearchParseException.class,
-                ExceptionsHelper.unwrapCause(
-                    safeAwaitFailure(
-                        AcknowledgedResponse.class,
-                        l -> client().execute(
-                            PutPipelineTransportAction.TYPE,
-                            IngestPipelineTestUtils.putJsonPipelineRequest("id", pipelineSource),
-                            l
-                        )
-                    )
+                AcknowledgedResponse.class,
+                l -> client().execute(
+                    PutPipelineTransportAction.TYPE,
+                    IngestPipelineTestUtils.putJsonPipelineRequest("id", pipelineSource),
+                    l
                 )
             ).getMessage(),
             equalTo("No processor type exists with name [test]")

--- a/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.script;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.cluster.storedscripts.DeleteStoredScriptRequest;
 import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptAction;
 import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
@@ -71,20 +70,16 @@ public class StoredScriptsIT extends ESIntegTestCase {
 
         assertEquals(
             "Validation Failed: 1: id cannot contain '#' for stored script;",
-            asInstanceOf(
+            safeAwaitAndUnwrapFailure(
                 IllegalArgumentException.class,
-                ExceptionsHelper.unwrapCause(
-                    safeAwaitFailure(
-                        AcknowledgedResponse.class,
-                        l -> client().execute(
-                            TransportPutStoredScriptAction.TYPE,
-                            new PutStoredScriptRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).id("id#")
-                                .content(new BytesArray(Strings.format("""
-                                    {"script": {"lang": "%s", "source": "1"} }
-                                    """, LANG)), XContentType.JSON),
-                            l
-                        )
-                    )
+                AcknowledgedResponse.class,
+                l -> client().execute(
+                    TransportPutStoredScriptAction.TYPE,
+                    new PutStoredScriptRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).id("id#")
+                        .content(new BytesArray(Strings.format("""
+                            {"script": {"lang": "%s", "source": "1"} }
+                            """, LANG)), XContentType.JSON),
+                    l
                 )
             ).getMessage()
         );
@@ -93,21 +88,16 @@ public class StoredScriptsIT extends ESIntegTestCase {
     public void testMaxScriptSize() {
         assertEquals(
             "exceeded max allowed stored script size in bytes [64] with size [65] for script [foobar]",
-            asInstanceOf(
+            safeAwaitAndUnwrapFailure(
                 IllegalArgumentException.class,
-                ExceptionsHelper.unwrapCause(
-                    safeAwaitFailure(
-                        AcknowledgedResponse.class,
-                        l -> client().execute(
-                            TransportPutStoredScriptAction.TYPE,
-                            new PutStoredScriptRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).id("foobar")
-                                .content(new BytesArray(Strings.format("""
-                                    {"script": { "lang": "%s", "source":"0123456789abcdef"} }\
-                                    """, LANG)), XContentType.JSON),
-                            l
-                        )
-
-                    )
+                AcknowledgedResponse.class,
+                l -> client().execute(
+                    TransportPutStoredScriptAction.TYPE,
+                    new PutStoredScriptRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).id("foobar")
+                        .content(new BytesArray(Strings.format("""
+                            {"script": { "lang": "%s", "source":"0123456789abcdef"} }\
+                            """, LANG)), XContentType.JSON),
+                    l
                 )
             ).getMessage()
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -382,9 +382,10 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         Files.write(repo.resolve(getRepositoryDataBlobName(repositoryData.getGenId())), randomByteArrayOfLength(randomIntBetween(1, 100)));
 
         logger.info("--> verify loading repository data throws RepositoryException");
-        asInstanceOf(
+        safeAwaitFailure(
             RepositoryException.class,
-            safeAwaitFailure(RepositoryData.class, l -> repository.getRepositoryData(EsExecutors.DIRECT_EXECUTOR_SERVICE, l))
+            RepositoryData.class,
+            l -> repository.getRepositoryData(EsExecutors.DIRECT_EXECUTOR_SERVICE, l)
         );
 
         final String otherRepoName = "other-repo";
@@ -397,9 +398,10 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         final Repository otherRepo = getRepositoryOnMaster(otherRepoName);
 
         logger.info("--> verify loading repository data from newly mounted repository throws RepositoryException");
-        asInstanceOf(
+        safeAwaitFailure(
             RepositoryException.class,
-            safeAwaitFailure(RepositoryData.class, l -> repository.getRepositoryData(EsExecutors.DIRECT_EXECUTOR_SERVICE, l))
+            RepositoryData.class,
+            l -> repository.getRepositoryData(EsExecutors.DIRECT_EXECUTOR_SERVICE, l)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterActionTests.java
@@ -88,9 +88,10 @@ public class TransportResolveClusterActionTests extends ESTestCase {
                 null
             );
 
-            final var ex = asInstanceOf(
+            final var ex = safeAwaitFailure(
                 IllegalArgumentException.class,
-                safeAwaitFailure(ResolveClusterActionResponse.class, listener -> action.doExecute(null, request, listener))
+                ResolveClusterActionResponse.class,
+                listener -> action.doExecute(null, request, listener)
             );
 
             assertThat(ex.getMessage(), containsString("not compatible with version"));

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -87,9 +87,10 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
                 null
             );
 
-            IllegalArgumentException ex = asInstanceOf(
+            IllegalArgumentException ex = safeAwaitFailure(
                 IllegalArgumentException.class,
-                safeAwaitFailure(FieldCapabilitiesResponse.class, l -> action.doExecute(null, fieldCapsRequest, l))
+                FieldCapabilitiesResponse.class,
+                l -> action.doExecute(null, fieldCapsRequest, l)
             );
 
             assertThat(

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -344,10 +344,8 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
 
         assertEquals(
             "blocked by: [SERVICE_UNAVAILABLE/1/test-block];",
-            asInstanceOf(
-                ClusterBlockException.class,
-                safeAwaitFailure(Response.class, listener -> action.doExecute(null, request, listener))
-            ).getMessage()
+            safeAwaitFailure(ClusterBlockException.class, Response.class, listener -> action.doExecute(null, request, listener))
+                .getMessage()
         );
     }
 
@@ -362,10 +360,8 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         setState(clusterService, ClusterState.builder(clusterService.state()).blocks(block));
         assertEquals(
             "index [" + TEST_INDEX + "] blocked by: [SERVICE_UNAVAILABLE/1/test-block];",
-            asInstanceOf(
-                ClusterBlockException.class,
-                safeAwaitFailure(Response.class, listener -> action.doExecute(null, request, listener))
-            ).getMessage()
+            safeAwaitFailure(ClusterBlockException.class, Response.class, listener -> action.doExecute(null, request, listener))
+                .getMessage()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -114,31 +114,27 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
             );
             assertEquals(
                 "fake remote-cluster client",
-                asInstanceOf(
+                safeAwaitFailure(
                     UnsupportedOperationException.class,
-                    safeAwaitFailure(
-                        ClusterStateResponse.class,
-                        listener -> remoteClusterClient.execute(
-                            ClusterStateAction.REMOTE_TYPE,
-                            new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
-                            listener
-                        )
+                    ClusterStateResponse.class,
+                    listener -> remoteClusterClient.execute(
+                        ClusterStateAction.REMOTE_TYPE,
+                        new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                        listener
                     )
                 ).getMessage()
             );
 
             assertEquals(
                 "fake remote-cluster client",
-                asInstanceOf(
+                safeAwaitFailure(
                     UnsupportedOperationException.class,
-                    safeAwaitFailure(
-                        ClusterStateResponse.class,
-                        listener -> remoteClusterClient.execute(
-                            null,
-                            ClusterStateAction.REMOTE_TYPE,
-                            new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
-                            listener
-                        )
+                    ClusterStateResponse.class,
+                    listener -> remoteClusterClient.execute(
+                        null,
+                        ClusterStateAction.REMOTE_TYPE,
+                        new ClusterStateRequest(TEST_REQUEST_TIMEOUT),
+                        listener
                     )
                 ).getMessage()
             );

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3206,9 +3206,10 @@ public class InternalEngineTests extends EngineTestCase {
                     engine.syncTranslog(); // to advance persisted local checkpoint
                     assertEquals(engine.getProcessedLocalCheckpoint(), engine.getPersistedLocalCheckpoint());
                     globalCheckpoint.set(engine.getPersistedLocalCheckpoint());
-                    asInstanceOf(
+                    safeAwaitFailure(
                         IllegalStateException.class,
-                        safeAwaitFailure(Void.class, listener -> engine.recoverFromTranslog(translogHandler, Long.MAX_VALUE, listener))
+                        Void.class,
+                        listener -> engine.recoverFromTranslog(translogHandler, Long.MAX_VALUE, listener)
                     );
                     Map<String, String> userData = engine.getLastCommittedSegmentInfos().getUserData();
                     assertEquals(engine.getTranslog().getTranslogUUID(), userData.get(Translog.TRANSLOG_UUID_KEY));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
@@ -565,9 +565,10 @@ public class IndexShardOperationPermitsTests extends ESTestCase {
 
             assertEquals(
                 "timeout while blocking operations after [0s]",
-                asInstanceOf(
+                safeAwaitFailure(
                     ElasticsearchTimeoutException.class,
-                    safeAwaitFailure(Releasable.class, f -> permits.blockOperations(f, 0, TimeUnit.SECONDS, threadPool.generic()))
+                    Releasable.class,
+                    f -> permits.blockOperations(f, 0, TimeUnit.SECONDS, threadPool.generic())
                 ).getMessage()
             );
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2169,16 +2169,14 @@ public class IndexShardTests extends IndexShardTestCase {
         final ShardRouting relocationRouting = ShardRoutingHelper.relocate(originalRouting, "other_node");
         IndexShardTestCase.updateRoutingEntry(shard, relocationRouting);
         IndexShardTestCase.updateRoutingEntry(shard, originalRouting);
-        asInstanceOf(
+        safeAwaitFailure(
             IllegalIndexShardStateException.class,
-            safeAwaitFailure(
-                Void.class,
-                listener -> shard.relocated(
-                    relocationRouting.relocatingNodeId(),
-                    relocationRouting.getTargetRelocatingShard().allocationId().getId(),
-                    (primaryContext, l) -> fail("should not be called"),
-                    listener
-                )
+            Void.class,
+            listener -> shard.relocated(
+                relocationRouting.relocatingNodeId(),
+                relocationRouting.getTargetRelocatingShard().allocationId().getId(),
+                (primaryContext, l) -> fail("should not be called"),
+                listener
             )
         );
         closeShards(shard);
@@ -2263,16 +2261,14 @@ public class IndexShardTests extends IndexShardTestCase {
 
         final AtomicBoolean relocated = new AtomicBoolean();
 
-        final IllegalIndexShardStateException wrongNodeException = asInstanceOf(
+        final IllegalIndexShardStateException wrongNodeException = safeAwaitFailure(
             IllegalIndexShardStateException.class,
-            safeAwaitFailure(
-                Void.class,
-                listener -> shard.relocated(
-                    wrongTargetNodeShardRouting.relocatingNodeId(),
-                    wrongTargetNodeShardRouting.getTargetRelocatingShard().allocationId().getId(),
-                    (ctx, l) -> relocated.set(true),
-                    listener
-                )
+            Void.class,
+            listener -> shard.relocated(
+                wrongTargetNodeShardRouting.relocatingNodeId(),
+                wrongTargetNodeShardRouting.getTargetRelocatingShard().allocationId().getId(),
+                (ctx, l) -> relocated.set(true),
+                listener
             )
         );
         assertThat(
@@ -2281,16 +2277,14 @@ public class IndexShardTests extends IndexShardTestCase {
         );
         assertFalse(relocated.get());
 
-        final IllegalStateException wrongTargetIdException = asInstanceOf(
+        final IllegalStateException wrongTargetIdException = safeAwaitFailure(
             IllegalStateException.class,
-            safeAwaitFailure(
-                Void.class,
-                listener -> shard.relocated(
-                    wrongTargetAllocationIdShardRouting.relocatingNodeId(),
-                    wrongTargetAllocationIdShardRouting.getTargetRelocatingShard().allocationId().getId(),
-                    (ctx, l) -> relocated.set(true),
-                    listener
-                )
+            Void.class,
+            listener -> shard.relocated(
+                wrongTargetAllocationIdShardRouting.relocatingNodeId(),
+                wrongTargetAllocationIdShardRouting.getTargetRelocatingShard().allocationId().getId(),
+                (ctx, l) -> relocated.set(true),
+                listener
             )
         );
         assertThat(

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.transport;
 
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
@@ -127,14 +126,10 @@ public class RemoteClusterClientTests extends ESTestCase {
                 assertNotNull(clusterStateResponse);
                 assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
                 // also test a failure, there is no handler for scroll registered
-                ActionNotFoundTransportException ex = asInstanceOf(
+                ActionNotFoundTransportException ex = safeAwaitAndUnwrapFailure(
                     ActionNotFoundTransportException.class,
-                    ExceptionsHelper.unwrapCause(
-                        safeAwaitFailure(
-                            SearchResponse.class,
-                            listener -> client.execute(TransportSearchScrollAction.REMOTE_TYPE, new SearchScrollRequest(""), listener)
-                        )
-                    )
+                    SearchResponse.class,
+                    listener -> client.execute(TransportSearchScrollAction.REMOTE_TYPE, new SearchScrollRequest(""), listener)
                 );
                 assertEquals("No handler for action [indices:data/read/scroll]", ex.getMessage());
             }

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -186,9 +186,10 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             )
         ) {
             assertThat(
-                asInstanceOf(
+                safeAwaitFailure(
                     IllegalStateException.class,
-                    safeAwaitFailure(DiscoveryNode.class, listener -> transportServiceA.handshake(connection, timeout, listener))
+                    DiscoveryNode.class,
+                    listener -> transportServiceA.handshake(connection, timeout, listener)
                 ).getMessage(),
                 containsString(
                     "handshake with [" + discoveryNode + "] failed: remote cluster name [b] does not match local cluster name [a]"
@@ -231,9 +232,10 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             )
         ) {
             assertThat(
-                asInstanceOf(
+                safeAwaitFailure(
                     IllegalStateException.class,
-                    safeAwaitFailure(DiscoveryNode.class, listener -> transportServiceA.handshake(connection, timeout, listener))
+                    DiscoveryNode.class,
+                    listener -> transportServiceA.handshake(connection, timeout, listener)
                 ).getMessage(),
                 containsString(
                     "handshake with ["
@@ -303,12 +305,10 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             .version(transportServiceB.getLocalNode().getVersionInformation())
             .build();
         assertThat(
-            asInstanceOf(
+            safeAwaitFailure(
                 ConnectTransportException.class,
-                safeAwaitFailure(
-                    Releasable.class,
-                    listener -> transportServiceA.connectToNode(discoveryNode, TestProfiles.LIGHT_PROFILE, listener)
-                )
+                Releasable.class,
+                listener -> transportServiceA.connectToNode(discoveryNode, TestProfiles.LIGHT_PROFILE, listener)
             ).getMessage(),
             allOf(
                 containsString("Connecting to [" + discoveryNode.getAddress() + "] failed"),
@@ -360,9 +360,10 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         ) {
             assertThat(
                 ExceptionsHelper.unwrap(
-                    asInstanceOf(
+                    safeAwaitFailure(
                         TransportSerializationException.class,
-                        safeAwaitFailure(DiscoveryNode.class, listener -> transportServiceA.handshake(connection, timeout, listener))
+                        DiscoveryNode.class,
+                        listener -> transportServiceA.handshake(connection, timeout, listener)
                     ),
                     IllegalArgumentException.class
                 ).getMessage(),

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -39,6 +39,7 @@ import org.apache.lucene.tests.util.TestRuleMarkFailure;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ElasticsearchWrapperException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionFuture;
@@ -215,7 +216,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.startsWith;
 
 /**
@@ -2428,6 +2428,44 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     public static <T> Exception safeAwaitFailure(@SuppressWarnings("unused") Class<T> responseType, Consumer<ActionListener<T>> consumer) {
         return safeAwaitFailure(consumer);
+    }
+
+    /**
+     * Wait for the exceptional completion of the given async action, with a timeout of {@link #SAFE_AWAIT_TIMEOUT},
+     * preserving the thread's interrupt status flag and converting a successful completion, interrupt or timeout into an {@link
+     * AssertionError} to trigger a test failure.
+     *
+     * @param responseType  Class of listener response type, to aid type inference but otherwise ignored.
+     * @param exceptionType Expected exception type. This method throws an {@link AssertionError} if a different type of exception is seen.
+     *
+     * @return The exception with which the {@code listener} was completed exceptionally.
+     */
+    public static <Response, ExpectedException extends Exception> ExpectedException safeAwaitFailure(
+        Class<ExpectedException> exceptionType,
+        Class<Response> responseType,
+        Consumer<ActionListener<Response>> consumer
+    ) {
+        return asInstanceOf(exceptionType, safeAwaitFailure(responseType, consumer));
+    }
+
+    /**
+     * Wait for the exceptional completion of the given async action, with a timeout of {@link #SAFE_AWAIT_TIMEOUT},
+     * preserving the thread's interrupt status flag and converting a successful completion, interrupt or timeout into an {@link
+     * AssertionError} to trigger a test failure. Any layers of {@link ElasticsearchWrapperException} are removed from the thrown exception
+     * using {@link ExceptionsHelper#unwrapCause}.
+     *
+     * @param responseType  Class of listener response type, to aid type inference but otherwise ignored.
+     * @param exceptionType Expected unwrapped exception type. This method throws an {@link AssertionError} if a different type of exception
+     *                      is seen.
+     *
+     * @return The unwrapped exception with which the {@code listener} was completed exceptionally.
+     */
+    public static <Response, ExpectedException extends Exception> ExpectedException safeAwaitAndUnwrapFailure(
+        Class<ExpectedException> exceptionType,
+        Class<Response> responseType,
+        Consumer<ActionListener<Response>> consumer
+    ) {
+        return asInstanceOf(exceptionType, ExceptionsHelper.unwrapCause(safeAwaitFailure(responseType, consumer)));
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -3507,9 +3507,10 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         DiscoveryNode node,
         ConnectionProfile connectionProfile
     ) {
-        return asInstanceOf(
+        return safeAwaitFailure(
             ConnectTransportException.class,
-            safeAwaitFailure(Releasable.class, listener -> service.connectToNode(node, connectionProfile, listener))
+            Releasable.class,
+            listener -> service.connectToNode(node, connectionProfile, listener)
         );
     }
 
@@ -3532,9 +3533,10 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         DiscoveryNode node,
         ConnectionProfile connectionProfile
     ) {
-        return asInstanceOf(
+        return safeAwaitFailure(
             ConnectTransportException.class,
-            safeAwaitFailure(Transport.Connection.class, listener -> service.openConnection(node, connectionProfile, listener))
+            Transport.Connection.class,
+            listener -> service.openConnection(node, connectionProfile, listener)
         );
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
@@ -126,10 +126,7 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
         final MonitoringBulkRequest request = randomRequest();
 
         assertThat(
-            asInstanceOf(
-                ClusterBlockException.class,
-                safeAwaitFailure(MonitoringBulkResponse.class, l -> action.execute(null, request, l))
-            ),
+            safeAwaitFailure(ClusterBlockException.class, MonitoringBulkResponse.class, l -> action.execute(null, request, l)),
             hasToString(containsString("ClusterBlockException: blocked by: [SERVICE_UNAVAILABLE/2/no master]"))
         );
     }
@@ -175,9 +172,10 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
         );
 
         assertThat(
-            asInstanceOf(
+            safeAwaitFailure(
                 ActionRequestValidationException.class,
-                safeAwaitFailure(MonitoringBulkResponse.class, l -> action.execute(null, new MonitoringBulkRequest(), l))
+                MonitoringBulkResponse.class,
+                l -> action.execute(null, new MonitoringBulkRequest(), l)
             ),
             hasToString(containsString("no monitoring documents added"))
         );

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -480,9 +480,10 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
     }
 
     private RepositoryVerificationException analyseRepositoryExpectFailure(RepositoryAnalyzeAction.Request request) {
-        return asInstanceOf(
+        return safeAwaitAndUnwrapFailure(
             RepositoryVerificationException.class,
-            ExceptionsHelper.unwrapCause(safeAwaitFailure(RepositoryAnalyzeAction.Response.class, l -> analyseRepository(request, l)))
+            RepositoryAnalyzeAction.Response.class,
+            l -> analyseRepository(request, l)
         );
     }
 


### PR DESCRIPTION
Very often we want to assert the exception type, possibly after
unwrapping any `ElasticsearchWrapperException` layers. This commit adds
utilities to better support these cases.