### PR TITLE
[8.x] Add a logsdb test that uses ignored dynamic fields (#113639)

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataChallengeRestIT.java
@@ -26,8 +26,12 @@ public class StandardVersusLogsIndexModeRandomDataChallengeRestIT extends Standa
     protected final DataGenerationHelper dataGenerationHelper;
 
     public StandardVersusLogsIndexModeRandomDataChallengeRestIT() {
+        this(new DataGenerationHelper());
+    }
+
+    protected StandardVersusLogsIndexModeRandomDataChallengeRestIT(DataGenerationHelper dataGenerationHelper) {
         super();
-        dataGenerationHelper = new DataGenerationHelper();
+        this.dataGenerationHelper = dataGenerationHelper;
     }
 
     @Override

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataDynamicMappingChallengeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/StandardVersusLogsIndexModeRandomDataDynamicMappingChallengeRestIT.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.datastreams.logsdb.qa;
+
+import org.elasticsearch.common.settings.Settings;
+
+public class StandardVersusLogsIndexModeRandomDataDynamicMappingChallengeRestIT extends
+    StandardVersusLogsIndexModeRandomDataChallengeRestIT {
+    public StandardVersusLogsIndexModeRandomDataDynamicMappingChallengeRestIT() {
+        super(new DataGenerationHelper(builder -> builder.withFullyDynamicMapping(true)));
+    }
+
+    @Override
+    public void contenderSettings(Settings.Builder builder) {
+        super.contenderSettings(builder);
+        // ignore_dynamic_beyond_limit is set in the template so it's always true
+        builder.put("index.mapping.total_fields.limit", randomIntBetween(1, 5000));
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add a logsdb test that uses ignored dynamic fields (#113639)