### PR TITLE
Unmute DotPrefixClientYamlTestSuiteIT again

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -278,9 +278,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testCreateJobsWithIndexNameOption
   issue: https://github.com/elastic/elasticsearch/issues/113528
-- class: org.elasticsearch.validation.DotPrefixClientYamlTestSuiteIT
-  method: test {p0=dot_prefix/10_basic/Deprecated index template with a dot prefix index pattern}
-  issue: https://github.com/elastic/elasticsearch/issues/113529
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testCantCreateJobWithSameID
   issue: https://github.com/elastic/elasticsearch/issues/113581


### PR DESCRIPTION
Originally unmuted in #113714 it was re-muted in #113749 after a badly resolved merge conflict. 

Looks like the unmute needs backporting to 8.x - https://github.com/elastic/elasticsearch/blob/8.x/muted-tests.yml#L284