### PR TITLE
[ESQL] Fix sorting on CSV test (#113689)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -115,22 +115,15 @@ tests:
 - class: org.elasticsearch.search.retriever.RankDocRetrieverBuilderIT
   method: testRankDocsRetrieverWithCollapse
   issue: https://github.com/elastic/elasticsearch/issues/112254
-- class: org.elasticsearch.search.ccs.CCSUsageTelemetryIT
-  issue: https://github.com/elastic/elasticsearch/issues/112324
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/rest-api/watcher/put-watch/line_120}
   issue: https://github.com/elastic/elasticsearch/issues/99517
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testMultiIndexDelete
   issue: https://github.com/elastic/elasticsearch/issues/112381
-- class: org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshotTests
-  method: testToXContent
-  issue: https://github.com/elastic/elasticsearch/issues/112325
 - class: org.elasticsearch.search.retriever.RankDocRetrieverBuilderIT
   method: testRankDocsRetrieverWithNestedQuery
   issue: https://github.com/elastic/elasticsearch/issues/112421
-- class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
-  issue: https://github.com/elastic/elasticsearch/issues/112423
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
   method: "testAggregateIntermediate {TestCase=<geo_point> #2}"
   issue: https://github.com/elastic/elasticsearch/issues/112461
@@ -190,15 +183,146 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testGetJob_GivenNoSuchJob
   issue: https://github.com/elastic/elasticsearch/issues/112730
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/cluster/stats/line_1450}
-  issue: https://github.com/elastic/elasticsearch/issues/112732
+- class: org.elasticsearch.script.StatsSummaryTests
+  method: testEqualsAndHashCode
+  issue: https://github.com/elastic/elasticsearch/issues/112439
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testDeleteJobAfterMissingAliases
+  issue: https://github.com/elastic/elasticsearch/issues/112823
+- class: org.elasticsearch.repositories.blobstore.testkit.analyze.HdfsRepositoryAnalysisRestIT
+  issue: https://github.com/elastic/elasticsearch/issues/112889
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testCreateJob_WithClashingFieldMappingsFails
+  issue: https://github.com/elastic/elasticsearch/issues/113046
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline1}
+  issue: https://github.com/elastic/elasticsearch/issues/112641
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline3}
+  issue: https://github.com/elastic/elasticsearch/issues/112643
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+  issue: https://github.com/elastic/elasticsearch/issues/112640
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+  issue: https://github.com/elastic/elasticsearch/issues/112642
+- class: org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests
+  method: testChunking
+  issue: https://github.com/elastic/elasticsearch/issues/113139
+- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
+  method: testResponse
+  issue: https://github.com/elastic/elasticsearch/issues/113148
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test30StartStop
   issue: https://github.com/elastic/elasticsearch/issues/113160
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test33JavaChanged
   issue: https://github.com/elastic/elasticsearch/issues/113177
+- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
+  method: testErrorMidStream
+  issue: https://github.com/elastic/elasticsearch/issues/113179
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {categorize.Categorize SYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/113054
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {categorize.Categorize ASYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/113055
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
+  issue: https://github.com/elastic/elasticsearch/issues/108997
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test80JavaOptsInEnvVar
+  issue: https://github.com/elastic/elasticsearch/issues/113219
+- class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
+  method: "testFold {TestCase=<double> #2}"
+  issue: https://github.com/elastic/elasticsearch/issues/113225
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test81JavaOptsInJvmOptions
+  issue: https://github.com/elastic/elasticsearch/issues/113313
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/50_index_patterns/disjoint_mappings}
+  issue: https://github.com/elastic/elasticsearch/issues/113315
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=wildcard/10_wildcard_basic/Query_string wildcard query}
+  issue: https://github.com/elastic/elasticsearch/issues/113316
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+  issue: https://github.com/elastic/elasticsearch/issues/113325
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_force_delete/Test force deleting a running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/113327
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=analytics/top_metrics/sort by scaled float field}
+  issue: https://github.com/elastic/elasticsearch/issues/113340
+- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+  method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
+  issue: https://github.com/elastic/elasticsearch/issues/113343
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testDeleteJob_TimingStatsDocumentIsDeleted
+  issue: https://github.com/elastic/elasticsearch/issues/113370
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/500_date_range/from, to, include_lower, include_upper deprecated}
+  issue: https://github.com/elastic/elasticsearch/pull/113286
+- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
+  method: testLimitedPrivilege
+  issue: https://github.com/elastic/elasticsearch/issues/113419
+- class: org.elasticsearch.index.mapper.extras.TokenCountFieldMapperTests
+  method: testBlockLoaderFromRowStrideReaderWithSyntheticSource
+  issue: https://github.com/elastic/elasticsearch/issues/113427
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+  method: test {categorize.Categorize}
+  issue: https://github.com/elastic/elasticsearch/issues/113428
+- class: org.elasticsearch.xpack.inference.InferenceCrudIT
+  method: testSupportedStream
+  issue: https://github.com/elastic/elasticsearch/issues/113430
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testOutOfOrderData
+  issue: https://github.com/elastic/elasticsearch/issues/113477
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testCreateJobsWithIndexNameOption
+  issue: https://github.com/elastic/elasticsearch/issues/113528
+- class: org.elasticsearch.validation.DotPrefixClientYamlTestSuiteIT
+  method: test {p0=dot_prefix/10_basic/Deprecated index template with a dot prefix index pattern}
+  issue: https://github.com/elastic/elasticsearch/issues/113529
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}
+  issue: https://github.com/elastic/elasticsearch/issues/113537
+- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+  method: testPutE5WithTrainedModelAndInference
+  issue: https://github.com/elastic/elasticsearch/issues/113565
+- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+  method: testPutE5Small_withPlatformAgnosticVariant
+  issue: https://github.com/elastic/elasticsearch/issues/113577
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testCantCreateJobWithSameID
+  issue: https://github.com/elastic/elasticsearch/issues/113581
+- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
+  method: testFieldMappings
+  issue: https://github.com/elastic/elasticsearch/issues/113592
+- class: org.elasticsearch.integration.KibanaUserRoleIntegTests
+  method: testSearchAndMSearch
+  issue: https://github.com/elastic/elasticsearch/issues/113593
+- class: org.elasticsearch.xpack.transform.integration.TransformIT
+  method: testStopWaitForCheckpoint
+  issue: https://github.com/elastic/elasticsearch/issues/106113
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
+  issue: https://github.com/elastic/elasticsearch/issues/101458
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/540_ignore_above_synthetic_source/ignore_above mapping level setting on arrays}
+  issue: https://github.com/elastic/elasticsearch/issues/113648
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testGetJobs_GivenMultipleJobs
+  issue: https://github.com/elastic/elasticsearch/issues/113654
+- class: org.elasticsearch.xpack.ml.integration.MlJobIT
+  method: testGetJobs_GivenSingleJob
+  issue: https://github.com/elastic/elasticsearch/issues/113655
+- class: org.elasticsearch.xpack.security.authz.interceptor.SearchRequestCacheDisablingInterceptorTests
+  method: testHasRemoteIndices
+  issue: https://github.com/elastic/elasticsearch/issues/113660
+- class: org.elasticsearch.xpack.security.authz.interceptor.SearchRequestCacheDisablingInterceptorTests
+  method: testRequestCacheWillBeDisabledWhenSearchRemoteIndices
+  issue: https://github.com/elastic/elasticsearch/issues/113659
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_nanos.csv-spec
@@ -204,7 +204,7 @@ null
 date nanos to long, index version
 required_capability: to_date_nanos
 
-FROM date_nanos | WHERE millis > "2020-02-02" | EVAL l = TO_LONG(nanos) | KEEP l;
+FROM date_nanos | WHERE millis > "2020-02-02" | EVAL l = TO_LONG(nanos) | SORT nanos DESC | KEEP l;
 
 l:long
 1698069301543123456
@@ -219,7 +219,7 @@ l:long
 long to date nanos, index version
 required_capability: to_date_nanos
 
-FROM date_nanos | WHERE millis > "2020-02-02" | EVAL d = TO_DATE_NANOS(num) | KEEP d;
+FROM date_nanos | WHERE millis > "2020-02-02" | EVAL d = TO_DATE_NANOS(num) | SORT nanos DESC | KEEP d;
 
 d:date_nanos
 2023-10-23T13:55:01.543123456Z
@@ -234,7 +234,7 @@ d:date_nanos
 date_nanos to date nanos, index version
 required_capability: to_date_nanos
 
-FROM date_nanos | WHERE millis > "2020-02-02" | EVAL d = TO_DATE_NANOS(nanos) | KEEP d;
+FROM date_nanos | WHERE millis > "2020-02-02" | EVAL d = TO_DATE_NANOS(nanos) | SORT nanos DESC | KEEP d;
 
 d:date_nanos
 2023-10-23T13:55:01.543123456Z


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/113689

Resolves https://github.com/elastic/elasticsearch/issues/113632

Fixes a test that relied on order without sorting.