### PR TITLE
[CI] Forward port Amazon Linux 2 dns fix

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -109,3 +109,11 @@ EOF
 <summary>Agent information from gobld</summary>
 EOF
 fi
+
+# Amazon Linux 2 has DNS resolution issues with resource-based hostnames in EC2
+# We have many functional tests that try to lookup and resolve the hostname of the local machine in a particular way
+# And they fail. This sets up a manual entry for the hostname in dnsmasq.
+if [[ -f /etc/os-release ]] && grep -q '"Amazon Linux 2"' /etc/os-release; then
+  echo "$(hostname -i | cut -d' ' -f 2)  $(hostname -f)." | sudo tee /etc/dnsmasq.hosts
+  sudo systemctl restart dnsmasq.service
+fi


### PR DESCRIPTION
This was a workaround used in `7.17`, see #107907

It was not required outside of `7.17` at the time, but now it is.

Fixes #113111 and #113457