### PR TITLE
[8.x] [DOCS] Fix typo in knn tuning guide (#113880)

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -48,7 +48,7 @@ expensive to load. This could significantly slow down the speed of kNN search.
 NOTE: <<docs-reindex, reindex>>, <<docs-update, update>>,
 and <<docs-update-by-query, update by query>> operations generally
 require the `_source` field. Disabling `_source` for a field might result in
-expected behavior for these operations. For example, reindex might not actually
+unexpected behavior for these operations. For example, reindex might not actually
 contain the `dense_vector` field in the new index.
 
 You can disable storing `dense_vector` fields in the `_source` through the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Fix typo in knn tuning guide (#113880)](https://github.com/elastic/elasticsearch/pull/113880)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)