### PR TITLE
Change default indexing primary limit in stateless

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexingPressure.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingPressure.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -45,7 +46,7 @@ public class IndexingPressure {
 
     public static final Setting<ByteSizeValue> MAX_PRIMARY_BYTES = Setting.memorySizeSetting(
         "indexing_pressure.memory.primary.limit",
-        MAX_INDEXING_BYTES,
+        s -> DiscoveryNode.isStateless(s) ? "15%" : MAX_INDEXING_BYTES.get(s).getStringRep(),
         Setting.Property.NodeScope
     );
 

--- a/server/src/test/java/org/elasticsearch/index/IndexingPressureTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingPressureTests.java
@@ -40,9 +40,7 @@ public class IndexingPressureTests extends ESTestCase {
     }
 
     public void testPrimaryMemoryLimitSettingsDefaultForStateless() {
-        Settings settingsDefault = Settings.builder()
-            .put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true)
-            .build();
+        Settings settingsDefault = Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true).build();
 
         assertThat(IndexingPressure.MAX_COORDINATING_BYTES.getDefaultRaw(settingsDefault), equalTo("10%"));
         assertThat(IndexingPressure.MAX_PRIMARY_BYTES.getDefaultRaw(settingsDefault), equalTo("15%"));


### PR DESCRIPTION
In stateless we would like to have the primary limit be greater than the
coordinating limit to push forward with indexing data that has already
been received.