### PR TITLE
[8.x] [plugin/otel-data] Add dynamic template for summary with min, max (#113791)

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -45,3 +45,8 @@ template:
             type: aggregate_metric_double
             metrics: sum, value_count
             default_metric: value_count
+      - summary_minmax:
+          mapping:
+            type: aggregate_metric_double
+            metrics: sum, value_count, min, max
+            default_metric: value_count


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[plugin/otel-data] Add dynamic template for summary with min, max (#113791)](https://github.com/elastic/elasticsearch/pull/113791)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)