### PR TITLE
[8.x] [ESQL] Fix init value in max float aggregation (#113699)

### DIFF
--- a/docs/changelog/113699.yaml
+++ b/docs/changelog/113699.yaml
@@ -1,0 +1,5 @@
+pr: 113699
+summary: "[ESQL] Fix init value in max float aggregation"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MaxFloatAggregator.java
@@ -16,7 +16,7 @@ import org.elasticsearch.compute.ann.IntermediateState;
 class MaxFloatAggregator {
 
     public static float init() {
-        return Float.MIN_VALUE;
+        return -Float.MAX_VALUE;
     }
 
     public static float combine(float current, float v) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxFloatGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxFloatGroupingAggregatorFunctionTests.java
@@ -27,7 +27,8 @@ public class MaxFloatGroupingAggregatorFunctionTests extends GroupingAggregatorF
     protected SourceOperator simpleInput(BlockFactory blockFactory, int end) {
         return new LongFloatTupleBlockSourceOperator(
             blockFactory,
-            LongStream.range(0, end).mapToObj(l -> Tuple.tuple(randomLongBetween(0, 4), randomFloat()))
+            LongStream.range(0, end)
+                .mapToObj(l -> Tuple.tuple(randomLongBetween(0, 4), randomFloatBetween(-Float.MAX_VALUE, Float.MAX_VALUE, true)))
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ESQL] Fix init value in max float aggregation (#113699)