### PR TITLE
[8.x] Ensure all Security configuration is covered by enhanced file protections (#112408)

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -16,6 +16,7 @@ import java.io.FilePermission;
 import java.io.IOException;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
@@ -39,6 +40,7 @@ final class ESPolicy extends Policy {
     static final String UNTRUSTED_RESOURCE = "untrusted.policy";
 
     private static final String ALL_FILE_MASK = "read,readlink,write,delete,execute";
+    private static final AllPermission ALL_PERMISSION = new AllPermission();
 
     final Policy template;
     final Policy untrusted;
@@ -124,7 +126,7 @@ final class ESPolicy extends Policy {
              * It's helpful to use the infrastructure around FilePermission here to do the directory structure check with implies
              * so we use ALL_FILE_MASK mask to check if we can do something with this file, whatever the actual operation we're requesting
              */
-            return canAccessSecuredFile(location, new FilePermission(permission.getName(), ALL_FILE_MASK));
+            return canAccessSecuredFile(domain, new FilePermission(permission.getName(), ALL_FILE_MASK));
         }
 
         if (location != null) {
@@ -157,15 +159,24 @@ final class ESPolicy extends Policy {
     }
 
     @SuppressForbidden(reason = "We get given an URL by the security infrastructure")
-    private boolean canAccessSecuredFile(URL location, FilePermission permission) {
-        if (location == null) {
+    private boolean canAccessSecuredFile(ProtectionDomain domain, FilePermission permission) {
+        if (domain == null || domain.getCodeSource() == null || domain.getCodeSource().getLocation() == null) {
             return false;
         }
+
+        // If the domain in question has AllPermission - only true of sources built into the JDK, as we prevent AllPermission from being
+        // configured in Elasticsearch - then it has access to this file.
+
+        if (system.implies(domain, ALL_PERMISSION)) {
+            return true;
+        }
+        URL location = domain.getCodeSource().getLocation();
 
         // check the source
         Set<URL> accessibleSources = securedFiles.get(permission);
         if (accessibleSources != null) {
             // simple case - single-file referenced directly
+
             return accessibleSources.contains(location);
         } else {
             // there's a directory reference in there somewhere

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
@@ -228,7 +228,8 @@ public class JwtUtil {
         throws SettingsException {
         try {
             final Path path = JwtUtil.resolvePath(environment, jwkSetPathPkc);
-            return Files.readAllBytes(path);
+            byte[] bytes = AccessController.doPrivileged((PrivilegedExceptionAction<byte[]>) () -> Files.readAllBytes(path));
+            return bytes;
         } catch (Exception e) {
             throw new SettingsException(
                 "Failed to read contents for setting [" + jwkSetConfigKeyPkc + "] value [" + jwkSetPathPkc + "].",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -93,6 +93,7 @@ import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
+import org.elasticsearch.xpack.security.PrivilegedFileWatcher;
 import org.elasticsearch.xpack.security.authc.jwt.JwtUtil;
 
 import java.io.IOException;
@@ -366,8 +367,14 @@ public class OpenIdConnectAuthenticator {
     private JWKSet readJwkSetFromFile(String jwkSetPath) throws IOException, ParseException {
         final Path path = realmConfig.env().configFile().resolve(jwkSetPath);
         // avoid using JWKSet.loadFile() as it does not close FileInputStream internally
-        String jwkSet = Files.readString(path, StandardCharsets.UTF_8);
-        return JWKSet.parse(jwkSet);
+        try {
+            String jwkSet = AccessController.doPrivileged(
+                (PrivilegedExceptionAction<String>) () -> Files.readString(path, StandardCharsets.UTF_8)
+            );
+            return JWKSet.parse(jwkSet);
+        } catch (PrivilegedActionException ex) {
+            throw (IOException) ex.getException();
+        }
     }
 
     /**
@@ -808,7 +815,7 @@ public class OpenIdConnectAuthenticator {
 
     private void setMetadataFileWatcher(String jwkSetPath) throws IOException {
         final Path path = realmConfig.env().configFile().resolve(jwkSetPath);
-        FileWatcher watcher = new FileWatcher(path);
+        FileWatcher watcher = new PrivilegedFileWatcher(path);
         watcher.addListener(new FileListener(LOGGER, () -> this.idTokenValidator.set(createIdTokenValidator(false))));
         watcherService.add(watcher, ResourceWatcherService.Frequency.MEDIUM);
     }

--- a/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
@@ -6,6 +6,10 @@ grant {
   permission org.elasticsearch.SecuredConfigFileAccessPermission "x-pack/users";
   // other security files specified by settings
   permission org.elasticsearch.SecuredConfigFileSettingAccessPermission "xpack.security.authc.realms.ldap.*.files.role_mapping";
+  permission org.elasticsearch.SecuredConfigFileSettingAccessPermission "xpack.security.authc.realms.pki.*.files.role_mapping";
+  permission org.elasticsearch.SecuredConfigFileSettingAccessPermission "xpack.security.authc.realms.jwt.*.pkc_jwkset_path";
+  permission org.elasticsearch.SecuredConfigFileSettingAccessPermission "xpack.security.authc.realms.saml.*.idp.metadata.path";
+  permission org.elasticsearch.SecuredConfigFileSettingAccessPermission "xpack.security.authc.realms.kerberos.*.keytab.path";
 
   // needed for SAML
   permission java.util.PropertyPermission "org.apache.xml.security.ignoreLineBreaks", "read,write";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Ensure all Security configuration is covered by enhanced file protections (#112408)](https://github.com/elastic/elasticsearch/pull/112408)

<!--- Backport version: 7.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)