### PR TITLE
[8.x] Remove special handling for objects and arrays with `dynamic` overrides (#113924)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -535,6 +535,8 @@ object array in object with dynamic override:
             _source:
               mode: synthetic
             properties:
+              id:
+                type: integer
               path_no:
                 dynamic: false
                 properties:
@@ -552,19 +554,25 @@ object array in object with dynamic override:
         refresh: true
         body:
           - '{ "create": { } }'
-          - '{ "path_no": [ { "some_int": 10 }, {"name": "foo"} ], "path_runtime": [ { "some_int": 20 }, {"name": "bar"} ], "name": "baz" }'
+          - '{ "id": 1, "path_no": [ { "some_int": 30 }, {"name": "baz"}, { "some_int": 20 }, {"name": "bar"} ], "name": "A" }'
+          - '{ "create": { } }'
+          - '{ "id": 2, "path_runtime": [ { "some_int": 30 }, {"name": "baz"}, { "some_int": 20 }, {"name": "bar"} ], "name": "B" }'
   - match: { errors: false }
 
   - do:
       search:
         index: test
+        sort: id
 
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._source.name: baz }
-  - match: { hits.hits.0._source.path_no.0.some_int: 10 }
-  - match: { hits.hits.0._source.path_no.1.name: foo }
-  - match: { hits.hits.0._source.path_runtime.0.some_int: 20 }
-  - match: { hits.hits.0._source.path_runtime.1.name: bar }
+  - match: { hits.hits.0._source.id: 1 }
+  - match: { hits.hits.0._source.name: A }
+  - match: { hits.hits.0._source.path_no.some_int: [ 30, 20 ] }
+  - match: { hits.hits.0._source.path_no.name: [ bar, baz ] }
+
+  - match: { hits.hits.1._source.id: 2 }
+  - match: { hits.hits.1._source.name: B }
+  - match: { hits.hits.1._source.path_runtime.some_int: [ 30, 20 ] }
+  - match: { hits.hits.1._source.path_runtime.name: [ bar, baz ] }
 
 
 ---


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Remove special handling for objects and arrays with &#x60;dynamic&#x60; overrides (#113924)](https://github.com/elastic/elasticsearch/pull/113924)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)