### PR TITLE
[DOCS] Removes link from semantic text tutorial

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-semantic-text.asciidoc
@@ -50,7 +50,7 @@ PUT _inference/sparse_embedding/my-elser-endpoint <1>
 be used and ELSER creates sparse vectors. The `inference_id` is
 `my-elser-endpoint`.
 <2> The `elser` service is used in this example.
-<3> This setting enables and configures {ml-docs}/ml-nlp-elser.html#elser-adaptive-allocations[adaptive allocations].
+<3> This setting enables and configures adaptive allocations.
 Adaptive allocations make it possible for ELSER to automatically scale up or down resources based on the current load on the process.
 
 [NOTE]


### PR DESCRIPTION
## Overview

This PR removes a link pointing to the adaptive allocations docs in the ML book. The documentation will be moved to a different page, to avoid failing docs builds, removing the link is required.