### PR TITLE
Fix IOOBE in BigArrayVectorTests

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
@@ -64,8 +64,8 @@ public class BigArrayVectorTests extends SerializationTestCase {
             if (positionCount > 1) {
                 assertLookup(
                     vector.asBlock(),
-                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
-                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                    positions(blockFactory, 0, 1, new int[] { 0, 1 }),
+                    List.of(List.of(values[0]), List.of(values[1]), List.of(values[0], values[1]))
                 );
             }
             assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
@@ -110,8 +110,8 @@ public class BigArrayVectorTests extends SerializationTestCase {
             if (positionCount > 1) {
                 assertLookup(
                     vector.asBlock(),
-                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
-                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                    positions(blockFactory, 0, 1, new int[] { 0, 1 }),
+                    List.of(List.of(values[0]), List.of(values[1]), List.of(values[0], values[1]))
                 );
             }
             assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
@@ -152,8 +152,8 @@ public class BigArrayVectorTests extends SerializationTestCase {
             if (positionCount > 1) {
                 assertLookup(
                     vector.asBlock(),
-                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
-                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                    positions(blockFactory, 0, 1, new int[] { 0, 1 }),
+                    List.of(List.of(values[0]), List.of(values[1]), List.of(values[0], values[1]))
                 );
             }
             assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
@@ -192,8 +192,8 @@ public class BigArrayVectorTests extends SerializationTestCase {
             if (positionCount > 1) {
                 assertLookup(
                     vector.asBlock(),
-                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
-                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                    positions(blockFactory, 0, 1, new int[] { 0, 1 }),
+                    List.of(List.of(values[0]), List.of(values[1]), List.of(values[0], values[1]))
                 );
             }
             assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));


### PR DESCRIPTION
Currently test in BigArrayVectorTests fails with the following error if the position count is set to 2 as we. will try to acces the position 2 of an array of size 2. 

```
   2> java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
        at org.elasticsearch.compute.data.BigArrayVectorTests.testBoolean(BigArrayVectorTests.java:68)

``` 

