### PR TITLE
Removing unnecessary platfromArchitectures from InferenceService tests

### DIFF
--- a/docs/changelog/113890.yaml
+++ b/docs/changelog/113890.yaml
@@ -1,5 +1,0 @@
-pr: 113890
-summary: Removing unnecessary `platfromArchitectures` from `InferenceService` tests
-area: Machine Learning
-type: bug
-issues: []

--- a/docs/changelog/113890.yaml
+++ b/docs/changelog/113890.yaml
@@ -1,0 +1,5 @@
+pr: 113890
+summary: Removing unnecessary `platfromArchitectures` from `InferenceService` tests
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
@@ -179,7 +179,6 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
                     createRandomChunkingSettingsMap(),
                     getSecretSettingsMap(apiKey)
                 ),
-                Set.of(),
                 modelVerificationListener
             );
         }
@@ -210,7 +209,6 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
                     createRandomChunkingSettingsMap(),
                     getSecretSettingsMap(apiKey)
                 ),
-                Set.of(),
                 modelListener
             );
         }
@@ -240,7 +238,6 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
                     new HashMap<>(Map.of()),
                     getSecretSettingsMap(apiKey)
                 ),
-                Set.of(),
                 modelListener
             );
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -131,7 +131,6 @@ public class HuggingFaceServiceTests extends ESTestCase {
                 "id",
                 TaskType.TEXT_EMBEDDING,
                 getRequestConfigMap(getServiceSettingsMap("url"), createRandomChunkingSettingsMap(), getSecretSettingsMap("secret")),
-                Set.of(),
                 modelVerificationListener
             );
         }
@@ -153,7 +152,6 @@ public class HuggingFaceServiceTests extends ESTestCase {
                 "id",
                 TaskType.TEXT_EMBEDDING,
                 getRequestConfigMap(getServiceSettingsMap("url"), createRandomChunkingSettingsMap(), getSecretSettingsMap("secret")),
-                Set.of(),
                 modelVerificationActionListener
             );
         }
@@ -175,7 +173,6 @@ public class HuggingFaceServiceTests extends ESTestCase {
                 "id",
                 TaskType.TEXT_EMBEDDING,
                 getRequestConfigMap(getServiceSettingsMap("url"), getSecretSettingsMap("secret")),
-                Set.of(),
                 modelVerificationActionListener
             );
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
@@ -142,7 +142,6 @@ public class MistralServiceTests extends ESTestCase {
                     createRandomChunkingSettingsMap(),
                     getSecretSettingsMap("secret")
                 ),
-                Set.of(),
                 modelVerificationListener
             );
         }
@@ -171,7 +170,6 @@ public class MistralServiceTests extends ESTestCase {
                     createRandomChunkingSettingsMap(),
                     getSecretSettingsMap("secret")
                 ),
-                Set.of(),
                 modelVerificationListener
             );
         }
@@ -199,7 +197,6 @@ public class MistralServiceTests extends ESTestCase {
                     getEmbeddingsTaskSettingsMap(),
                     getSecretSettingsMap("secret")
                 ),
-                Set.of(),
                 modelVerificationListener
             );
         }


### PR DESCRIPTION
Fixing a java compilation failure caused by merging https://github.com/elastic/elasticsearch/pull/113623. This was caused because [another change](https://github.com/elastic/elasticsearch/commit/071e7ce620baf3a3751855f29eaacc82463e3ca8#diff-67a6ab4969beb7d75e13fa780cf5c6f4f241b0aaa63dc75ef1c42cc136c56ffeL113) was merged that removed some inputs to the parseRequestConfig method of inference services. This change removes these lines.