### PR TITLE
Only track feature usage when creating an index.

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProvider.java
@@ -43,8 +43,11 @@ public class SyntheticSourceIndexSettingsProvider implements IndexSettingProvide
         Settings indexTemplateAndCreateRequestSettings,
         List<CompressedXContent> combinedTemplateMappings
     ) {
+        // This index name is used when validating component and index templates, we should skip this check in that case.
+        // (See MetadataIndexTemplateService#validateIndexTemplateV2(...) method)
+        boolean isTemplateValidation = "validate-index-name".equals(indexName);
         if (newIndexHasSyntheticSourceUsage(indexTemplateAndCreateRequestSettings)
-            && syntheticSourceLicenseService.fallbackToStoredSource()) {
+            && syntheticSourceLicenseService.fallbackToStoredSource(isTemplateValidation)) {
             LOGGER.debug("creation of index [{}] with synthetic source without it being allowed", indexName);
             // TODO: handle falling back to stored source
         }

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
@@ -46,12 +46,16 @@ public final class SyntheticSourceLicenseService {
     /**
      * @return whether synthetic source mode should fallback to stored source.
      */
-    public boolean fallbackToStoredSource() {
+    public boolean fallbackToStoredSource(boolean isTemplateValidation) {
         if (syntheticSourceFallback) {
             return true;
         }
 
-        return SYNTHETIC_SOURCE_FEATURE.check(licenseState) == false;
+        if (isTemplateValidation) {
+            return SYNTHETIC_SOURCE_FEATURE.checkWithoutTracking(licenseState) == false;
+        } else {
+            return SYNTHETIC_SOURCE_FEATURE.check(licenseState) == false;
+        }
     }
 
     void setSyntheticSourceFallback(boolean syntheticSourceFallback) {


### PR DESCRIPTION
The SyntheticSourceLicenseService should only track if usage is allowed and an index will actually be created.

Relates to #113468