### PR TITLE
Fix test: create enough nodes to make cluster always be able to go green

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -327,9 +327,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/112980
 - class: org.elasticsearch.xpack.searchablesnapshots.hdfs.SecureHdfsSearchableSnapshotsIT
   issue: https://github.com/elastic/elasticsearch/issues/113753
-- class: org.elasticsearch.action.admin.cluster.stats.ClusterStatsRemoteIT
-  method: testRemoteClusterStats
-  issue: https://github.com/elastic/elasticsearch/issues/113822
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRemoteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRemoteIT.java
@@ -117,7 +117,7 @@ public class ClusterStatsRemoteIT extends AbstractMultiClustersTestCase {
         int numShardsRemote = randomIntBetween(2, 10);
         for (String clusterAlias : remoteClusterAlias()) {
             final InternalTestCluster remoteCluster = cluster(clusterAlias);
-            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(2, 3));
             assertAcked(
                 client(clusterAlias).admin()
                     .indices()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRemoteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRemoteIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -22,6 +23,7 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 
 import java.util.Collection;
 import java.util.List;
@@ -44,6 +46,7 @@ public class ClusterStatsRemoteIT extends AbstractMultiClustersTestCase {
     private static final String REMOTE2 = "cluster-b";
 
     private static final String INDEX_NAME = "demo";
+    private static final FeatureFlag CCS_TELEMETRY_FEATURE_FLAG = new FeatureFlag("ccs_telemetry");
 
     @Override
     protected boolean reuseClusters() {
@@ -58,6 +61,11 @@ public class ClusterStatsRemoteIT extends AbstractMultiClustersTestCase {
     @Override
     protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
         return Map.of(REMOTE1, false, REMOTE2, true);
+    }
+
+    @BeforeClass
+    protected static void skipIfTelemetryDisabled() {
+        assumeTrue("Skipping test as CCS_TELEMETRY_FEATURE_FLAG is disabled", CCS_TELEMETRY_FEATURE_FLAG.isEnabled());
     }
 
     public void testRemoteClusterStats() throws ExecutionException, InterruptedException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CCSUsageTelemetryIT.java
@@ -662,7 +662,7 @@ public class CCSUsageTelemetryIT extends AbstractMultiClustersTestCase {
         int numShardsRemote = randomIntBetween(2, 10);
         for (String clusterAlias : remoteClusterAlias()) {
             final InternalTestCluster remoteCluster = cluster(clusterAlias);
-            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+            remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(2, 3));
             assertAcked(
                 client(clusterAlias).admin()
                     .indices()


### PR DESCRIPTION
Also disable stats test when feature is disabled. 

Fixes #113822