### PR TITLE
[8.x] Make xpack.otel_data.registry.enabled default to true (#113468)

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/AbstractDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/AbstractDataStreamIT.java
@@ -44,6 +44,7 @@ public abstract class AbstractDataStreamIT extends ESRestTestCase {
         // Disable apm-data so the index templates it installs do not impact
         // tests such as testIgnoreDynamicBeyondLimit.
         .setting("xpack.apm_data.enabled", "false")
+        .setting("xpack.otel_data.registry.enabled", "false")
         .build();
     protected RestClient client;
 

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeCustomSettingsIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/LogsIndexModeCustomSettingsIT.java
@@ -37,6 +37,7 @@ public class LogsIndexModeCustomSettingsIT extends LogsIndexModeRestTestIT {
         .module("x-pack-aggregate-metric")
         .module("x-pack-stack")
         .setting("xpack.security.enabled", "false")
+        .setting("xpack.otel_data.registry.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("cluster.logsdb.enabled", "true")
         .build();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -59,6 +59,7 @@ testClusters.configureEach {
   setting 'stack.templates.enabled', 'false'
   setting 'xpack.ent_search.enabled', 'false'
   setting 'xpack.apm_data.enabled', 'false'
+  setting 'xpack.otel_data.registry.enabled', 'false'
   // To spice things up a bit, one of the nodes is not an ML node
   nodes.'javaRestTest-0'.setting 'node.roles', '["master","data","ingest"]'
   nodes.'javaRestTest-1'.setting 'node.roles', '["master","data","ingest","ml"]'

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
@@ -33,9 +33,7 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
     // This setting will be ignored if the plugin is disabled.
     static final Setting<Boolean> OTEL_DATA_REGISTRY_ENABLED = Setting.boolSetting(
         "xpack.otel_data.registry.enabled",
-        // OTel-data is under development, and we start with opt-in first.
-        // Furthermore, this could help with staged rollout in serverless
-        false,
+        true,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/x-pack/plugin/otel-data/src/yamlRestTest/java/org/elasticsearch/xpack/oteldata/OTelYamlTestSuiteIT.java
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/java/org/elasticsearch/xpack/oteldata/OTelYamlTestSuiteIT.java
@@ -35,7 +35,6 @@ public class OTelYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         .module("x-pack-stack")
         .module("mapper-version")
         .setting("ingest.geoip.downloader.enabled", "false")
-        .setting("xpack.otel_data.registry.enabled", "true")
         .build();
 
     public OTelYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make xpack.otel_data.registry.enabled default to true (#113468)