### PR TITLE
[DOCS] ES|QL: Adding a tip to the WHERE documentation

### DIFF
--- a/docs/reference/esql/processing-commands/where.asciidoc
+++ b/docs/reference/esql/processing-commands/where.asciidoc
@@ -7,7 +7,7 @@ the input table for which the provided condition evaluates to `true`.
 
 [TIP]
 ====
-Docs with `null` field values will be excluded from search results where you are excluding a specific value from that field. For example: `WHERE field != "value"` will be interpreted as `WHERE field != "value" and field is not null`.
+In case of value exclusions, fields with `null` values (a `null` means either there is an explicit `null` value in the document or there is no value at all) will be excluded from search results. For example: `WHERE field != "value"` will be interpreted as `WHERE field != "value" AND field IS NOT NULL`.
 ====
 
 **Syntax**

--- a/docs/reference/esql/processing-commands/where.asciidoc
+++ b/docs/reference/esql/processing-commands/where.asciidoc
@@ -7,7 +7,9 @@ the input table for which the provided condition evaluates to `true`.
 
 [TIP]
 ====
-In case of value exclusions, fields with `null` values (a `null` means either there is an explicit `null` value in the document or there is no value at all) will be excluded from search results. For example: `WHERE field != "value"` will be interpreted as `WHERE field != "value" AND field IS NOT NULL`.
+In case of value exclusions, fields with `null` values will be excluded from search results. 
+In this context a `null` means either there is an explicit `null` value in the document or there is no value at all.
+For example: `WHERE field != "value"` will be interpreted as `WHERE field != "value" AND field IS NOT NULL`.
 ====
 
 **Syntax**

--- a/docs/reference/esql/processing-commands/where.asciidoc
+++ b/docs/reference/esql/processing-commands/where.asciidoc
@@ -5,6 +5,11 @@
 The `WHERE` processing command produces a table that contains all the rows from
 the input table for which the provided condition evaluates to `true`.
 
+[TIP]
+====
+Docs with `null` field values will be excluded from search results where you are excluding a specific value from that field. For example: `WHERE field != "value"` will be interpreted as `WHERE field != "value" and field is not null`.
+====
+
 **Syntax**
 
 [source,esql]


### PR DESCRIPTION
The `WHERE` clause in ES|QL will exclude `null` results when using a `!=` operator. Examples provided in screenshots. This is the opposite behavior from other query languages supported in Elastic. I tested KQL, Query DSL, and Lucene. I did not test any scripting languages.

This can result in users accidentally excluding data they do not want to. This is especially concerning in Security applications where customers are building their rules to span multiple source types and those source types have mapping conflicts or other field disparity.

There is currently no information on this behavior in the ES|QL support docs. This PR is to address documentation.

No filters (for reference)
<img width="742" alt="No Filters" src="https://github.com/user-attachments/assets/9bbd8d8b-ead8-4d03-852e-acbe0ec5744f">

KQL
<img width="742" alt="KQL" src="https://github.com/user-attachments/assets/ae4e4e16-a69d-466b-8e8b-074fca837cda">

Lucene
<img width="843" alt="Lucene" src="https://github.com/user-attachments/assets/27fdff94-dd65-4256-89db-8c1fc1d62ef3">

Query DSL
<img width="742" alt="Query DSL" src="https://github.com/user-attachments/assets/cb304030-d7dc-4e76-b513-719bd2066fbb">

ES|QL without filters (for reference)
<img width="742" alt="ES|QL No Filters" src="https://github.com/user-attachments/assets/b3dd0837-7f28-46a5-a0f9-f0cf8c1417a6">

ES|QL with NOT filter only (excludes the `null` result)
<img width="843" alt="ES|QL with NOT filter" src="https://github.com/user-attachments/assets/ef6c0074-28d2-45a5-b65e-09a46730b578">

ES|QL with NOT or IS NULL filter (includes the `null` result)
<img width="978" alt="ES|QL with NOT or IS NULL filter" src="https://github.com/user-attachments/assets/756abcad-a372-49f8-a8cd-c8e4e5b239f2">