### PR TITLE
Avoid using concurrent collector manager in LuceneChangesSnapshot

### DIFF
--- a/docs/changelog/113816.yaml
+++ b/docs/changelog/113816.yaml
@@ -1,0 +1,5 @@
+pr: 113816
+summary: Avoid using concurrent collector manager in `LuceneChangesSnapshot`
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -301,7 +301,8 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             new Sort(sortBySeqNo),
             searchBatchSize,
             after,
-            accurateTotalHits ? Integer.MAX_VALUE : 0
+            accurateTotalHits ? Integer.MAX_VALUE : 0,
+            false
         );
         return indexSearcher.search(rangeQuery, topFieldCollectorManager);
     }


### PR DESCRIPTION
The searcher never gets an executor set, then we can save the overhead of the concurrent collector manager / collectors.