### PR TITLE
[8.x] [ML] Check Search Inference ID Usage When Deleting An Inference Endpoint (#113895)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/SemanticTextInfoExtractor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/SemanticTextInfoExtractor.java
@@ -33,15 +33,11 @@ public class SemanticTextInfoExtractor {
         Map<String, IndexMetadata> indices = metadata.indices();
 
         indices.forEach((indexName, indexMetadata) -> {
-            if (indexMetadata.getInferenceFields() != null) {
-                Map<String, InferenceFieldMetadata> inferenceFields = indexMetadata.getInferenceFields();
-                if (inferenceFields.entrySet()
-                    .stream()
-                    .anyMatch(
-                        entry -> entry.getValue().getInferenceId() != null && endpointIds.contains(entry.getValue().getInferenceId())
-                    )) {
-                    referenceIndices.add(indexName);
-                }
+            Map<String, InferenceFieldMetadata> inferenceFields = indexMetadata.getInferenceFields();
+            if (inferenceFields.values()
+                .stream()
+                .anyMatch(im -> endpointIds.contains(im.getInferenceId()) || endpointIds.contains(im.getSearchInferenceId()))) {
+                referenceIndices.add(indexName);
             }
         });
 

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -168,6 +168,26 @@ public class InferenceBaseRestTest extends ESRestTestCase {
         assertOkOrCreated(response);
     }
 
+    protected void putSemanticText(String endpointId, String searchEndpointId, String indexName) throws IOException {
+        var request = new Request("PUT", Strings.format("%s", indexName));
+        String body = Strings.format("""
+            {
+                "mappings": {
+                "properties": {
+                    "inference_field": {
+                        "type": "semantic_text",
+                            "inference_id": "%s",
+                            "search_inference_id": "%s"
+                    }
+                }
+                }
+            }
+            """, endpointId, searchEndpointId);
+        request.setJsonEntity(body);
+        var response = client().performRequest(request);
+        assertOkOrCreated(response);
+    }
+
     protected Map<String, Object> putModel(String modelId, String modelConfig, TaskType taskType) throws IOException {
         String endpoint = Strings.format("_inference/%s/%s", taskType, modelId);
         return putRequest(endpoint, modelConfig);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Check Search Inference ID Usage When Deleting An Inference Endpoint (#113895)