### PR TITLE
Add deprecation counts to cluster stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -227,6 +227,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_CHUNKING_SETTINGS = def(8_751_00_0);
     public static final TransportVersion SEMANTIC_QUERY_INNER_HITS = def(8_752_00_0);
     public static final TransportVersion RETAIN_ILM_STEP_INFO = def(8_753_00_0);
+    public static final TransportVersion DEPRECATIONS_TELEMETRY_STATS = def(8_754_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -51,6 +51,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.Transports;
+import org.elasticsearch.usage.DeprecatedUsageHolder;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.usage.UsageService;
 
@@ -87,6 +88,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
     private final SearchUsageHolder searchUsageHolder;
     private final CCSUsageTelemetry ccsUsageHolder;
 
+    private final DeprecatedUsageHolder deprecatedUsageHolder;
+
     private final Executor clusterStateStatsExecutor;
     private final MetadataStatsCache<MappingStats> mappingStatsCache;
     private final MetadataStatsCache<AnalysisStats> analysisStatsCache;
@@ -115,6 +118,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
         this.repositoriesService = repositoriesService;
         this.searchUsageHolder = usageService.getSearchUsageHolder();
         this.ccsUsageHolder = usageService.getCcsUsageHolder();
+        this.deprecatedUsageHolder = usageService.getDeprecatedUsageHolder();
         this.clusterStateStatsExecutor = threadPool.executor(ThreadPool.Names.MANAGEMENT);
         this.mappingStatsCache = new MetadataStatsCache<>(threadPool.getThreadContext(), MappingStats::of);
         this.analysisStatsCache = new MetadataStatsCache<>(threadPool.getThreadContext(), AnalysisStats::of);
@@ -250,6 +254,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             : null;
 
         final SearchUsageStats searchUsageStats = searchUsageHolder.getSearchUsageStats();
+        final Map<String, Long> deprecatedUsageStats = deprecatedUsageHolder.getDeprecatedUsageStats();
 
         final RepositoryUsageStats repositoryUsageStats = repositoriesService.getUsageStats();
         final CCSTelemetrySnapshot ccsTelemetry = ccsUsageHolder.getCCSTelemetrySnapshot();
@@ -261,6 +266,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             nodeStats,
             shardsStats.toArray(new ShardStats[shardsStats.size()]),
             searchUsageStats,
+            deprecatedUsageStats,
             repositoryUsageStats,
             ccsTelemetry
         );

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -898,6 +898,9 @@ class NodeConstruction {
             threadPool.getThreadContext()
         );
 
+        UsageService usageService = createUsageService();
+        DeprecationLogger.setUsageService(usageService);
+
         ActionModule actionModule = new ActionModule(
             settings,
             clusterModule.getIndexNameExpressionResolver(),
@@ -909,7 +912,7 @@ class NodeConstruction {
             pluginsService.filterPlugins(ActionPlugin.class).toList(),
             client,
             circuitBreakerService,
-            createUsageService(),
+            usageService,
             systemIndices,
             telemetryProvider,
             clusterService,

--- a/server/src/main/java/org/elasticsearch/usage/DeprecatedUsageHolder.java
+++ b/server/src/main/java/org/elasticsearch/usage/DeprecatedUsageHolder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.usage;
+
+import org.elasticsearch.common.util.Maps;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+public final class DeprecatedUsageHolder {
+    DeprecatedUsageHolder() {}
+
+    private final Map<String, LongAdder> usage = new ConcurrentHashMap<>();
+
+    public void incrementDeprecationUsage(String deprecation_key) {
+        usage.computeIfAbsent(deprecation_key, key -> new LongAdder()).increment();
+    }
+
+    public Map<String, Long> getDeprecatedUsageStats() {
+        Map<String, Long> stats = Maps.newMapWithExpectedSize(usage.size());
+
+        usage.forEach((deprecationKey, adder) -> stats.put(deprecationKey, adder.longValue()));
+        return stats;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/usage/UsageService.java
+++ b/server/src/main/java/org/elasticsearch/usage/UsageService.java
@@ -27,10 +27,13 @@ public class UsageService {
     private final SearchUsageHolder searchUsageHolder;
     private final CCSUsageTelemetry ccsUsageHolder;
 
+    private final DeprecatedUsageHolder deprecatedUsageHolder;
+
     public UsageService() {
         this.handlers = new HashMap<>();
         this.searchUsageHolder = new SearchUsageHolder();
         this.ccsUsageHolder = new CCSUsageTelemetry();
+        this.deprecatedUsageHolder = new DeprecatedUsageHolder();
     }
 
     /**
@@ -88,5 +91,9 @@ public class UsageService {
 
     public CCSUsageTelemetry getCcsUsageHolder() {
         return ccsUsageHolder;
+    }
+
+    public DeprecatedUsageHolder getDeprecatedUsageHolder() {
+        return deprecatedUsageHolder;
     }
 }


### PR DESCRIPTION
Adds deprecation counts to `GET _cluster/stats` in a similar way to how we add query counts for `_search`.

Deprecation log message already contain a deprecation key.
When logging a deprecation message, the `DeprecationLogger` will also increment the deprecation key if the deprecation is not produced by an Elastic product (the product origin header is missing).

The deprecation counts are then exposed through the `GET _cluster/stats` API by summing the deprecation counts for each node.

Example:

```
GET test-index/_search
{
  "query": {
    "text_expansion": {
      "sparse_vector_field": {
        "model_id": "the model to produce the token weights",
        "model_text": "the query string"
      }
    }
  },
  "highlight": {
    "force_source": "true"
  }
}

```
Doing `GET _cluster/stats` will contain:

```
{
  ...
  "nodes": {
     ...
    "deprecations": {
      "deprecated_field_force_source": 1,
      "text_expansion": 2
    }
  }
}
```

A draft for now - I am looking for feedback if the approach makes sense.
