### PR TITLE
[DOCS] Documents that embeddings are filtered out from `semantic_text` results 

### DIFF
--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -142,12 +142,12 @@ The `include_vectors` parameter can be used as follows:
 --------------------------------------------------
 GET my-index-000001/_search
 {
-  "_source": { "include_vectors": true },
   "query": {
     "match": {
       "content": "Test Data"
     }
-  }
+  },
+  "_source": { "include_vectors": true }
 }
 --------------------------------------------------
 // TEST[skip: TBD]

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -140,7 +140,7 @@ The `include_vectors` parameter can be used as follows:
 
 [source,console]
 --------------------------------------------------
-GET index-000001/_search
+GET my-index-000001/_search
 {
   "_source": { "include_vectors": true },
   "query": {

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -142,7 +142,7 @@ The `include_vectors` parameter can be used as follows:
 --------------------------------------------------
 GET index-000001/_search
 {
-  "_source": {"include_vectors": true},
+  "_source": { "include_vectors": true },
   "query": {
     "match": {
       "content": "Test Data"

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -122,3 +122,96 @@ GET logs/_search
 
 <1> These fields will be removed from the stored `_source` field.
 <2> We can still search on this field, even though it is not in the stored `_source`.
+
+
+[[ifilter-vectors]]
+==== Filtering vectors from `_source`
+
+The `include_vectors` parameter enables you to include or exclude embeddings for `sparse_vector`, `dense_vector`, and `semantic_text` fields from `_source` when it's displayed in API results.
+
+The default behavior varies by field typse:
+
+* `sparse_vector` and `dense_vector` fields are included by default if `include_vectors` is not set to `false`
+* `semantic_text` fields are excluded by default if `include_vectors` is not set to `true`
+  * `update_by_query` and `reindex` operations on `semantic_text` fields are included by default if `include_vectors` is not set to `false`
+
+
+The `include_vectors` parameter can be used as follows:
+
+[source,console]
+--------------------------------------------------
+GET index-000001/_search
+{
+  "_source": { "include_vectors": true },
+  "query": {
+    "match": {
+      "content": "Test Data"
+    }
+  }
+}
+--------------------------------------------------
+
+When the parameter is `true`, the results will show the vector fields in the results:
+
+[source,console-result]
+--------------------------------------------------
+"_source": {
+  "data_value": 15,
+  "semantic_text_field": {
+    "text": "Test Data",
+    "inference": {
+      "inference_id": "my-elser-model",
+      "model_settings": {
+        "task_type": "sparse_embedding"
+        },
+        "chunks": [
+          {
+            "text": "Test Data",
+            "embeddings": {
+              "test": 2.7982168,
+              "data": 2.5768325,
+              "testing": 1.6320102,
+              "(...)",
+            }
+          }
+        ]
+    }
+  },
+  "sparse_vector": {
+    "Test": 1,
+    "Data": 2
+  },
+  "content": "Test Data",
+  "dense_vector": [
+    0.5,
+    10
+  ]
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+When the parameter is `false`, the results won't show the vector fields in the results:
+
+[source,console]
+--------------------------------------------------
+(...)
+"_source": {
+  "data_value": 15,
+  "semantic_text_field": {
+    "text": "Test Data",
+    "inference": {
+      "inference_id": "my-elser-model",
+      "model_settings": {
+        "task_type": "sparse_embedding"
+        },
+        "chunks": [
+          {
+            "text": "Test Data"
+          }
+        ]
+      }
+    },
+  "content": "Test Data"
+}
+--------------------------------------------------
+// NOTCONSOLE

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -189,7 +189,7 @@ When the parameter is `true`, the results will show the vector fields in the res
   ]
 }
 --------------------------------------------------
-// NOTCONSOLE
+// TESTRESPONSE[skip:TBD]
 
 When the parameter is `false`, the results won't show the vector fields in the results:
 
@@ -215,4 +215,4 @@ When the parameter is `false`, the results won't show the vector fields in the r
   "content": "Test Data"
 }
 --------------------------------------------------
-// NOTCONSOLE
+// TESTRESPONSE[skip:TBD]

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -150,6 +150,7 @@ GET index-000001/_search
   }
 }
 --------------------------------------------------
+// TEST[skip: TBD]
 
 When the parameter is `true`, the results will show the vector fields in the results:
 

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -142,12 +142,12 @@ The `include_vectors` parameter can be used as follows:
 --------------------------------------------------
 GET index-000001/_search
 {
-   "_source":{
-      "include_vectors":true
+   "_source": {
+      "include_vectors": true
    },
-   "query":{
-      "match":{
-         "content":"Test Data"
+   "query": {
+      "match": {
+         "content": "Test Data"
       }
    }
 }

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -142,14 +142,14 @@ The `include_vectors` parameter can be used as follows:
 --------------------------------------------------
 GET index-000001/_search
 {
-  "_source": {
-    "include_vectors": true
-    },
-  "query": {
-    "match": {
-      "content": "Test Data"
-    }
-  }
+   "_source":{
+      "include_vectors":true
+   },
+   "query":{
+      "match":{
+         "content":"Test Data"
+      }
+   }
 }
 --------------------------------------------------
 // TEST[skip: TBD]

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -124,7 +124,7 @@ GET logs/_search
 <2> We can still search on this field, even though it is not in the stored `_source`.
 
 
-[[ifilter-vectors]]
+[[filter-vectors]]
 ==== Filtering vectors from `_source`
 
 The `include_vectors` parameter enables you to include or exclude embeddings for `sparse_vector`, `dense_vector`, and `semantic_text` fields from `_source` when it's displayed in API results.
@@ -138,16 +138,16 @@ The default behavior varies by field typse:
 
 The `include_vectors` parameter can be used as follows:
 
-[source,console]
+[source,js]
 --------------------------------------------------
 GET my-index-000001/_search
 {
+  "_source": { "include_vectors": true },
   "query": {
     "match": {
       "content": "Test Data"
     }
-  },
-  "_source": { "include_vectors": true }
+  }
 }
 --------------------------------------------------
 // TEST[skip: TBD]

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -192,7 +192,7 @@ When the parameter is `true`, the results will show the vector fields in the res
 
 When the parameter is `false`, the results won't show the vector fields in the results:
 
-[source,console]
+[source,console-result]
 --------------------------------------------------
 (...)
 "_source": {

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -142,7 +142,9 @@ The `include_vectors` parameter can be used as follows:
 --------------------------------------------------
 GET index-000001/_search
 {
-  "_source": { "include_vectors": true },
+  "_source": {
+    "include_vectors": true
+    },
   "query": {
     "match": {
       "content": "Test Data"

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -142,14 +142,12 @@ The `include_vectors` parameter can be used as follows:
 --------------------------------------------------
 GET index-000001/_search
 {
-   "_source": {
-      "include_vectors": true
-   },
-   "query": {
-      "match": {
-         "content": "Test Data"
-      }
-   }
+  "_source": {"include_vectors": true},
+  "query": {
+    "match": {
+      "content": "Test Data"
+    }
+  }
 }
 --------------------------------------------------
 // TEST[skip: TBD]

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -138,7 +138,7 @@ The default behavior varies by field typse:
 
 The `include_vectors` parameter can be used as follows:
 
-[source,js]
+[source,console]
 --------------------------------------------------
 GET my-index-000001/_search
 {
@@ -150,6 +150,7 @@ GET my-index-000001/_search
   }
 }
 --------------------------------------------------
+// TEST[skip: TBD]
 
 When the parameter is `true`, the results will show the vector fields in the results:
 

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -138,7 +138,7 @@ The default behavior varies by field typse:
 
 The `include_vectors` parameter can be used as follows:
 
-[source,console-result]
+[source,console]
 --------------------------------------------------
 GET my-index-000001/_search
 {

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -138,7 +138,7 @@ The default behavior varies by field typse:
 
 The `include_vectors` parameter can be used as follows:
 
-[source,console]
+[source,console-result]
 --------------------------------------------------
 GET my-index-000001/_search
 {

--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -150,7 +150,6 @@ GET my-index-000001/_search
   }
 }
 --------------------------------------------------
-// TEST[skip: TBD]
 
 When the parameter is `true`, the results will show the vector fields in the results:
 

--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -114,10 +114,7 @@ Once a document is ingested, a `semantic_text` field will have the following str
     },
     "chunks": [ <4>
       {
-        "text": "these are not the droids you're looking for",
-        "embeddings": {
-          (...)
-        }
+        "text": "these are not the droids you're looking for"
       }
     ]
   }

--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -201,10 +201,7 @@ query from the `semantic-embedding` index:
           },
           "chunks": [
             {
-              "text": "There are a few foods and food groups that will help to fight inflammation and delayed onset muscle soreness (both things that are inevitable after a long, hard workout) when you incorporate them into your postworkout eats, whether immediately after your run or at a meal later in the day. Advertisement. Advertisement.",
-              "embeddings": {
-                (...)
-              }
+              "text": "There are a few foods and food groups that will help to fight inflammation and delayed onset muscle soreness (both things that are inevitable after a long, hard workout) when you incorporate them into your postworkout eats, whether immediately after your run or at a meal later in the day. Advertisement. Advertisement."
             }
           ]
         }
@@ -226,10 +223,7 @@ query from the `semantic-embedding` index:
           },
           "chunks": [
             {
-              "text": "During Your Workout. There are a few things you can do during your workout to help prevent muscle injury and soreness. According to personal trainer and writer for Iron Magazine, Marc David, doing warm-ups and cool-downs between sets can help keep muscle soreness to a minimum.",
-              "embeddings": {
-                (...)
-              }
+              "text": "During Your Workout. There are a few things you can do during your workout to help prevent muscle injury and soreness. According to personal trainer and writer for Iron Magazine, Marc David, doing warm-ups and cool-downs between sets can help keep muscle soreness to a minimum."
             }
           ]
         }
@@ -251,10 +245,7 @@ query from the `semantic-embedding` index:
           },
           "chunks": [
             {
-              "text": "This is especially important if the soreness is due to a weightlifting routine. For this time period, do not exert more than around 50% of the level of effort (weight, distance and speed) that caused the muscle groups to be sore.",
-              "embeddings": {
-                (...)
-              }
+              "text": "This is especially important if the soreness is due to a weightlifting routine. For this time period, do not exert more than around 50% of the level of effort (weight, distance and speed) that caused the muscle groups to be sore."
             }
           ]
         }


### PR DESCRIPTION
## Overview

When displayed in an API response for semantic_text fields, the embeddings are automatically filtered out from `_source`. This PR changes the API results in the documentation and documents the `include_vectors` parameter in `_source` documentation.

### Preview

* [semantic_text tutorial](https://elasticsearch_bk_113701.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-semantic-text.html)
* [_source](https://elasticsearch_bk_113701.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/mapping-source-field.html#filter-vectors)