### PR TITLE
Updated Date Range to Follow Documentation When Assuming Missing Values - Feature Fix

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -29,8 +29,12 @@ public class MapperFeatures implements FeatureSpecification {
             DenseVectorFieldMapper.BIT_VECTORS,
             DocumentMapper.INDEX_SORTING_ON_NESTED,
             KeywordFieldMapper.KEYWORD_DIMENSION_IGNORE_ABOVE,
-            SourceFieldMapper.SYNTHETIC_SOURCE_STORED_FIELDS_ADVANCE_FIX,
-            RangeFieldMapper.DATE_RANGE_INDEXING_FIX
+            SourceFieldMapper.SYNTHETIC_SOURCE_STORED_FIELDS_ADVANCE_FIX
         );
+    }
+
+    @Override
+    public Set<NodeFeature> getTestFeatures() {
+        return Set.of(RangeFieldMapper.DATE_RANGE_INDEXING_FIX);
     }
 }


### PR DESCRIPTION
Fixing an issue with how cluster features were inappropriately used instead of the new test features.

Related to: https://github.com/elastic/elasticsearch/pull/113956
Related to: https://github.com/elastic/elasticsearch/pull/112258
