### PR TITLE
[docs] Remove xpack.security.enabled Kibana reference

### DIFF
--- a/docs/reference/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/run-elasticsearch-locally.asciidoc
@@ -98,7 +98,6 @@ docker run -p 127.0.0.1:5601:5601 -d --name kibana --network elastic-net \
   -e ELASTICSEARCH_HOSTS=http://elasticsearch:9200 \
   -e ELASTICSEARCH_USERNAME=kibana_system \
   -e ELASTICSEARCH_PASSWORD=$KIBANA_PASSWORD \
-  -e "xpack.security.enabled=false" \
   -e "xpack.license.self_generated.type=trial" \
   {kib-docker-image}
 ----


### PR DESCRIPTION
This setting was removed from Kibana in 8.0.  It's inferred based on Elasticsearch's configuration.

This issue was found in
https://discuss.elastic.co/t/why-is-the-non-existent-xpack-security-enabled-mentioned-in-kibanas-configuration-documentation/366131

The Kibana setting was removed in https://github.com/elastic/kibana/pull/111681