### PR TITLE
Remove `onItemCompletion` param from `ThrottledIterator`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/ChunkedZipResponseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/ChunkedZipResponseIT.java
@@ -269,7 +269,6 @@ public class ChunkedZipResponseIT extends ESIntegTestCase {
                         )
                     ),
                     between(1, 10),
-                    () -> {},
                     Releasables.wrap(refs.acquire(), chunkedZipResponse)::close
                 );
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/StreamingXContentResponseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/StreamingXContentResponseIT.java
@@ -192,7 +192,6 @@ public class StreamingXContentResponseIT extends ESIntegTestCase {
                         })
                     ),
                     between(1, 10),
-                    () -> {},
                     () -> {
                         try (streamingXContentResponse; finalRef) {
                             streamingXContentResponse.writeFragment(p -> ChunkedToXContentHelper.endObject(), refs.acquire());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -322,7 +322,6 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                                 })
                             ),
                             getSnapshotInfoExecutor.getMaxRunningTasks(),
-                            () -> {},
                             () -> {}
                         );
                     }));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -191,7 +191,6 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
                 Iterators.flatMap(Iterators.forArray(concreteIndices), this::getIndexIterator),
                 this::doShardRequest,
                 maxConcurrentShardRequests,
-                () -> {},
                 outerListener::close
             );
         }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1212,7 +1212,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     l -> new IndexSnapshotsDeletion(indexId).run(l)
                 ),
                 threadPool.info(ThreadPool.Names.SNAPSHOT).getMax(),
-                () -> {},
                 listeners::close
             );
         }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
@@ -64,8 +64,8 @@ public class ThrottledIteratorTests extends ESTestCase {
 
             ThrottledIterator.run(IntStream.range(0, items).boxed().iterator(), (releasable, item) -> {
                 try (var refs = new RefCountingRunnable(() -> {
-                    releasable.close();
                     completedItems.incrementAndGet();
+                    releasable.close();
                 })) {
                     assertTrue(itemPermits.tryAcquire());
                     if (forkSupplier.getAsBoolean()) {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
@@ -63,7 +63,10 @@ public class ThrottledIteratorTests extends ESTestCase {
             final var blockPermits = new Semaphore(between(0, Math.min(maxRelaxedThreads, maxConcurrency) - 1));
 
             ThrottledIterator.run(IntStream.range(0, items).boxed().iterator(), (releasable, item) -> {
-                try (var refs = new RefCountingRunnable(releasable::close)) {
+                try (var refs = new RefCountingRunnable(() -> {
+                    releasable.close();
+                    completedItems.incrementAndGet();
+                })) {
                     assertTrue(itemPermits.tryAcquire());
                     if (forkSupplier.getAsBoolean()) {
                         var ref = refs.acquire();
@@ -108,7 +111,7 @@ public class ThrottledIteratorTests extends ESTestCase {
                         itemPermits.release();
                     }
                 }
-            }, maxConcurrency, completedItems::incrementAndGet, completionLatch::countDown);
+            }, maxConcurrency, completionLatch::countDown);
 
             assertTrue(completionLatch.await(30, TimeUnit.SECONDS));
             assertEquals(items, completedItems.get());

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalyzeAction.java
@@ -538,13 +538,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
                 queue.add(ref -> runBlobAnalysis(ref, blobAnalyzeRequest, node));
             }
 
-            ThrottledIterator.run(
-                getQueueIterator(),
-                (ref, task) -> task.accept(ref),
-                request.getConcurrency(),
-                () -> {},
-                requestRefs::close
-            );
+            ThrottledIterator.run(getQueueIterator(), (ref, task) -> task.accept(ref), request.getConcurrency(), requestRefs::close);
         }
 
         private boolean rarely(Random random) {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.util.concurrent.ThrottledIterator;
 import org.elasticsearch.common.util.concurrent.ThrottledTaskRunner;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots;
@@ -824,7 +825,12 @@ class RepositoryIntegrityVerifier {
         AtomicLong progressCounter,
         Releasable onCompletion
     ) {
-        ThrottledIterator.run(iterator, itemConsumer, maxConcurrency, progressCounter::incrementAndGet, onCompletion::close);
+        ThrottledIterator.run(
+            iterator,
+            (ref, item) -> itemConsumer.accept(Releasables.wrap(ref, progressCounter::incrementAndGet), item),
+            maxConcurrency,
+            onCompletion::close
+        );
     }
 
     private RepositoryVerifyIntegrityResponseChunk.Builder anomaly(String anomaly) {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryIntegrityVerifier.java
@@ -827,7 +827,7 @@ class RepositoryIntegrityVerifier {
     ) {
         ThrottledIterator.run(
             iterator,
-            (ref, item) -> itemConsumer.accept(Releasables.wrap(ref, progressCounter::incrementAndGet), item),
+            (ref, item) -> itemConsumer.accept(Releasables.wrap(progressCounter::incrementAndGet, ref), item),
             maxConcurrency,
             onCompletion::close
         );


### PR DESCRIPTION
This param is a no-op for all production callers but one, and it's easy
to adapt the one exception to its removal, so it's effectively useless.
This commit removes it.