### PR TITLE
[Docs] Update "Securing clients and integrations" to include Fleet & Elastic Agent

### DIFF
--- a/docs/reference/security/ccs-clients-integrations/index.asciidoc
+++ b/docs/reference/security/ccs-clients-integrations/index.asciidoc
@@ -13,6 +13,7 @@ be secured as well, or at least communicate with the cluster in a secured way:
 * <<hadoop, Apache Hadoop>>
 * {auditbeat-ref}/securing-auditbeat.html[Auditbeat]
 * {filebeat-ref}/securing-filebeat.html[Filebeat]
+* {fleet-guide}/secure.html[{fleet} & {agent}]
 * {heartbeat-ref}/securing-heartbeat.html[Heartbeat]
 * {kibana-ref}/using-kibana-with-security.html[{kib}]
 * {logstash-ref}/ls-security.html[Logstash]


### PR DESCRIPTION
The https://www.elastic.co/guide/en/elasticsearch/reference/master/security-clients-integrations.html does not include a reference to Fleet and Agent, despite links to the other Elastic software.

![image](https://github.com/user-attachments/assets/ddbb50ed-56a7-4088-b105-430a55e16d05)

It should probably link to [Secure Elastic Agent connections](https://www.elastic.co/guide/en/fleet/current/secure.html).
