### PR TITLE
Ensure that supported params are computed once

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestGetDataStreamsAction.java
@@ -29,6 +29,23 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetDataStreamsAction extends BaseRestHandler {
 
+    private static final Set<String> SUPPORTED_QUERY_PARAMETERS = Set.copyOf(
+        Sets.union(
+            RestRequest.INTERNAL_MARKER_REQUEST_PARAMETERS,
+            Set.of(
+                "name",
+                "include_defaults",
+                "timeout",
+                "master_timeout",
+                IndicesOptions.WildcardOptions.EXPAND_WILDCARDS,
+                IndicesOptions.ConcreteTargetOptions.IGNORE_UNAVAILABLE,
+                IndicesOptions.WildcardOptions.ALLOW_NO_INDICES,
+                IndicesOptions.GatekeeperOptions.IGNORE_THROTTLED,
+                "verbose"
+            )
+        )
+    );
+
     @Override
     public String getName() {
         return "get_data_streams_action";
@@ -63,19 +80,6 @@ public class RestGetDataStreamsAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedQueryParameters() {
-        return Sets.union(
-            RestRequest.INTERNAL_MARKER_REQUEST_PARAMETERS,
-            Set.of(
-                "name",
-                "include_defaults",
-                "timeout",
-                "master_timeout",
-                IndicesOptions.WildcardOptions.EXPAND_WILDCARDS,
-                IndicesOptions.ConcreteTargetOptions.IGNORE_UNAVAILABLE,
-                IndicesOptions.WildcardOptions.ALLOW_NO_INDICES,
-                IndicesOptions.GatekeeperOptions.IGNORE_THROTTLED,
-                "verbose"
-            )
-        );
+        return SUPPORTED_QUERY_PARAMETERS;
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -85,6 +85,7 @@ public abstract class BaseRestHandler implements RestHandler {
     public final void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
         // check if the query has any parameters that are not in the supported set (if declared)
         Set<String> supported = allSupportedParameters();
+        assert supported == allSupportedParameters() : getName() + ": did not return same instance from allSupportedParameters()";
         if (supported != null) {
             var allSupported = Sets.union(
                 RestResponse.RESPONSE_PARAMS,

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -397,6 +397,8 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
             if (handler != null) {
                 var supportedParams = handler.supportedQueryParameters();
+                assert supportedParams == handler.supportedQueryParameters()
+                    : handler.getName() + ": did not return same instance from supportedQueryParameters()";
                 return (supportedParams == null || supportedParams.containsAll(parameters))
                     && handler.supportedCapabilities().containsAll(capabilities);
             }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -35,8 +35,9 @@ public class RestClusterStatsAction extends BaseRestHandler {
         "human-readable-total-docs-size",
         "verbose-dense-vector-mapping-stats"
     );
-    private static final Set<String> SUPPORTED_CAPABILITIES_CCS_STATS = Sets.union(SUPPORTED_CAPABILITIES, Set.of("ccs-stats"));
+    private static final Set<String> SUPPORTED_CAPABILITIES_CCS_STATS = Set.copyOf(Sets.union(SUPPORTED_CAPABILITIES, Set.of("ccs-stats")));
     public static final FeatureFlag CCS_TELEMETRY_FEATURE_FLAG = new FeatureFlag("ccs_telemetry");
+    private static final Set<String> SUPPORTED_QUERY_PARAMETERS = Set.of("include_remotes", "nodeId", REST_TIMEOUT_PARAM);
 
     @Override
     public List<Route> routes() {
@@ -50,7 +51,7 @@ public class RestClusterStatsAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedQueryParameters() {
-        return Set.of("include_remotes", "nodeId", REST_TIMEOUT_PARAM);
+        return SUPPORTED_QUERY_PARAMETERS;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesCapabilitiesAction.java
@@ -32,6 +32,14 @@ public class RestNodesCapabilitiesAction extends BaseRestHandler {
 
     public static final NodeFeature CAPABILITIES_ACTION = new NodeFeature("rest.capabilities_action");
     public static final NodeFeature LOCAL_ONLY_CAPABILITIES = new NodeFeature("rest.local_only_capabilities");
+    private static final Set<String> SUPPORTED_QUERY_PARAMETERS = Set.of(
+        "timeout",
+        "method",
+        "path",
+        "parameters",
+        "capabilities",
+        "local_only"
+    );
 
     @Override
     public List<Route> routes() {
@@ -40,7 +48,7 @@ public class RestNodesCapabilitiesAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedQueryParameters() {
-        return Set.of("timeout", "method", "path", "parameters", "capabilities", "local_only");
+        return SUPPORTED_QUERY_PARAMETERS;
     }
 
     @Override


### PR DESCRIPTION
A few of today's REST handler implementations compute a new set of
supported parameters on each request. This is needlessly inefficient
since the set never changes. This commit fixes those implementations and
adds assertions to verify that we are returning the exact same instance
each time.