### PR TITLE
[8.15] [ML] Handle parsing ingest processors where the definition is not a object (#113697)

### DIFF
--- a/docs/changelog/113697.yaml
+++ b/docs/changelog/113697.yaml
@@ -1,0 +1,6 @@
+pr: 113697
+summary: Handle parsing ingest processors where definition is not a object
+area: Machine Learning
+type: bug
+issues:
+ - 113615


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [ML] Handle parsing ingest processors where the definition is not a object (#113697)