### PR TITLE
[8.x] Reinstate support for `GET _cluster/stats?timeout=...` (#113852)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -31,6 +31,19 @@
   - is_true: nodes.network_types
 
 ---
+"cluster stats accepts timeout param":
+  - skip:
+      cluster_features: "gte_v8.16.0"
+      reason: "Suppress this test for merging & backporting https://github.com/elastic/elasticsearch/pull/113852"
+
+  - do:
+      cluster.stats:
+        timeout: 24h
+
+  - is_true: timestamp
+  - is_true: cluster_name
+
+---
 "cluster stats with human flag returns docs as human readable size":
   - requires:
       test_runner_features: [ capabilities ]

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestUtils.REST_TIMEOUT_PARAM;
 import static org.elasticsearch.rest.RestUtils.getTimeout;
 
 @ServerlessScope(Scope.INTERNAL)
@@ -46,7 +47,7 @@ public class RestClusterStatsAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedQueryParameters() {
-        return Set.of("include_remotes", "nodeId");
+        return Set.of("include_remotes", "nodeId", REST_TIMEOUT_PARAM);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Reinstate support for `GET _cluster/stats?timeout=...` (#113852)