### PR TITLE
[8.x] Support long marked offset in SlicedInputStream (#113629)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStream.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStream.java
@@ -24,12 +24,12 @@ import java.io.InputStream;
 public abstract class SlicedInputStream extends InputStream {
     private int nextSlice = 0;
     private InputStream currentStream;
-    private int currentSliceOffset = 0;
+    private long currentSliceOffset = 0;
     private final int numSlices;
     private boolean closed = false;
     private boolean initialized = false;
     private int markedSlice = -1;
-    private int markedSliceOffset = -1;
+    private long markedSliceOffset = -1;
 
     /**
      * Creates a new SlicedInputStream
@@ -99,6 +99,30 @@ public abstract class SlicedInputStream extends InputStream {
     }
 
     @Override
+    public long skip(long n) throws IOException {
+        long remaining = n;
+        while (remaining > 0) {
+            final InputStream stream = currentStream();
+            if (stream == null) {
+                break;
+            }
+            long skipped = stream.skip(remaining);
+            currentSliceOffset += skipped;
+            if (skipped < remaining) {
+                // read one more byte to see if we reached EOF in order to proceed to the next stream.
+                if (stream.read() < 0) {
+                    nextStream();
+                } else {
+                    currentSliceOffset++;
+                    skipped++;
+                }
+            }
+            remaining -= skipped;
+        }
+        return n - remaining;
+    }
+
+    @Override
     public void close() throws IOException {
         closed = true;
         initialized = true;
@@ -129,7 +153,7 @@ public abstract class SlicedInputStream extends InputStream {
         // According to JDK documentation, marking a closed InputStream should have no effect.
         if (markSupported() && isClosed() == false && numSlices > 0) {
             if (initialized) {
-                markedSlice = nextSlice - 1;
+                markedSlice = (currentStream == null) ? numSlices : nextSlice - 1;
                 markedSliceOffset = currentSliceOffset;
             } else {
                 markedSlice = 0;
@@ -148,12 +172,16 @@ public abstract class SlicedInputStream extends InputStream {
                     throw new IOException("Mark has not been set");
                 }
 
-                // We do not call the SlicedInputStream's skipNBytes but call skipNBytes directly on the returned stream, to ensure that
-                // the skip is performed on the marked slice and no other slices are involved. This may help uncover any bugs.
                 nextSlice = markedSlice;
-                final InputStream stream = nextStream();
-                if (stream != null) {
-                    stream.skipNBytes(markedSliceOffset);
+                initialized = true;
+                IOUtils.close(currentStream);
+                if (nextSlice < numSlices) {
+                    currentStream = openSlice(nextSlice++);
+                    // We do not call the SlicedInputStream's skipNBytes but call skipNBytes directly on the returned stream, to ensure that
+                    // the skip is performed on the marked slice and no other slices are involved. This may help uncover any bugs.
+                    currentStream.skipNBytes(markedSliceOffset);
+                } else {
+                    currentStream = null;
                 }
                 currentSliceOffset = markedSliceOffset;
             }

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.snapshots.blobstore;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.ByteArrayInputStream;
@@ -18,11 +19,15 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
+import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.in;
 
 public class SlicedInputStreamTests extends ESTestCase {
+
     public void testReadRandom() throws IOException {
         int parts = randomIntBetween(1, 20);
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -79,6 +84,42 @@ public class SlicedInputStreamTests extends ESTestCase {
         }
     }
 
+    public void testSkip() throws IOException {
+        final int slices = randomIntBetween(1, 20);
+        final var bytes = randomByteArrayOfLength(randomIntBetween(1000, 10000));
+        final int sliceSize = bytes.length / slices;
+
+        final var streamsOpened = new ArrayList<CheckClosedInputStream>();
+        SlicedInputStream input = new SlicedInputStream(slices) {
+            @Override
+            protected InputStream openSlice(int slice) throws IOException {
+                final int sliceOffset = slice * sliceSize;
+                final int length = slice == slices - 1 ? bytes.length - sliceOffset : sliceSize;
+                final var stream = new CheckClosedInputStream(new ByteArrayInputStream(bytes, sliceOffset, length));
+                streamsOpened.add(stream);
+                return stream;
+            }
+        };
+
+        // Skip up to a random point
+        final int skip = randomIntBetween(0, bytes.length);
+        input.skipNBytes(skip);
+
+        // Read all remaining bytes, which should be the bytes from skip up to the end
+        final int remainingBytes = bytes.length - skip;
+        if (remainingBytes > 0) {
+            final var remainingBytesRead = new byte[remainingBytes];
+            input.readNBytes(remainingBytesRead, 0, remainingBytes);
+            final var expectedRemainingBytes = Arrays.copyOfRange(bytes, skip, bytes.length);
+            assertArrayEquals(expectedRemainingBytes, remainingBytesRead);
+        }
+
+        // Confirm we reached the end and close the stream
+        assertThat(input.read(), equalTo(-1));
+        input.close();
+        streamsOpened.forEach(stream -> assertTrue(stream.closed));
+    }
+
     public void testRandomMarkReset() throws IOException {
         final int slices = randomIntBetween(1, 20);
         final var bytes = randomByteArrayOfLength(randomIntBetween(1000, 10000));
@@ -96,13 +137,17 @@ public class SlicedInputStreamTests extends ESTestCase {
             }
         };
 
-        // Read up to a random point
+        // Read or skip up to a random point
         final int mark = randomIntBetween(0, bytes.length);
         if (mark > 0) {
-            final var bytesReadUntilMark = new byte[mark];
-            input.readNBytes(bytesReadUntilMark, 0, mark);
-            final var expectedBytesUntilMark = new ByteArrayInputStream(bytes, 0, mark).readAllBytes();
-            assertArrayEquals(expectedBytesUntilMark, bytesReadUntilMark);
+            if (randomBoolean()) {
+                final var bytesReadUntilMark = new byte[mark];
+                input.readNBytes(bytesReadUntilMark, 0, mark);
+                final var expectedBytesUntilMark = Arrays.copyOfRange(bytes, 0, mark);
+                assertArrayEquals(expectedBytesUntilMark, bytesReadUntilMark);
+            } else {
+                input.skipNBytes(mark);
+            }
         }
 
         // Reset should throw since there is no mark
@@ -111,13 +156,22 @@ public class SlicedInputStreamTests extends ESTestCase {
         // Mark
         input.mark(randomNonNegativeInt());
 
-        // Read up to another random point
+        // Read or skip up to another random point
         final int moreBytes = randomIntBetween(0, bytes.length - mark);
         if (moreBytes > 0) {
-            final var moreBytesRead = new byte[moreBytes];
-            input.readNBytes(moreBytesRead, 0, moreBytes);
-            final var expectedMoreBytes = new ByteArrayInputStream(bytes, mark, moreBytes).readAllBytes();
-            assertArrayEquals(expectedMoreBytes, moreBytesRead);
+            if (randomBoolean()) {
+                final var moreBytesRead = new byte[moreBytes];
+                input.readNBytes(moreBytesRead, 0, moreBytes);
+                final var expectedMoreBytes = Arrays.copyOfRange(bytes, mark, mark + moreBytes);
+                assertArrayEquals(expectedMoreBytes, moreBytesRead);
+            } else {
+                input.skipNBytes(moreBytes);
+            }
+        }
+
+        // Randomly read to EOF
+        if (randomBoolean()) {
+            input.readAllBytes();
         }
 
         // Reset
@@ -128,7 +182,7 @@ public class SlicedInputStreamTests extends ESTestCase {
         if (remainingBytes > 0) {
             final var remainingBytesRead = new byte[remainingBytes];
             input.readNBytes(remainingBytesRead, 0, remainingBytes);
-            final var expectedRemainingBytes = new ByteArrayInputStream(bytes, mark, remainingBytes).readAllBytes();
+            final var expectedRemainingBytes = Arrays.copyOfRange(bytes, mark, bytes.length);
             assertArrayEquals(expectedRemainingBytes, remainingBytesRead);
         }
 
@@ -136,6 +190,67 @@ public class SlicedInputStreamTests extends ESTestCase {
         assertThat(input.read(), equalTo(-1));
         input.close();
         streamsOpened.forEach(stream -> assertTrue(stream.closed));
+    }
+
+    public void testMarkSkipResetInBigSlice() throws IOException {
+        SlicedInputStream input = new SlicedInputStream(1) {
+            @Override
+            protected InputStream openSlice(int slice) throws IOException {
+                assertThat(slice, equalTo(0));
+                return new IncreasingBytesUnlimitedInputStream();
+            }
+        };
+
+        // Buffer to use for reading a few KiB from a start byte of IncreasingBytesUnlimitedInputStream, to verify expected bytes.
+        final byte[] buffer = new byte[Math.toIntExact(ByteSizeValue.ofKb(randomIntBetween(1, 8)).getBytes())];
+        Consumer<Long> readAndAssert = (start) -> {
+            try {
+                final int read = input.read(buffer);
+                assertThat("Unexpected number of bytes read", read, equalTo(buffer.length));
+                for (int i = 0; i < read; i++) {
+                    assertThat("Unexpected value for startByte=" + start + " and i=" + i, buffer[i], equalTo((byte) ((start + i) % 255)));
+                }
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        };
+
+        // Skip up to a random point that is larger than 2GiB so that the marked offset is larger than an int (ES-9639).
+        final long mark = randomLongBetween(Integer.MAX_VALUE, Long.MAX_VALUE - buffer.length);
+        input.skipNBytes(mark);
+
+        // Mark
+        input.mark(randomNonNegativeInt());
+
+        // Skip a large amount of bytes
+        final long skipTo = randomLongBetween(mark, Long.MAX_VALUE - buffer.length);
+        input.skipNBytes(skipTo - mark);
+
+        // Read a few KiB, asserting the bytes are what they are expected
+        readAndAssert.accept(skipTo);
+
+        // Reset
+        input.reset();
+
+        // Read a few KiB, asserting the bytes are what they are expected
+        readAndAssert.accept(mark);
+    }
+
+    public void testMarkBeyondEOF() throws IOException {
+        final int slices = randomIntBetween(1, 20);
+        SlicedInputStream input = new SlicedInputStream(slices) {
+            @Override
+            protected InputStream openSlice(int slice) throws IOException {
+                return new ByteArrayInputStream(new byte[] { 0 }, 0, 1);
+            }
+        };
+
+        input.readAllBytes();
+        assertThat(input.read(), equalTo(-1));
+        input.mark(randomNonNegativeInt());
+        assertThat(input.read(), equalTo(-1));
+        input.reset();
+        assertThat(input.read(), equalTo(-1));
     }
 
     public void testMarkResetClosedStream() throws IOException {
@@ -147,7 +262,7 @@ public class SlicedInputStreamTests extends ESTestCase {
             }
         };
 
-        input.skip(randomIntBetween(1, slices));
+        input.skipNBytes(randomIntBetween(1, slices));
         input.mark(randomNonNegativeInt());
         input.close();
         // SlicedInputStream supports reading -1 after close without throwing
@@ -230,6 +345,21 @@ public class SlicedInputStreamTests extends ESTestCase {
         public void close() throws IOException {
             closed = true;
             super.close();
+        }
+    }
+
+    private static final class IncreasingBytesUnlimitedInputStream extends InputStream {
+        long currentByte = 0;
+
+        @Override
+        public int read() throws IOException {
+            return (int) (currentByte++ % 255);
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            currentByte += n;
+            return n;
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Support long marked offset in SlicedInputStream (#113629)