### PR TITLE
[8.x] Collect and display execution metadata for ES|QL cross cluster searches (#112595)

### DIFF
--- a/docs/changelog/112595.yaml
+++ b/docs/changelog/112595.yaml
@@ -1,0 +1,6 @@
+pr: 112595
+summary: Collect and display execution metadata for ES|QL cross cluster searches
+area: ES|QL
+type: enhancement
+issues:
+ - 112402

--- a/docs/reference/esql/esql-across-clusters.asciidoc
+++ b/docs/reference/esql/esql-across-clusters.asciidoc
@@ -85,7 +85,7 @@ POST /_security/role/remote1
       "privileges": [ "read","read_cross_cluster" ], <4>
       "clusters" : ["my_remote_cluster"] <5>
     }
-  ], 
+  ],
    "remote_cluster": [ <6>
         {
             "privileges": [
@@ -100,15 +100,23 @@ POST /_security/role/remote1
 ----
 
 <1> The `cross_cluster_search` cluster privilege is required for the _local_ cluster.
-<2> Typically, users will have permissions to read both local and remote indices. However, for cases where the role is intended to ONLY search the remote cluster, the `read` permission is still required for the local cluster. To provide read access to the local cluster, but disallow reading any indices in the local cluster, the `names` field may be an empty string.
-<3> The indices allowed read access to the remote cluster. The configured <<security-api-create-cross-cluster-api-key,cross-cluster API key>> must also allow this index to be read.
-<4> The `read_cross_cluster` privilege is always required when using {esql} across clusters with the API key based security model.
+<2> Typically, users will have permissions to read both local and remote indices. However, for cases where the role
+is intended to ONLY search the remote cluster, the `read` permission is still required for the local cluster.
+To provide read access to the local cluster, but disallow reading any indices in the local cluster, the `names`
+field may be an empty string.
+<3> The indices allowed read access to the remote cluster. The configured
+<<security-api-create-cross-cluster-api-key,cross-cluster API key>> must also allow this index to be read.
+<4> The `read_cross_cluster` privilege is always required when using {esql} across clusters with the API key based
+security model.
 <5> The remote clusters to which these privileges apply.
-This remote cluster must be configured with a <<security-api-create-cross-cluster-api-key,cross-cluster API key>> and connected to the remote cluster before the remote index can be queried.
+This remote cluster must be configured with a <<security-api-create-cross-cluster-api-key,cross-cluster API key>>
+and connected to the remote cluster before the remote index can be queried.
 Verify connection using the <<cluster-remote-info, Remote cluster info>> API.
-<6> Required to allow remote enrichment. Without this, the user cannot read from the `.enrich` indices on the remote cluster. The `remote_cluster` security privilege was introduced in version *8.15.0*.
+<6> Required to allow remote enrichment. Without this, the user cannot read from the `.enrich` indices on the
+remote cluster. The `remote_cluster` security privilege was introduced in version *8.15.0*.
 
-You will then need a user or API key with the permissions you created above. The following example API call creates a user with the `remote1` role.
+You will then need a user or API key with the permissions you created above. The following example API call creates
+a user with the `remote1` role.
 
 [source,console]
 ----
@@ -119,11 +127,13 @@ POST /_security/user/remote_user
 }
 ----
 
-Remember that all cross-cluster requests from the local cluster are bound by the cross cluster API key’s privileges, which are controlled by the remote cluster's administrator.
+Remember that all cross-cluster requests from the local cluster are bound by the cross cluster API key’s privileges,
+which are controlled by the remote cluster's administrator.
 
 [TIP]
 ====
-Cross cluster API keys created in versions prior to 8.15.0 will need to replaced or updated to add the new permissions required for {esql} with ENRICH.
+Cross cluster API keys created in versions prior to 8.15.0 will need to replaced or updated to add the new permissions
+required for {esql} with ENRICH.
 ====
 
 [discrete]
@@ -173,6 +183,189 @@ remote clusters (`cluster_one`, `cluster_two`, and `cluster_three`):
 FROM *:my-index-000001
 | LIMIT 10
 ----
+
+[discrete]
+[[ccq-cluster-details]]
+==== Cross-cluster metadata
+
+ES|QL {ccs} responses include metadata about the search on each cluster when the response format is JSON.
+Here we show an example using the async search endpoint. {ccs-cap} metadata is also present in the synchronous
+search endpoint.
+
+[source,console]
+----
+POST /_query/async?format=json
+{
+  "query": """
+    FROM my-index-000001,cluster_one:my-index-000001,cluster_two:my-index*
+    | STATS COUNT(http.response.status_code) BY user.id
+    | LIMIT 2
+  """
+}
+----
+// TEST[setup:my_index]
+// TEST[s/cluster_one:my-index-000001,cluster_two:my-index//]
+
+Which returns:
+
+[source,console-result]
+----
+{
+  "is_running": false,
+  "took": 42,  <1>
+  "columns" : [
+    {
+      "name" : "COUNT(http.response.status_code)",
+      "type" : "long"
+    },
+    {
+      "name" : "user.id",
+      "type" : "keyword"
+    }
+  ],
+  "values" : [
+    [4, "elkbee"],
+    [1, "kimchy"]
+  ],
+  "_clusters": {  <2>
+    "total": 3,
+    "successful": 3,
+    "running": 0,
+    "skipped": 0,
+    "partial": 0,
+    "failed": 0,
+    "details": { <3>
+      "(local)": { <4>
+        "status": "successful",
+        "indices": "blogs",
+        "took": 36,  <5>
+        "_shards": { <6>
+          "total": 13,
+          "successful": 13,
+          "skipped": 0,
+          "failed": 0
+        }
+      },
+      "cluster_one": {
+        "status": "successful",
+        "indices": "cluster_one:my-index-000001",
+        "took": 38,
+        "_shards": {
+          "total": 4,
+          "successful": 4,
+          "skipped": 0,
+          "failed": 0
+        }
+      },
+      "cluster_two": {
+        "status": "successful",
+        "indices": "cluster_two:my-index*",
+        "took": 41,
+        "_shards": {
+          "total": 18,
+          "successful": 18,
+          "skipped": 1,
+          "failed": 0
+        }
+      }
+    }
+  }
+}
+----
+// TEST[skip: cross-cluster testing env not set up]
+
+<1> How long the entire search (across all clusters) took, in milliseconds.
+<2> This section of counters shows all possible cluster search states and how many cluster
+searches are currently in that state. The clusters can have one of the following statuses: *running*,
+*successful* (searches on all shards were successful), *skipped* (the search
+failed on a cluster marked with `skip_unavailable`=`true`) or *failed* (the search
+failed on a cluster marked with `skip_unavailable`=`false`).
+<3> The `_clusters/details` section shows metadata about the search on each cluster.
+<4> If you included indices from the local cluster you sent the request to in your {ccs},
+it is identified as "(local)".
+<5> How long (in milliseconds) the search took on each cluster. This can be useful to determine
+which clusters have slower response times than others.
+<6> The shard details for the search on that cluster, including a count of shards that were
+skipped due to the can-match phase. Shards are skipped when they cannot have any matching data
+and therefore are not included in the full ES|QL query.
+
+
+The cross-cluster metadata can be used to determine whether any data came back from a cluster.
+For instance, in the query below, the wildcard expression for `cluster-two` did not resolve
+to a concrete index (or indices). The cluster is, therefore, marked as 'skipped' and the total
+number of shards searched is set to zero.
+Since the other cluster did have a matching index, the search did not return an error, but
+instead returned all the matching data it could find.
+
+
+[source,console]
+----
+POST /_query/async?format=json
+{
+  "query": """
+    FROM cluster_one:my-index*,cluster_two:logs*
+    | STATS COUNT(http.response.status_code) BY user.id
+    | LIMIT 2
+  """
+}
+----
+// TEST[continued]
+// TEST[s/cluster_one:my-index\*,cluster_two:logs\*/my-index-000001/]
+
+Which returns:
+
+[source,console-result]
+----
+{
+  "is_running": false,
+  "took": 55,
+  "columns": [
+     ... // not shown
+  ],
+  "values": [
+     ... // not shown
+  ],
+  "_clusters": {
+    "total": 2,
+    "successful": 2,
+    "running": 0,
+    "skipped": 0,
+    "partial": 0,
+    "failed": 0,
+    "details": {
+      "cluster_one": {
+        "status": "successful",
+        "indices": "cluster_one:my-index*",
+        "took": 38,
+        "_shards": {
+          "total": 4,
+          "successful": 4,
+          "skipped": 0,
+          "failed": 0
+        }
+      },
+      "cluster_two": {
+        "status": "skipped", <1>
+        "indices": "cluster_two:logs*",
+        "took": 0,
+        "_shards": {
+          "total": 0, <2>
+          "successful": 0,
+          "skipped": 0,
+          "failed": 0
+        }
+      }
+    }
+  }
+}
+----
+// TEST[skip: cross-cluster testing env not set up]
+
+<1> This cluster is marked as 'skipped', since there were no matching indices on that cluster.
+<2> Indicates that no shards were searched (due to not having any matching indices).
+
+
+
 
 [discrete]
 [[ccq-enrich]]
@@ -331,8 +524,7 @@ setting. As a result, if a remote cluster specified in the request is
 unavailable or failed, {ccs} for {esql} queries will fail regardless of the setting.
 
 We are actively working to align the behavior of {ccs} for {esql} with other
-{ccs} APIs. This includes providing detailed execution information for each cluster
-in the response, such as execution time, selected target indices, and shards.
+{ccs} APIs.
 
 [discrete]
 [[ccq-during-upgrade]]

--- a/docs/reference/esql/esql-rest.asciidoc
+++ b/docs/reference/esql/esql-rest.asciidoc
@@ -192,6 +192,7 @@ Which returns:
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     {"name": "author", "type": "text"},
     {"name": "name", "type": "text"},
@@ -206,6 +207,7 @@ Which returns:
   ]
 }
 ----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
 
 [discrete]
 [[esql-locale-param]]
@@ -385,12 +387,13 @@ GET /_query/async/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUT
 // TEST[skip: no access to query ID - may return response values]
 
 If the response's `is_running` value is `false`, the query has finished
-and the results are returned.
+and the results are returned, along with the `took` time for the query.
 
 [source,console-result]
 ----
 {
   "is_running": false,
+  "took": 48,
   "columns": ...
 }
 ----

--- a/docs/reference/esql/multivalued-fields.asciidoc
+++ b/docs/reference/esql/multivalued-fields.asciidoc
@@ -26,6 +26,7 @@ Multivalued fields come back as a JSON array:
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     { "name": "a", "type": "long"},
     { "name": "b", "type": "long"}
@@ -36,6 +37,8 @@ Multivalued fields come back as a JSON array:
   ]
 }
 ----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
+
 
 The relative order of values in a multivalued field is undefined. They'll frequently be in
 ascending order but don't rely on that.
@@ -74,6 +77,7 @@ And {esql} sees that removal:
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     { "name": "a", "type": "long"},
     { "name": "b", "type": "keyword"}
@@ -84,6 +88,8 @@ And {esql} sees that removal:
   ]
 }
 ----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
+
 
 But other types, like `long` don't remove duplicates.
 
@@ -115,6 +121,7 @@ And {esql} also sees that:
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     { "name": "a", "type": "long"},
     { "name": "b", "type": "long"}
@@ -125,6 +132,8 @@ And {esql} also sees that:
   ]
 }
 ----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
+
 
 This is all at the storage layer. If you store duplicate `long`s and then
 convert them to strings the duplicates will stay:
@@ -155,6 +164,7 @@ POST /_query
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     { "name": "a", "type": "long"},
     { "name": "b", "type": "keyword"}
@@ -165,6 +175,7 @@ POST /_query
   ]
 }
 ----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
 
 [discrete]
 [[esql-multivalued-fields-functions]]
@@ -198,6 +209,7 @@ POST /_query
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     { "name": "a",   "type": "long"},
     { "name": "b",   "type": "long"},
@@ -210,6 +222,7 @@ POST /_query
   ]
 }
 ----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
 
 Work around this limitation by converting the field to single value with one of:
 
@@ -233,6 +246,7 @@ POST /_query
 [source,console-result]
 ----
 {
+  "took": 28,
   "columns": [
     { "name": "a",   "type": "long"},
     { "name": "b",   "type": "long"},
@@ -245,4 +259,4 @@ POST /_query
   ]
 }
 ----
-
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -19,6 +19,9 @@ import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.NoSeedNodeLeftException;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
 import org.elasticsearch.xcontent.XContentParseException;
 
 import java.io.IOException;
@@ -472,7 +475,7 @@ public final class ExceptionsHelper {
     }
 
     /**
-     * Utility method useful for determine whether to log an Exception or perhaps
+     * Utility method useful for determining whether to log an Exception or perhaps
      * avoid logging a stacktrace if the caller/logger is not interested in these
      * types of node/shard issues.
      *
@@ -488,6 +491,27 @@ public final class ExceptionsHelper {
             || t instanceof org.elasticsearch.discovery.MasterNotDiscoveredException
             || t instanceof org.elasticsearch.transport.NodeNotConnectedException
             || t instanceof org.elasticsearch.cluster.block.ClusterBlockException);
+    }
+
+    /**
+     * Checks the exception against a known list of exceptions that indicate a remote cluster
+     * cannot be connected to.
+     *
+     * @param e Exception to inspect
+     * @return true if the Exception is known to indicate that a remote cluster
+     *         is unavailable (cannot be connected to by the transport layer)
+     */
+    public static boolean isRemoteUnavailableException(Exception e) {
+        Throwable unwrap = unwrap(e, ConnectTransportException.class, NoSuchRemoteClusterException.class, NoSeedNodeLeftException.class);
+        if (unwrap != null) {
+            return true;
+        }
+        Throwable ill = unwrap(e, IllegalStateException.class, IllegalArgumentException.class);
+        if (ill != null && (ill.getMessage().contains("Unable to open any connections") || ill.getMessage().contains("unknown host"))) {
+            return true;
+        }
+        // doesn't look like any of the known remote exceptions
+        return false;
     }
 
     private static class GroupBy {

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -229,6 +229,7 @@ public class TransportVersions {
     public static final TransportVersion RETAIN_ILM_STEP_INFO = def(8_753_00_0);
     public static final TransportVersion ADD_DATA_STREAM_OPTIONS = def(8_754_00_0);
     public static final TransportVersion CCS_REMOTE_TELEMETRY_STATS = def(8_755_00_0);
+    public static final TransportVersion ESQL_CCS_EXECUTION_INFO = def(8_756_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
@@ -63,6 +63,16 @@ public enum ChunkedToXContentHelper {
         );
     }
 
+    /**
+     * Like xContentFragmentValuesMap, but allows the underlying XContent object to define its own "name" with startObject(string)
+     * and endObject, rather than assuming that the key in the map should be the name in the XContent output.
+     * @param name name to use in the XContent for the outer object wrapping the map being rendered to XContent
+     * @param map map being rendered to XContent
+     */
+    public static Iterator<ToXContent> xContentFragmentValuesMapCreateOwnName(String name, Map<String, ? extends ToXContent> map) {
+        return map(name, map, entry -> (ToXContent) (builder, params) -> entry.getValue().toXContent(builder, params));
+    }
+
     public static Iterator<ToXContent> field(String name, boolean value) {
         return Iterators.single(((builder, params) -> builder.field(name, value)));
     }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesExpressionGrouper.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesExpressionGrouper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.Strings;
+
+import java.util.Map;
+
+/**
+ * Interface for grouping index expressions, along with IndicesOptions by cluster alias.
+ * Implementations should support the following:
+ * - plain index names
+ * - cluster:index notation
+ * - date math expression, including date math prefixed by a clusterAlias
+ * - wildcards
+ * - multiple index expressions (e.g., logs1,logs2,cluster-a:logs*)
+ *
+ * Note: these methods do not resolve index expressions to concrete indices.
+ */
+public interface IndicesExpressionGrouper {
+
+    /**
+     * @param indicesOptions IndicesOptions to clarify how the index expression should be parsed/applied
+     * @param indexExpressionCsv Multiple index expressions as CSV string (with no spaces), e.g., "logs1,logs2,cluster-a:logs1".
+     *                           A single index expression is also supported.
+     * @return Map where the key is the cluster alias (for "local" cluster, it is RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)
+     *         and the value for that cluster from the index expression is an OriginalIndices object.
+     */
+    default Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String indexExpressionCsv) {
+        return groupIndices(indicesOptions, Strings.splitStringByCommaToArray(indexExpressionCsv));
+    }
+
+    /**
+     * Same behavior as the other groupIndices, except the incoming multiple index expressions must already be
+     * parsed into a String array.
+     * @param indicesOptions IndicesOptions to clarify how the index expressions should be parsed/applied
+     * @param indexExpressions Multiple index expressions as string[].
+     * @return Map where the key is the cluster alias (for "local" cluster, it is RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY)
+     *         and the value for that cluster from the index expression is an OriginalIndices object.
+     */
+    Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indexExpressions);
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -69,6 +69,20 @@ public abstract class RemoteClusterAware {
     }
 
     /**
+     * @param indexExpression expects a single index expression at a time (not a csv list of expression)
+     * @return cluster alias in the index expression. If none is present, returns RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
+     */
+    public static String parseClusterAlias(String indexExpression) {
+        assert indexExpression != null : "Must not pass null indexExpression";
+        String[] parts = splitIndexName(indexExpression.trim());
+        if (parts[0] == null) {
+            return RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        } else {
+            return parts[0];
+        }
+    }
+
+    /**
      * Split the index name into remote cluster alias and index name.
      * The index expression is assumed to be individual index (no commas) but can contain `-`, wildcards,
      * datemath, remote cluster name and any other syntax permissible in index expression component.

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.indices.IndicesExpressionGrouper;
 import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.transport.RemoteClusterCredentialsManager.UpdateRemoteClusterCredentialsResult;
 
@@ -61,7 +62,11 @@ import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUST
 /**
  * Basic service for accessing remote clusters via gateway nodes
  */
-public final class RemoteClusterService extends RemoteClusterAware implements Closeable, ReportingService<RemoteClusterServerInfo> {
+public final class RemoteClusterService extends RemoteClusterAware
+    implements
+        Closeable,
+        ReportingService<RemoteClusterServerInfo>,
+        IndicesExpressionGrouper {
 
     private static final Logger logger = LogManager.getLogger(RemoteClusterService.class);
 

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ListMatcher;
+import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.threadpool.Scheduler;
@@ -90,7 +91,8 @@ public class HeapAttackIT extends ESRestTestCase {
                 values = values.item(List.of(0, b));
             }
         }
-        assertMap(map, matchesMap().entry("columns", columns).entry("values", values));
+        MapMatcher mapMatcher = matchesMap();
+        assertMap(map, mapMatcher.entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
     }
 
     /**
@@ -207,7 +209,8 @@ public class HeapAttackIT extends ESRestTestCase {
         Map<?, ?> map = responseAsMap(resp);
         ListMatcher columns = matchesList().item(matchesMap().entry("name", "MAX(a)").entry("type", "long"));
         ListMatcher values = matchesList().item(List.of(9));
-        assertMap(map, matchesMap().entry("columns", columns).entry("values", values));
+        MapMatcher mapMatcher = matchesMap();
+        assertMap(map, mapMatcher.entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
     }
 
     /**
@@ -219,7 +222,8 @@ public class HeapAttackIT extends ESRestTestCase {
         Map<?, ?> map = responseAsMap(resp);
         ListMatcher columns = matchesList().item(matchesMap().entry("name", "MAX(a)").entry("type", "long"));
         ListMatcher values = matchesList().item(List.of(9));
-        assertMap(map, matchesMap().entry("columns", columns).entry("values", values));
+        MapMatcher mapMatcher = matchesMap();
+        assertMap(map, mapMatcher.entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
     }
 
     private Response groupOnManyLongs(int count) throws IOException {
@@ -249,7 +253,8 @@ public class HeapAttackIT extends ESRestTestCase {
         ListMatcher columns = matchesList().item(matchesMap().entry("name", "a").entry("type", "long"))
             .item(matchesMap().entry("name", "str").entry("type", "keyword"));
         ListMatcher values = matchesList().item(List.of(1, "1".repeat(100)));
-        assertMap(map, matchesMap().entry("columns", columns).entry("values", values));
+        MapMatcher mapMatcher = matchesMap();
+        assertMap(map, mapMatcher.entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
     }
 
     public void testHugeConcat() throws IOException {
@@ -257,9 +262,10 @@ public class HeapAttackIT extends ESRestTestCase {
         ResponseException e = expectThrows(ResponseException.class, () -> concat(10));
         Map<?, ?> map = responseAsMap(e.getResponse());
         logger.info("expected request rejected {}", map);
+        MapMatcher mapMatcher = matchesMap();
         assertMap(
             map,
-            matchesMap().entry("status", 400)
+            mapMatcher.entry("status", 400)
                 .entry("error", matchesMap().extraOk().entry("reason", "concatenating more than [1048576] bytes is not supported"))
         );
     }
@@ -287,7 +293,8 @@ public class HeapAttackIT extends ESRestTestCase {
         for (int s = 0; s < 300; s++) {
             columns = columns.item(matchesMap().entry("name", "str" + s).entry("type", "keyword"));
         }
-        assertMap(map, matchesMap().entry("columns", columns).entry("values", any(List.class)));
+        MapMatcher mapMatcher = matchesMap();
+        assertMap(map, mapMatcher.entry("columns", columns).entry("values", any(List.class)).entry("took", greaterThanOrEqualTo(0)));
     }
 
     /**
@@ -344,7 +351,8 @@ public class HeapAttackIT extends ESRestTestCase {
         for (int i = 0; i < 20; i++) {
             columns = columns.item(matchesMap().entry("name", "i0" + i).entry("type", "long"));
         }
-        assertMap(map, matchesMap().entry("columns", columns).entry("values", hasSize(10_000)));
+        MapMatcher mapMatcher = matchesMap();
+        assertMap(map, mapMatcher.entry("columns", columns).entry("values", hasSize(10_000)).entry("took", greaterThanOrEqualTo(0)));
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch-serverless/issues/1874")

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -149,24 +149,40 @@ public class EsqlSecurityIT extends ESRestTestCase {
         for (String user : List.of("test-admin", "user1")) {
             Response resp = runESQLCommand(user, "from index-user1 | stats sum=sum(value)");
             assertOK(resp);
-            MapMatcher matcher = responseMatcher().entry("columns", List.of(Map.of("name", "sum", "type", "double")))
+            Map<String, Object> responseMap = entityAsMap(resp);
+            MapMatcher mapMatcher = responseMatcher();
+            if (responseMap.get("took") != null) {
+                mapMatcher = mapMatcher.entry("took", ((Integer) responseMap.get("took")).intValue());
+            }
+            MapMatcher matcher = mapMatcher.entry("columns", List.of(Map.of("name", "sum", "type", "double")))
                 .entry("values", List.of(List.of(43.0d)));
-            assertMap(entityAsMap(resp), matcher);
+            assertMap(responseMap, matcher);
         }
 
         for (String user : List.of("test-admin", "user2")) {
             Response resp = runESQLCommand(user, "from index-user2 | stats sum=sum(value)");
             assertOK(resp);
-            MapMatcher matcher = responseMatcher().entry("columns", List.of(Map.of("name", "sum", "type", "double")))
+            Map<String, Object> responseMap = entityAsMap(resp);
+            MapMatcher mapMatcher = responseMatcher();
+            if (responseMap.get("took") != null) {
+                mapMatcher = mapMatcher.entry("took", ((Integer) responseMap.get("took")).intValue());
+            }
+            MapMatcher matcher = mapMatcher.entry("columns", List.of(Map.of("name", "sum", "type", "double")))
                 .entry("values", List.of(List.of(72.0d)));
-            assertMap(entityAsMap(resp), matcher);
+            assertMap(responseMap, matcher);
         }
+
         for (var index : List.of("index-user2", "index-user*", "index*")) {
             Response resp = runESQLCommand("metadata1_read2", "from " + index + " | stats sum=sum(value)");
             assertOK(resp);
-            MapMatcher matcher = responseMatcher().entry("columns", List.of(Map.of("name", "sum", "type", "double")))
+            Map<String, Object> responseMap = entityAsMap(resp);
+            MapMatcher mapMatcher = responseMatcher();
+            if (responseMap.get("took") != null) {
+                mapMatcher = mapMatcher.entry("took", ((Integer) responseMap.get("took")).intValue());
+            }
+            MapMatcher matcher = mapMatcher.entry("columns", List.of(Map.of("name", "sum", "type", "double")))
                 .entry("values", List.of(List.of(72.0d)));
-            assertMap(entityAsMap(resp), matcher);
+            assertMap(responseMap, matcher);
         }
     }
 
@@ -177,11 +193,11 @@ public class EsqlSecurityIT extends ESRestTestCase {
                 "from " + index + " METADATA _index" + "| stats sum=sum(value), index=VALUES(_index)"
             );
             assertOK(resp);
-            MapMatcher matcher = responseMatcher().entry(
-                "columns",
-                List.of(Map.of("name", "sum", "type", "double"), Map.of("name", "index", "type", "keyword"))
-            ).entry("values", List.of(List.of(72.0d, "index-user2")));
-            assertMap(entityAsMap(resp), matcher);
+            Map<String, Object> responseMap = entityAsMap(resp);
+            MapMatcher matcher = responseMatcher().entry("took", ((Integer) responseMap.get("took")).intValue())
+                .entry("columns", List.of(Map.of("name", "sum", "type", "double"), Map.of("name", "index", "type", "keyword")))
+                .entry("values", List.of(List.of(72.0d, "index-user2")));
+            assertMap(responseMap, matcher);
         }
     }
 
@@ -189,15 +205,18 @@ public class EsqlSecurityIT extends ESRestTestCase {
         for (var index : List.of("first-alias", "first-alias,index-*", "first-*,index-*")) {
             Response resp = runESQLCommand("alias_user1", "from " + index + " METADATA _index" + "| KEEP _index, org, value | LIMIT 10");
             assertOK(resp);
-            MapMatcher matcher = responseMatcher().entry(
-                "columns",
-                List.of(
-                    Map.of("name", "_index", "type", "keyword"),
-                    Map.of("name", "org", "type", "keyword"),
-                    Map.of("name", "value", "type", "double")
+            Map<String, Object> responseMap = entityAsMap(resp);
+            MapMatcher matcher = responseMatcher().entry("took", ((Integer) responseMap.get("took")).intValue())
+                .entry(
+                    "columns",
+                    List.of(
+                        Map.of("name", "_index", "type", "keyword"),
+                        Map.of("name", "org", "type", "keyword"),
+                        Map.of("name", "value", "type", "double")
+                    )
                 )
-            ).entry("values", List.of(List.of("index-user1", "sales", 31.0d)));
-            assertMap(entityAsMap(resp), matcher);
+                .entry("values", List.of(List.of("index-user1", "sales", 31.0d)));
+            assertMap(responseMap, matcher);
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -22,6 +22,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ListMatcher;
+import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -48,6 +49,7 @@ import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.entityToMap;
 import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.runEsqlSync;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 /**
  * Creates indices with many different mappings and fetches values from them to make sure
@@ -302,7 +304,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("flattened", "unsupported")))
+            matchesMapWithOptionalTook(result.get("took")).entry("columns", List.of(columnInfo("flattened", "unsupported")))
                 .entry("values", List.of(matchesList().item(null)))
         );
     }
@@ -344,8 +346,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("text_field", "text"), columnInfo("text_field.raw", "keyword")))
-                .entry("values", List.of(matchesList().item(value).item(value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("text_field", "text"), columnInfo("text_field.raw", "keyword"))
+            ).entry("values", List.of(matchesList().item(value).item(value)))
         );
     }
 
@@ -368,8 +372,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("text_field", "text"), columnInfo("text_field.int", "integer")))
-                .entry("values", List.of(matchesList().item(Integer.toString(value)).item(value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("text_field", "text"), columnInfo("text_field.int", "integer"))
+            ).entry("values", List.of(matchesList().item(Integer.toString(value)).item(value)))
         );
     }
 
@@ -392,8 +398,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("text_field", "text"), columnInfo("text_field.int", "integer")))
-                .entry("values", List.of(matchesList().item(value).item(null)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("text_field", "text"), columnInfo("text_field.int", "integer"))
+            ).entry("values", List.of(matchesList().item(value).item(null)))
         );
     }
 
@@ -416,8 +424,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("text_field", "text"), columnInfo("text_field.ip", "ip")))
-                .entry("values", List.of(matchesList().item(value).item(value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("text_field", "text"), columnInfo("text_field.ip", "ip"))
+            ).entry("values", List.of(matchesList().item(value).item(value)))
         );
     }
 
@@ -440,8 +450,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("text_field", "text"), columnInfo("text_field.ip", "ip")))
-                .entry("values", List.of(matchesList().item(value).item(null)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("text_field", "text"), columnInfo("text_field.ip", "ip"))
+            ).entry("values", List.of(matchesList().item(value).item(null)))
         );
     }
 
@@ -465,7 +477,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry(
+            matchesMapWithOptionalTook(result.get("took")).entry(
                 "columns",
                 List.of(columnInfo("integer_field", "integer"), columnInfo("integer_field.str", text ? "text" : "keyword"))
             ).entry("values", List.of(matchesList().item(value).item(Integer.toString(value))))
@@ -492,7 +504,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry(
+            matchesMapWithOptionalTook(result.get("took")).entry(
                 "columns",
                 List.of(columnInfo("integer_field", "integer"), columnInfo("integer_field.str", text ? "text" : "keyword"))
             ).entry("values", List.of(matchesList().item(null).item(value)))
@@ -519,8 +531,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("ip_field", "ip"), columnInfo("ip_field.str", text ? "text" : "keyword")))
-                .entry("values", List.of(matchesList().item(value).item(value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("ip_field", "ip"), columnInfo("ip_field.str", text ? "text" : "keyword"))
+            ).entry("values", List.of(matchesList().item(value).item(value)))
         );
     }
 
@@ -544,8 +558,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("ip_field", "ip"), columnInfo("ip_field.str", text ? "text" : "keyword")))
-                .entry("values", List.of(matchesList().item(null).item(value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("ip_field", "ip"), columnInfo("ip_field.str", text ? "text" : "keyword"))
+            ).entry("values", List.of(matchesList().item(null).item(value)))
         );
     }
 
@@ -569,8 +585,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("integer_field", "integer"), columnInfo("integer_field.byte", "integer")))
-                .entry("values", List.of(matchesList().item((int) value).item((int) value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("integer_field", "integer"), columnInfo("integer_field.byte", "integer"))
+            ).entry("values", List.of(matchesList().item((int) value).item((int) value)))
         );
     }
 
@@ -596,8 +614,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("integer_field", "integer"), columnInfo("integer_field.byte", "integer")))
-                .entry("values", List.of(matchesList().item(value).item(null)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("integer_field", "integer"), columnInfo("integer_field.byte", "integer"))
+            ).entry("values", List.of(matchesList().item(value).item(null)))
         );
     }
 
@@ -621,9 +641,19 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("byte_field", "integer"), columnInfo("byte_field.int", "integer")))
-                .entry("values", List.of(matchesList().item((int) value).item((int) value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("byte_field", "integer"), columnInfo("byte_field.int", "integer"))
+            ).entry("values", List.of(matchesList().item((int) value).item((int) value)))
         );
+    }
+
+    static MapMatcher matchesMapWithOptionalTook(Object tookTimeValue) {
+        MapMatcher mapMatcher = matchesMap();
+        if (tookTimeValue instanceof Number) {
+            mapMatcher = mapMatcher.entry("took", greaterThanOrEqualTo(0));
+        }
+        return mapMatcher;
     }
 
     /**
@@ -646,8 +676,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
 
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("byte_field", "integer"), columnInfo("byte_field.int", "integer")))
-                .entry("values", List.of(matchesList().item(null).item(value)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("byte_field", "integer"), columnInfo("byte_field.int", "integer"))
+            ).entry("values", List.of(matchesList().item(null).item(value)))
         );
     }
 
@@ -676,7 +708,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test*");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("f", "unsupported")))
+            matchesMapWithOptionalTook(result.get("took")).entry("columns", List.of(columnInfo("f", "unsupported")))
                 .entry("values", List.of(matchesList().item(null), matchesList().item(null)))
         );
         ResponseException e = expectThrows(ResponseException.class, () -> runEsql("FROM test* | SORT f | LIMIT 3"));
@@ -714,8 +746,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | SORT file, other");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("file", "keyword"), columnInfo("other", "keyword")))
-                .entry("values", List.of(matchesList().item("f1").item(null), matchesList().item(null).item("o2")))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("file", "keyword"), columnInfo("other", "keyword"))
+            ).entry("values", List.of(matchesList().item("f1").item(null), matchesList().item(null).item("o2")))
         );
     }
 
@@ -778,8 +812,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | SORT file.raw | LIMIT 2");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("file", "unsupported"), columnInfo("file.raw", "keyword")))
-                .entry("values", List.of(matchesList().item(null).item("o2"), matchesList().item(null).item(null)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("file", "unsupported"), columnInfo("file.raw", "keyword"))
+            ).entry("values", List.of(matchesList().item(null).item("o2"), matchesList().item(null).item(null)))
         );
     }
 
@@ -823,8 +859,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | LIMIT 2");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("f", "unsupported"), columnInfo("f.raw", "unsupported")))
-                .entry("values", List.of(matchesList().item(null).item(null)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("f", "unsupported"), columnInfo("f.raw", "unsupported"))
+            ).entry("values", List.of(matchesList().item(null).item(null)))
         );
     }
 
@@ -886,8 +924,10 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | LIMIT 2");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("f", "unsupported"), columnInfo("f.raw", "unsupported")))
-                .entry("values", List.of(matchesList().item(null).item(null), matchesList().item(null).item(null)))
+            matchesMapWithOptionalTook(result.get("took")).entry(
+                "columns",
+                List.of(columnInfo("f", "unsupported"), columnInfo("f.raw", "unsupported"))
+            ).entry("values", List.of(matchesList().item(null).item(null), matchesList().item(null).item(null)))
         );
     }
 
@@ -921,7 +961,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | SORT emp_no | LIMIT 2");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("emp_no", "integer")))
+            matchesMapWithOptionalTook(result.get("took")).entry("columns", List.of(columnInfo("emp_no", "integer")))
                 .entry("values", List.of(matchesList().item(1), matchesList().item(2)))
         );
     }
@@ -967,7 +1007,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | LIMIT 2");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("emp_no", "unsupported")))
+            matchesMapWithOptionalTook(result.get("took")).entry("columns", List.of(columnInfo("emp_no", "unsupported")))
                 .entry("values", List.of(matchesList().item(null), matchesList().item(null)))
         );
     }
@@ -1013,7 +1053,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("FROM test* | LIMIT 2");
         assertMap(
             result,
-            matchesMap().entry("columns", List.of(columnInfo("emp_no", "unsupported")))
+            matchesMapWithOptionalTook(result.get("took")).entry("columns", List.of(columnInfo("emp_no", "unsupported")))
                 .entry("values", List.of(matchesList().item(null), matchesList().item(null)))
         );
     }
@@ -1312,7 +1352,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
                 values = values.item(expectedValue);
             }
 
-            assertMap(result, matchesMap().entry("columns", columns).entry("values", List.of(values)));
+            assertMap(result, matchesMapWithOptionalTook(result.get("took")).entry("columns", columns).entry("values", List.of(values)));
         }
 
         void createIndex(String name, String fieldName) throws IOException {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public abstract class RestEnrichTestCase extends ESRestTestCase {
 
@@ -161,16 +162,14 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql("from test | enrich countries | keep number | sort number");
         var columns = List.of(Map.of("name", "number", "type", "long"));
         var values = List.of(List.of(1000), List.of(1000), List.of(5000));
-
-        assertMap(result, matchesMap().entry("columns", columns).entry("values", values));
+        assertMap(result, matchesMap().entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
     }
 
     public void testMatchField_ImplicitFieldsList_WithStats() throws IOException {
         Map<String, Object> result = runEsql("from test | enrich countries | stats s = sum(number) by country_name");
         var columns = List.of(Map.of("name", "s", "type", "long"), Map.of("name", "country_name", "type", "keyword"));
         var values = List.of(List.of(2000, "United States of America"), List.of(5000, "China"));
-
-        assertMap(result, matchesMap().entry("columns", columns).entry("values", values));
+        assertMap(result, matchesMap().entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
     }
 
     private Map<String, Object> runEsql(String query) throws IOException {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -290,7 +290,9 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         Map<String, Object> result = runEsql(builder);
         assertMap(
             result,
-            matchesMap().entry("values", List.of(List.of(1))).entry("columns", List.of(Map.of("name", "min(value)", "type", "long")))
+            matchesMap().entry("values", List.of(List.of(1)))
+                .entry("columns", List.of(Map.of("name", "min(value)", "type", "long")))
+                .entry("took", greaterThanOrEqualTo(0))
         );
 
         builder = requestObjectBuilder().query(fromIndex() + " | stats min(value) by group | sort group, `min(value)`");
@@ -299,6 +301,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             result,
             matchesMap().entry("values", List.of(List.of(2, 0), List.of(1, 1)))
                 .entry("columns", List.of(Map.of("name", "min(value)", "type", "long"), Map.of("name", "group", "type", "long")))
+                .entry("took", greaterThanOrEqualTo(0))
         );
     }
 
@@ -556,7 +559,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         );
         var values = List.of(List.of(3, testIndexName() + "-2", 1, "id-2"), List.of(2, testIndexName() + "-1", 2, "id-1"));
 
-        assertMap(result, matchesMap().entry("columns", columns).entry("values", values));
+        assertMap(result, matchesMap().entry("columns", columns).entry("values", values).entry("took", greaterThanOrEqualTo(0)));
 
         assertThat(deleteIndex(testIndexName() + "-1").isAcknowledged(), is(true)); // clean up
         assertThat(deleteIndex(testIndexName() + "-2").isAcknowledged(), is(true)); // clean up
@@ -746,7 +749,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
                     .item(matchesMap().entry("name", "value").entry("type", "long"))
                     .item(matchesMap().entry("name", "now").entry("type", "date"))
                     .item(matchesMap().entry("name", "AVG(value)").entry("type", "double"))
-            ).entry("values", values)
+            ).entry("values", values).entry("took", greaterThanOrEqualTo(0))
         );
     }
 
@@ -760,10 +763,13 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             }
             b.endObject();
         }).query(fromIndex() + " | STATS SUM(value)");
+
+        Map<String, Object> result = runEsql(builder);
         assertMap(
-            runEsql(builder),
+            result,
             matchesMap().entry("columns", matchesList().item(matchesMap().entry("name", "SUM(value)").entry("type", "long")))
                 .entry("values", List.of(List.of(499500)))
+                .entry("took", greaterThanOrEqualTo(0))
         );
     }
 
@@ -777,10 +783,12 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             }
             b.endObject();
         }).query(fromIndex() + " | WHERE value == 12 | STATS SUM(value)");
+        Map<String, Object> result = runEsql(builder);
         assertMap(
-            runEsql(builder),
+            result,
             matchesMap().entry("columns", matchesList().item(matchesMap().entry("name", "SUM(value)").entry("type", "long")))
                 .entry("values", List.of(List.of(12)))
+                .entry("took", greaterThanOrEqualTo(0))
         );
     }
 
@@ -809,10 +817,12 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
                 }
                 b.endObject();
             }).query(fromIndex() + " | WHERE @timestamp > \"2010-01-01\" | STATS SUM(value)");
+            Map<String, Object> result = runEsql(builder);
             assertMap(
-                runEsql(builder),
+                result,
                 matchesMap().entry("columns", matchesList().item(matchesMap().entry("name", "SUM(value)").entry("type", "long")))
                     .entry("values", List.of(List.of(12)))
+                    .entry("took", greaterThanOrEqualTo(0))
             );
         }
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/ConfigurationTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/ConfigurationTestUtils.java
@@ -70,7 +70,8 @@ public class ConfigurationTestUtils {
             defaultTruncation,
             query,
             profile,
-            tables
+            tables,
+            System.nanoTime()
         );
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -270,7 +270,8 @@ public final class EsqlTestUtils {
             EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
             query,
             false,
-            TABLES
+            TABLES,
+            System.nanoTime()
         );
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersEnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersEnrichIT.java
@@ -51,11 +51,13 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
 
@@ -232,6 +234,7 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                assertFalse(resp.getExecutionInfo().isCrossClusterSearch());
             }
         }
         for (var mode : Enrich.Mode.values()) {
@@ -251,6 +254,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.clusterAliases(), equalTo(Set.of("c1", "c2")));
+                assertCCSExecutionInfoDetails(executionInfo);
             }
         }
 
@@ -271,6 +277,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.clusterAliases(), equalTo(Set.of("", "c1", "c2")));
+                assertCCSExecutionInfoDetails(executionInfo);
             }
         }
     }
@@ -299,6 +308,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.clusterAliases(), equalTo(Set.of("", "c1", "c2")));
+                assertCCSExecutionInfoDetails(executionInfo);
             }
         }
     }
@@ -326,6 +338,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.clusterAliases(), equalTo(Set.of("", "c1", "c2")));
+                assertCCSExecutionInfoDetails(executionInfo);
             }
         }
     }
@@ -352,6 +367,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                     )
                 )
             );
+            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of("", "c1", "c2")));
+            assertCCSExecutionInfoDetails(executionInfo);
         }
     }
 
@@ -378,6 +396,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.clusterAliases(), equalTo(Set.of("", "c1", "c2")));
+                assertCCSExecutionInfoDetails(executionInfo);
             }
         }
 
@@ -408,6 +429,9 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
                         )
                     )
                 );
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.clusterAliases(), equalTo(Set.of("", "c1", "c2")));
+                assertCCSExecutionInfoDetails(executionInfo);
             }
         }
     }
@@ -471,6 +495,25 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
             request.profile(true);
         }
         return client(LOCAL_CLUSTER).execute(EsqlQueryAction.INSTANCE, request).actionGet(30, TimeUnit.SECONDS);
+    }
+
+    private static void assertCCSExecutionInfoDetails(EsqlExecutionInfo executionInfo) {
+        assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
+        assertTrue(executionInfo.isCrossClusterSearch());
+        List<EsqlExecutionInfo.Cluster> clusters = executionInfo.clusterAliases()
+            .stream()
+            .map(alias -> executionInfo.getCluster(alias))
+            .collect(Collectors.toList());
+
+        for (EsqlExecutionInfo.Cluster cluster : clusters) {
+            assertThat(cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+            assertThat(cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+            assertThat(cluster.getIndexExpression(), equalTo("events"));
+            assertThat(cluster.getTotalShards(), equalTo(1));
+            assertThat(cluster.getSuccessfulShards(), equalTo(1));
+            assertThat(cluster.getSkippedShards(), equalTo(0));
+            assertThat(cluster.getFailedShards(), equalTo(0));
+        }
     }
 
     public static class LocalStateEnrich extends LocalStateCompositeXPackPlugin {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.core.Predicates;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+/**
+ * Holds execution metadata about ES|QL queries for cross-cluster searches in order to display
+ * this information in ES|QL JSON responses.
+ * Patterned after the SearchResponse.Clusters and SearchResponse.Cluster classes.
+ */
+public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
+    // for cross-cluster scenarios where cluster names are shown in API responses, use this string
+    // rather than empty string (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY) we use internally
+    public static final String LOCAL_CLUSTER_NAME_REPRESENTATION = "(local)";
+
+    public static final ParseField TOTAL_FIELD = new ParseField("total");
+    public static final ParseField SUCCESSFUL_FIELD = new ParseField("successful");
+    public static final ParseField SKIPPED_FIELD = new ParseField("skipped");
+    public static final ParseField RUNNING_FIELD = new ParseField("running");
+    public static final ParseField PARTIAL_FIELD = new ParseField("partial");
+    public static final ParseField FAILED_FIELD = new ParseField("failed");
+    public static final ParseField DETAILS_FIELD = new ParseField("details");
+    public static final ParseField TOOK = new ParseField("took");
+
+    // map key is clusterAlias on the primary querying cluster of a CCS minimize_roundtrips=true query
+    // the Map itself is immutable after construction - all Clusters will be accounted for at the start of the search
+    // updates to the Cluster occur with the updateCluster method that given the key to map transforms an
+    // old Cluster Object to a new Cluster Object with the remapping function.
+    public final Map<String, Cluster> clusterInfo;
+    // not Writeable since it is only needed on the primary CCS coordinator
+    private final transient Predicate<String> skipUnavailablePredicate;
+    private TimeValue overallTook;
+
+    public EsqlExecutionInfo() {
+        this(Predicates.always());  // default all clusters to skip_unavailable=true
+    }
+
+    /**
+     * @param skipUnavailablePredicate provide lookup for whether a given cluster has skip_unavailable set to true or false
+     */
+    public EsqlExecutionInfo(Predicate<String> skipUnavailablePredicate) {
+        this.clusterInfo = ConcurrentCollections.newConcurrentMap();
+        this.skipUnavailablePredicate = skipUnavailablePredicate;
+    }
+
+    /**
+     * For testing use with fromXContent parsing only
+     * @param clusterInfo
+     */
+    EsqlExecutionInfo(ConcurrentMap<String, Cluster> clusterInfo) {
+        this.clusterInfo = clusterInfo;
+        this.skipUnavailablePredicate = Predicates.always();
+    }
+
+    public EsqlExecutionInfo(StreamInput in) throws IOException {
+        this.overallTook = in.readOptionalTimeValue();
+        List<EsqlExecutionInfo.Cluster> clusterList = in.readCollectionAsList(EsqlExecutionInfo.Cluster::new);
+        if (clusterList.isEmpty()) {
+            this.clusterInfo = ConcurrentCollections.newConcurrentMap();
+        } else {
+            Map<String, EsqlExecutionInfo.Cluster> m = ConcurrentCollections.newConcurrentMap();
+            clusterList.forEach(c -> m.put(c.getClusterAlias(), c));
+            this.clusterInfo = m;
+        }
+        this.skipUnavailablePredicate = Predicates.always();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalTimeValue(overallTook);
+        if (clusterInfo != null) {
+            out.writeCollection(clusterInfo.values().stream().toList());
+        } else {
+            out.writeCollection(Collections.emptyList());
+        }
+    }
+
+    public void overallTook(TimeValue took) {
+        this.overallTook = took;
+    }
+
+    public TimeValue overallTook() {
+        return overallTook;
+    }
+
+    public Set<String> clusterAliases() {
+        return clusterInfo.keySet();
+    }
+
+    /**
+     * @param clusterAlias to lookup skip_unavailable from
+     * @return skip_unavailable setting (true/false)
+     * @throws org.elasticsearch.transport.NoSuchRemoteClusterException if clusterAlias is unknown to this node's RemoteClusterService
+     */
+    public boolean isSkipUnavailable(String clusterAlias) {
+        if (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(clusterAlias)) {
+            return false;
+        }
+        return skipUnavailablePredicate.test(clusterAlias);
+    }
+
+    public boolean isCrossClusterSearch() {
+        return clusterInfo.size() > 1
+            || clusterInfo.size() == 1 && clusterInfo.containsKey(RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY) == false;
+    }
+
+    public Cluster getCluster(String clusterAlias) {
+        return clusterInfo.get(clusterAlias);
+    }
+
+    /**
+     * Utility to swap a Cluster object. Guidelines for the remapping function:
+     * <ul>
+     * <li> The remapping function should return a new Cluster object to swap it for
+     * the existing one.</li>
+     * <li> If in the remapping function you decide to abort the swap you must return
+     * the original Cluster object to keep the map unchanged.</li>
+     * <li> Do not return {@code null}. If the remapping function returns {@code null},
+     * the mapping is removed (or remains absent if initially absent).</li>
+     * <li> If the remapping function itself throws an (unchecked) exception, the exception
+     * is rethrown, and the current mapping is left unchanged. Throwing exception therefore
+     * is OK, but it is generally discouraged.</li>
+     * <li> The remapping function may be called multiple times in a CAS fashion underneath,
+     * make sure that is safe to do so.</li>
+     * </ul>
+     * @param clusterAlias key with which the specified value is associated
+     * @param remappingFunction function to swap the oldCluster to a newCluster
+     * @return the new Cluster object
+     */
+    public Cluster swapCluster(String clusterAlias, BiFunction<String, Cluster, Cluster> remappingFunction) {
+        return clusterInfo.compute(clusterAlias, remappingFunction);
+    }
+
+    @Override
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+        if (isCrossClusterSearch() == false || clusterInfo.isEmpty()) {
+            return Iterators.concat();
+        }
+        return Iterators.concat(
+            ChunkedToXContentHelper.startObject(),
+            ChunkedToXContentHelper.field(TOTAL_FIELD.getPreferredName(), clusterInfo.size()),
+            ChunkedToXContentHelper.field(SUCCESSFUL_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.SUCCESSFUL)),
+            ChunkedToXContentHelper.field(RUNNING_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.RUNNING)),
+            ChunkedToXContentHelper.field(SKIPPED_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.SKIPPED)),
+            ChunkedToXContentHelper.field(PARTIAL_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.PARTIAL)),
+            ChunkedToXContentHelper.field(FAILED_FIELD.getPreferredName(), getClusterStateCount(Cluster.Status.FAILED)),
+            ChunkedToXContentHelper.xContentFragmentValuesMapCreateOwnName("details", clusterInfo),
+            ChunkedToXContentHelper.endObject()
+        );
+    }
+
+    /**
+     * @param status the status you want a count of
+     * @return how many clusters are currently in a specific state
+     */
+    public int getClusterStateCount(Cluster.Status status) {
+        assert clusterInfo.size() > 0 : "ClusterMap in EsqlExecutionInfo must not be empty";
+        return (int) clusterInfo.values().stream().filter(cluster -> cluster.getStatus() == status).count();
+    }
+
+    @Override
+    public String toString() {
+        return "EsqlExecutionInfo{" + "overallTook=" + overallTook + ", clusterInfo=" + clusterInfo + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EsqlExecutionInfo that = (EsqlExecutionInfo) o;
+        return Objects.equals(clusterInfo, that.clusterInfo) && Objects.equals(overallTook, that.overallTook);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterInfo, overallTook);
+    }
+
+    /**
+     * Represents the search metadata about a particular cluster involved in a cross-cluster search.
+     * The Cluster object can represent either the local cluster or a remote cluster.
+     * For the local cluster, clusterAlias should be specified as RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.
+     * Its XContent is put into the "details" section the "_clusters" entry in the REST query response.
+     * This is an immutable class, so updates made during the search progress (especially important for async
+     * CCS searches) must be done by replacing the Cluster object with a new one.
+     */
+    public static class Cluster implements ToXContentFragment, Writeable {
+        public static final ParseField INDICES_FIELD = new ParseField("indices");
+        public static final ParseField STATUS_FIELD = new ParseField("status");
+        public static final ParseField TOOK = new ParseField("took");
+
+        private final String clusterAlias;
+        private final String indexExpression; // original index expression from the user for this cluster
+        private final boolean skipUnavailable;
+        private final Cluster.Status status;
+        private final Integer totalShards;
+        private final Integer successfulShards;
+        private final Integer skippedShards;
+        private final Integer failedShards;
+        private final TimeValue took;  // search latency for this cluster sub-search
+
+        /**
+         * Marks the status of a Cluster search involved in a Cross-Cluster search.
+         */
+        public enum Status {
+            RUNNING,     // still running
+            SUCCESSFUL,  // all shards completed search
+            PARTIAL,     // only some shards completed the search, partial results from cluster
+            SKIPPED,     // entire cluster was skipped
+            FAILED;      // search was failed due to errors on this cluster
+
+            @Override
+            public String toString() {
+                return this.name().toLowerCase(Locale.ROOT);
+            }
+        }
+
+        public Cluster(String clusterAlias, String indexExpression) {
+            this(clusterAlias, indexExpression, true, Cluster.Status.RUNNING, null, null, null, null, null);
+        }
+
+        /**
+         * Create a Cluster object representing the initial RUNNING state of a Cluster.
+         *
+         * @param clusterAlias clusterAlias as defined in the remote cluster settings or RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
+         *                     for the local cluster
+         * @param indexExpression the original (not resolved/concrete) indices expression provided for this cluster.
+         * @param skipUnavailable whether this Cluster is marked as skip_unavailable in remote cluster settings
+         */
+        public Cluster(String clusterAlias, String indexExpression, boolean skipUnavailable) {
+            this(clusterAlias, indexExpression, skipUnavailable, Cluster.Status.RUNNING, null, null, null, null, null);
+        }
+
+        /**
+         * Create a Cluster with a new Status other than the default of RUNNING.
+         * @param clusterAlias clusterAlias as defined in the remote cluster settings or RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
+         *                     for the local cluster
+         * @param indexExpression the original (not resolved/concrete) indices expression provided for this cluster.
+         * @param skipUnavailable whether cluster is marked as skip_unavailable in remote cluster settings
+         * @param status current status of the search on this Cluster
+         */
+        public Cluster(String clusterAlias, String indexExpression, boolean skipUnavailable, Cluster.Status status) {
+            this(clusterAlias, indexExpression, skipUnavailable, status, null, null, null, null, null);
+        }
+
+        public Cluster(
+            String clusterAlias,
+            String indexExpression,
+            boolean skipUnavailable,
+            Cluster.Status status,
+            Integer totalShards,
+            Integer successfulShards,
+            Integer skippedShards,
+            Integer failedShards,
+            TimeValue took
+        ) {
+            assert clusterAlias != null : "clusterAlias cannot be null";
+            assert indexExpression != null : "indexExpression of Cluster cannot be null";
+            assert status != null : "status of Cluster cannot be null";
+            this.clusterAlias = clusterAlias;
+            this.indexExpression = indexExpression;
+            this.skipUnavailable = skipUnavailable;
+            this.status = status;
+            this.totalShards = totalShards;
+            this.successfulShards = successfulShards;
+            this.skippedShards = skippedShards;
+            this.failedShards = failedShards;
+            this.took = took;
+        }
+
+        public Cluster(StreamInput in) throws IOException {
+            this.clusterAlias = in.readString();
+            this.indexExpression = in.readString();
+            this.status = Cluster.Status.valueOf(in.readString().toUpperCase(Locale.ROOT));
+            this.totalShards = in.readOptionalInt();
+            this.successfulShards = in.readOptionalInt();
+            this.skippedShards = in.readOptionalInt();
+            this.failedShards = in.readOptionalInt();
+            this.took = in.readOptionalTimeValue();
+            this.skipUnavailable = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(clusterAlias);
+            out.writeString(indexExpression);
+            out.writeString(status.toString());
+            out.writeOptionalInt(totalShards);
+            out.writeOptionalInt(successfulShards);
+            out.writeOptionalInt(skippedShards);
+            out.writeOptionalInt(failedShards);
+            out.writeOptionalTimeValue(took);
+            out.writeBoolean(skipUnavailable);
+        }
+
+        /**
+         * Since the Cluster object is immutable, use this Builder class to create
+         * a new Cluster object using the "copyFrom" Cluster passed in and set only
+         * changed values.
+         *
+         * Since the clusterAlias, indexExpression and skipUnavailable fields are
+         * never changed once set, this Builder provides no setter method for them.
+         * All other fields can be set and override the value in the "copyFrom" Cluster.
+         */
+        public static class Builder {
+            private String indexExpression;
+            private Cluster.Status status;
+            private Integer totalShards;
+            private Integer successfulShards;
+            private Integer skippedShards;
+            private Integer failedShards;
+            private TimeValue took;
+            private final Cluster original;
+
+            public Builder(Cluster copyFrom) {
+                this.original = copyFrom;
+            }
+
+            /**
+             * @return new Cluster object using the new values passed in via setters
+             *         or the values in the "copyFrom" Cluster object set in the
+             *         Builder constructor.
+             */
+            public Cluster build() {
+                return new Cluster(
+                    original.getClusterAlias(),
+                    indexExpression == null ? original.getIndexExpression() : indexExpression,
+                    original.isSkipUnavailable(),
+                    status != null ? status : original.getStatus(),
+                    totalShards != null ? totalShards : original.getTotalShards(),
+                    successfulShards != null ? successfulShards : original.getSuccessfulShards(),
+                    skippedShards != null ? skippedShards : original.getSkippedShards(),
+                    failedShards != null ? failedShards : original.getFailedShards(),
+                    took != null ? took : original.getTook()
+                );
+            }
+
+            public Cluster.Builder setIndexExpression(String indexExpression) {
+                this.indexExpression = indexExpression;
+                return this;
+            }
+
+            public Cluster.Builder setStatus(Cluster.Status status) {
+                this.status = status;
+                return this;
+            }
+
+            public Cluster.Builder setTotalShards(int totalShards) {
+                this.totalShards = totalShards;
+                return this;
+            }
+
+            public Cluster.Builder setSuccessfulShards(int successfulShards) {
+                this.successfulShards = successfulShards;
+                return this;
+            }
+
+            public Cluster.Builder setSkippedShards(int skippedShards) {
+                this.skippedShards = skippedShards;
+                return this;
+            }
+
+            public Cluster.Builder setFailedShards(int failedShards) {
+                this.failedShards = failedShards;
+                return this;
+            }
+
+            public Cluster.Builder setTook(TimeValue took) {
+                this.took = took;
+                return this;
+            }
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            String name = clusterAlias;
+            if (clusterAlias.equals("")) {
+                name = LOCAL_CLUSTER_NAME_REPRESENTATION;
+            }
+            builder.startObject(name);
+            {
+                builder.field(STATUS_FIELD.getPreferredName(), getStatus().toString());
+                builder.field(INDICES_FIELD.getPreferredName(), indexExpression);
+                if (took != null) {
+                    // TODO: change this to took_nanos and call took.nanos?
+                    builder.field(TOOK.getPreferredName(), took.millis());
+                }
+                if (totalShards != null) {
+                    builder.startObject(RestActions._SHARDS_FIELD.getPreferredName());
+                    builder.field(RestActions.TOTAL_FIELD.getPreferredName(), totalShards);
+                    if (successfulShards != null) {
+                        builder.field(RestActions.SUCCESSFUL_FIELD.getPreferredName(), successfulShards);
+                    }
+                    if (skippedShards != null) {
+                        builder.field(RestActions.SKIPPED_FIELD.getPreferredName(), skippedShards);
+                    }
+                    if (failedShards != null) {
+                        builder.field(RestActions.FAILED_FIELD.getPreferredName(), failedShards);
+                    }
+                    builder.endObject();
+                }
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean isFragment() {
+            return ToXContentFragment.super.isFragment();
+        }
+
+        public String getClusterAlias() {
+            return clusterAlias;
+        }
+
+        public String getIndexExpression() {
+            return indexExpression;
+        }
+
+        public boolean isSkipUnavailable() {
+            return skipUnavailable;
+        }
+
+        public Cluster.Status getStatus() {
+            return status;
+        }
+
+        public TimeValue getTook() {
+            return took;
+        }
+
+        public Integer getTotalShards() {
+            return totalShards;
+        }
+
+        public Integer getSuccessfulShards() {
+            return successfulShards;
+        }
+
+        public Integer getSkippedShards() {
+            return skippedShards;
+        }
+
+        public Integer getFailedShards() {
+            return failedShards;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Cluster cluster = (Cluster) o;
+            return Objects.equals(clusterAlias, cluster.clusterAlias)
+                && Objects.equals(indexExpression, cluster.indexExpression)
+                && status == cluster.status
+                && Objects.equals(totalShards, cluster.totalShards)
+                && Objects.equals(successfulShards, cluster.successfulShards)
+                && Objects.equals(skippedShards, cluster.skippedShards)
+                && Objects.equals(failedShards, cluster.failedShards)
+                && Objects.equals(took, cluster.took);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(clusterAlias, indexExpression, status, totalShards, successfulShards, skippedShards, failedShards, took);
+        }
+
+        @Override
+        public String toString() {
+            return "Cluster{"
+                + "alias='"
+                + clusterAlias
+                + '\''
+                + ", status="
+                + status
+                + ", totalShards="
+                + totalShards
+                + ", successfulShards="
+                + successfulShards
+                + ", skippedShards="
+                + skippedShards
+                + ", failedShards="
+                + failedShards
+                + ", took="
+                + took
+                + ", indexExpression='"
+                + indexExpression
+                + '\''
+                + ", skipUnavailable="
+                + skipUnavailable
+                + '}';
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -53,6 +53,7 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
     private final boolean isRunning;
     // True if this response is as a result of an async query request
     private final boolean isAsync;
+    private final EsqlExecutionInfo executionInfo;
 
     public EsqlQueryResponse(
         List<ColumnInfoImpl> columns,
@@ -61,7 +62,8 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
         boolean columnar,
         @Nullable String asyncExecutionId,
         boolean isRunning,
-        boolean isAsync
+        boolean isAsync,
+        EsqlExecutionInfo executionInfo
     ) {
         this.columns = columns;
         this.pages = pages;
@@ -70,10 +72,18 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
         this.asyncExecutionId = asyncExecutionId;
         this.isRunning = isRunning;
         this.isAsync = isAsync;
+        this.executionInfo = executionInfo;
     }
 
-    public EsqlQueryResponse(List<ColumnInfoImpl> columns, List<Page> pages, @Nullable Profile profile, boolean columnar, boolean isAsync) {
-        this(columns, pages, profile, columnar, null, false, isAsync);
+    public EsqlQueryResponse(
+        List<ColumnInfoImpl> columns,
+        List<Page> pages,
+        @Nullable Profile profile,
+        boolean columnar,
+        boolean isAsync,
+        EsqlExecutionInfo executionInfo
+    ) {
+        this(columns, pages, profile, columnar, null, false, isAsync, executionInfo);
     }
 
     /**
@@ -103,7 +113,11 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
             profile = in.readOptionalWriteable(Profile::new);
         }
         boolean columnar = in.readBoolean();
-        return new EsqlQueryResponse(columns, pages, profile, columnar, asyncExecutionId, isRunning, isAsync);
+        EsqlExecutionInfo executionInfo = null;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_CCS_EXECUTION_INFO)) {
+            executionInfo = in.readOptionalWriteable(EsqlExecutionInfo::new);
+        }
+        return new EsqlQueryResponse(columns, pages, profile, columnar, asyncExecutionId, isRunning, isAsync, executionInfo);
     }
 
     @Override
@@ -119,6 +133,9 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
             out.writeOptionalWriteable(profile);
         }
         out.writeBoolean(columnar);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_CCS_EXECUTION_INFO)) {
+            out.writeOptionalWriteable(executionInfo);
+        }
     }
 
     public List<ColumnInfoImpl> columns() {
@@ -164,6 +181,10 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
         return isRunning;
     }
 
+    public EsqlExecutionInfo getExecutionInfo() {
+        return executionInfo;
+    }
+
     private Iterator<? extends ToXContent> asyncPropertiesOrEmpty() {
         if (isAsync) {
             return ChunkedToXContentHelper.singleChunk((builder, params) -> {
@@ -182,6 +203,17 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         boolean dropNullColumns = params.paramAsBoolean(DROP_NULL_COLUMNS_OPTION, false);
         boolean[] nullColumns = dropNullColumns ? nullColumns() : null;
+
+        Iterator<ToXContent> tookTime;
+        if (executionInfo != null && executionInfo.overallTook() != null) {
+            tookTime = ChunkedToXContentHelper.singleChunk((builder, p) -> {
+                builder.field("took", executionInfo.overallTook().millis());
+                return builder;
+            });
+        } else {
+            tookTime = Collections.emptyIterator();
+        }
+
         Iterator<? extends ToXContent> columnHeadings = dropNullColumns
             ? Iterators.concat(
                 ResponseXContentUtils.allColumns(columns, "all_columns"),
@@ -192,11 +224,16 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
         Iterator<ToXContent> profileRender = profile == null
             ? List.<ToXContent>of().iterator()
             : ChunkedToXContentHelper.field("profile", profile, params);
+        Iterator<ToXContent> executionInfoRender = executionInfo == null || executionInfo.isCrossClusterSearch() == false
+            ? List.<ToXContent>of().iterator()
+            : ChunkedToXContentHelper.field("_clusters", executionInfo, params);
         return Iterators.concat(
             ChunkedToXContentHelper.startObject(),
             asyncPropertiesOrEmpty(),
+            tookTime,
             columnHeadings,
             ChunkedToXContentHelper.array("values", valuesIt),
+            executionInfoRender,
             profileRender,
             ChunkedToXContentHelper.endObject()
         );
@@ -234,7 +271,8 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
             && Objects.equals(isRunning, that.isRunning)
             && columnar == that.columnar
             && Iterators.equals(values(), that.values(), (row1, row2) -> Iterators.equals(row1, row2, Objects::equals))
-            && Objects.equals(profile, that.profile);
+            && Objects.equals(profile, that.profile)
+            && Objects.equals(executionInfo, that.executionInfo);
     }
 
     @Override
@@ -244,7 +282,8 @@ public class EsqlQueryResponse extends org.elasticsearch.xpack.core.esql.action.
             isRunning,
             columns,
             Iterators.hashCode(values(), row -> Iterators.hashCode(row, Objects::hashCode)),
-            columnar
+            columnar,
+            executionInfo
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryTask.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryTask.java
@@ -33,6 +33,6 @@ public class EsqlQueryTask extends StoredAsyncTask<EsqlQueryResponse> {
 
     @Override
     public EsqlQueryResponse getCurrentResult() {
-        return new EsqlQueryResponse(List.of(), List.of(), null, false, getExecutionId().getEncoded(), true, true);
+        return new EsqlQueryResponse(List.of(), List.of(), null, false, getExecutionId().getEncoded(), true, true, null);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/execution/PlanExecutor.java
@@ -8,7 +8,9 @@
 package org.elasticsearch.xpack.esql.execution;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.indices.IndicesExpressionGrouper;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.analysis.PreAnalyzer;
 import org.elasticsearch.xpack.esql.analysis.Verifier;
@@ -56,6 +58,8 @@ public class PlanExecutor {
         String sessionId,
         Configuration cfg,
         EnrichPolicyResolver enrichPolicyResolver,
+        EsqlExecutionInfo executionInfo,
+        IndicesExpressionGrouper indicesExpressionGrouper,
         BiConsumer<PhysicalPlan, ActionListener<Result>> runPhase,
         ActionListener<Result> listener
     ) {
@@ -70,11 +74,12 @@ public class PlanExecutor {
             new LogicalPlanOptimizer(new LogicalOptimizerContext(cfg)),
             mapper,
             verifier,
-            planningMetrics
+            planningMetrics,
+            indicesExpressionGrouper
         );
         QueryMetric clientId = QueryMetric.fromString("rest");
         metrics.total(clientId);
-        session.execute(request, runPhase, wrap(x -> {
+        session.execute(request, executionInfo, runPhase, wrap(x -> {
             planningMetricsManager.publish(planningMetrics, true);
             listener.onResponse(x);
         }, ex -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -12,15 +12,20 @@ import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.FailureCollector;
 import org.elasticsearch.compute.operator.ResponseHeadersCollector;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -29,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * 2. Collects driver profiles from sub tasks.
  * 3. Collects response headers from sub tasks, specifically warnings emitted during compute
  * 4. Collects failures and returns the most appropriate exception to the caller.
+ * 5. Updates {@link EsqlExecutionInfo} for display in the response for cross-cluster searches
  */
 final class ComputeListener implements Releasable {
     private static final Logger LOGGER = LogManager.getLogger(ComputeService.class);
@@ -40,17 +46,130 @@ final class ComputeListener implements Releasable {
     private final TransportService transportService;
     private final List<DriverProfile> collectedProfiles;
     private final ResponseHeadersCollector responseHeaders;
+    private final EsqlExecutionInfo esqlExecutionInfo;
+    private final long queryStartTimeNanos;
+    // clusterAlias indicating where this ComputeListener is running
+    // used by the top level ComputeListener in ComputeService on both local and remote clusters
+    private final String whereRunning;
 
-    ComputeListener(TransportService transportService, CancellableTask task, ActionListener<ComputeResponse> delegate) {
+    /**
+     * Create a ComputeListener that does not need to gather any metadata in EsqlExecutionInfo
+     * (currently that's the ComputeListener in DataNodeRequestHandler).
+     */
+    public static ComputeListener create(
+        TransportService transportService,
+        CancellableTask task,
+        ActionListener<ComputeResponse> delegate
+    ) {
+        return new ComputeListener(transportService, task, null, null, -1, delegate);
+    }
+
+    /**
+     * Create a ComputeListener that gathers metadata in EsqlExecutionInfo
+     * (currently that's the top level ComputeListener in ComputeService).
+     * @param clusterAlias the clusterAlias where this ComputeListener is running. For the querying cluster, use
+     *                     RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY. For remote clusters that are part of a CCS,
+     *                     the remote cluster is given its clusterAlias in the request sent to it, so that should be
+     *                     passed in here. This gives context to the ComputeListener as to where this listener is running
+     *                     and thus how it should behave with respect to the {@link EsqlExecutionInfo} metadata it gathers.
+     * @param transportService
+     * @param task
+     * @param executionInfo {@link EsqlExecutionInfo} to capture execution metadata
+     * @param queryStartTimeNanos Start time of the ES|QL query (stored in {@link org.elasticsearch.xpack.esql.session.Configuration})
+     * @param delegate
+     */
+    public static ComputeListener create(
+        String clusterAlias,
+        TransportService transportService,
+        CancellableTask task,
+        EsqlExecutionInfo executionInfo,
+        long queryStartTimeNanos,
+        ActionListener<ComputeResponse> delegate
+    ) {
+        return new ComputeListener(transportService, task, clusterAlias, executionInfo, queryStartTimeNanos, delegate);
+    }
+
+    private ComputeListener(
+        TransportService transportService,
+        CancellableTask task,
+        String clusterAlias,
+        EsqlExecutionInfo executionInfo,
+        long queryStartTimeNanos,
+        ActionListener<ComputeResponse> delegate
+    ) {
         this.transportService = transportService;
         this.task = task;
         this.responseHeaders = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
         this.collectedProfiles = Collections.synchronizedList(new ArrayList<>());
+        this.esqlExecutionInfo = executionInfo;
+        this.queryStartTimeNanos = queryStartTimeNanos;
+        this.whereRunning = clusterAlias;
+        // for the DataNodeHandler ComputeListener, clusterAlias and executionInfo will be null
+        // for the top level ComputeListener in ComputeService both will be non-null
+        assert (clusterAlias == null && executionInfo == null) || (clusterAlias != null && executionInfo != null)
+            : "clusterAlias and executionInfo must both be null or both non-null";
+
+        // listener that executes after all the sub-listeners refs (created via acquireCompute) have completed
         this.refs = new RefCountingListener(1, ActionListener.wrap(ignored -> {
             responseHeaders.finish();
-            var result = new ComputeResponse(collectedProfiles.isEmpty() ? List.of() : collectedProfiles.stream().toList());
+            ComputeResponse result;
+
+            if (runningOnRemoteCluster()) {
+                // for remote executions - this ComputeResponse is created on the remote cluster/node and will be serialized and
+                // received by the acquireCompute method callback on the coordinating cluster
+                EsqlExecutionInfo.Cluster cluster = esqlExecutionInfo.getCluster(clusterAlias);
+                result = new ComputeResponse(
+                    collectedProfiles.isEmpty() ? List.of() : collectedProfiles.stream().toList(),
+                    cluster.getTook(),
+                    cluster.getTotalShards(),
+                    cluster.getSuccessfulShards(),
+                    cluster.getSkippedShards(),
+                    cluster.getFailedShards()
+                );
+            } else {
+                result = new ComputeResponse(collectedProfiles.isEmpty() ? List.of() : collectedProfiles.stream().toList());
+                if (coordinatingClusterIsSearchedInCCS()) {
+                    // mark local cluster as finished once the coordinator and all data nodes have finished processing
+                    executionInfo.swapCluster(
+                        RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
+                        (k, v) -> new EsqlExecutionInfo.Cluster.Builder(v).setStatus(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL).build()
+                    );
+                }
+            }
             delegate.onResponse(result);
         }, e -> delegate.onFailure(failureCollector.getFailure())));
+    }
+
+    /**
+     * @return true if the "local" querying/coordinator cluster is being searched in a cross-cluster search
+     */
+    private boolean coordinatingClusterIsSearchedInCCS() {
+        return esqlExecutionInfo != null
+            && esqlExecutionInfo.isCrossClusterSearch()
+            && esqlExecutionInfo.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY) != null;
+    }
+
+    /**
+     * @return true if this Listener is running on a remote cluster (i.e., not the querying cluster)
+     */
+    private boolean runningOnRemoteCluster() {
+        return whereRunning != null && whereRunning.equals(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY) == false;
+    }
+
+    /**
+     * @return true if the listener is in a context where the took time needs to be recorded into the EsqlExecutionInfo
+     */
+    private boolean shouldRecordTookTime() {
+        return runningOnRemoteCluster() || coordinatingClusterIsSearchedInCCS();
+    }
+
+    /**
+     * @param computeClusterAlias the clusterAlias passed to the acquireCompute method
+     * @return true if this listener is waiting for a remote response in a CCS search
+     */
+    private boolean isCCSListener(String computeClusterAlias) {
+        return RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(whereRunning)
+            && computeClusterAlias.equals(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY) == false;
     }
 
     /**
@@ -71,17 +190,58 @@ final class ComputeListener implements Releasable {
     }
 
     /**
-     * Acquires a new listener that collects compute result. This listener will also collects warnings emitted during compute
+     * Acquires a new listener that collects compute result. This listener will also collect warnings emitted during compute
+     * @param computeClusterAlias The cluster alias where the compute is happening. Used when metadata needs to be gathered
+     *                            into the {@link EsqlExecutionInfo} Cluster objects. Callers that do not required execution
+     *                            info to be gathered (namely, the DataNodeRequestHandler ComputeListener) should pass in null.
      */
-    ActionListener<ComputeResponse> acquireCompute() {
+    ActionListener<ComputeResponse> acquireCompute(@Nullable String computeClusterAlias) {
+        assert computeClusterAlias == null || (esqlExecutionInfo != null && queryStartTimeNanos > 0)
+            : "When clusterAlias is provided to acquireCompute, executionInfo must be non-null and queryStartTimeNanos must be positive";
+
         return acquireAvoid().map(resp -> {
             responseHeaders.collect();
             var profiles = resp.getProfiles();
             if (profiles != null && profiles.isEmpty() == false) {
                 collectedProfiles.addAll(profiles);
             }
+            if (computeClusterAlias == null) {
+                return null;
+            }
+            if (isCCSListener(computeClusterAlias)) {
+                // this is the callback for the listener to the CCS compute
+                esqlExecutionInfo.swapCluster(
+                    computeClusterAlias,
+                    (k, v) -> new EsqlExecutionInfo.Cluster.Builder(v)
+                        // for now ESQL doesn't return partial results, so set status to SUCCESSFUL
+                        .setStatus(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL)
+                        .setTook(resp.getTook())
+                        .setTotalShards(resp.getTotalShards())
+                        .setSuccessfulShards(resp.getSuccessfulShards())
+                        .setSkippedShards(resp.getSkippedShards())
+                        .setFailedShards(resp.getFailedShards())
+                        .build()
+                );
+            } else if (shouldRecordTookTime()) {
+                // handler for this cluster's data node and coordinator completion (runs on "local" and remote clusters)
+                TimeValue tookTime = new TimeValue(System.nanoTime() - queryStartTimeNanos, TimeUnit.NANOSECONDS);
+                esqlExecutionInfo.swapCluster(computeClusterAlias, (k, v) -> {
+                    if (v.getTook() == null || v.getTook().nanos() < tookTime.nanos()) {
+                        return new EsqlExecutionInfo.Cluster.Builder(v).setTook(tookTime).build();
+                    } else {
+                        return v;
+                    }
+                });
+            }
             return null;
         });
+    }
+
+    /**
+     * Use this method when no execution metadata needs to be added to {@link EsqlExecutionInfo}
+     */
+    ActionListener<ComputeResponse> acquireCompute() {
+        return acquireCompute(null);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -25,10 +25,12 @@ import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
 import org.elasticsearch.xpack.esql.action.ColumnInfoImpl;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
@@ -64,6 +66,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     private final EnrichPolicyResolver enrichPolicyResolver;
     private final EnrichLookupService enrichLookupService;
     private final AsyncTaskManagementService<EsqlQueryRequest, EsqlQueryResponse, EsqlQueryTask> asyncTaskManagementService;
+    private final RemoteClusterService remoteClusterService;
 
     @Inject
     @SuppressWarnings("this-escape")
@@ -114,6 +117,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             threadPool,
             bigArrays
         );
+        this.remoteClusterService = transportService.getRemoteClusterService();
     }
 
     @Override
@@ -159,22 +163,26 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             clusterService.getClusterSettings().get(EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE),
             request.query(),
             request.profile(),
-            request.tables()
+            request.tables(),
+            System.nanoTime()
         );
         String sessionId = sessionID(task);
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo(clusterAlias -> remoteClusterService.isSkipUnavailable(clusterAlias));
         BiConsumer<PhysicalPlan, ActionListener<Result>> runPhase = (physicalPlan, resultListener) -> computeService.execute(
             sessionId,
             (CancellableTask) task,
             physicalPlan,
             configuration,
+            executionInfo,
             resultListener
         );
-
         planExecutor.esql(
             request,
             sessionId,
             configuration,
             enrichPolicyResolver,
+            executionInfo,
+            remoteClusterService,
             runPhase,
             listener.map(result -> toResponse(task, request, configuration, result))
         );
@@ -187,9 +195,18 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         if (task instanceof EsqlQueryTask asyncTask && request.keepOnCompletion()) {
             String asyncExecutionId = asyncTask.getExecutionId().getEncoded();
             threadPool.getThreadContext().addResponseHeader(AsyncExecutionId.ASYNC_EXECUTION_ID_HEADER, asyncExecutionId);
-            return new EsqlQueryResponse(columns, result.pages(), profile, request.columnar(), asyncExecutionId, false, request.async());
+            return new EsqlQueryResponse(
+                columns,
+                result.pages(),
+                profile,
+                request.columnar(),
+                asyncExecutionId,
+                false,
+                request.async(),
+                result.executionInfo()
+            );
         }
-        return new EsqlQueryResponse(columns, result.pages(), profile, request.columnar(), request.async());
+        return new EsqlQueryResponse(columns, result.pages(), profile, request.columnar(), request.async(), result.executionInfo());
     }
 
     /**
@@ -245,7 +262,8 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             false,
             asyncExecutionId,
             true, // is_running
-            true // isAsync
+            true, // isAsync
+            null
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Configuration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Configuration.java
@@ -51,6 +51,7 @@ public class Configuration implements Writeable {
     private final boolean profile;
 
     private final Map<String, Map<String, Column>> tables;
+    private final long queryStartTimeNanos;
 
     public Configuration(
         ZoneId zi,
@@ -62,7 +63,8 @@ public class Configuration implements Writeable {
         int resultTruncationDefaultSize,
         String query,
         boolean profile,
-        Map<String, Map<String, Column>> tables
+        Map<String, Map<String, Column>> tables,
+        long queryStartTimeNanos
     ) {
         this.zoneId = zi.normalized();
         this.now = ZonedDateTime.now(Clock.tick(Clock.system(zoneId), Duration.ofNanos(1)));
@@ -76,6 +78,7 @@ public class Configuration implements Writeable {
         this.profile = profile;
         this.tables = tables;
         assert tables != null;
+        this.queryStartTimeNanos = queryStartTimeNanos;
     }
 
     public Configuration(BlockStreamInput in) throws IOException {
@@ -98,6 +101,11 @@ public class Configuration implements Writeable {
         } else {
             this.tables = Map.of();
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_CCS_EXECUTION_INFO)) {
+            this.queryStartTimeNanos = in.readLong();
+        } else {
+            this.queryStartTimeNanos = -1;
+        }
     }
 
     @Override
@@ -118,6 +126,9 @@ public class Configuration implements Writeable {
         }
         if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_REQUEST_TABLES)) {
             out.writeMap(tables, (o1, columns) -> o1.writeMap(columns, StreamOutput::writeWriteable));
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_CCS_EXECUTION_INFO)) {
+            out.writeLong(queryStartTimeNanos);
         }
     }
 
@@ -163,7 +174,15 @@ public class Configuration implements Writeable {
      * Note: Currently, it returns {@link System#currentTimeMillis()}, but this value will be serialized between nodes.
      */
     public long absoluteStartedTimeInMillis() {
+        // MP TODO: I'm confused - Why is this not a fixed value taken at the start of the query processing?
         return System.currentTimeMillis();
+    }
+
+    /**
+     * @return Start time of the ESQL query in nanos
+     */
+    public long getQueryStartTimeNanos() {
+        return queryStartTimeNanos;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -8,15 +8,22 @@
 package org.elasticsearch.xpack.esql.session;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.indices.IndicesExpressionGrouper;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
@@ -61,7 +68,9 @@ import org.elasticsearch.xpack.esql.stats.PlanningMetrics;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -88,6 +97,7 @@ public class EsqlSession {
     private final Mapper mapper;
     private final PhysicalPlanOptimizer physicalPlanOptimizer;
     private final PlanningMetrics planningMetrics;
+    private final IndicesExpressionGrouper indicesExpressionGrouper;
 
     public EsqlSession(
         String sessionId,
@@ -99,7 +109,8 @@ public class EsqlSession {
         LogicalPlanOptimizer logicalPlanOptimizer,
         Mapper mapper,
         Verifier verifier,
-        PlanningMetrics planningMetrics
+        PlanningMetrics planningMetrics,
+        IndicesExpressionGrouper indicesExpressionGrouper
     ) {
         this.sessionId = sessionId;
         this.configuration = configuration;
@@ -112,6 +123,7 @@ public class EsqlSession {
         this.logicalPlanOptimizer = logicalPlanOptimizer;
         this.physicalPlanOptimizer = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(configuration));
         this.planningMetrics = planningMetrics;
+        this.indicesExpressionGrouper = indicesExpressionGrouper;
     }
 
     public String sessionId() {
@@ -123,14 +135,16 @@ public class EsqlSession {
      */
     public void execute(
         EsqlQueryRequest request,
+        EsqlExecutionInfo executionInfo,
         BiConsumer<PhysicalPlan, ActionListener<Result>> runPhase,
         ActionListener<Result> listener
     ) {
         LOGGER.debug("ESQL query:\n{}", request.query());
         analyzedPlan(
             parse(request.query(), request.params()),
+            executionInfo,
             listener.delegateFailureAndWrap(
-                (next, analyzedPlan) -> executeOptimizedPlan(request, runPhase, optimizedPlan(analyzedPlan), next)
+                (next, analyzedPlan) -> executeOptimizedPlan(request, executionInfo, runPhase, optimizedPlan(analyzedPlan), next)
             )
         );
     }
@@ -141,6 +155,7 @@ public class EsqlSession {
      */
     public void executeOptimizedPlan(
         EsqlQueryRequest request,
+        EsqlExecutionInfo executionInfo,
         BiConsumer<PhysicalPlan, ActionListener<Result>> runPhase,
         LogicalPlan optimizedPlan,
         ActionListener<Result> listener
@@ -149,7 +164,7 @@ public class EsqlSession {
         if (firstPhase == null) {
             runPhase.accept(logicalPlanToPhysicalPlan(optimizedPlan, request), listener);
         } else {
-            executePhased(new ArrayList<>(), optimizedPlan, request, firstPhase, runPhase, listener);
+            executePhased(new ArrayList<>(), optimizedPlan, request, executionInfo, firstPhase, runPhase, listener);
         }
     }
 
@@ -157,6 +172,7 @@ public class EsqlSession {
         List<DriverProfile> profileAccumulator,
         LogicalPlan mainPlan,
         EsqlQueryRequest request,
+        EsqlExecutionInfo executionInfo,
         LogicalPlan firstPhase,
         BiConsumer<PhysicalPlan, ActionListener<Result>> runPhase,
         ActionListener<Result> listener
@@ -171,10 +187,10 @@ public class EsqlSession {
                     PhysicalPlan finalPhysicalPlan = logicalPlanToPhysicalPlan(newMainPlan, request);
                     runPhase.accept(finalPhysicalPlan, next.delegateFailureAndWrap((finalListener, finalResult) -> {
                         profileAccumulator.addAll(finalResult.profiles());
-                        finalListener.onResponse(new Result(finalResult.schema(), finalResult.pages(), profileAccumulator));
+                        finalListener.onResponse(new Result(finalResult.schema(), finalResult.pages(), profileAccumulator, executionInfo));
                     }));
                 } else {
-                    executePhased(profileAccumulator, newMainPlan, request, newFirstPhase, runPhase, next);
+                    executePhased(profileAccumulator, newMainPlan, request, executionInfo, newFirstPhase, runPhase, next);
                 }
             } finally {
                 Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(result.pages().iterator(), p -> p::releaseBlocks)));
@@ -188,13 +204,13 @@ public class EsqlSession {
         return parsed;
     }
 
-    public void analyzedPlan(LogicalPlan parsed, ActionListener<LogicalPlan> listener) {
+    public void analyzedPlan(LogicalPlan parsed, EsqlExecutionInfo executionInfo, ActionListener<LogicalPlan> listener) {
         if (parsed.analyzed()) {
             listener.onResponse(parsed);
             return;
         }
 
-        preAnalyze(parsed, (indices, policies) -> {
+        preAnalyze(parsed, executionInfo, (indices, policies) -> {
             planningMetrics.gatherPreAnalysisMetrics(parsed);
             Analyzer analyzer = new Analyzer(new AnalyzerContext(configuration, functionRegistry, indices, policies), verifier);
             var plan = analyzer.analyze(parsed);
@@ -204,7 +220,12 @@ public class EsqlSession {
         }, listener);
     }
 
-    private <T> void preAnalyze(LogicalPlan parsed, BiFunction<IndexResolution, EnrichResolution, T> action, ActionListener<T> listener) {
+    private <T> void preAnalyze(
+        LogicalPlan parsed,
+        EsqlExecutionInfo executionInfo,
+        BiFunction<IndexResolution, EnrichResolution, T> action,
+        ActionListener<T> listener
+    ) {
         PreAnalyzer.PreAnalysis preAnalysis = preAnalyzer.preAnalyze(parsed);
         var unresolvedPolicies = preAnalysis.enriches.stream()
             .map(e -> new EnrichPolicyResolver.UnresolvedPolicy((String) e.policyName().fold(), e.mode()))
@@ -220,8 +241,10 @@ public class EsqlSession {
                 .stream()
                 .map(ResolvedEnrichPolicy::matchField)
                 .collect(Collectors.toSet());
-            preAnalyzeIndices(parsed, l.delegateFailureAndWrap((ll, indexResolution) -> {
+            preAnalyzeIndices(parsed, executionInfo, l.delegateFailureAndWrap((ll, indexResolution) -> {
                 if (indexResolution.isValid()) {
+                    updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
+                    updateExecutionInfoWithUnavailableClusters(executionInfo, indexResolution.getUnavailableClusters());
                     Set<String> newClusters = enrichPolicyResolver.groupIndicesPerCluster(
                         indexResolution.get().concreteIndices().toArray(String[]::new)
                     ).keySet();
@@ -242,7 +265,51 @@ public class EsqlSession {
         }));
     }
 
-    private void preAnalyzeIndices(LogicalPlan parsed, ActionListener<IndexResolution> listener, Set<String> enrichPolicyMatchFields) {
+    // visible for testing
+    static void updateExecutionInfoWithUnavailableClusters(EsqlExecutionInfo executionInfo, Set<String> unavailableClusters) {
+        for (String clusterAlias : unavailableClusters) {
+            executionInfo.swapCluster(
+                clusterAlias,
+                (k, v) -> new EsqlExecutionInfo.Cluster.Builder(v).setStatus(EsqlExecutionInfo.Cluster.Status.SKIPPED).build()
+            );
+            // TODO: follow-on PR will set SKIPPED status when skip_unavailable=true and throw an exception when skip_un=false
+        }
+    }
+
+    // visible for testing
+    static void updateExecutionInfoWithClustersWithNoMatchingIndices(EsqlExecutionInfo executionInfo, IndexResolution indexResolution) {
+        Set<String> clustersWithResolvedIndices = new HashSet<>();
+        // determine missing clusters
+        for (String indexName : indexResolution.get().indexNameWithModes().keySet()) {
+            clustersWithResolvedIndices.add(RemoteClusterAware.parseClusterAlias(indexName));
+        }
+        Set<String> clustersRequested = executionInfo.clusterAliases();
+        Set<String> clustersWithNoMatchingIndices = Sets.difference(clustersRequested, clustersWithResolvedIndices);
+        /*
+         * These are clusters in the original request that are not present in the field-caps response. They were
+         * specified with an index or indices that do not exist, so the search on that cluster is done.
+         * Mark it as SKIPPED with 0 shards searched and took=0.
+         */
+        for (String c : clustersWithNoMatchingIndices) {
+            executionInfo.swapCluster(
+                c,
+                (k, v) -> new EsqlExecutionInfo.Cluster.Builder(v).setStatus(EsqlExecutionInfo.Cluster.Status.SKIPPED)
+                    .setTook(new TimeValue(0))
+                    .setTotalShards(0)
+                    .setSuccessfulShards(0)
+                    .setSkippedShards(0)
+                    .setFailedShards(0)
+                    .build()
+            );
+        }
+    }
+
+    private void preAnalyzeIndices(
+        LogicalPlan parsed,
+        EsqlExecutionInfo executionInfo,
+        ActionListener<IndexResolution> listener,
+        Set<String> enrichPolicyMatchFields
+    ) {
         PreAnalyzer.PreAnalysis preAnalysis = new PreAnalyzer().preAnalyze(parsed);
         // TODO we plan to support joins in the future when possible, but for now we'll just fail early if we see one
         if (preAnalysis.indices.size() > 1) {
@@ -252,6 +319,16 @@ public class EsqlSession {
             TableInfo tableInfo = preAnalysis.indices.get(0);
             TableIdentifier table = tableInfo.id();
             var fieldNames = fieldNames(parsed, enrichPolicyMatchFields);
+
+            Map<String, OriginalIndices> clusterIndices = indicesExpressionGrouper.groupIndices(IndicesOptions.DEFAULT, table.index());
+            for (Map.Entry<String, OriginalIndices> entry : clusterIndices.entrySet()) {
+                final String clusterAlias = entry.getKey();
+                String indexExpr = Strings.arrayToCommaDelimitedString(entry.getValue().indices());
+                executionInfo.swapCluster(clusterAlias, (k, v) -> {
+                    assert v == null : "No cluster for " + clusterAlias + " should have been added to ExecutionInfo yet";
+                    return new EsqlExecutionInfo.Cluster(clusterAlias, indexExpr, executionInfo.isSkipUnavailable(clusterAlias));
+                });
+            }
             indexResolver.resolveAsMergedMapping(table.index(), fieldNames, listener);
         } else {
             try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Result.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/Result.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.session;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverProfile;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
@@ -25,5 +27,6 @@ import java.util.List;
  *                 are quite cheap to build, so we build them for all ESQL runs, regardless of if
  *                 users have asked for them. But we only include them in the results if users ask
  *                 for them.
+ * @param executionInfo Metadata about the execution of this query. Used for cross cluster queries.
  */
-public record Result(List<Attribute> schema, List<Page> pages, List<DriverProfile> profiles) {}
+public record Result(List<Attribute> schema, List<Page> pages, List<DriverProfile> profiles, @Nullable EsqlExecutionInfo executionInfo) {}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.CsvTestUtils.ActualResults;
 import org.elasticsearch.xpack.esql.CsvTestUtils.Type;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
@@ -423,7 +424,8 @@ public class CsvTests extends ESTestCase {
             new LogicalPlanOptimizer(new LogicalOptimizerContext(configuration)),
             mapper,
             TEST_VERIFIER,
-            new PlanningMetrics()
+            new PlanningMetrics(),
+            null
         );
         TestPhysicalOperationProviders physicalOperationProviders = testOperationProviders(testDataset);
 
@@ -431,6 +433,7 @@ public class CsvTests extends ESTestCase {
 
         session.executeOptimizedPlan(
             new EsqlQueryRequest(),
+            new EsqlExecutionInfo(),
             runPhase(bigArrays, physicalOperationProviders),
             session.optimizedPlan(analyzed),
             listener.delegateFailureAndWrap(
@@ -567,6 +570,6 @@ public class CsvTests extends ESTestCase {
             }
         };
         listener = ActionListener.releaseAfter(listener, () -> Releasables.close(drivers));
-        runner.runToCompletion(drivers, listener.map(ignore -> new Result(physicalPlan.output(), collectedPages, List.of())));
+        runner.runToCompletion(drivers, listener.map(ignore -> new Result(physicalPlan.output(), collectedPages, List.of(), null)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
@@ -33,9 +34,12 @@ import org.elasticsearch.compute.operator.DriverSleeps;
 import org.elasticsearch.compute.operator.DriverStatus;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
+import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.InstantiatingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -57,10 +61,13 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.ChunkedToXContent.wrapAsToXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryResponse.DROP_NULL_COLUMNS_OPTION;
@@ -123,7 +130,41 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
             id = randomAlphaOfLengthBetween(1, 16);
             isRunning = randomBoolean();
         }
-        return new EsqlQueryResponse(columns, values, profile, columnar, id, isRunning, async);
+        return new EsqlQueryResponse(columns, values, profile, columnar, id, isRunning, async, createExecutionInfo());
+    }
+
+    EsqlExecutionInfo createExecutionInfo() {
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+        executionInfo.overallTook(new TimeValue(5000));
+        executionInfo.swapCluster(
+            "",
+            (k, v) -> new EsqlExecutionInfo.Cluster(
+                "",
+                "logs-1",
+                false,
+                EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                10,
+                10,
+                3,
+                0,
+                new TimeValue(4444L)
+            )
+        );
+        executionInfo.swapCluster(
+            "remote1",
+            (k, v) -> new EsqlExecutionInfo.Cluster(
+                "remote1",
+                "remote1:logs-1",
+                true,
+                EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                12,
+                12,
+                5,
+                0,
+                new TimeValue(4999L)
+            )
+        );
+        return executionInfo;
     }
 
     private ColumnInfoImpl randomColumnInfo() {
@@ -205,21 +246,30 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 List<ColumnInfoImpl> cols = new ArrayList<>(instance.columns());
                 // keep the type the same so the values are still valid but change the name
                 cols.set(mutCol, new ColumnInfoImpl(cols.get(mutCol).name() + "mut", cols.get(mutCol).type()));
-                yield new EsqlQueryResponse(cols, deepCopyOfPages(instance), instance.profile(), instance.columnar(), instance.isAsync());
+                yield new EsqlQueryResponse(
+                    cols,
+                    deepCopyOfPages(instance),
+                    instance.profile(),
+                    instance.columnar(),
+                    instance.isAsync(),
+                    instance.getExecutionInfo()
+                );
             }
             case 1 -> new EsqlQueryResponse(
                 instance.columns(),
                 deepCopyOfPages(instance),
                 instance.profile(),
                 false == instance.columnar(),
-                instance.isAsync()
+                instance.isAsync(),
+                instance.getExecutionInfo()
             );
             case 2 -> new EsqlQueryResponse(
                 instance.columns(),
                 deepCopyOfPages(instance),
                 randomValueOtherThan(instance.profile(), this::randomProfile),
                 instance.columnar(),
-                instance.isAsync()
+                instance.isAsync(),
+                instance.getExecutionInfo()
             );
             case 3 -> {
                 int noPages = instance.pages().size();
@@ -233,7 +283,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                     differentPages,
                     instance.profile(),
                     instance.columnar(),
-                    instance.isAsync()
+                    instance.isAsync(),
+                    instance.getExecutionInfo()
                 );
             }
             default -> throw new IllegalArgumentException();
@@ -288,8 +339,10 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 IS_RUNNING,
                 ObjectParser.ValueType.BOOLEAN_OR_NULL
             );
+            parser.declareInt(constructorArg(), new ParseField("took"));
             parser.declareObjectArray(constructorArg(), (p, c) -> ColumnInfoImpl.fromXContent(p), new ParseField("columns"));
             parser.declareField(constructorArg(), (p, c) -> p.list(), new ParseField("values"), ObjectParser.ValueType.OBJECT_ARRAY);
+            parser.declareObject(optionalConstructorArg(), (p, c) -> parseClusters(p), new ParseField("_clusters"));
             PARSER = parser.build();
         }
 
@@ -300,9 +353,12 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         public ResponseBuilder(
             @Nullable String asyncExecutionId,
             Boolean isRunning,
+            Integer took,
             List<ColumnInfoImpl> columns,
-            List<List<Object>> values
+            List<List<Object>> values,
+            EsqlExecutionInfo executionInfo
         ) {
+            executionInfo.overallTook(new TimeValue(took));
             this.response = new EsqlQueryResponse(
                 columns,
                 List.of(valuesToPage(TestBlockFactory.getNonBreakingInstance(), columns, values)),
@@ -310,7 +366,138 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 false,
                 asyncExecutionId,
                 isRunning != null,
-                isAsync(asyncExecutionId, isRunning)
+                isAsync(asyncExecutionId, isRunning),
+                executionInfo
+            );
+        }
+
+        static EsqlExecutionInfo parseClusters(XContentParser parser) throws IOException {
+            XContentParser.Token token = parser.currentToken();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
+            int total = -1;
+            int successful = -1;
+            int skipped = -1;
+            int running = 0;
+            int partial = 0;
+            int failed = 0;
+            ConcurrentMap<String, EsqlExecutionInfo.Cluster> clusterInfoMap = ConcurrentCollections.newConcurrentMap();
+            String currentFieldName = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (EsqlExecutionInfo.TOTAL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        total = parser.intValue();
+                    } else if (EsqlExecutionInfo.SUCCESSFUL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        successful = parser.intValue();
+                    } else if (EsqlExecutionInfo.SKIPPED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        skipped = parser.intValue();
+                    } else if (EsqlExecutionInfo.RUNNING_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        running = parser.intValue();
+                    } else if (EsqlExecutionInfo.PARTIAL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        partial = parser.intValue();
+                    } else if (EsqlExecutionInfo.FAILED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        failed = parser.intValue();
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    if (EsqlExecutionInfo.DETAILS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        String currentDetailsFieldName = null;
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                            if (token == XContentParser.Token.FIELD_NAME) {
+                                currentDetailsFieldName = parser.currentName();  // cluster alias
+                                if (currentDetailsFieldName.equals(EsqlExecutionInfo.LOCAL_CLUSTER_NAME_REPRESENTATION)) {
+                                    currentDetailsFieldName = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+                                }
+                            } else if (token == XContentParser.Token.START_OBJECT) {
+                                EsqlExecutionInfo.Cluster c = parseCluster(currentDetailsFieldName, parser);
+                                clusterInfoMap.put(currentDetailsFieldName, c);
+                            } else {
+                                parser.skipChildren();
+                            }
+                        }
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else {
+                    parser.skipChildren();
+                }
+            }
+            if (clusterInfoMap.isEmpty()) {
+                return new EsqlExecutionInfo();
+            } else {
+                return new EsqlExecutionInfo(clusterInfoMap);
+            }
+        }
+
+        private static EsqlExecutionInfo.Cluster parseCluster(String clusterAlias, XContentParser parser) throws IOException {
+            XContentParser.Token token = parser.currentToken();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
+
+            String indexExpression = null;
+            String status = "running";
+            long took = -1L;
+            // these are all from the _shards section
+            int totalShards = -1;
+            int successfulShards = -1;
+            int skippedShards = -1;
+            int failedShards = -1;
+
+            String currentFieldName = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (EsqlExecutionInfo.Cluster.INDICES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        indexExpression = parser.text();
+                    } else if (EsqlExecutionInfo.Cluster.STATUS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        status = parser.text();
+                    } else if (EsqlExecutionInfo.TOOK.match(currentFieldName, parser.getDeprecationHandler())) {
+                        took = parser.longValue();
+                    } else {
+                        parser.skipChildren();
+                    }
+                } else if (RestActions._SHARDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                        if (token == XContentParser.Token.FIELD_NAME) {
+                            currentFieldName = parser.currentName();
+                        } else if (token.isValue()) {
+                            if (RestActions.FAILED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                                failedShards = parser.intValue();
+                            } else if (RestActions.SUCCESSFUL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                                successfulShards = parser.intValue();
+                            } else if (RestActions.TOTAL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                                totalShards = parser.intValue();
+                            } else if (RestActions.SKIPPED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                                skippedShards = parser.intValue();
+                            } else {
+                                parser.skipChildren();
+                            }
+                        } else {
+                            parser.skipChildren();
+                        }
+                    }
+                } else {
+                    parser.skipChildren();
+                }
+            }
+
+            Integer totalShardsFinal = totalShards == -1 ? null : totalShards;
+            Integer successfulShardsFinal = successfulShards == -1 ? null : successfulShards;
+            Integer skippedShardsFinal = skippedShards == -1 ? null : skippedShards;
+            Integer failedShardsFinal = failedShards == -1 ? null : failedShards;
+            TimeValue tookTimeValue = took == -1L ? null : new TimeValue(took);
+            return new EsqlExecutionInfo.Cluster(
+                clusterAlias,
+                indexExpression,
+                true,
+                EsqlExecutionInfo.Cluster.Status.valueOf(status.toUpperCase(Locale.ROOT)),
+                totalShardsFinal,
+                successfulShardsFinal,
+                skippedShardsFinal,
+                failedShardsFinal,
+                tookTimeValue
             );
         }
 
@@ -327,27 +514,29 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
     }
 
     public void testChunkResponseSizeColumnar() {
+        int sizeClusterDetails = 14;
         try (EsqlQueryResponse resp = randomResponse(true, null)) {
             int columnCount = resp.pages().get(0).getBlockCount();
             int bodySize = resp.pages().stream().mapToInt(p -> p.getPositionCount() * p.getBlockCount()).sum() + columnCount * 2;
-            assertChunkCount(resp, r -> 5 + bodySize);
+            assertChunkCount(resp, r -> 5 + sizeClusterDetails + bodySize);
         }
 
         try (EsqlQueryResponse resp = randomResponseAsync(true, null, true)) {
             int columnCount = resp.pages().get(0).getBlockCount();
             int bodySize = resp.pages().stream().mapToInt(p -> p.getPositionCount() * p.getBlockCount()).sum() + columnCount * 2;
-            assertChunkCount(resp, r -> 6 + bodySize); // is_running
+            assertChunkCount(resp, r -> 6 + sizeClusterDetails + bodySize); // is_running
         }
     }
 
     public void testChunkResponseSizeRows() {
+        int sizeClusterDetails = 14;
         try (EsqlQueryResponse resp = randomResponse(false, null)) {
             int bodySize = resp.pages().stream().mapToInt(p -> p.getPositionCount()).sum();
-            assertChunkCount(resp, r -> 5 + bodySize);
+            assertChunkCount(resp, r -> 5 + sizeClusterDetails + bodySize);
         }
         try (EsqlQueryResponse resp = randomResponseAsync(false, null, true)) {
             int bodySize = resp.pages().stream().mapToInt(p -> p.getPositionCount()).sum();
-            assertChunkCount(resp, r -> 6 + bodySize);
+            assertChunkCount(resp, r -> 6 + sizeClusterDetails + bodySize);
         }
     }
 
@@ -398,7 +587,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 false,
                 "id-123",
                 true,
-                true
+                true,
+                null
             )
         ) {
             assertThat(Strings.toString(response), equalTo("""
@@ -415,7 +605,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 false,
                 null,
                 false,
-                false
+                false,
+                null
             )
         ) {
             assertThat(
@@ -444,7 +635,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                     false,
                     null,
                     false,
-                    false
+                    false,
+                    null
                 )
             ) {
                 assertThat(
@@ -468,7 +660,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
             List.of(new Page(blockFactory.newIntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
             null,
             columnar,
-            async
+            async,
+            null
         );
     }
 
@@ -491,7 +684,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                     )
                 ),
                 false,
-                false
+                false,
+                null
             );
         ) {
             assertThat(Strings.toString(response, true, false), equalTo("""
@@ -552,7 +746,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         var longBlk2 = blockFactory.newLongArrayVector(new long[] { 300L, 400L, 500L }, 3).asBlock();
         var columnInfo = List.of(new ColumnInfoImpl("foo", "integer"), new ColumnInfoImpl("bar", "long"));
         var pages = List.of(new Page(intBlk1, longBlk1), new Page(intBlk2, longBlk2));
-        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false)) {
+        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false, null)) {
             assertThat(columnValues(response.column(0)), contains(10, 20, 30, 40, 50));
             assertThat(columnValues(response.column(1)), contains(100L, 200L, 300L, 400L, 500L));
             expectThrows(IllegalArgumentException.class, () -> response.column(-1));
@@ -564,7 +758,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         var intBlk1 = blockFactory.newIntArrayVector(new int[] { 10 }, 1).asBlock();
         var columnInfo = List.of(new ColumnInfoImpl("foo", "integer"));
         var pages = List.of(new Page(intBlk1));
-        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false)) {
+        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false, null)) {
             expectThrows(IllegalArgumentException.class, () -> response.column(-1));
             expectThrows(IllegalArgumentException.class, () -> response.column(1));
         }
@@ -583,7 +777,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         }
         var columnInfo = List.of(new ColumnInfoImpl("foo", "integer"));
         var pages = List.of(new Page(blk1), new Page(blk2), new Page(blk3));
-        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false)) {
+        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false, null)) {
             assertThat(columnValues(response.column(0)), contains(10, null, 30, null, null, 60, null, 80, 90, null));
             expectThrows(IllegalArgumentException.class, () -> response.column(-1));
             expectThrows(IllegalArgumentException.class, () -> response.column(2));
@@ -603,7 +797,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         }
         var columnInfo = List.of(new ColumnInfoImpl("foo", "integer"));
         var pages = List.of(new Page(blk1), new Page(blk2), new Page(blk3));
-        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false)) {
+        try (var response = new EsqlQueryResponse(columnInfo, pages, null, false, null, false, false, null)) {
             assertThat(columnValues(response.column(0)), contains(List.of(10, 20), null, List.of(40, 50), null, 70, 80, null));
             expectThrows(IllegalArgumentException.class, () -> response.column(-1));
             expectThrows(IllegalArgumentException.class, () -> response.column(2));
@@ -616,7 +810,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
             List<ColumnInfoImpl> columns = randomList(numColumns, numColumns, this::randomColumnInfo);
             int noPages = randomIntBetween(1, 20);
             List<Page> pages = randomList(noPages, noPages, () -> randomPage(columns));
-            try (var resp = new EsqlQueryResponse(columns, pages, null, false, "", false, false)) {
+            try (var resp = new EsqlQueryResponse(columns, pages, null, false, "", false, false, null)) {
                 var rowValues = getValuesList(resp.rows());
                 var valValues = getValuesList(resp.values());
                 for (int i = 0; i < rowValues.size(); i++) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/AbstractConfigurationFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/AbstractConfigurationFunctionTestCase.java
@@ -42,7 +42,8 @@ public abstract class AbstractConfigurationFunctionTestCase extends AbstractScal
             EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
             StringUtils.EMPTY,
             randomBoolean(),
-            Map.of()
+            Map.of(),
+            System.nanoTime()
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToLowerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToLowerTests.java
@@ -68,7 +68,8 @@ public class ToLowerTests extends AbstractConfigurationFunctionTestCase {
             EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
             "",
             false,
-            Map.of()
+            Map.of(),
+            System.nanoTime()
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToUpperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToUpperTests.java
@@ -68,7 +68,8 @@ public class ToUpperTests extends AbstractConfigurationFunctionTestCase {
             EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
             "",
             false,
-            Map.of()
+            Map.of(),
+            System.nanoTime()
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
@@ -241,12 +241,12 @@ public class TextFormatTests extends ESTestCase {
     public void testPlainTextEmptyCursorWithoutColumns() {
         assertEquals(
             StringUtils.EMPTY,
-            getTextBodyContent(PLAIN_TEXT.format(req(), new EsqlQueryResponse(emptyList(), emptyList(), null, false, false)))
+            getTextBodyContent(PLAIN_TEXT.format(req(), new EsqlQueryResponse(emptyList(), emptyList(), null, false, false, null)))
         );
     }
 
     private static EsqlQueryResponse emptyData() {
-        return new EsqlQueryResponse(singletonList(new ColumnInfoImpl("name", "keyword")), emptyList(), null, false, false);
+        return new EsqlQueryResponse(singletonList(new ColumnInfoImpl("name", "keyword")), emptyList(), null, false, false, null);
     }
 
     private static EsqlQueryResponse regularData() {
@@ -278,7 +278,7 @@ public class TextFormatTests extends ESTestCase {
             )
         );
 
-        return new EsqlQueryResponse(headers, values, null, false, false);
+        return new EsqlQueryResponse(headers, values, null, false, false, null);
     }
 
     private static EsqlQueryResponse escapedData() {
@@ -299,7 +299,7 @@ public class TextFormatTests extends ESTestCase {
             )
         );
 
-        return new EsqlQueryResponse(headers, values, null, false, false);
+        return new EsqlQueryResponse(headers, values, null, false, false, null);
     }
 
     private static RestRequest req() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
 import org.elasticsearch.xpack.esql.action.ColumnInfoImpl;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 
 import java.util.Arrays;
@@ -80,7 +81,8 @@ public class TextFormatterTests extends ESTestCase {
         ),
         null,
         randomBoolean(),
-        randomBoolean()
+        randomBoolean(),
+        new EsqlExecutionInfo()
     );
 
     TextFormatter formatter = new TextFormatter(esqlResponse);
@@ -154,7 +156,8 @@ public class TextFormatterTests extends ESTestCase {
             ),
             null,
             randomBoolean(),
-            randomBoolean()
+            randomBoolean(),
+            new EsqlExecutionInfo()
         );
 
         String[] result = getTextBodyContent(new TextFormatter(response).format(false)).split("\n");
@@ -194,7 +197,8 @@ public class TextFormatterTests extends ESTestCase {
                         ),
                         null,
                         randomBoolean(),
-                        randomBoolean()
+                        randomBoolean(),
+                        new EsqlExecutionInfo()
                     )
                 ).format(false)
             )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EvalMapperTests.java
@@ -75,7 +75,8 @@ public class EvalMapperTests extends ESTestCase {
         10000,
         StringUtils.EMPTY,
         false,
-        Map.of()
+        Map.of(),
+        System.nanoTime()
     );
 
     @ParametersFactory(argumentFormatting = "%1$s")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -146,7 +146,8 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             EsqlPlugin.QUERY_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(null),
             StringUtils.EMPTY,
             false,
-            Map.of()
+            Map.of(),
+            System.nanoTime()
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
@@ -27,7 +27,9 @@ import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
@@ -48,8 +50,10 @@ import java.util.stream.IntStream;
 import static org.elasticsearch.test.tasks.MockTaskManager.SPY_TASK_MANAGER_SETTING;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -89,7 +93,7 @@ public class ComputeListenerTests extends ESTestCase {
         );
     }
 
-    private ComputeResponse randomResponse() {
+    private ComputeResponse randomResponse(boolean includeExecutionInfo) {
         int numProfiles = randomIntBetween(0, 2);
         List<DriverProfile> profiles = new ArrayList<>(numProfiles);
         for (int i = 0; i < numProfiles; i++) {
@@ -105,12 +109,33 @@ public class ComputeListenerTests extends ESTestCase {
                 )
             );
         }
-        return new ComputeResponse(profiles);
+        if (includeExecutionInfo) {
+            return new ComputeResponse(
+                profiles,
+                new TimeValue(randomLongBetween(0, 50000), TimeUnit.NANOSECONDS),
+                10,
+                10,
+                randomIntBetween(0, 3),
+                0
+            );
+        } else {
+            return new ComputeResponse(profiles);
+        }
     }
 
     public void testEmpty() {
         PlainActionFuture<ComputeResponse> results = new PlainActionFuture<>();
-        try (ComputeListener ignored = new ComputeListener(transportService, newTask(), results)) {
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+        try (
+            ComputeListener ignored = ComputeListener.create(
+                RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
+                transportService,
+                newTask(),
+                executionInfo,
+                System.nanoTime(),
+                results
+            )
+        ) {
             assertFalse(results.isDone());
         }
         assertTrue(results.isDone());
@@ -120,7 +145,17 @@ public class ComputeListenerTests extends ESTestCase {
     public void testCollectComputeResults() {
         PlainActionFuture<ComputeResponse> future = new PlainActionFuture<>();
         List<DriverProfile> allProfiles = new ArrayList<>();
-        try (ComputeListener computeListener = new ComputeListener(transportService, newTask(), future)) {
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+        try (
+            ComputeListener computeListener = ComputeListener.create(
+                RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
+                transportService,
+                newTask(),
+                executionInfo,
+                System.nanoTime(),
+                future
+            )
+        ) {
             int tasks = randomIntBetween(1, 100);
             for (int t = 0; t < tasks; t++) {
                 if (randomBoolean()) {
@@ -131,7 +166,7 @@ public class ComputeListenerTests extends ESTestCase {
                         threadPool.generic()
                     );
                 } else {
-                    ComputeResponse resp = randomResponse();
+                    ComputeResponse resp = randomResponse(false);
                     allProfiles.addAll(resp.getProfiles());
                     ActionListener<ComputeResponse> subListener = computeListener.acquireCompute();
                     threadPool.schedule(
@@ -142,11 +177,188 @@ public class ComputeListenerTests extends ESTestCase {
                 }
             }
         }
-        ComputeResponse result = future.actionGet(10, TimeUnit.SECONDS);
+        ComputeResponse response = future.actionGet(10, TimeUnit.SECONDS);
         assertThat(
-            result.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
+            response.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
             equalTo(allProfiles.stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)))
         );
+        Mockito.verifyNoInteractions(transportService.getTaskManager());
+    }
+
+    /**
+     * Tests the acquireCompute functionality running on the querying ("local") cluster, that is waiting upon
+     * a ComputeResponse from a remote cluster. The acquireCompute code under test should fill in the
+     * {@link EsqlExecutionInfo.Cluster} with the information in the ComputeResponse from the remote cluster.
+     */
+    public void testAcquireComputeCCSListener() {
+        PlainActionFuture<ComputeResponse> future = new PlainActionFuture<>();
+        List<DriverProfile> allProfiles = new ArrayList<>();
+        String remoteAlias = "rc1";
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+        executionInfo.swapCluster(remoteAlias, (k, v) -> new EsqlExecutionInfo.Cluster(remoteAlias, "logs*", false));
+        try (
+            ComputeListener computeListener = ComputeListener.create(
+                // 'whereRunning' for this test is the local cluster, waiting for a response from the remote cluster
+                RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
+                transportService,
+                newTask(),
+                executionInfo,
+                System.nanoTime(),
+                future
+            )
+        ) {
+            int tasks = randomIntBetween(1, 5);
+            for (int t = 0; t < tasks; t++) {
+                ComputeResponse resp = randomResponse(true);
+                allProfiles.addAll(resp.getProfiles());
+                // Use remoteAlias here to indicate what remote cluster alias the listener is waiting to hear back from
+                ActionListener<ComputeResponse> subListener = computeListener.acquireCompute(remoteAlias);
+                threadPool.schedule(
+                    ActionRunnable.wrap(subListener, l -> l.onResponse(resp)),
+                    TimeValue.timeValueNanos(between(0, 100)),
+                    threadPool.generic()
+                );
+            }
+        }
+        ComputeResponse response = future.actionGet(10, TimeUnit.SECONDS);
+        assertThat(
+            response.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
+            equalTo(allProfiles.stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)))
+        );
+
+        assertTrue(executionInfo.isCrossClusterSearch());
+        EsqlExecutionInfo.Cluster rc1Cluster = executionInfo.getCluster(remoteAlias);
+        assertThat(rc1Cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+        assertThat(rc1Cluster.getTotalShards(), equalTo(10));
+        assertThat(rc1Cluster.getSuccessfulShards(), equalTo(10));
+        assertThat(rc1Cluster.getSkippedShards(), greaterThanOrEqualTo(0));
+        assertThat(rc1Cluster.getSkippedShards(), lessThanOrEqualTo(3));
+        assertThat(rc1Cluster.getFailedShards(), equalTo(0));
+        assertThat(rc1Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+
+        Mockito.verifyNoInteractions(transportService.getTaskManager());
+    }
+
+    /**
+     * Run an acquireCompute cycle on the RemoteCluster.
+     * AcquireCompute will fill in the took time on the EsqlExecutionInfo (the shard info is filled in before this,
+     * so we just hard code them in the Cluster in this test) and then a ComputeResponse will be created in the refs
+     * listener and returned with the shard and took time info.
+     */
+    public void testAcquireComputeRunningOnRemoteClusterFillsInTookTime() {
+        PlainActionFuture<ComputeResponse> future = new PlainActionFuture<>();
+        List<DriverProfile> allProfiles = new ArrayList<>();
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+        String remoteAlias = "rc1";
+        executionInfo.swapCluster(
+            remoteAlias,
+            (k, v) -> new EsqlExecutionInfo.Cluster(
+                remoteAlias,
+                "logs*",
+                false,
+                EsqlExecutionInfo.Cluster.Status.RUNNING,
+                10,
+                10,
+                3,
+                0,
+                null  // to be filled in the acquireCompute listener
+            )
+        );
+        try (
+            ComputeListener computeListener = ComputeListener.create(
+                // whereRunning=remoteAlias simulates running on the remote cluster
+                remoteAlias,
+                transportService,
+                newTask(),
+                executionInfo,
+                System.nanoTime(),
+                future
+            )
+        ) {
+            int tasks = randomIntBetween(1, 5);
+            for (int t = 0; t < tasks; t++) {
+                ComputeResponse resp = randomResponse(true);
+                allProfiles.addAll(resp.getProfiles());
+                ActionListener<ComputeResponse> subListener = computeListener.acquireCompute(remoteAlias);
+                threadPool.schedule(
+                    ActionRunnable.wrap(subListener, l -> l.onResponse(resp)),
+                    TimeValue.timeValueNanos(between(0, 100)),
+                    threadPool.generic()
+                );
+            }
+        }
+        ComputeResponse response = future.actionGet(10, TimeUnit.SECONDS);
+        assertThat(
+            response.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
+            equalTo(allProfiles.stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)))
+        );
+        assertThat(response.getTotalShards(), equalTo(10));
+        assertThat(response.getSuccessfulShards(), equalTo(10));
+        assertThat(response.getSkippedShards(), equalTo(3));
+        assertThat(response.getFailedShards(), equalTo(0));
+        // check that the took time was filled in on the ExecutionInfo for the remote cluster and put into the ComputeResponse to be
+        // sent back to the querying cluster
+        assertThat(response.getTook().millis(), greaterThanOrEqualTo(0L));
+        assertThat(executionInfo.getCluster(remoteAlias).getTook().millis(), greaterThanOrEqualTo(0L));
+        assertThat(executionInfo.getCluster(remoteAlias).getTook(), equalTo(response.getTook()));
+
+        // the status in the (remote) executionInfo will still be RUNNING, since the SUCCESSFUL status gets set on the querying
+        // cluster executionInfo in the acquireCompute CCS listener, NOT present in this test - see testCollectComputeResultsInCCSListener
+        assertThat(executionInfo.getCluster(remoteAlias).getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.RUNNING));
+
+        Mockito.verifyNoInteractions(transportService.getTaskManager());
+    }
+
+    /**
+     * Run an acquireCompute cycle on the RemoteCluster.
+     * AcquireCompute will fill in the took time on the EsqlExecutionInfo (the shard info is filled in before this,
+     * so we just hard code them in the Cluster in this test) and then a ComputeResponse will be created in the refs
+     * listener and returned with the shard and took time info.
+     */
+    public void testAcquireComputeRunningOnQueryingClusterFillsInTookTime() {
+        PlainActionFuture<ComputeResponse> future = new PlainActionFuture<>();
+        List<DriverProfile> allProfiles = new ArrayList<>();
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+        String localCluster = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        // we need a remote cluster in the ExecutionInfo in order to simulate a CCS, since ExecutionInfo is only
+        // fully filled in for cross-cluster searches
+        executionInfo.swapCluster(localCluster, (k, v) -> new EsqlExecutionInfo.Cluster(localCluster, "logs*", false));
+        executionInfo.swapCluster("my_remote", (k, v) -> new EsqlExecutionInfo.Cluster("my_remote", "my_remote:logs*", false));
+        try (
+            ComputeListener computeListener = ComputeListener.create(
+                // whereRunning=localCluster simulates running on the querying cluster
+                localCluster,
+                transportService,
+                newTask(),
+                executionInfo,
+                System.nanoTime(),
+                future
+            )
+        ) {
+            int tasks = randomIntBetween(1, 5);
+            for (int t = 0; t < tasks; t++) {
+                ComputeResponse resp = randomResponse(true);
+                allProfiles.addAll(resp.getProfiles());
+                ActionListener<ComputeResponse> subListener = computeListener.acquireCompute(localCluster);
+                threadPool.schedule(
+                    ActionRunnable.wrap(subListener, l -> l.onResponse(resp)),
+                    TimeValue.timeValueNanos(between(0, 100)),
+                    threadPool.generic()
+                );
+            }
+        }
+        ComputeResponse response = future.actionGet(10, TimeUnit.SECONDS);
+        assertThat(
+            response.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
+            equalTo(allProfiles.stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)))
+        );
+        // check that the took time was filled in on the ExecutionInfo for the remote cluster and put into the ComputeResponse to be
+        // sent back to the querying cluster
+        assertNull("took time is not added to the ComputeResponse on the querying cluster", response.getTook());
+        assertThat(executionInfo.getCluster(localCluster).getTook().millis(), greaterThanOrEqualTo(0L));
+        // once all the took times have been gathered from the tasks, the refs callback will set execution status to SUCCESSFUL
+        assertThat(executionInfo.getCluster(localCluster).getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+
         Mockito.verifyNoInteractions(transportService.getTaskManager());
     }
 
@@ -160,11 +372,21 @@ public class ComputeListenerTests extends ESTestCase {
         int failedTasks = between(1, 100);
         PlainActionFuture<ComputeResponse> rootListener = new PlainActionFuture<>();
         CancellableTask rootTask = newTask();
-        try (ComputeListener computeListener = new ComputeListener(transportService, rootTask, rootListener)) {
+        EsqlExecutionInfo execInfo = new EsqlExecutionInfo();
+        try (
+            ComputeListener computeListener = ComputeListener.create(
+                RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
+                transportService,
+                rootTask,
+                execInfo,
+                System.nanoTime(),
+                rootListener
+            )
+        ) {
             for (int i = 0; i < successTasks; i++) {
                 ActionListener<ComputeResponse> subListener = computeListener.acquireCompute();
                 threadPool.schedule(
-                    ActionRunnable.wrap(subListener, l -> l.onResponse(randomResponse())),
+                    ActionRunnable.wrap(subListener, l -> l.onResponse(randomResponse(false))),
                     TimeValue.timeValueNanos(between(0, 100)),
                     threadPool.generic()
                 );
@@ -214,10 +436,14 @@ public class ComputeListenerTests extends ESTestCase {
             }
         };
         CountDownLatch latch = new CountDownLatch(1);
+        EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
         try (
-            ComputeListener computeListener = new ComputeListener(
+            ComputeListener computeListener = ComputeListener.create(
+                RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY,
                 transportService,
                 newTask(),
+                executionInfo,
+                System.nanoTime(),
                 ActionListener.runAfter(rootListener, latch::countDown)
             )
         ) {
@@ -231,7 +457,7 @@ public class ComputeListenerTests extends ESTestCase {
                         threadPool.generic()
                     );
                 } else {
-                    ComputeResponse resp = randomResponse();
+                    ComputeResponse resp = randomResponse(false);
                     allProfiles.addAll(resp.getProfiles());
                     int numWarnings = randomIntBetween(1, 5);
                     Map<String, String> warnings = new HashMap<>();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/ConfigurationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/ConfigurationSerializationTests.java
@@ -102,7 +102,8 @@ public class ConfigurationSerializationTests extends AbstractWireSerializingTest
             resultTruncationDefaultSize,
             query,
             profile,
-            tables
+            tables,
+            System.nanoTime()
         );
 
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.session;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.index.IndexResolution;
+import org.elasticsearch.xpack.esql.type.EsFieldTests;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class EsqlSessionTests extends ESTestCase {
+
+    public void testUpdateExecutionInfoWithUnavailableClusters() {
+        // skip_unavailable=true clusters are unavailable, both marked as SKIPPED
+        {
+            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            final String remote1Alias = "remote1";
+            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", true));
+
+            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Set.of(remote1Alias, remote2Alias));
+
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(localClusterAlias, remote1Alias, remote2Alias)));
+            assertNull(executionInfo.overallTook());
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            assertClusterStatusAndHasNullCounts(remote1Cluster, EsqlExecutionInfo.Cluster.Status.SKIPPED);
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.SKIPPED);
+        }
+
+        // skip_unavailable=false cluster is unavailable, marked as SKIPPED // TODO: in follow on PR this will change to throwing an
+        // Exception
+        {
+            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            final String remote1Alias = "remote1";
+            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
+
+            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Set.of(remote2Alias));
+
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(localClusterAlias, remote1Alias, remote2Alias)));
+            assertNull(executionInfo.overallTook());
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            assertClusterStatusAndHasNullCounts(remote1Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.SKIPPED);
+        }
+
+        // all clusters available, no Clusters in ExecutionInfo should be modified
+        {
+            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            final String remote1Alias = "remote1";
+            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
+
+            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Set.of());
+
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(localClusterAlias, remote1Alias, remote2Alias)));
+            assertNull(executionInfo.overallTook());
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            assertClusterStatusAndHasNullCounts(remote1Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+        }
+    }
+
+    public void testUpdateExecutionInfoWithClustersWithNoMatchingIndices() {
+        // all clusters present in EsIndex, so no updates to EsqlExecutionInfo should happen
+        {
+            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            final String remote1Alias = "remote1";
+            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
+
+            EsIndex esIndex = new EsIndex(
+                "logs*,remote1:*,remote2:mylogs1,remote2:mylogs2,remote2:logs*",
+                randomMapping(),
+                Map.of(
+                    "logs-a",
+                    IndexMode.STANDARD,
+                    "remote1:logs-a",
+                    IndexMode.STANDARD,
+                    "remote2:mylogs1",
+                    IndexMode.STANDARD,
+                    "remote2:mylogs2",
+                    IndexMode.STANDARD,
+                    "remote2:logs-b",
+                    IndexMode.STANDARD
+                )
+            );
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Set.of());
+
+            EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            assertClusterStatusAndHasNullCounts(remote1Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+        }
+
+        // remote1 is missing from EsIndex info, so it should be updated and marked as SKIPPED with 0 total shards, 0 took time, etc.
+        {
+            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            final String remote1Alias = "remote1";
+            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
+
+            EsIndex esIndex = new EsIndex(
+                "logs*,remote2:mylogs1,remote2:mylogs2,remote2:logs*",
+                randomMapping(),
+                Map.of(
+                    "logs-a",
+                    IndexMode.STANDARD,
+                    "remote2:mylogs1",
+                    IndexMode.STANDARD,
+                    "remote2:mylogs2",
+                    IndexMode.STANDARD,
+                    "remote2:logs-b",
+                    IndexMode.STANDARD
+                )
+            );
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Set.of());
+
+            EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            assertThat(remote1Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            assertThat(remote1Cluster.getTook().millis(), equalTo(0L));
+            assertThat(remote1Cluster.getTotalShards(), equalTo(0));
+            assertThat(remote1Cluster.getSuccessfulShards(), equalTo(0));
+            assertThat(remote1Cluster.getSkippedShards(), equalTo(0));
+            assertThat(remote1Cluster.getFailedShards(), equalTo(0));
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+        }
+
+        // all remotes are missing from EsIndex info, so they should be updated and marked as SKIPPED with 0 total shards, 0 took time, etc.
+        {
+            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            final String remote1Alias = "remote1";
+            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
+
+            EsIndex esIndex = new EsIndex(
+                "logs*,remote2:mylogs1,remote2:mylogs2,remote2:logs*",
+                randomMapping(),
+                Map.of("logs-a", IndexMode.STANDARD)
+            );
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Set.of(remote1Alias));
+
+            EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            assertThat(remote1Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            assertThat(remote1Cluster.getTook().millis(), equalTo(0L));
+            assertThat(remote1Cluster.getTotalShards(), equalTo(0));
+            assertThat(remote1Cluster.getSuccessfulShards(), equalTo(0));
+            assertThat(remote1Cluster.getSkippedShards(), equalTo(0));
+            assertThat(remote1Cluster.getFailedShards(), equalTo(0));
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertThat(remote2Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            assertThat(remote2Cluster.getTook().millis(), equalTo(0L));
+            assertThat(remote2Cluster.getTotalShards(), equalTo(0));
+            assertThat(remote2Cluster.getSuccessfulShards(), equalTo(0));
+            assertThat(remote2Cluster.getSkippedShards(), equalTo(0));
+            assertThat(remote2Cluster.getFailedShards(), equalTo(0));
+        }
+    }
+
+    private void assertClusterStatusAndHasNullCounts(EsqlExecutionInfo.Cluster cluster, EsqlExecutionInfo.Cluster.Status status) {
+        assertThat(cluster.getStatus(), equalTo(status));
+        assertNull(cluster.getTook());
+        assertNull(cluster.getTotalShards());
+        assertNull(cluster.getSuccessfulShards());
+        assertNull(cluster.getSkippedShards());
+        assertNull(cluster.getFailedShards());
+    }
+
+    private static Map<String, EsField> randomMapping() {
+        int size = between(0, 10);
+        Map<String, EsField> result = new HashMap<>(size);
+        while (result.size() < size) {
+            result.put(randomAlphaOfLength(5), EsFieldTests.randomAnyEsField(1));
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.session;
+
+import org.apache.lucene.index.CorruptIndexException;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesFailure;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.NoSeedNodeLeftException;
+import org.elasticsearch.transport.NoSuchRemoteClusterException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexResolverTests extends ESTestCase {
+
+    public void testDetermineUnavailableRemoteClusters() {
+        // two clusters, both "remote unavailable" type exceptions
+        {
+            List<FieldCapabilitiesFailure> failures = new ArrayList<>();
+            failures.add(new FieldCapabilitiesFailure(new String[] { "remote2:mylogs1" }, new NoSuchRemoteClusterException("remote2")));
+            failures.add(
+                new FieldCapabilitiesFailure(
+                    new String[] { "remote1:foo", "remote1:bar" },
+                    new IllegalStateException("Unable to open any connections")
+                )
+            );
+
+            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters, equalTo(Set.of("remote1", "remote2")));
+        }
+
+        // one cluster with "remote unavailable" with two failures
+        {
+            List<FieldCapabilitiesFailure> failures = new ArrayList<>();
+            failures.add(new FieldCapabilitiesFailure(new String[] { "remote2:mylogs1" }, new NoSuchRemoteClusterException("remote2")));
+            failures.add(new FieldCapabilitiesFailure(new String[] { "remote2:mylogs1" }, new NoSeedNodeLeftException("no seed node")));
+
+            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters, equalTo(Set.of("remote2")));
+        }
+
+        // two clusters, one "remote unavailable" type exceptions and one with another type
+        {
+            List<FieldCapabilitiesFailure> failures = new ArrayList<>();
+            failures.add(new FieldCapabilitiesFailure(new String[] { "remote1:mylogs1" }, new CorruptIndexException("foo", "bar")));
+            failures.add(
+                new FieldCapabilitiesFailure(
+                    new String[] { "remote2:foo", "remote2:bar" },
+                    new IllegalStateException("Unable to open any connections")
+                )
+            );
+            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters, equalTo(Set.of("remote2")));
+        }
+
+        // one cluster1 with exception not known to indicate "remote unavailable"
+        {
+            List<FieldCapabilitiesFailure> failures = new ArrayList<>();
+            failures.add(new FieldCapabilitiesFailure(new String[] { "remote1:mylogs1" }, new RuntimeException("foo")));
+            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters, equalTo(Set.of()));
+        }
+
+        // empty failures list
+        {
+            List<FieldCapabilitiesFailure> failures = new ArrayList<>();
+            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters, equalTo(Set.of()));
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/PlanExecutorMetricsTests.java
@@ -8,18 +8,22 @@
 package org.elasticsearch.xpack.esql.stats;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.IndexFieldCapabilities;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.indices.IndicesExpressionGrouper;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlResolveFieldsAction;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
@@ -106,17 +110,31 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         // test a failed query: xyz field doesn't exist
         request.query("from test | stats m = max(xyz)");
         BiConsumer<PhysicalPlan, ActionListener<Result>> runPhase = (p, r) -> fail("this shouldn't happen");
-        planExecutor.esql(request, randomAlphaOfLength(10), EsqlTestUtils.TEST_CFG, enrichResolver, runPhase, new ActionListener<>() {
-            @Override
-            public void onResponse(Result result) {
-                fail("this shouldn't happen");
-            }
+        IndicesExpressionGrouper groupIndicesByCluster = (indicesOptions, indexExpressions) -> Map.of(
+            "",
+            new OriginalIndices(new String[] { "test" }, IndicesOptions.DEFAULT)
+        );
 
-            @Override
-            public void onFailure(Exception e) {
-                assertThat(e, instanceOf(VerificationException.class));
+        planExecutor.esql(
+            request,
+            randomAlphaOfLength(10),
+            EsqlTestUtils.TEST_CFG,
+            enrichResolver,
+            new EsqlExecutionInfo(),
+            groupIndicesByCluster,
+            runPhase,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Result result) {
+                    fail("this shouldn't happen");
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    assertThat(e, instanceOf(VerificationException.class));
+                }
             }
-        });
+        );
 
         // check we recorded the failure and that the query actually came
         assertEquals(1, planExecutor.metrics().stats().get("queries._all.failed"));
@@ -126,15 +144,24 @@ public class PlanExecutorMetricsTests extends ESTestCase {
         // fix the failing query: foo field does exist
         request.query("from test | stats m = max(foo)");
         runPhase = (p, r) -> r.onResponse(null);
-        planExecutor.esql(request, randomAlphaOfLength(10), EsqlTestUtils.TEST_CFG, enrichResolver, runPhase, new ActionListener<>() {
-            @Override
-            public void onResponse(Result result) {}
+        planExecutor.esql(
+            request,
+            randomAlphaOfLength(10),
+            EsqlTestUtils.TEST_CFG,
+            enrichResolver,
+            new EsqlExecutionInfo(),
+            groupIndicesByCluster,
+            runPhase,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Result result) {}
 
-            @Override
-            public void onFailure(Exception e) {
-                fail("this shouldn't happen");
+                @Override
+                public void onFailure(Exception e) {
+                    fail("this shouldn't happen");
+                }
             }
-        });
+        );
 
         // check the new metrics
         assertEquals(1, planExecutor.metrics().stats().get("queries._all.failed"));

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.StreamsUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
@@ -1062,9 +1063,14 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
                 }""");
             // {"columns":[{"name":"dv","type":"keyword"},{"name":"no_dv","type":"keyword"}],"values":[["test",null]]}
             try {
+                Map<String, Object> result = entityAsMap(client().performRequest(esql));
+                MapMatcher mapMatcher = matchesMap();
+                if (result.get("took") != null) {
+                    mapMatcher = mapMatcher.entry("took", ((Integer) result.get("took")).intValue());
+                }
                 assertMap(
-                    entityAsMap(client().performRequest(esql)),
-                    matchesMap().entry(
+                    result,
+                    mapMatcher.entry(
                         "columns",
                         List.of(Map.of("name", "dv", "type", "keyword"), Map.of("name", "no_dv", "type", "keyword"))
                     ).entry("values", List.of(List.of("test", "test")))


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Collect and display execution metadata for ES|QL cross cluster searches (#112595)