### PR TITLE
Update lucene snapshot buildkite config to build from branch_10_0

### DIFF
--- a/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
+++ b/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
@@ -4,7 +4,7 @@ steps:
     key: lucene-build
     if: (build.env("LUCENE_BUILD_ID") == null || build.env("LUCENE_BUILD_ID") == "")
     build:
-      branch: main
+      branch: branch_10_0
   - wait
   - label: Upload and update lucene snapshot
     command: .buildkite/scripts/lucene-snapshot/upload-snapshot.sh


### PR DESCRIPTION
The Lucene 10 branch has been cut, we want to switch the snapshot creation to the newly created branch until Lucene 10 has been released. Later, we will switch to branch_10x.