### PR TITLE
warn on undesired allocation ratio on non-shutting-down nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -87,9 +87,7 @@ public class DesiredBalanceReconciler {
      * Number of assigned shards during last reconciliation that are not allocated on desired node and need to be moved
      */
     protected final LongGaugeMetric undesiredAllocations;
-    protected final LongGaugeMetric undesiredAllocationsExcludingShuttingDownNodes;
     private final DoubleGauge undesiredAllocationsRatio;
-    private final DoubleGauge undesiredAllocationsRatioExcludingShuttingDownNodes;
 
     public DesiredBalanceReconciler(ClusterSettings clusterSettings, ThreadPool threadPool, MeterRegistry meterRegistry) {
         this.undesiredAllocationLogInterval = new FrequencyCappedAction(
@@ -117,32 +115,16 @@ public class DesiredBalanceReconciler {
         undesiredAllocations = LongGaugeMetric.create(
             meterRegistry,
             "es.allocator.desired_balance.allocations.undesired.current",
-            "Total number of shards allocated on undesired nodes",
+            "Total number of shards allocated on undesired nodes excluding shutting down nodes",
             "{shard}"
         );
         undesiredAllocationsRatio = meterRegistry.registerDoubleGauge(
             "es.allocator.desired_balance.allocations.undesired.ratio",
-            "Ratio of undesired allocations to shard count",
-            "1",
-            () -> {
-                var total = totalAllocations.get();
-                var undesired = undesiredAllocations.get();
-                return new DoubleWithAttributes(total != 0 ? (double) undesired / total : 0.0);
-            }
-        );
-        undesiredAllocationsExcludingShuttingDownNodes = LongGaugeMetric.create(
-            meterRegistry,
-            "es.allocator.desired_balance.allocations.undesired.exclude_shutdowns.current",
-            "Total number of shards allocated on undesired nodes excluding shutting down nodes",
-            "{shard}"
-        );
-        undesiredAllocationsRatioExcludingShuttingDownNodes = meterRegistry.registerDoubleGauge(
-            "es.allocator.desired_balance.allocations.undesired.exclude_shutdowns.ratio",
             "Ratio of undesired allocations to shard count excluding shutting down nodes",
             "1",
             () -> {
                 var total = totalAllocations.get();
-                var undesired = undesiredAllocationsExcludingShuttingDownNodes.get();
+                var undesired = undesiredAllocations.get();
                 return new DoubleWithAttributes(total != 0 ? (double) undesired / total : 0.0);
             }
         );
@@ -519,7 +501,6 @@ public class DesiredBalanceReconciler {
             int unassignedShards = routingNodes.unassigned().size() + routingNodes.unassigned().ignored().size();
             int totalAllocations = 0;
             int undesiredAllocationsExcludingShuttingDownNodes = 0;
-            int undesiredAllocations = 0;
 
             // Iterate over all started shards and try to move any which are on undesired nodes. In the presence of throttling shard
             // movements, the goal of this iteration order is to achieve a fairer movement of shards from the nodes that are offloading the
@@ -545,7 +526,6 @@ public class DesiredBalanceReconciler {
                     continue;
                 }
 
-                undesiredAllocations++;
                 if (allocation.metadata().nodeShutdowns().contains(shardRouting.currentNodeId()) == false) {
                     undesiredAllocationsExcludingShuttingDownNodes++;
                 }
@@ -582,57 +562,26 @@ public class DesiredBalanceReconciler {
             }
 
             DesiredBalanceReconciler.this.unassignedShards.set(unassignedShards);
-            DesiredBalanceReconciler.this.undesiredAllocations.set(undesiredAllocations);
-            DesiredBalanceReconciler.this.undesiredAllocationsExcludingShuttingDownNodes.set(
-                undesiredAllocationsExcludingShuttingDownNodes
-            );
+            DesiredBalanceReconciler.this.undesiredAllocations.set(undesiredAllocationsExcludingShuttingDownNodes);
             DesiredBalanceReconciler.this.totalAllocations.set(totalAllocations);
 
-            maybeLogUndesiredAllocationsWarning(
-                totalAllocations,
-                undesiredAllocations,
-                undesiredAllocationsExcludingShuttingDownNodes,
-                routingNodes.size()
-            );
+            maybeLogUndesiredAllocationsWarning(totalAllocations, undesiredAllocationsExcludingShuttingDownNodes, routingNodes.size());
         }
 
-        private void maybeLogUndesiredAllocationsWarning(
-            int totalAllocations,
-            int undesiredAllocations,
-            int undesiredAllocationsExcludingShuttingDownNodes,
-            int nodeCount
-        ) {
-            // shards that cluster can relocate with one reroute
-            final boolean emptyRelocationBacklog = undesiredAllocations <= 2L * nodeCount;
-            if (totalAllocations == 0 || emptyRelocationBacklog) {
-                return;
-            }
-            final long maxUndesiredAllocations = (long) (undesiredAllocationsLogThreshold * totalAllocations);
-            final boolean warningThresholdReached = undesiredAllocations > maxUndesiredAllocations
-                || undesiredAllocationsExcludingShuttingDownNodes > maxUndesiredAllocations;
-            if (warningThresholdReached) {
-                undesiredAllocationLogInterval.maybeExecute(() -> {
-                    if (undesiredAllocations > maxUndesiredAllocations) {
-                        logger.warn(
-                            "[{}] of assigned shards ({}/{}) on all nodes are not on their desired nodes, "
-                                + "which exceeds the warn threshold of [{}]",
-                            Strings.format1Decimals(100.0 * undesiredAllocations / totalAllocations, "%"),
-                            undesiredAllocations,
-                            totalAllocations,
-                            Strings.format1Decimals(100.0 * undesiredAllocationsLogThreshold, "%")
-                        );
-                    }
-                    if (undesiredAllocationsExcludingShuttingDownNodes > maxUndesiredAllocations) {
-                        logger.warn(
-                            "[{}] of assigned shards ({}/{}) on non-shutting-down nodes are not on their desired nodes, "
-                                + "which exceeds the warn threshold of [{}]",
-                            Strings.format1Decimals(100.0 * undesiredAllocationsExcludingShuttingDownNodes / totalAllocations, "%"),
-                            undesiredAllocationsExcludingShuttingDownNodes,
-                            totalAllocations,
-                            Strings.format1Decimals(100.0 * undesiredAllocationsLogThreshold, "%")
-                        );
-                    }
-                });
+        private void maybeLogUndesiredAllocationsWarning(int totalAllocations, int undesiredAllocations, int nodeCount) {
+            // more shards than cluster can relocate with one reroute
+            final boolean nonEmptyRelocationBacklog = undesiredAllocations > 2L * nodeCount;
+            final boolean warningThresholdReached = undesiredAllocations > undesiredAllocationsLogThreshold * totalAllocations;
+            if (totalAllocations > 0 && nonEmptyRelocationBacklog && warningThresholdReached) {
+                undesiredAllocationLogInterval.maybeExecute(
+                    () -> logger.warn(
+                        "[{}] of assigned shards ({}/{}) are not on their desired nodes, which exceeds the warn threshold of [{}]",
+                        Strings.format1Decimals(100.0 * undesiredAllocations / totalAllocations, "%"),
+                        undesiredAllocations,
+                        totalAllocations,
+                        Strings.format1Decimals(100.0 * undesiredAllocationsLogThreshold, "%")
+                    )
+                );
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -1301,16 +1301,11 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         final long initialDelayInMillis = TimeValue.timeValueMinutes(5).getMillis();
         timeInMillisSupplier.addAndGet(randomLongBetween(initialDelayInMillis, 2 * initialDelayInMillis));
 
-        var expectedWarningMessageAllAllocations = "[100%] of assigned shards ("
+        var expectedWarningMessage = "[100%] of assigned shards ("
             + shardCount
             + "/"
             + shardCount
-            + ") on all nodes are not on their desired nodes, which exceeds the warn threshold of [10%]";
-        var expectedWarningMessageExcludingShutdowns = "[100%] of assigned shards ("
-            + shardCount
-            + "/"
-            + shardCount
-            + ") on non-shutting-down nodes are not on their desired nodes, which exceeds the warn threshold of [10%]";
+            + ") are not on their desired nodes, which exceeds the warn threshold of [10%]";
         // Desired assignment matches current routing table
         assertThatLogger(
             () -> reconciler.reconcile(new DesiredBalance(1, allShardsDesiredOnDataNode1), createRoutingAllocationFrom(clusterState)),
@@ -1319,30 +1314,24 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
                 "Should not log if all shards on desired location",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
-                expectedWarningMessageAllAllocations
+                expectedWarningMessage
             )
         );
         assertThatLogger(
             () -> reconciler.reconcile(new DesiredBalance(1, allShardsDesiredOnDataNode2), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
-            new MockLog.SeenEventExpectation(
-                "Should log first too many shards on undesired locations",
-                DesiredBalanceReconciler.class.getCanonicalName(),
-                Level.WARN,
-                expectedWarningMessageAllAllocations
-            ),
             node1ShuttingDown
                 ? new MockLog.UnseenEventExpectation(
-                    "Should log first too many shards on undesired non-shutting-down locations",
+                    "Should not log first too many shards on undesired locations",
                     DesiredBalanceReconciler.class.getCanonicalName(),
                     Level.WARN,
-                    expectedWarningMessageExcludingShutdowns
+                    expectedWarningMessage
                 )
                 : new MockLog.SeenEventExpectation(
-                    "Should log first too many shards on undesired non-shutting-down locations",
+                    "Should log first too many shards on undesired locations",
                     DesiredBalanceReconciler.class.getCanonicalName(),
                     Level.WARN,
-                    expectedWarningMessageExcludingShutdowns
+                    expectedWarningMessage
                 )
         );
         assertThatLogger(
@@ -1352,13 +1341,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
                 "Should not log immediate second too many shards on undesired locations",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
-                expectedWarningMessageAllAllocations
-            ),
-            new MockLog.UnseenEventExpectation(
-                "Should not log immediate second too many too many shards on undesired non-shutting-down locations",
-                DesiredBalanceReconciler.class.getCanonicalName(),
-                Level.WARN,
-                expectedWarningMessageExcludingShutdowns
+                expectedWarningMessage
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -1258,8 +1258,8 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
 
         final int shardCount = 5;
 
-        final var dataNode1Assignments = Maps.<ShardId, ShardAssignment>newMapWithExpectedSize(shardCount);
-        final var dataNode2Assignments = Maps.<ShardId, ShardAssignment>newMapWithExpectedSize(shardCount);
+        final var allShardsDesiredOnDataNode1 = Maps.<ShardId, ShardAssignment>newMapWithExpectedSize(shardCount);
+        final var allShardsDesiredOnDataNode2 = Maps.<ShardId, ShardAssignment>newMapWithExpectedSize(shardCount);
 
         final var metadataBuilder = Metadata.builder();
         final var routingTableBuilder = RoutingTable.builder();
@@ -1270,10 +1270,23 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
             metadataBuilder.put(indexMetadata, false);
             routingTableBuilder.add(IndexRoutingTable.builder(index).addShard(newShardRouting(shardId, "data-node-1", true, STARTED)));
 
-            dataNode1Assignments.put(shardId, new ShardAssignment(Set.of("data-node-1"), 1, 0, 0));
-            dataNode2Assignments.put(shardId, new ShardAssignment(Set.of("data-node-2"), 1, 0, 0));
+            allShardsDesiredOnDataNode1.put(shardId, new ShardAssignment(Set.of("data-node-1"), 1, 0, 0));
+            allShardsDesiredOnDataNode2.put(shardId, new ShardAssignment(Set.of("data-node-2"), 1, 0, 0));
         }
 
+        final var node1ShuttingDown = randomBoolean();
+        if (node1ShuttingDown) {
+            var type = randomFrom(SingleNodeShutdownMetadata.Type.SIGTERM, SingleNodeShutdownMetadata.Type.REMOVE);
+            var builder = SingleNodeShutdownMetadata.builder()
+                .setType(type)
+                .setNodeId("data-node-1")
+                .setStartedAtMillis(randomNonNegativeLong())
+                .setReason("test");
+            if (type.equals(SingleNodeShutdownMetadata.Type.SIGTERM)) {
+                builder.setGracePeriod(randomPositiveTimeValue());
+            }
+            metadataBuilder.putCustom(NodesShutdownMetadata.TYPE, new NodesShutdownMetadata(Map.of("data-node-1", builder.build())));
+        }
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(newNode("data-node-1")).add(newNode("data-node-2")))
             .metadata(metadataBuilder)
@@ -1288,39 +1301,64 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         final long initialDelayInMillis = TimeValue.timeValueMinutes(5).getMillis();
         timeInMillisSupplier.addAndGet(randomLongBetween(initialDelayInMillis, 2 * initialDelayInMillis));
 
-        var expectedWarningMessage = "[100%] of assigned shards ("
+        var expectedWarningMessageAllAllocations = "[100%] of assigned shards ("
             + shardCount
             + "/"
             + shardCount
-            + ") are not on their desired nodes, which exceeds the warn threshold of [10%]";
+            + ") on all nodes are not on their desired nodes, which exceeds the warn threshold of [10%]";
+        var expectedWarningMessageExcludingShutdowns = "[100%] of assigned shards ("
+            + shardCount
+            + "/"
+            + shardCount
+            + ") on non-shutting-down nodes are not on their desired nodes, which exceeds the warn threshold of [10%]";
+        // Desired assignment matches current routing table
         assertThatLogger(
-            () -> reconciler.reconcile(new DesiredBalance(1, dataNode1Assignments), createRoutingAllocationFrom(clusterState)),
+            () -> reconciler.reconcile(new DesiredBalance(1, allShardsDesiredOnDataNode1), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
             new MockLog.UnseenEventExpectation(
                 "Should not log if all shards on desired location",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
-                expectedWarningMessage
+                expectedWarningMessageAllAllocations
             )
         );
         assertThatLogger(
-            () -> reconciler.reconcile(new DesiredBalance(1, dataNode2Assignments), createRoutingAllocationFrom(clusterState)),
+            () -> reconciler.reconcile(new DesiredBalance(1, allShardsDesiredOnDataNode2), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
             new MockLog.SeenEventExpectation(
                 "Should log first too many shards on undesired locations",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
-                expectedWarningMessage
-            )
+                expectedWarningMessageAllAllocations
+            ),
+            node1ShuttingDown
+                ? new MockLog.UnseenEventExpectation(
+                    "Should log first too many shards on undesired non-shutting-down locations",
+                    DesiredBalanceReconciler.class.getCanonicalName(),
+                    Level.WARN,
+                    expectedWarningMessageExcludingShutdowns
+                )
+                : new MockLog.SeenEventExpectation(
+                    "Should log first too many shards on undesired non-shutting-down locations",
+                    DesiredBalanceReconciler.class.getCanonicalName(),
+                    Level.WARN,
+                    expectedWarningMessageExcludingShutdowns
+                )
         );
         assertThatLogger(
-            () -> reconciler.reconcile(new DesiredBalance(1, dataNode2Assignments), createRoutingAllocationFrom(clusterState)),
+            () -> reconciler.reconcile(new DesiredBalance(1, allShardsDesiredOnDataNode2), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
             new MockLog.UnseenEventExpectation(
                 "Should not log immediate second too many shards on undesired locations",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
-                expectedWarningMessage
+                expectedWarningMessageAllAllocations
+            ),
+            new MockLog.UnseenEventExpectation(
+                "Should not log immediate second too many too many shards on undesired non-shutting-down locations",
+                DesiredBalanceReconciler.class.getCanonicalName(),
+                Level.WARN,
+                expectedWarningMessageExcludingShutdowns
             )
         );
     }


### PR DESCRIPTION
Adjust existing log and metric for undesired allocations to consider only non-shutting-down nodes.

Closes ES-7849