### PR TITLE
Add JIT compiler directives to workaround performance regression in memory segment access in JDK 23

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -58,7 +58,7 @@
 # result in less optimal vector performance
 20-:--add-modules=jdk.incubator.vector
 
-# Required to workaround perform issue in JDK 23, https://github.com/elastic/elasticsearch/issues/113030
+# Required to workaround performance issue in JDK 23, https://github.com/elastic/elasticsearch/issues/113030
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
 23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
 

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -59,8 +59,8 @@
 20-:--add-modules=jdk.incubator.vector
 
 # Required to workaround perform issue in JDK 23, https://github.com/elastic/elasticsearch/issues/113030
-23-23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
-23-23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
+23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
 
 ## heap dumps
 

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -58,6 +58,10 @@
 # result in less optimal vector performance
 20-:--add-modules=jdk.incubator.vector
 
+# Required to workaround perform issue in JDK 23, https://github.com/elastic/elasticsearch/issues/113030
+23-23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
+23-23:-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails; heap dumps


### PR DESCRIPTION
This commit adds a couple of JIT compiler directives to avoid a performance pitfall in JDK 23.

Ultimately this is a workaround for a JDK 23 bug [1], which has been reported and will be fixed in a future version of the JDK. 

The nested rally track uncovered the JDK performance regression. Running JDK 23 with the compiler directives in this PR restores performance, and in fact improves it in several cases.
 
closes #113030

[1] https://bugs.openjdk.org/browse/JDK-8341127
