### PR TITLE
Fix URI path and query parsing in `uri_parts` processor

### DIFF
--- a/docs/changelog/113765.yaml
+++ b/docs/changelog/113765.yaml
@@ -1,0 +1,6 @@
+pr: 113765
+summary: Fix URI path and query parsing in `uri_parts` processor
+area: Ingest Node
+type: bug
+issues:
+ - 112904

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -117,9 +117,9 @@ public class UriPartsProcessor extends AbstractProcessor {
         if (uri != null) {
             domain = uri.getHost();
             fragment = uri.getFragment();
-            path = uri.getPath();
+            path = uri.getRawPath();
             port = uri.getPort();
-            query = uri.getQuery();
+            query = uri.getRawQuery();
             scheme = uri.getScheme();
             userInfo = uri.getUserInfo();
         } else if (fallbackUrl != null) {
@@ -165,7 +165,7 @@ public class UriPartsProcessor extends AbstractProcessor {
             if (userInfo.contains(":")) {
                 int colonIndex = userInfo.indexOf(':');
                 uriParts.put("username", userInfo.substring(0, colonIndex));
-                uriParts.put("password", colonIndex < userInfo.length() ? userInfo.substring(colonIndex + 1) : "");
+                uriParts.put("password", userInfo.substring(colonIndex + 1));
             }
         }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
@@ -149,6 +149,12 @@ public class UriPartsProcessorTests extends ESTestCase {
             "http://www.google.com:88/foo#bar",
             Map.of("scheme", "http", "domain", "www.google.com", "fragment", "bar", "path", "/foo", "port", 88)
         );
+
+        // raw path and query
+        testUriParsing(
+            "http://www.google.com/some%2fthing?a=123&b=x%26c%3dy",
+            Map.of("scheme", "http", "domain", "www.google.com", "path", "/some%2fthing", "query", "a=123&b=x%26c%3dy")
+        );
     }
 
     public void testUrlWithCharactersNotToleratedByUri() throws Exception {


### PR DESCRIPTION
This PR addresses the problem of URL decoding potentially altering the original path and query information.


closes #112904