### PR TITLE
Update format docs for the correct week-date locale source

### DIFF
--- a/docs/reference/mapping/params/format.asciidoc
+++ b/docs/reference/mapping/params/format.asciidoc
@@ -304,19 +304,19 @@ The following tables lists all the defaults ISO formats supported:
 `weekyear` or `strict_weekyear`::
 
     A formatter for a four digit weekyear: `YYYY`.
-    This uses the ISO week-date definition.
+    This uses the locale week-date definition.
 
 `weekyear_week` or `strict_weekyear_week`::
 
     A formatter for a four digit weekyear and two digit week of weekyear:
     `YYYY-'W'ww`.
-    This uses the ISO week-date definition.
+    This uses the locale week-date definition.
 
 `weekyear_week_day` or `strict_weekyear_week_day`::
 
     A formatter for a four digit weekyear, two digit week of weekyear, and one
     digit day of week: `YYYY-'W'ww-e`.
-    This uses the ISO week-date definition.
+    This uses the locale week-date definition.
 
 `year` or `strict_year`::
 

--- a/docs/reference/mapping/params/format.asciidoc
+++ b/docs/reference/mapping/params/format.asciidoc
@@ -54,8 +54,7 @@ which are not affected by locale information.
 There can also be differences in week-date calculations using the `Y`, `W`, and `w` field specifiers.
 The underlying data used to calculate week-dates can vary depending on the JDK version and locale;
 this can cause differences in the calculated week-date for the same calendar dates.
-It is recommended that the built-in week-date formats are used, which will always use ISO rules
-for calculating week-dates.
+It is recommended that the built-in week-date formats that use ISO week-date definitions are used.
 
 In particular, there is a significant change in locale information between JDK releases 22 and 23.
 Elasticsearch will use the _COMPAT_ locale database when run on JDK 22 and before,


### PR DESCRIPTION
Update from #113587, `week_date` uses ISO, `weekyear` uses locale