### PR TITLE
Mute MixedClusterClientYamlTestSuiteIT test {p0=indices.create/20_synthetic_source/object array in object with dynamic override}

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -320,6 +320,9 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=range/20_synthetic_source/Date range}
   issue: https://github.com/elastic/elasticsearch/issues/113874
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=indices.create/20_synthetic_source/object array in object with dynamic override}
+  issue: https://github.com/elastic/elasticsearch/issues/114043
 
 
 # Examples:

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.inference.services.validation.ModelValidatorBuild
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;


### PR DESCRIPTION
Mute this test failure that is blocking the ability to merge #114027 and #113977
