### PR TITLE
[plugin/otel-data] Add dynamic template for summary with min, max

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -45,3 +45,8 @@ template:
             type: aggregate_metric_double
             metrics: sum, value_count
             default_metric: value_count
+      - summary_minmax:
+          mapping:
+            type: aggregate_metric_double
+            metrics: sum, value_count, min, max
+            default_metric: value_count


### PR DESCRIPTION
Adds dynamic template mapping for summary metrics which have the min and max. Note that the dynamic template is currently not used and shipped to avoid version checks when we do use this mapping.

More context available at: https://github.com/elastic/opentelemetry-dev/pull/461#discussion_r1778172674