### PR TITLE
[github] actions should only run for the elastic repo

### DIFF
--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -4,10 +4,11 @@ on:
   pull_request_target:
     types: [opened]
     paths:
-      - '**.asciidoc'
+      - "**.asciidoc"
 
 jobs:
   doc-preview:
+    if: github.repository == 'elastic/elasticsearch'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,6 +7,7 @@ permissions:
 jobs:
   validation:
     name: "Validation"
+    if: github.repository == 'elastic/elasticsearch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sync-main-to-jdk-branch.yml
+++ b/.github/workflows/sync-main-to-jdk-branch.yml
@@ -2,11 +2,12 @@
 name: "Merge main to openjdk23-bundle branch"
 on:
   schedule:
-    - cron: '30 17 * * *'
+    - cron: "30 17 * * *"
   workflow_dispatch: {}
 
 jobs:
   merge-branch:
+    if: github.repository == 'elastic/elasticsearch'
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -15,6 +16,6 @@ jobs:
       - name: merge
         uses: devmasx/merge-branch@1.4.0
         with:
-          type: 'now'
+          type: "now"
           target_branch: openjdk23-bundle
           github_token: ${{ secrets.ELASTICSEARCHMACHINE_TOKEN }}

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -4,13 +4,14 @@ name: updatecli-compose
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 
 permissions:
   contents: read
 
 jobs:
   compose:
+    if: github.repository == 'elastic/elasticsearch'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
They are running for forks, but don't need to.