### PR TITLE
Note in docs about interpreting IO stats when running in docker

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1717,7 +1717,7 @@ See <<disk-based-shard-allocation>> for more information about disk watermarks a
 `io_stats` (Linux only)::
 (objects) Contains I/O statistics for the node.
 
-**NOTE**: Due to limitations of the Linux kernel, When running the application within a container such as Docker, these statistics may not be accurate.
+NOTE: Due to limitations of the Linux kernel, When running the application within a container such as Docker, these statistics may not be accurate.
 In this scenario, they represent activity for the entire host filesystem your data is stored on and are *not* scoped to the container.
 +
 .Properties of `io_stats`

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1716,6 +1716,9 @@ See <<disk-based-shard-allocation>> for more information about disk watermarks a
 
 `io_stats` (Linux only)::
 (objects) Contains I/O statistics for the node.
+
+**NOTE**: Due to limitations of the Linux kernel, When running the application within a container such as Docker, these statistics may not be accurate.
+In this scenario, they represent activity for the entire host filesystem your data is stored on and are *not* scoped to the container.
 +
 .Properties of `io_stats`
 [%collapsible%open]

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1717,8 +1717,8 @@ See <<disk-based-shard-allocation>> for more information about disk watermarks a
 `io_stats` (Linux only)::
 (objects) Contains I/O statistics for the node.
 
-NOTE: Due to limitations of the Linux kernel, When running the application within a container such as Docker, these statistics may not be accurate.
-In this scenario, they represent activity for the entire host filesystem your data is stored on and are *not* scoped to the container.
+NOTE: These statistics are derived from the `/proc/diskstats` kernel interface.
+This interface accounts for IO performed by all processes on the system, even if you are running {es} within a container.
 +
 .Properties of `io_stats`
 [%collapsible%open]

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1718,7 +1718,8 @@ See <<disk-based-shard-allocation>> for more information about disk watermarks a
 (objects) Contains I/O statistics for the node.
 
 NOTE: These statistics are derived from the `/proc/diskstats` kernel interface.
-This interface accounts for IO performed by all processes on the system, even if you are running {es} within a container.
+This interface accounts for IO performed by all processes on the system, even
+if you are running {es} within a container.
 +
 .Properties of `io_stats`
 [%collapsible%open]


### PR DESCRIPTION
This PR adds documentation describing possible inaccuracies in the FS statistics from the `_nodes/stats` endpoint when running inside a container  