### PR TITLE
Fix for RRF and RankDoc tests due to different shard and doc ordering

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,9 +354,6 @@ tests:
 - class: org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilderIT
   method: testRRFWithCollapse
   issue: https://github.com/elastic/elasticsearch/issues/114074
-- class: org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilderIT
-  method: testMultipleRRFRetrievers
-  issue: https://github.com/elastic/elasticsearch/issues/114079
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/retriever/RankDocRetrieverBuilderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/retriever/RankDocRetrieverBuilderIT.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -112,7 +113,7 @@ public class RankDocRetrieverBuilderIT extends ESIntegTestCase {
               }
             }
             """;
-        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).build());
+        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).build());
         admin().indices().preparePutMapping(INDEX).setSource(mapping, XContentType.JSON).get();
         indexDoc(
             INDEX,

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderIT.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -97,7 +98,7 @@ public class RRFRetrieverBuilderIT extends ESIntegTestCase {
               }
             }
             """;
-        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 5).build());
+        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).build());
         admin().indices().preparePutMapping(INDEX).setSource(mapping, XContentType.JSON).get();
         indexDoc(INDEX, "doc_1", DOC_FIELD, "doc_1", TOPIC_FIELD, "technology", TEXT_FIELD, "term");
         indexDoc(
@@ -301,7 +302,7 @@ public class RRFRetrieverBuilderIT extends ESIntegTestCase {
         });
     }
 
-    public void testRankDocsRetrieverWithCollapseAndAggs() {
+    public void testRRFRetrieverWithCollapseAndAggs() {
         final int rankWindowSize = 100;
         final int rankConstant = 10;
         SearchSourceBuilder source = new SearchSourceBuilder();

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderNestedDocsIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderNestedDocsIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Arrays;
 
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -67,7 +68,7 @@ public class RRFRetrieverBuilderNestedDocsIT extends RRFRetrieverBuilderIT {
               }
             }
             """;
-        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 5).build());
+        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0).build());
         admin().indices().preparePutMapping(INDEX).setSource(mapping, XContentType.JSON).get();
         indexDoc(INDEX, "doc_1", DOC_FIELD, "doc_1", TOPIC_FIELD, "technology", TEXT_FIELD, "term", LAST_30D_FIELD, 100);
         indexDoc(


### PR DESCRIPTION
`RRFRetrieverBuilderIT#testMultipleRRFRetrievers` was failing due to incorrect order between `doc_1` and `doc_3`. Comparing `explain` for a successful and failed run for the result at position 4 we have respectively: 
```
...
"_id": "doc_1",
"_score": 0.071428575,
...
"_explanation":
{
    "value": 0.071428575,
    "description": "sum of:",
    "details":
    [
        {
            "value": 0.071428575,
            "description": "rrf score: [0.071428575] computed for initial ranks [4, 0] with rankConstant: [10] as sum of [1 / (rank + rankConstant)] for each query",
            "details":
            [
                {
                    "value": 4,
                    "description": "rrf score: [0.071428575], for rank [4] in query at index [0] computed as [1 / (4 + 10)], for matching query with score",
                    "details":
                    [
                        {
                            "value": 0.09090909,
                            "description": "rrf score: [0.09090909] computed for initial ranks [1, 0, 0] with rankConstant: [10] as sum of [1 / (rank + rankConstant)] for each query",
                            "details":
```
and
```
...
"_id": "doc_3",
"_score": 0.071428575,
...
"_explanation":
{
    "value": 0.071428575,
    "description": "sum of:",
    "details":
    [
        {
            "value": 0.071428575,
            "description": "rrf score: [0.071428575] computed for initial ranks [4, 0] with rankConstant: [10] as sum of [1 / (rank + rankConstant)] for each query",
            "details":
            [
                {
                    "value": 4,
                    "description": "rrf score: [0.071428575], for rank [4] in query at index [0] computed as [1 / (4 + 10)], for matching query with score",
                    "details":
                    [
                        {
                            "value": 0.09090909,
                            "description": "rrf score: [0.09090909] computed for initial ranks [0, 0, 1] with rankConstant: [10] as sum of [1 / (rank + rankConstant)] for each query",

```

As we can see, the score for `doc_1` and `doc_3` are the same, as their relative ranks in the nested queries are `[1, 0, 0]` and `[0, 0, 1]` respectively. So, the tiebreaker that is applied is shardIndex first, and then docId.  So these results could vary depending both on the number of shards we have, as well as the order at which the documents were indexed. 

So, in order to ensure consistent results, as far as testing go, in this PR we set `SETTING_NUMBER_OF_SHARDS` to 1 and `SETTING_NUMBER_OF_REPLICAS` to 0 for all affected test classes.  Tried locally with `-Dtests.iters=1000` and all 1000 runs were successful. 

Closes https://github.com/elastic/elasticsearch/issues/114079