### PR TITLE
ES|QL cross-cluster searches honor the skip_unavailable cluster setting

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexValidator.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexValidator.java
@@ -159,7 +159,7 @@ public class ReindexValidator {
         // An index expression that references a remote cluster uses ":" to separate the cluster-alias from the index portion of the
         // expression, e.g., cluster0:index-name
         return new SearchRequest(source).indices(
-            Arrays.stream(source.indices()).filter(name -> RemoteClusterAware.isRemoteIndexName(name) == false).toArray(String[]::new)
+            Arrays.stream(source.indices()).filter(name -> RemoteClusterAware.isRemoteIndexExpression(name) == false).toArray(String[]::new)
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -231,6 +231,7 @@ public class TransportVersions {
     public static final TransportVersion CCS_REMOTE_TELEMETRY_STATS = def(8_755_00_0);
     public static final TransportVersion ESQL_CCS_EXECUTION_INFO = def(8_756_00_0);
     public static final TransportVersion REGEX_AND_RANGE_INTERVAL_QUERIES = def(8_757_00_0);
+    public static final TransportVersion ESQL_CCS_EXEC_INFO_WITH_FAILURES = def(8_758_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -165,7 +165,7 @@ public class ResolveClusterActionRequest extends ActionRequest implements Indice
 
     boolean localIndicesPresent(String[] indices) {
         for (String index : indices) {
-            if (RemoteClusterAware.isRemoteIndexName(index) == false) {
+            if (RemoteClusterAware.isRemoteIndexExpression(index) == false) {
                 return true;
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1754,7 +1754,7 @@ public class IndexNameExpressionResolver {
                 return;
             }
             for (String index : indexExpressions) {
-                if (RemoteClusterAware.isRemoteIndexName(index)) {
+                if (RemoteClusterAware.isRemoteIndexExpression(index)) {
                     failOnRemoteIndicesNotIgnoringUnavailable(indexExpressions);
                 }
             }
@@ -1763,7 +1763,7 @@ public class IndexNameExpressionResolver {
         private static void failOnRemoteIndicesNotIgnoringUnavailable(List<String> indexExpressions) {
             List<String> crossClusterIndices = new ArrayList<>();
             for (String index : indexExpressions) {
-                if (RemoteClusterAware.isRemoteIndexName(index)) {
+                if (RemoteClusterAware.isRemoteIndexExpression(index)) {
                     crossClusterIndices.add(index);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -58,7 +58,7 @@ public abstract class RemoteClusterAware {
      * The index name is assumed to be individual index (no commas) but can contain `-`, wildcards,
      * datemath, remote cluster name and any other syntax permissible in index expression component.
      */
-    public static boolean isRemoteIndexName(String indexExpression) {
+    public static boolean isRemoteIndexExpression(String indexExpression) {
         if (indexExpression.isEmpty() || indexExpression.charAt(0) == '<' || indexExpression.startsWith("-<")) {
             // This is date math, but even if it is not, the remote can't start with '<'.
             // Thus, whatever it is, this is definitely not a remote index.
@@ -107,18 +107,33 @@ public abstract class RemoteClusterAware {
     }
 
     /**
-     *
      * @param indexExpression The index expression is assumed to be an individual index (no commas) but can
      *                        contain `-`, wildcards, datemath, a remote cluster alias prefix and any other
      *                        syntax permissible in index expression component.
-     * @return true if the index portion (not the cluster alias portion) has a wildcard '*' character.
+     * @return true if:
+     *   - the expression is not an index exclusion (does not start with a "-")
+     *   - the expression is not an cluster exclusion (does not start with a "-")
+     *   - the index is not a date math expression
+     *   - the index does not have a wildcard '*' character.
      */
-    public static boolean indexHasWildcard(String indexExpression) {
+    public static boolean isConcreteIndexName(String indexExpression) {
+        if (indexExpression.isEmpty()) {
+            return false;
+        }
         String[] split = splitIndexName(indexExpression);
-        assert split[0] == null || split[0].contains(",") == false : "Should only be a single index expression but was: " + indexExpression;
-        assert ((split[1].charAt(0) != '<' && split[1].startsWith("-<") == false) && split[1].contains(",")) == false
-            : "Should only be a single index expression but was not date math and index has comma: " + indexExpression;
-        return split[1].contains("*");
+        String clusterAlias = split[0];
+        String indexName = split[1];
+        assert clusterAlias == null || clusterAlias.contains(",") == false
+            : "Should only be a single index expression but was: " + indexExpression;
+        assert ((indexName.charAt(0) != '<' && indexName.startsWith("-<") == false) && indexName.contains(",")) == false
+            : "Should only be a single index expression but comma is present in indexExpression: " + indexExpression;
+        if (clusterAlias != null && clusterAlias.charAt(0) == '-') {
+            return false;
+        }
+        if (indexName.charAt(0) == '-' || indexName.charAt(0) == '<') {
+            return false;
+        }
+        return indexName.contains("*") == false;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -107,6 +107,21 @@ public abstract class RemoteClusterAware {
     }
 
     /**
+     *
+     * @param indexExpression The index expression is assumed to be an individual index (no commas) but can
+     *                        contain `-`, wildcards, datemath, a remote cluster alias prefix and any other
+     *                        syntax permissible in index expression component.
+     * @return true if the index portion (not the cluster alias portion) has a wildcard '*' character.
+     */
+    public static boolean indexHasWildcard(String indexExpression) {
+        String[] split = splitIndexName(indexExpression);
+        assert split[0] == null || split[0].contains(",") == false : "Should only be a single index expression but was: " + indexExpression;
+        assert ((split[1].charAt(0) != '<' && split[1].startsWith("-<") == false) && split[1].contains(",")) == false
+            : "Should only be a single index expression but was not date math and index has comma: " + indexExpression;
+        return split[1].contains("*");
+    }
+
+    /**
      * Groups indices per cluster by splitting remote cluster-alias, index-name pairs on {@link #REMOTE_CLUSTER_INDEX_SEPARATOR}. All
      * indices per cluster are collected as a list in the returned map keyed by the cluster alias. Local indices are grouped under
      * {@link #LOCAL_CLUSTER_GROUP_KEY}. The returned map is mutable.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RemoteClusterLicenseChecker.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RemoteClusterLicenseChecker.java
@@ -239,7 +239,7 @@ public final class RemoteClusterLicenseChecker {
      * @return true if the collection of indices contains a remote index, otherwise false
      */
     public static boolean isRemoteIndex(final String index) {
-        return RemoteClusterAware.isRemoteIndexName(index);
+        return RemoteClusterAware.isRemoteIndexExpression(index);
     }
 
     /**

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/util/StringUtils.java
@@ -391,7 +391,7 @@ public final class StringUtils {
     }
 
     public static boolean isQualified(String indexWildcard) {
-        return RemoteClusterAware.isRemoteIndexName(indexWildcard);
+        return RemoteClusterAware.isRemoteIndexExpression(indexWildcard);
     }
 
     public static boolean isInteger(String value) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
@@ -21,9 +21,11 @@ import org.elasticsearch.compute.lucene.DataPartitioning;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
@@ -39,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -103,6 +106,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(0));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
@@ -112,6 +116,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(0));
         }
 
         try (EsqlQueryResponse resp = runQuery("from logs-*,*:logs-* | stats count(*) by tag | sort tag | keep tag")) {
@@ -135,6 +140,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(0));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
@@ -144,6 +150,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(0));
         }
     }
 
@@ -151,43 +158,55 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
         Map<String, Object> testClusterInfo = setupTwoClusters();
         int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
         int remoteNumShards = (Integer) testClusterInfo.get("remote.num_shards");
+        boolean skipUnavailable = (Boolean) testClusterInfo.get("remote.skip_unavailable");
 
-        // since a valid local index was specified, the invalid index on cluster-a does not throw an exception,
-        // but instead is simply ignored - ensure this is captured in the EsqlExecutionInfo
-        try (EsqlQueryResponse resp = runQuery("from logs-*,cluster-a:no_such_index | stats sum (v)")) {
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values, hasSize(1));
-            assertThat(values.get(0), equalTo(List.of(45L)));
+        {
+            String query = "FROM logs-*,cluster-a:nomatch | STATS sum (v)";
+            if (skipUnavailable == false) {
+                // throws an exception when skip_unavailable=false and concrete index was specified
+                IndexNotFoundException exception = expectThrows(IndexNotFoundException.class, () -> runQuery(query));
+                assertThat(exception.getDetailedMessage(), containsString("nomatch"));
+            } else {
+                // since a valid local index was specified, the invalid index on cluster-a does not throw an exception,
+                // but instead is simply ignored - ensure this is captured in the EsqlExecutionInfo
+                try (EsqlQueryResponse resp = runQuery(query)) {
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    List<List<Object>> values = getValuesList(resp);
+                    assertThat(values, hasSize(1));
+                    assertThat(values.get(0), equalTo(List.of(45L)));
 
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
+                    assertNotNull(executionInfo);
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+                    assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));  // 0 since no matching index, thus no shards to search
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                    EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+                    assertThat(remoteCluster.getIndexExpression(), equalTo("nomatch"));
+                    assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+                    assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+                    assertThat(remoteCluster.getTotalShards(), equalTo(0));  // 0 since no matching index, thus no shards to search
+                    assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
+                    assertThat(remoteCluster.getSkippedShards(), equalTo(0));
+                    assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                    assertThat(remoteCluster.getFailures().size(), equalTo(1));
+                    assertThat(remoteCluster.getFailures().get(0).reason(), containsString("no such index [nomatch]"));
 
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+                    EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
+                    assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
+                    assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+                    assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+                    assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
+                    assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
+                    assertThat(localCluster.getSkippedShards(), equalTo(0));
+                    assertThat(localCluster.getFailedShards(), equalTo(0));
+                    assertThat(localCluster.getFailures().size(), equalTo(0));
+                }
+            }
         }
 
-        // since the remote cluster has a valid index expression, the missing local index is ignored
-        // make this is captured in the EsqlExecutionInfo
-        try (EsqlQueryResponse resp = runQuery("from no_such_index,*:logs-* | stats count(*) by tag | sort tag | keep tag")) {
+        // since the remote cluster has a valid index expression, the missing local index is ignored and local cluster is marked as SKIPPED
+        try (EsqlQueryResponse resp = runQuery("from nomatch,*:logs-* | stats count(*) by tag | sort tag | keep tag")) {
             List<List<Object>> values = getValuesList(resp);
             assertThat(values, hasSize(1));
             assertThat(values.get(0), equalTo(List.of("remote")));
@@ -207,55 +226,70 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(0));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("no_such_index"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+            assertThat(localCluster.getIndexExpression(), equalTo("nomatch"));
+            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
             assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
             assertThat(localCluster.getTotalShards(), equalTo(0));
             assertThat(localCluster.getSuccessfulShards(), equalTo(0));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(1));
+            assertThat(localCluster.getFailures().get(0).reason(), containsString("no such index [nomatch]"));
         }
 
-        // when multiple invalid indices are specified on the remote cluster, both should be ignored and present
-        // in the index expression of the EsqlExecutionInfo and with an indication that zero shards were searched
-        try (
-            EsqlQueryResponse resp = runQuery(
-                "FROM no_such_index*,*:no_such_index1,*:no_such_index2,logs-1 | STATS COUNT(*) by tag | SORT tag | KEEP tag"
-            )
-        ) {
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values, hasSize(1));
-            assertThat(values.get(0), equalTo(List.of("local")));
+        {
+            String query = "FROM no_such_index*,*:no_such_index1,*:no_such_index2,logs-1 | STATS COUNT(*) by tag | SORT tag | KEEP tag";
+            if (skipUnavailable == false) {
+                // throws an exception when skip_unavailable=false and concrete index was specified
+                IndexNotFoundException exception = expectThrows(IndexNotFoundException.class, () -> runQuery(query));
+                assertThat(exception.getDetailedMessage(), containsString("no such index [no_such_index1,no_such_index2]"));
+            } else {
+                // when multiple wildcard non-matching index expressions are specified on the remote,
+                // the remote should be SKIPPED with an indication that zero shards were searched and a failure message
+                try (EsqlQueryResponse resp = runQuery(query)) {
+                    List<List<Object>> values = getValuesList(resp);
+                    assertThat(values, hasSize(1));
+                    assertThat(values.get(0), equalTo(List.of("local")));
 
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertNotNull(executionInfo);
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+                    assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index1,no_such_index2"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                    EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+                    assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index1,no_such_index2"));
+                    assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+                    assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+                    assertThat(remoteCluster.getTotalShards(), equalTo(0));
+                    assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
+                    assertThat(remoteCluster.getSkippedShards(), equalTo(0));
+                    assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                    assertThat(remoteCluster.getFailures().size(), equalTo(1));
+                    assertThat(
+                        remoteCluster.getFailures().get(0).reason(),
+                        containsString("no such index [no_such_index1,no_such_index2]")
+                    );
 
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("no_such_index*,logs-1"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+                    EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
+                    assertThat(localCluster.getIndexExpression(), equalTo("no_such_index*,logs-1"));
+                    assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+                    assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
+                    assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
+                    assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
+                    assertThat(localCluster.getSkippedShards(), equalTo(0));
+                    assertThat(localCluster.getFailedShards(), equalTo(0));
+                    assertThat(localCluster.getFailures().size(), equalTo(0));
+                }
+            }
         }
 
-        // wildcard on remote cluster that matches nothing - should be present in EsqlExecutionInfo marked as SKIPPED, no shards searched
+        // local index matches, wildcard on remote cluster that matches nothing - should be present in EsqlExecutionInfo marked as
+        // SKIPPED, no shards searched, with failure message
         try (EsqlQueryResponse resp = runQuery("from cluster-a:no_such_index*,logs-* | stats sum (v)")) {
             EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
             List<List<Object>> values = getValuesList(resp);
@@ -276,6 +310,8 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(1));
+            assertThat(remoteCluster.getFailures().get(0).reason(), containsString("no such index [no_such_index*]"));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
@@ -285,6 +321,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(0));
         }
     }
 
@@ -327,6 +364,8 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(1));
+            assertThat(remoteCluster.getFailures().get(0).reason(), containsString("no such index [no_such_index*]"));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs-*,no_such_index*"));
@@ -336,6 +375,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(0));
         }
     }
 
@@ -362,6 +402,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(0));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
@@ -371,6 +412,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(0));
         }
     }
 
@@ -489,6 +531,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
                 assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
                 assertThat(remoteCluster.getSkippedShards(), equalTo(0));
                 assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                assertThat(remoteCluster.getFailures().size(), equalTo(0));
 
                 EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
                 assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
@@ -498,6 +541,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
                 assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
                 assertThat(localCluster.getSkippedShards(), equalTo(0));
                 assertThat(localCluster.getFailedShards(), equalTo(0));
+                assertThat(localCluster.getFailures().size(), equalTo(0));
             }
         }
         assertThat(allProfiles, equalTo(localOnlyProfiles + remoteOnlyProfiles - 1));
@@ -541,6 +585,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
             assertThat(remoteCluster.getSkippedShards(), equalTo(0));
             assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertThat(remoteCluster.getFailures().size(), equalTo(0));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
@@ -550,6 +595,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertThat(localCluster.getFailures().size(), equalTo(0));
 
             latch.countDown();
         }, e -> {
@@ -585,6 +631,14 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
         clusterInfo.put("local.index", localIndex);
         clusterInfo.put("remote.num_shards", numShardsRemote);
         clusterInfo.put("remote.index", remoteIndex);
+
+        String skipUnavailableKey = Strings.format("cluster.remote.%s.skip_unavailable", REMOTE_CLUSTER);
+        Setting<?> skipUnavailableSetting = cluster(REMOTE_CLUSTER).clusterService().getClusterSettings().get(skipUnavailableKey);
+        boolean skipUnavailable = (boolean) cluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).clusterService()
+            .getClusterSettings()
+            .get(skipUnavailableSetting);
+        clusterInfo.put("remote.skip_unavailable", skipUnavailable);
+
         return clusterInfo;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -127,7 +129,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
      */
     public boolean isSkipUnavailable(String clusterAlias) {
         if (RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY.equals(clusterAlias)) {
-            return false;
+            return true;
         }
         return skipUnavailablePredicate.test(clusterAlias);
     }
@@ -230,6 +232,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
         private final Integer successfulShards;
         private final Integer skippedShards;
         private final Integer failedShards;
+        private final List<ShardSearchFailure> failures;
         private final TimeValue took;  // search latency for this cluster sub-search
 
         /**
@@ -249,7 +252,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
         }
 
         public Cluster(String clusterAlias, String indexExpression) {
-            this(clusterAlias, indexExpression, true, Cluster.Status.RUNNING, null, null, null, null, null);
+            this(clusterAlias, indexExpression, true, Cluster.Status.RUNNING, null, null, null, null, null, null);
         }
 
         /**
@@ -261,7 +264,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
          * @param skipUnavailable whether this Cluster is marked as skip_unavailable in remote cluster settings
          */
         public Cluster(String clusterAlias, String indexExpression, boolean skipUnavailable) {
-            this(clusterAlias, indexExpression, skipUnavailable, Cluster.Status.RUNNING, null, null, null, null, null);
+            this(clusterAlias, indexExpression, skipUnavailable, Cluster.Status.RUNNING, null, null, null, null, null, null);
         }
 
         /**
@@ -273,7 +276,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
          * @param status current status of the search on this Cluster
          */
         public Cluster(String clusterAlias, String indexExpression, boolean skipUnavailable, Cluster.Status status) {
-            this(clusterAlias, indexExpression, skipUnavailable, status, null, null, null, null, null);
+            this(clusterAlias, indexExpression, skipUnavailable, status, null, null, null, null, null, null);
         }
 
         public Cluster(
@@ -285,6 +288,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
             Integer successfulShards,
             Integer skippedShards,
             Integer failedShards,
+            List<ShardSearchFailure> failures,
             TimeValue took
         ) {
             assert clusterAlias != null : "clusterAlias cannot be null";
@@ -298,6 +302,11 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
             this.successfulShards = successfulShards;
             this.skippedShards = skippedShards;
             this.failedShards = failedShards;
+            if (failures == null) {
+                this.failures = Collections.emptyList();
+            } else {
+                this.failures = failures;
+            }
             this.took = took;
         }
 
@@ -311,6 +320,11 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
             this.failedShards = in.readOptionalInt();
             this.took = in.readOptionalTimeValue();
             this.skipUnavailable = in.readBoolean();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_CCS_EXEC_INFO_WITH_FAILURES)) {
+                this.failures = Collections.unmodifiableList(in.readCollectionAsList(ShardSearchFailure::readShardSearchFailure));
+            } else {
+                this.failures = Collections.emptyList();  // MP TODO: should this be emptyList or null?
+            }
         }
 
         @Override
@@ -324,6 +338,9 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
             out.writeOptionalInt(failedShards);
             out.writeOptionalTimeValue(took);
             out.writeBoolean(skipUnavailable);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_CCS_EXEC_INFO_WITH_FAILURES)) {
+                out.writeCollection(failures);
+            }
         }
 
         /**
@@ -342,6 +359,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
             private Integer successfulShards;
             private Integer skippedShards;
             private Integer failedShards;
+            private List<ShardSearchFailure> failures;
             private TimeValue took;
             private final Cluster original;
 
@@ -364,13 +382,9 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
                     successfulShards != null ? successfulShards : original.getSuccessfulShards(),
                     skippedShards != null ? skippedShards : original.getSkippedShards(),
                     failedShards != null ? failedShards : original.getFailedShards(),
+                    failures != null ? failures : original.getFailures(),
                     took != null ? took : original.getTook()
                 );
-            }
-
-            public Cluster.Builder setIndexExpression(String indexExpression) {
-                this.indexExpression = indexExpression;
-                return this;
             }
 
             public Cluster.Builder setStatus(Cluster.Status status) {
@@ -395,6 +409,11 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
 
             public Cluster.Builder setFailedShards(int failedShards) {
                 this.failedShards = failedShards;
+                return this;
+            }
+
+            public Cluster.Builder setFailures(List<ShardSearchFailure> failures) {
+                this.failures = failures;
                 return this;
             }
 
@@ -431,6 +450,13 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
                         builder.field(RestActions.FAILED_FIELD.getPreferredName(), failedShards);
                     }
                     builder.endObject();
+                }
+                if (failures != null && failures.size() > 0) {
+                    builder.startArray(RestActions.FAILURES_FIELD.getPreferredName());
+                    for (ShardSearchFailure failure : failures) {
+                        failure.toXContent(builder, params);
+                    }
+                    builder.endArray();
                 }
             }
             builder.endObject();
@@ -476,6 +502,10 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
 
         public Integer getFailedShards() {
             return failedShards;
+        }
+
+        public List<ShardSearchFailure> getFailures() {
+            return failures;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
@@ -6,27 +6,28 @@
  */
 package org.elasticsearch.xpack.esql.index;
 
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesFailure;
 import org.elasticsearch.core.Nullable;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public final class IndexResolution {
 
-    public static IndexResolution valid(EsIndex index, Set<String> unavailableClusters) {
+    public static IndexResolution valid(EsIndex index, Map<String, FieldCapabilitiesFailure> unavailableClusters) {
         Objects.requireNonNull(index, "index must not be null if it was found");
         Objects.requireNonNull(unavailableClusters, "unavailableClusters must not be null");
         return new IndexResolution(index, null, unavailableClusters);
     }
 
     public static IndexResolution valid(EsIndex index) {
-        return valid(index, Collections.emptySet());
+        return valid(index, Collections.emptyMap());
     }
 
     public static IndexResolution invalid(String invalid) {
         Objects.requireNonNull(invalid, "invalid must not be null to signal that the index is invalid");
-        return new IndexResolution(null, invalid, Collections.emptySet());
+        return new IndexResolution(null, invalid, Collections.emptyMap());
     }
 
     public static IndexResolution notFound(String name) {
@@ -39,9 +40,9 @@ public final class IndexResolution {
     private final String invalid;
 
     // remote clusters included in the user's index expression that could not be connected to
-    private final Set<String> unavailableClusters;
+    private final Map<String, FieldCapabilitiesFailure> unavailableClusters;
 
-    private IndexResolution(EsIndex index, @Nullable String invalid, Set<String> unavailableClusters) {
+    private IndexResolution(EsIndex index, @Nullable String invalid, Map<String, FieldCapabilitiesFailure> unavailableClusters) {
         this.index = index;
         this.invalid = invalid;
         this.unavailableClusters = unavailableClusters;
@@ -70,7 +71,7 @@ public final class IndexResolution {
         return invalid == null;
     }
 
-    public Set<String> getUnavailableClusters() {
+    public Map<String, FieldCapabilitiesFailure> getUnavailableClusters() {
         return unavailableClusters;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -158,18 +158,18 @@ public class IndexResolver {
         for (FieldCapabilitiesIndexResponse ir : fieldCapsResponse.getIndexResponses()) {
             concreteIndices.put(ir.getIndexName(), ir.getIndexMode());
         }
-        Set<String> unavailableRemoteClusters = determineUnavailableRemoteClusters(fieldCapsResponse.getFailures());
-        return IndexResolution.valid(new EsIndex(indexPattern, rootFields, concreteIndices), unavailableRemoteClusters);
+        Map<String, FieldCapabilitiesFailure> unavailableRemotes = determineUnavailableRemoteClusters(fieldCapsResponse.getFailures());
+        return IndexResolution.valid(new EsIndex(indexPattern, rootFields, concreteIndices), unavailableRemotes);
     }
 
     // visible for testing
-    static Set<String> determineUnavailableRemoteClusters(List<FieldCapabilitiesFailure> failures) {
-        Set<String> unavailableRemotes = new HashSet<>();
+    static Map<String, FieldCapabilitiesFailure> determineUnavailableRemoteClusters(List<FieldCapabilitiesFailure> failures) {
+        Map<String, FieldCapabilitiesFailure> unavailableRemotes = new HashMap<>();
         for (FieldCapabilitiesFailure failure : failures) {
             if (ExceptionsHelper.isRemoteUnavailableException(failure.getException())) {
                 for (String indexExpression : failure.getIndices()) {
                     if (indexExpression.indexOf(RemoteClusterAware.REMOTE_CLUSTER_INDEX_SEPARATOR) > 0) {
-                        unavailableRemotes.add(RemoteClusterAware.parseClusterAlias(indexExpression));
+                        unavailableRemotes.put(RemoteClusterAware.parseClusterAlias(indexExpression), failure);
                     }
                 }
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -147,6 +147,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 10,
                 3,
                 0,
+                null,
                 new TimeValue(4444L)
             )
         );
@@ -161,6 +162,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 12,
                 5,
                 0,
+                null,
                 new TimeValue(4999L)
             )
         );
@@ -497,6 +499,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 successfulShardsFinal,
                 skippedShardsFinal,
                 failedShardsFinal,
+                List.of(),
                 tookTimeValue
             );
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
@@ -261,7 +261,8 @@ public class ComputeListenerTests extends ESTestCase {
                 10,
                 3,
                 0,
-                null  // to be filled in the acquireCompute listener
+                null,
+                null  // took time to be filled in the acquireCompute listener
             )
         );
         try (

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlSessionTests.java
@@ -7,9 +7,13 @@
 
 package org.elasticsearch.xpack.esql.session;
 
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesFailure;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.NoSeedNodeLeftException;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.index.EsIndex;
@@ -20,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class EsqlSessionTests extends ESTestCase {
@@ -35,7 +40,9 @@ public class EsqlSessionTests extends ESTestCase {
             executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
             executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", true));
 
-            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Set.of(remote1Alias, remote2Alias));
+            var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
+            var unvailableClusters = Map.of(remote1Alias, failure, remote2Alias, failure);
+            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, unvailableClusters);
 
             assertThat(executionInfo.clusterAliases(), equalTo(Set.of(localClusterAlias, remote1Alias, remote2Alias)));
             assertNull(executionInfo.overallTook());
@@ -53,8 +60,7 @@ public class EsqlSessionTests extends ESTestCase {
             assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.SKIPPED);
         }
 
-        // skip_unavailable=false cluster is unavailable, marked as SKIPPED // TODO: in follow on PR this will change to throwing an
-        // Exception
+        // skip_unavailable=false cluster is unavailable, throws Exception
         {
             final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
             final String remote1Alias = "remote1";
@@ -64,22 +70,17 @@ public class EsqlSessionTests extends ESTestCase {
             executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
             executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
 
-            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Set.of(remote2Alias));
-
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(localClusterAlias, remote1Alias, remote2Alias)));
-            assertNull(executionInfo.overallTook());
-
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
-
-            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
-            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
-            assertClusterStatusAndHasNullCounts(remote1Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
-
-            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
-            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
-            assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.SKIPPED);
+            var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
+            RemoteTransportException e = expectThrows(
+                RemoteTransportException.class,
+                () -> EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Map.of(remote2Alias, failure))
+            );
+            assertThat(e.status().getStatus(), equalTo(500));
+            assertThat(
+                e.getDetailedMessage(),
+                containsString("Remote cluster [remote2] (with setting skip_unavailable=false) is not available")
+            );
+            assertThat(e.getCause().getMessage(), containsString("unable to connect"));
         }
 
         // all clusters available, no Clusters in ExecutionInfo should be modified
@@ -92,7 +93,7 @@ public class EsqlSessionTests extends ESTestCase {
             executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
             executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", false));
 
-            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Set.of());
+            EsqlSession.updateExecutionInfoWithUnavailableClusters(executionInfo, Map.of());
 
             assertThat(executionInfo.clusterAliases(), equalTo(Set.of(localClusterAlias, remote1Alias, remote2Alias)));
             assertNull(executionInfo.overallTook());
@@ -112,11 +113,11 @@ public class EsqlSessionTests extends ESTestCase {
     }
 
     public void testUpdateExecutionInfoWithClustersWithNoMatchingIndices() {
+        final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+        final String remote1Alias = "remote1";
+        final String remote2Alias = "remote2";
         // all clusters present in EsIndex, so no updates to EsqlExecutionInfo should happen
         {
-            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
-            final String remote1Alias = "remote1";
-            final String remote2Alias = "remote2";
             EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
             executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
             executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
@@ -138,7 +139,7 @@ public class EsqlSessionTests extends ESTestCase {
                     IndexMode.STANDARD
                 )
             );
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, Set.of());
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Map.of());
 
             EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
 
@@ -157,9 +158,6 @@ public class EsqlSessionTests extends ESTestCase {
 
         // remote1 is missing from EsIndex info, so it should be updated and marked as SKIPPED with 0 total shards, 0 took time, etc.
         {
-            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
-            final String remote1Alias = "remote1";
-            final String remote2Alias = "remote2";
             EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
             executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
             executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
@@ -179,7 +177,7 @@ public class EsqlSessionTests extends ESTestCase {
                     IndexMode.STANDARD
                 )
             );
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, Set.of());
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Map.of());
 
             EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
 
@@ -201,11 +199,47 @@ public class EsqlSessionTests extends ESTestCase {
             assertClusterStatusAndHasNullCounts(remote2Cluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
         }
 
-        // all remotes are missing from EsIndex info, so they should be updated and marked as SKIPPED with 0 total shards, 0 took time, etc.
+        // all remotes are missing from EsIndex info. Since they are configured with skip_unavailable=true,
+        // they should be updated and marked as SKIPPED with 0 total shards, 0 took time, etc.
         {
-            final String localClusterAlias = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
-            final String remote1Alias = "remote1";
-            final String remote2Alias = "remote2";
+            EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
+            executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*"));
+            executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
+            executionInfo.swapCluster(remote2Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote2Alias, "mylogs1,mylogs2,logs*", true));
+
+            EsIndex esIndex = new EsIndex(
+                "logs*,remote2:mylogs1,remote2:mylogs2,remote2:logs*",
+                randomMapping(),
+                Map.of("logs-a", IndexMode.STANDARD)
+            );
+            var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Map.of(remote1Alias, failure));
+
+            EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
+
+            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
+            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
+            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
+
+            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
+            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
+            // since remote1 is in the unavailable Map (passed to IndexResolution.valid), it's status will not be changed
+            // by updateExecutionInfoWithClustersWithNoMatchingIndices (it is handled in updateExecutionInfoWithUnavailableClusters)
+            assertThat(remote1Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.RUNNING));
+
+            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
+            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
+            assertThat(remote2Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+            assertThat(remote2Cluster.getTook().millis(), equalTo(0L));
+            assertThat(remote2Cluster.getTotalShards(), equalTo(0));
+            assertThat(remote2Cluster.getSuccessfulShards(), equalTo(0));
+            assertThat(remote2Cluster.getSkippedShards(), equalTo(0));
+            assertThat(remote2Cluster.getFailedShards(), equalTo(0));
+        }
+
+        // all remotes are missing from EsIndex info. Since one is configured with skip_unavailable=false,
+        // an exception should be thrown
+        {
             EsqlExecutionInfo executionInfo = new EsqlExecutionInfo();
             executionInfo.swapCluster(localClusterAlias, (k, v) -> new EsqlExecutionInfo.Cluster(localClusterAlias, "logs*", false));
             executionInfo.swapCluster(remote1Alias, (k, v) -> new EsqlExecutionInfo.Cluster(remote1Alias, "*", true));
@@ -216,31 +250,15 @@ public class EsqlSessionTests extends ESTestCase {
                 randomMapping(),
                 Map.of("logs-a", IndexMode.STANDARD)
             );
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, Set.of(remote1Alias));
+            var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Map.of(remote1Alias, failure));
 
-            EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
-
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(localClusterAlias);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertClusterStatusAndHasNullCounts(localCluster, EsqlExecutionInfo.Cluster.Status.RUNNING);
-
-            EsqlExecutionInfo.Cluster remote1Cluster = executionInfo.getCluster(remote1Alias);
-            assertThat(remote1Cluster.getIndexExpression(), equalTo("*"));
-            assertThat(remote1Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remote1Cluster.getTook().millis(), equalTo(0L));
-            assertThat(remote1Cluster.getTotalShards(), equalTo(0));
-            assertThat(remote1Cluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remote1Cluster.getSkippedShards(), equalTo(0));
-            assertThat(remote1Cluster.getFailedShards(), equalTo(0));
-
-            EsqlExecutionInfo.Cluster remote2Cluster = executionInfo.getCluster(remote2Alias);
-            assertThat(remote2Cluster.getIndexExpression(), equalTo("mylogs1,mylogs2,logs*"));
-            assertThat(remote2Cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remote2Cluster.getTook().millis(), equalTo(0L));
-            assertThat(remote2Cluster.getTotalShards(), equalTo(0));
-            assertThat(remote2Cluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remote2Cluster.getSkippedShards(), equalTo(0));
-            assertThat(remote2Cluster.getFailedShards(), equalTo(0));
+            IndexNotFoundException e = expectThrows(
+                IndexNotFoundException.class,
+                () -> EsqlSession.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution)
+            );
+            assertThat(e.getDetailedMessage(), containsString("no such index"));
+            assertThat(e.getDetailedMessage(), containsString("mylogs1,mylogs2,logs*"));
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.transport.NoSuchRemoteClusterException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -33,8 +34,8 @@ public class IndexResolverTests extends ESTestCase {
                 )
             );
 
-            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
-            assertThat(unavailableClusters, equalTo(Set.of("remote1", "remote2")));
+            Map<String, FieldCapabilitiesFailure> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters.keySet(), equalTo(Set.of("remote1", "remote2")));
         }
 
         // one cluster with "remote unavailable" with two failures
@@ -43,8 +44,8 @@ public class IndexResolverTests extends ESTestCase {
             failures.add(new FieldCapabilitiesFailure(new String[] { "remote2:mylogs1" }, new NoSuchRemoteClusterException("remote2")));
             failures.add(new FieldCapabilitiesFailure(new String[] { "remote2:mylogs1" }, new NoSeedNodeLeftException("no seed node")));
 
-            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
-            assertThat(unavailableClusters, equalTo(Set.of("remote2")));
+            Map<String, FieldCapabilitiesFailure> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters.keySet(), equalTo(Set.of("remote2")));
         }
 
         // two clusters, one "remote unavailable" type exceptions and one with another type
@@ -57,23 +58,23 @@ public class IndexResolverTests extends ESTestCase {
                     new IllegalStateException("Unable to open any connections")
                 )
             );
-            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
-            assertThat(unavailableClusters, equalTo(Set.of("remote2")));
+            Map<String, FieldCapabilitiesFailure> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters.keySet(), equalTo(Set.of("remote2")));
         }
 
         // one cluster1 with exception not known to indicate "remote unavailable"
         {
             List<FieldCapabilitiesFailure> failures = new ArrayList<>();
             failures.add(new FieldCapabilitiesFailure(new String[] { "remote1:mylogs1" }, new RuntimeException("foo")));
-            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
-            assertThat(unavailableClusters, equalTo(Set.of()));
+            Map<String, FieldCapabilitiesFailure> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters.keySet(), equalTo(Set.of()));
         }
 
         // empty failures list
         {
             List<FieldCapabilitiesFailure> failures = new ArrayList<>();
-            Set<String> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
-            assertThat(unavailableClusters, equalTo(Set.of()));
+            Map<String, FieldCapabilitiesFailure> unavailableClusters = IndexResolver.determineUnavailableRemoteClusters(failures);
+            assertThat(unavailableClusters.keySet(), equalTo(Set.of()));
         }
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -388,6 +388,6 @@ public final class StringUtils {
     }
 
     public static boolean isQualified(String indexWildcard) {
-        return RemoteClusterAware.isRemoteIndexName(indexWildcard);
+        return RemoteClusterAware.isRemoteIndexExpression(indexWildcard);
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptor.java
@@ -55,6 +55,6 @@ public class SearchRequestCacheDisablingInterceptor implements RequestIntercepto
 
     // package private for test
     static boolean hasRemoteIndices(SearchRequest request) {
-        return Arrays.stream(request.indices()).anyMatch(RemoteClusterAware::isRemoteIndexName);
+        return Arrays.stream(request.indices()).anyMatch(RemoteClusterAware::isRemoteIndexExpression);
     }
 }


### PR DESCRIPTION
Do not review yet.

Fixes https://github.com/elastic/elasticsearch/issues/112886