### PR TITLE
Bump version for otel-data

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 1
+version: 2
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
Addressing https://github.com/elastic/elasticsearch/pull/113409#issuecomment-2385526706

I think after https://github.com/elastic/elasticsearch/pull/113791 we'd also need it.

So far there was no release with this, so only affects testing. 