### PR TITLE
ES|QL: fix EsqlQueryResponseTests.testEqualsAndHashcode

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -236,6 +236,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
     protected EsqlQueryResponse mutateInstance(EsqlQueryResponse instance) {
         boolean allNull = true;
         for (ColumnInfoImpl info : instance.columns()) {
+            // values inside NULL and UNSUPPORTED blocks cannot be mutated, because they are all null
             if (info.type() != DataType.NULL && info.type() != DataType.UNSUPPORTED) {
                 allNull = false;
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -236,7 +236,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
     protected EsqlQueryResponse mutateInstance(EsqlQueryResponse instance) {
         boolean allNull = true;
         for (ColumnInfoImpl info : instance.columns()) {
-            if (info.type() != DataType.NULL) {
+            if (info.type() != DataType.NULL && info.type() != DataType.UNSUPPORTED) {
                 allNull = false;
             }
         }


### PR DESCRIPTION
Fixes: #113754

For a specific seed, the test tried to mutate a page made of all UNSUPPORTED columns, leading to an infinite loop (unsupported values are always null)