### PR TITLE
Save some duplicate Codec instances

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch814Codec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/Elasticsearch814Codec.java
@@ -30,7 +30,7 @@ public class Elasticsearch814Codec extends CodecService.DeduplicateFieldInfosCod
 
     private final StoredFieldsFormat storedFieldsFormat;
 
-    private final PostingsFormat defaultPostingsFormat;
+    private static final PostingsFormat defaultPostingsFormat = new Lucene99PostingsFormat();
     private final PostingsFormat postingsFormat = new PerFieldPostingsFormat() {
         @Override
         public PostingsFormat getPostingsFormatForField(String field) {
@@ -38,7 +38,7 @@ public class Elasticsearch814Codec extends CodecService.DeduplicateFieldInfosCod
         }
     };
 
-    private final DocValuesFormat defaultDVFormat;
+    private static final DocValuesFormat defaultDVFormat = new Lucene90DocValuesFormat();
     private final DocValuesFormat docValuesFormat = new PerFieldDocValuesFormat() {
         @Override
         public DocValuesFormat getDocValuesFormatForField(String field) {
@@ -46,13 +46,15 @@ public class Elasticsearch814Codec extends CodecService.DeduplicateFieldInfosCod
         }
     };
 
-    private final KnnVectorsFormat defaultKnnVectorsFormat;
+    private static final KnnVectorsFormat defaultKnnVectorsFormat = new Lucene99HnswVectorsFormat();
     private final KnnVectorsFormat knnVectorsFormat = new PerFieldKnnVectorsFormat() {
         @Override
         public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
             return Elasticsearch814Codec.this.getKnnVectorsFormatForField(field);
         }
     };
+
+    private static final Lucene99Codec lucene99Codec = new Lucene99Codec();
 
     /** Public no-arg constructor, needed for SPI loading at read-time. */
     public Elasticsearch814Codec() {
@@ -64,11 +66,8 @@ public class Elasticsearch814Codec extends CodecService.DeduplicateFieldInfosCod
      * worse space-efficiency or vice-versa.
      */
     public Elasticsearch814Codec(Zstd814StoredFieldsFormat.Mode mode) {
-        super("Elasticsearch814", new Lucene99Codec());
+        super("Elasticsearch814", lucene99Codec);
         this.storedFieldsFormat = new Zstd814StoredFieldsFormat(mode);
-        this.defaultPostingsFormat = new Lucene99PostingsFormat();
-        this.defaultDVFormat = new Lucene90DocValuesFormat();
-        this.defaultKnnVectorsFormat = new Lucene99HnswVectorsFormat();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -31,19 +31,17 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
  */
 public class PerFieldFormatSupplier {
 
-    private final MapperService mapperService;
-    private final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
-    private final KnnVectorsFormat knnVectorsFormat = new Lucene99HnswVectorsFormat();
-    private final ES87BloomFilterPostingsFormat bloomFilterPostingsFormat;
-    private final ES87TSDBDocValuesFormat tsdbDocValuesFormat;
+    private static final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
+    private static final KnnVectorsFormat knnVectorsFormat = new Lucene99HnswVectorsFormat();
+    private static final ES87TSDBDocValuesFormat tsdbDocValuesFormat = new ES87TSDBDocValuesFormat();
+    private static final ES812PostingsFormat es812PostingsFormat = new ES812PostingsFormat();
 
-    private final ES812PostingsFormat es812PostingsFormat;
+    private final ES87BloomFilterPostingsFormat bloomFilterPostingsFormat;
+    private final MapperService mapperService;
 
     public PerFieldFormatSupplier(MapperService mapperService, BigArrays bigArrays) {
         this.mapperService = mapperService;
         this.bloomFilterPostingsFormat = new ES87BloomFilterPostingsFormat(bigArrays, this::internalGetPostingsFormatForField);
-        this.tsdbDocValuesFormat = new ES87TSDBDocValuesFormat();
-        this.es812PostingsFormat = new ES812PostingsFormat();
     }
 
     public PostingsFormat getPostingsFormatForField(String field) {


### PR DESCRIPTION
A couple of these can be made constants to save some footprint and indirection.
