### PR TITLE
[8.x] Avoid using concurrent collector manager in LuceneChangesSnapshot (#113816)

### DIFF
--- a/docs/changelog/113816.yaml
+++ b/docs/changelog/113816.yaml
@@ -1,0 +1,5 @@
+pr: 113816
+summary: Avoid using concurrent collector manager in `LuceneChangesSnapshot`
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -301,7 +301,8 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             new Sort(sortBySeqNo),
             searchBatchSize,
             after,
-            accurateTotalHits ? Integer.MAX_VALUE : 0
+            accurateTotalHits ? Integer.MAX_VALUE : 0,
+            false
         );
         return indexSearcher.search(rangeQuery, topFieldCollectorManager);
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Avoid using concurrent collector manager in LuceneChangesSnapshot (#113816)