### PR TITLE
[Inference API] Fix bug in elser parsing when no model id in request

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserInternalService.java
@@ -101,17 +101,16 @@ public class ElserInternalService extends BaseElasticsearchInternalService {
                     serviceSettingsBuilder.setModelId(
                         selectDefaultModelVariantBasedOnClusterArchitecture(arch, ELSER_V2_MODEL_LINUX_X86, ELSER_V2_MODEL)
                     );
+                    parsedModelListener.onResponse(
+                        new ElserInternalModel(
+                            inferenceEntityId,
+                            taskType,
+                            NAME,
+                            new ElserInternalServiceSettings(serviceSettingsBuilder.build()),
+                            taskSettings
+                        )
+                    );
                 }));
-
-                parsedModelListener.onResponse(
-                    new ElserInternalModel(
-                        inferenceEntityId,
-                        taskType,
-                        NAME,
-                        new ElserInternalServiceSettings(serviceSettingsBuilder.build()),
-                        taskSettings
-                    )
-                );
             } else {
                 parsedModelListener.onResponse(
                     new ElserInternalModel(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elser/ElserInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elser/ElserInternalServiceTests.java
@@ -120,6 +120,31 @@ public class ElserInternalServiceTests extends ESTestCase {
 
     }
 
+    public void testParseConfigWithoutModelId() {
+        Client mockClient = mock(Client.class);
+        when(mockClient.threadPool()).thenReturn(threadPool);
+        var service = createService(mockClient);
+
+        var settings = new HashMap<String, Object>();
+        settings.put(
+            ModelConfigurations.SERVICE_SETTINGS,
+            new HashMap<>(Map.of(ElserInternalServiceSettings.NUM_ALLOCATIONS, 1, ElserInternalServiceSettings.NUM_THREADS, 4))
+        );
+
+        var expectedModel = new ElserInternalModel(
+            "foo",
+            TaskType.SPARSE_EMBEDDING,
+            ElserInternalService.NAME,
+            new ElserInternalServiceSettings(1, 4, ".elser_model_2", null),
+            ElserMlNodeTaskSettings.DEFAULT
+        );
+
+        var modelVerificationListener = getModelVerificationListener(expectedModel);
+
+        service.parseRequestConfig("foo", TaskType.SPARSE_EMBEDDING, settings, modelVerificationListener);
+
+    }
+
     public void testParseConfigLooseWithOldModelId() {
         var service = createService(mock(Client.class));
 


### PR DESCRIPTION
Fixed the bug by moving the onResponse call into the new action listener so that the response happens after we have set the model ID. Also add new test to catch this bug. 

Non-issue because this bug never reached prod.

