### PR TITLE
[8.15] [CI] Remove centos-7 testing since it is EOL (#113896)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -7,7 +7,6 @@ steps:
         matrix:
           setup:
             image:
-              - centos-7
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -8,7 +8,6 @@ steps:
         matrix:
           setup:
             image:
-              - centos-7
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -7,7 +7,6 @@ steps:
         matrix:
           setup:
             image:
-              - centos-7
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -10,7 +10,6 @@ steps:
         matrix:
           setup:
             image:
-              - centos-7
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7
@@ -38,7 +37,6 @@ steps:
         matrix:
           setup:
             image:
-              - centos-7
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7
@@ -66,7 +64,6 @@ steps:
         matrix:
           setup:
             image:
-              - centos-7
               - debian-11
               - opensuse-leap-15
               - oraclelinux-7


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[CI] Remove centos-7 testing since it is EOL (#113896)](https://github.com/elastic/elasticsearch/pull/113896)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)