### PR TITLE
[8.x] Add attribute type conflict handling test (#114100)

### DIFF
--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_tests.yml
@@ -92,3 +92,28 @@ setup:
           fields: ["data_stream.type"]
   - length: { hits.hits: 1 }
   - match: { hits.hits.0.fields.data_stream\.type: ["traces"] }
+---
+Conflicting attribute types:
+  - do:
+      bulk:
+        index: traces-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - "@timestamp": 2024-10-04T00:00:00
+            attributes:
+              http.status_code: 200
+          - create: {}
+          - "@timestamp": 2024-10-04T01:00:00
+            attributes:
+              http.status_code: "foo"
+  - is_false: errors
+  - do:
+      search:
+        index: traces-generic.otel-default
+        body:
+          fields: ["*"]
+          "sort" : [ "@timestamp" ]
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0.fields.attributes\.http\.status_code: [200] }
+  - match: { hits.hits.1._ignored: ["attributes.http.status_code"] }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add attribute type conflict handling test (#114100)](https://github.com/elastic/elasticsearch/pull/114100)

<!--- Backport version: 9.4.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)