### PR TITLE
Make ssl-config a dependency of server

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -38,7 +38,6 @@ testClusters.configureEach {
 
 dependencies {
   api project(":client:rest")
-  api project(":libs:elasticsearch-ssl-config")
   // for parent/child testing
   testImplementation project(':modules:parent-join')
   testImplementation project(':modules:rest-root')

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -35,8 +35,6 @@ configurations {
 }
 
 dependencies {
-  api project(":libs:elasticsearch-ssl-config")
-
   // network stack
   api "io.netty:netty-buffer:${versions.netty}"
   api "io.netty:netty-codec:${versions.netty}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,6 +29,7 @@ base {
 dependencies {
 
   api project(':libs:elasticsearch-core')
+  api project(":libs:elasticsearch-ssl-config")
   api project(':libs:elasticsearch-logging')
   api project(':libs:elasticsearch-secure-sm')
   api project(':libs:elasticsearch-x-content')

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'elasticsearch.publish'
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')
-  api project(':libs:elasticsearch-ssl-config')
   api project(":server")
   api project(":libs:elasticsearch-cli")
   api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -37,7 +37,6 @@ configurations {
 dependencies {
   compileOnly project(":server")
   api project(':libs:elasticsearch-grok')
-  api project(":libs:elasticsearch-ssl-config")
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"


### PR DESCRIPTION
I noticed that we are loading ssl-config classes multiple times when investing heap dumps. I think we can just fix this by making it a dependency of server. It has no dependencies of its own and it is loaded in every conceivable configuration of ES because the netty transport requires it so I can't see how this would need any special isolation.
