### PR TITLE
Explicitly use ISO weekfields for weekyear date formats

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -97,6 +97,7 @@ enum DateFormat {
                 // fill the rest of the date up with the parsed date
                 if (accessor.isSupported(ChronoField.YEAR) == false
                     && accessor.isSupported(ChronoField.YEAR_OF_ERA) == false
+                    && accessor.isSupported(WeekFields.ISO.weekBasedYear()) == false
                     && accessor.isSupported(WeekFields.of(locale).weekBasedYear()) == false
                     && accessor.isSupported(ChronoField.INSTANT_SECONDS) == false) {
                     int year = LocalDate.now(ZoneOffset.UTC).getYear();

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -2391,6 +2391,7 @@ public class DateFormatters {
         boolean isLocalTimeSet = localTime != null;
 
         // the first two cases are the most common, so this allows us to exit early when parsing dates
+        WeekFields localeWeekFields;
         if (isLocalDateSet && isLocalTimeSet) {
             return of(localDate, localTime, zoneId);
         } else if (accessor.isSupported(ChronoField.INSTANT_SECONDS) && accessor.isSupported(NANO_OF_SECOND)) {
@@ -2409,8 +2410,10 @@ public class DateFormatters {
         } else if (accessor.isSupported(MONTH_OF_YEAR)) {
             // missing year, falling back to the epoch and then filling
             return getLocalDate(accessor, locale).atStartOfDay(zoneId);
-        } else if (accessor.isSupported(WeekFields.of(locale).weekBasedYear())) {
-            return localDateFromWeekBasedDate(accessor, locale).atStartOfDay(zoneId);
+        } else if (accessor.isSupported(WeekFields.ISO.weekBasedYear())) {
+            return localDateFromWeekBasedDate(accessor, locale, WeekFields.ISO).atStartOfDay(zoneId);
+        } else if (accessor.isSupported((localeWeekFields = WeekFields.of(locale)).weekBasedYear())) {
+            return localDateFromWeekBasedDate(accessor, locale, localeWeekFields).atStartOfDay(zoneId);
         }
 
         // we should not reach this piece of code, everything being parsed we should be able to
@@ -2418,8 +2421,7 @@ public class DateFormatters {
         throw new IllegalArgumentException("temporal accessor [" + accessor + "] cannot be converted to zoned date time");
     }
 
-    private static LocalDate localDateFromWeekBasedDate(TemporalAccessor accessor, Locale locale) {
-        WeekFields weekFields = WeekFields.of(locale);
+    private static LocalDate localDateFromWeekBasedDate(TemporalAccessor accessor, Locale locale, WeekFields weekFields) {
         if (accessor.isSupported(weekFields.weekOfWeekBasedYear())) {
             return LocalDate.ofEpochDay(0)
                 .with(weekFields.weekBasedYear(), accessor.get(weekFields.weekBasedYear()))
@@ -2461,8 +2463,11 @@ public class DateFormatters {
     };
 
     private static LocalDate getLocalDate(TemporalAccessor accessor, Locale locale) {
-        if (accessor.isSupported(WeekFields.of(locale).weekBasedYear())) {
-            return localDateFromWeekBasedDate(accessor, locale);
+        WeekFields localeWeekFields;
+        if (accessor.isSupported(WeekFields.ISO.weekBasedYear())) {
+            return localDateFromWeekBasedDate(accessor, locale, WeekFields.ISO);
+        } else if (accessor.isSupported((localeWeekFields = WeekFields.of(locale)).weekBasedYear())) {
+            return localDateFromWeekBasedDate(accessor, locale, localeWeekFields);
         } else if (accessor.isSupported(MONTH_OF_YEAR)) {
             int year = getYear(accessor);
             if (accessor.isSupported(DAY_OF_MONTH)) {

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -82,7 +82,7 @@ public class DateFormatters {
         );
     }
 
-    public static final WeekFields WEEK_FIELDS_ROOT = WeekFields.of(Locale.ROOT);
+    public static final WeekFields WEEK_FIELDS_ROOT = WeekFields.ISO;
 
     private static final DateTimeFormatter TIME_ZONE_FORMATTER_NO_COLON = new DateTimeFormatterBuilder().appendOffset("+HHmm", "Z")
         .toFormatter(Locale.ROOT)


### PR DESCRIPTION
Contrary to what you might think, this is actually maintaining existing behaviour when run on JDK 22 and 23. `IsoCalendarDataProvider` overrides the root locale weekyear to use ISO, which effectively means we are already using ISO for all week-based date formats. Changing to JDK 23 means the locale-based ones use Sunday/1-day for weekfield definitions, so setting this to explicitly ISO is maintaining the existing behaviour. It also makes all week-date formats definitely use ISO definitions.

This is aimed at 8.x, as that's where all the docs are targetting. When we're all settled on the various PRs, I'll forward-port this to main, along with any relevant locale docs already merged into 8.x