### PR TITLE
[CI] Only trigger DRA workflow on intake for main branches

### DIFF
--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -76,6 +76,7 @@ steps:
   - trigger: elasticsearch-dra-workflow
     label: Trigger DRA snapshot workflow
     async: true
+    branches: "main 8.* 7.17"
     build:
       branch: "$BUILDKITE_BRANCH"
       commit: "$BUILDKITE_COMMIT"


### PR DESCRIPTION
So if someone runs this pipeline against a branch, it won't also trigger the DRA pipeline.