### PR TITLE
Remove special handling for objects and arrays with `dynamic` overrides

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -535,6 +535,8 @@ object array in object with dynamic override:
             _source:
               mode: synthetic
             properties:
+              id:
+                type: integer
               path_no:
                 dynamic: false
                 properties:
@@ -552,19 +554,25 @@ object array in object with dynamic override:
         refresh: true
         body:
           - '{ "create": { } }'
-          - '{ "path_no": [ { "some_int": 10 }, {"name": "foo"} ], "path_runtime": [ { "some_int": 20 }, {"name": "bar"} ], "name": "baz" }'
+          - '{ "id": 1, "path_no": [ { "some_int": 30 }, {"name": "baz"}, { "some_int": 20 }, {"name": "bar"} ], "name": "A" }'
+          - '{ "create": { } }'
+          - '{ "id": 2, "path_runtime": [ { "some_int": 30 }, {"name": "baz"}, { "some_int": 20 }, {"name": "bar"} ], "name": "B" }'
   - match: { errors: false }
 
   - do:
       search:
         index: test
+        sort: id
 
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._source.name: baz }
-  - match: { hits.hits.0._source.path_no.0.some_int: 10 }
-  - match: { hits.hits.0._source.path_no.1.name: foo }
-  - match: { hits.hits.0._source.path_runtime.0.some_int: 20 }
-  - match: { hits.hits.0._source.path_runtime.1.name: bar }
+  - match: { hits.hits.0._source.id: 1 }
+  - match: { hits.hits.0._source.name: A }
+  - match: { hits.hits.0._source.path_no.some_int: [ 30, 20 ] }
+  - match: { hits.hits.0._source.path_no.name: [ bar, baz ] }
+
+  - match: { hits.hits.1._source.id: 2 }
+  - match: { hits.hits.1._source.name: B }
+  - match: { hits.hits.1._source.path_runtime.some_int: [ 30, 20 ] }
+  - match: { hits.hits.1._source.path_runtime.name: [ bar, baz ] }
 
 
 ---

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -981,7 +981,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             b.endArray();
         });
         assertEquals("""
-            {"path":{"disabled":[{"leaf":10},{"leaf":20}],"regular":{"leaf":[10,20]}}}""", syntheticSource);
+            {"path":{"disabled":{"leaf":[10,20]},"regular":{"leaf":[10,20]}}}""", syntheticSource);
     }
 
     public void testDisabledObjectWithinHigherLevelArray() throws IOException {
@@ -1423,6 +1423,19 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         });
         assertEquals("""
             {"path":{"to":[{"foo":"A","bar":"B"},{"foo":"C","bar":"D"}]}}""", syntheticSource);
+    }
+
+    public void testNoDynamicRootObject() throws IOException {
+        DocumentMapper documentMapper = createMapperService(topMapping(b -> {
+            b.startObject("_source").field("mode", "synthetic").endObject().field("dynamic", "false");
+        })).documentMapper();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.field("foo", "bar");
+            b.startObject("path").field("X", "Y").endObject();
+            b.array("name", "A", "D", "C", "B");
+        });
+        assertEquals("""
+            {"foo":"bar","name":["A","D","C","B"],"path":{"X":"Y"}}""", syntheticSource);
     }
 
     public void testRuntimeDynamicObjectSingleField() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -902,7 +902,6 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             }
             b.endObject();
         })).documentMapper();
-        // { "path": [ { "stored":[ { "leaf": 10 } ] }, { "stored": { "leaf": 20 } } ] }
         var syntheticSource = syntheticSource(documentMapper, b -> {
             b.startArray("path");
             {
@@ -925,6 +924,64 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         });
         assertEquals("""
             {"path":{"stored":[{"leaf":10},{"leaf":20}]}}""", syntheticSource);
+    }
+
+    public void testObjectArrayAndValueDisabledObject() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").field("type", "object").startObject("properties");
+            {
+                b.startObject("regular");
+                {
+                    b.startObject("properties").startObject("leaf").field("type", "integer").endObject().endObject();
+                }
+                b.endObject();
+                b.startObject("disabled").field("type", "object").field("enabled", false);
+                {
+                    b.startObject("properties").startObject("leaf").field("type", "integer").endObject().endObject();
+                }
+                b.endObject();
+            }
+            b.endObject().endObject();
+        })).documentMapper();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject().startArray("disabled").startObject().field("leaf", 10).endObject().endArray().endObject();
+                b.startObject().startObject("disabled").field("leaf", 20).endObject().endObject();
+                b.startObject().startArray("regular").startObject().field("leaf", 10).endObject().endArray().endObject();
+                b.startObject().startObject("regular").field("leaf", 20).endObject().endObject();
+            }
+            b.endArray();
+        });
+        assertEquals("""
+            {"path":{"disabled":[{"leaf":10},{"leaf":20}],"regular":{"leaf":[10,20]}}}""", syntheticSource);
+    }
+
+    public void testObjectArrayAndValueNonDynamicObject() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").field("type", "object").startObject("properties");
+            {
+                b.startObject("regular");
+                {
+                    b.startObject("properties").startObject("leaf").field("type", "integer").endObject().endObject();
+                }
+                b.endObject();
+                b.startObject("disabled").field("type", "object").field("dynamic", "false").endObject();
+            }
+            b.endObject().endObject();
+        })).documentMapper();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject().startArray("disabled").startObject().field("leaf", 10).endObject().endArray().endObject();
+                b.startObject().startObject("disabled").field("leaf", 20).endObject().endObject();
+                b.startObject().startArray("regular").startObject().field("leaf", 10).endObject().endArray().endObject();
+                b.startObject().startObject("regular").field("leaf", 20).endObject().endObject();
+            }
+            b.endArray();
+        });
+        assertEquals("""
+            {"path":{"disabled":[{"leaf":10},{"leaf":20}],"regular":{"leaf":[10,20]}}}""", syntheticSource);
     }
 
     public void testDisabledObjectWithinHigherLevelArray() throws IOException {
@@ -1337,7 +1394,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             b.endArray();
         });
         assertEquals("""
-            {"path":[{"name":"foo"},{"name":"bar"}]}""", syntheticSource);
+            {"path":{"name":["foo","bar"]}}""", syntheticSource);
     }
 
     public void testNoDynamicObjectSimpleValueArray() throws IOException {
@@ -1365,7 +1422,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             b.endArray();
         });
         assertEquals("""
-            {"path":[{"to":{"foo":"A","bar":"B"}},{"to":{"foo":"C","bar":"D"}}]}""", syntheticSource);
+            {"path":{"to":[{"foo":"A","bar":"B"},{"foo":"C","bar":"D"}]}}""", syntheticSource);
     }
 
     public void testRuntimeDynamicObjectSingleField() throws IOException {
@@ -1445,7 +1502,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             b.endArray();
         });
         assertEquals("""
-            {"path":[{"name":"foo"},{"name":"bar"}]}""", syntheticSource);
+            {"path":{"name":["foo","bar"]}}""", syntheticSource);
     }
 
     public void testRuntimeDynamicObjectSimpleValueArray() throws IOException {
@@ -1473,7 +1530,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             b.endArray();
         });
         assertEquals("""
-            {"path":[{"to":{"foo":"A","bar":"B"}},{"to":{"foo":"C","bar":"D"}}]}""", syntheticSource);
+            {"path":{"to":[{"foo":"A","bar":"B"},{"foo":"C","bar":"D"}]}}""", syntheticSource);
     }
 
     public void testDisabledSubObjectWithNameOverlappingParentName() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -984,6 +984,33 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             {"path":{"disabled":{"leaf":[10,20]},"regular":{"leaf":[10,20]}}}""", syntheticSource);
     }
 
+    public void testObjectArrayAndValueDynamicRuntimeObject() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").field("type", "object").startObject("properties");
+            {
+                b.startObject("regular");
+                {
+                    b.startObject("properties").startObject("leaf").field("type", "integer").endObject().endObject();
+                }
+                b.endObject();
+                b.startObject("runtime").field("type", "object").field("dynamic", "runtime").endObject();
+            }
+            b.endObject().endObject();
+        })).documentMapper();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject().startArray("runtime").startObject().field("leaf", 10).endObject().endArray().endObject();
+                b.startObject().startObject("runtime").field("leaf", 20).endObject().endObject();
+                b.startObject().startArray("regular").startObject().field("leaf", 10).endObject().endArray().endObject();
+                b.startObject().startObject("regular").field("leaf", 20).endObject().endObject();
+            }
+            b.endArray();
+        });
+        assertEquals("""
+            {"path":{"regular":{"leaf":[10,20]},"runtime":{"leaf":[10,20]}}}""", syntheticSource);
+    }
+
     public void testDisabledObjectWithinHigherLevelArray() throws IOException {
         DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
             b.startObject("path");


### PR DESCRIPTION
`ObjectMapper` has been extended to combine multiple regular and ignored values, so it's no longer required to always store objects (or array of objects) with `dynamic` set to `runtime` or `false`.

This also fixes a parsing bug for disabled objects where the object leaf name wasn't properly retrieved.