### PR TITLE
Fix HuggingFaceMixedIT test sometimes failing when run on version before 8.16

### DIFF
--- a/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/HuggingFaceServiceMixedIT.java
+++ b/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/HuggingFaceServiceMixedIT.java
@@ -72,7 +72,7 @@ public class HuggingFaceServiceMixedIT extends BaseMixedTestCase {
                     e.getMessage(),
                     containsString(
                         "One or more nodes in your cluster does not support chunking_settings. "
-                            + "Please update all nodes in your cluster to use chunking_settings."
+                            + "Please update all nodes in your cluster to the latest version to use chunking_settings."
                     )
                 );
                 return;

--- a/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/HuggingFaceServiceMixedIT.java
+++ b/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/HuggingFaceServiceMixedIT.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -27,6 +28,7 @@ public class HuggingFaceServiceMixedIT extends BaseMixedTestCase {
 
     private static final String HF_EMBEDDINGS_ADDED = "8.12.0";
     private static final String HF_ELSER_ADDED = "8.12.0";
+    private static final String HF_EMBEDDINGS_CHUNKING_SETTINGS_ADDED = "8.16.0";
     private static final String MINIMUM_SUPPORTED_VERSION = "8.15.0";
 
     private static MockWebServer embeddingsServer;
@@ -59,7 +61,24 @@ public class HuggingFaceServiceMixedIT extends BaseMixedTestCase {
         final String inferenceId = "mixed-cluster-embeddings";
 
         embeddingsServer.enqueue(new MockResponse().setResponseCode(200).setBody(embeddingResponse()));
-        put(inferenceId, embeddingConfig(getUrl(embeddingsServer)), TaskType.TEXT_EMBEDDING);
+
+        try {
+            put(inferenceId, embeddingConfig(getUrl(embeddingsServer)), TaskType.TEXT_EMBEDDING);
+        } catch (Exception e) {
+            if (bwcVersion.before(Version.fromString(HF_EMBEDDINGS_CHUNKING_SETTINGS_ADDED))) {
+                // Chunking settings were added in 8.16.0. if the version is before that, an exception will be thrown if the index mapping
+                // was created based on a mapping from an old node
+                assertThat(
+                    e.getMessage(),
+                    containsString(
+                        "One or more nodes in your cluster does not support chunking_settings. "
+                            + "Please update all nodes in your cluster to use chunking_settings."
+                    )
+                );
+                return;
+            }
+        }
+
         var configs = (List<Map<String, Object>>) get(TaskType.TEXT_EMBEDDING, inferenceId).get("endpoints");
         assertThat(configs, hasSize(1));
         assertEquals("hugging_face", configs.get(0).get("service"));


### PR DESCRIPTION
In a previous PR, chunking settings were added to HuggingFaceService. This means that the integration tests will now generate models with chunking settings. When running the mixed cluster integration tests it is possible that the inference index that stores the models is created based off of the mapping known to the older node in the cluster (this does not always happen but it can). If this node is pre-8.16, then the index mapping will not have chunking settings which will cause the mixed integration test to fail to store a model with chunking settings. We ran into this issue with OpenAIServiceMixedIT as well and did a similar fix to catch this exception and successfully complete the test as this is the expected behavior.

The HuggingFaceService changes have not been backported to 8.x yet. Once this is merged to main, we can include it in the backport - https://github.com/elastic/elasticsearch/pull/113886