### PR TITLE
[CI] Replace openjdk17 with openjdk21 in failing java-matrix tasks

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -69,7 +69,7 @@ steps:
         matrix:
           setup:
             ES_RUNTIME_JAVA:
-              - openjdk17
+              - openjdk21
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -430,7 +430,7 @@ steps:
         matrix:
           setup:
             ES_RUNTIME_JAVA:
-              - openjdk17
+              - openjdk21
             BWC_VERSION: ["8.15.3", "8.16.0", "9.0.0"]
         agents:
           provider: gcp


### PR DESCRIPTION
I'm not sure which JDK should ultimately be here, but `openjdk17` is failing in `main` `ES_BUILD_JAVA` was bumped.