### PR TITLE
[8.x] Flush response stream in `Ec2DiscoveryTests` (#114101)

### DIFF
--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
@@ -59,7 +59,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
     private static final String PREFIX_PUBLIC_IP = "8.8.8.";
     private static final String PREFIX_PRIVATE_IP = "10.0.0.";
 
-    private Map<String, TransportAddress> poorMansDNS = new ConcurrentHashMap<>();
+    private final Map<String, TransportAddress> poorMansDNS = new ConcurrentHashMap<>();
 
     protected MockTransportService createTransportService() {
         final Transport transport = new Netty4Transport(
@@ -133,7 +133,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
                                             .stream()
                                             .filter(t -> t.getKey().equals(entry.getKey()))
                                             .map(Tag::getValue)
-                                            .collect(Collectors.toList())
+                                            .toList()
                                             .containsAll(entry.getValue())
                                     )
                             )
@@ -144,6 +144,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
                                 exchange.getResponseHeaders().set("Content-Type", "text/xml; charset=UTF-8");
                                 exchange.sendResponseHeaders(HttpStatus.SC_OK, responseBody.length);
                                 exchange.getResponseBody().write(responseBody);
+                                exchange.getResponseBody().flush();
                                 return;
                             }
                         }
@@ -160,14 +161,14 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
         }
     }
 
-    public void testDefaultSettings() throws InterruptedException {
+    public void testDefaultSettings() {
         int nodes = randomInt(10);
         Settings nodeSettings = Settings.builder().build();
         List<TransportAddress> discoveryNodes = buildDynamicHosts(nodeSettings, nodes);
         assertThat(discoveryNodes, hasSize(nodes));
     }
 
-    public void testPrivateIp() throws InterruptedException {
+    public void testPrivateIp() {
         int nodes = randomInt(10);
         for (int i = 0; i < nodes; i++) {
             poorMansDNS.put(PREFIX_PRIVATE_IP + (i + 1), buildNewFakeTransportAddress());
@@ -183,7 +184,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
         }
     }
 
-    public void testPublicIp() throws InterruptedException {
+    public void testPublicIp() {
         int nodes = randomInt(10);
         for (int i = 0; i < nodes; i++) {
             poorMansDNS.put(PREFIX_PUBLIC_IP + (i + 1), buildNewFakeTransportAddress());
@@ -199,7 +200,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
         }
     }
 
-    public void testPrivateDns() throws InterruptedException {
+    public void testPrivateDns() {
         int nodes = randomInt(10);
         for (int i = 0; i < nodes; i++) {
             String instanceId = "node" + (i + 1);
@@ -217,7 +218,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
         }
     }
 
-    public void testPublicDns() throws InterruptedException {
+    public void testPublicDns() {
         int nodes = randomInt(10);
         for (int i = 0; i < nodes; i++) {
             String instanceId = "node" + (i + 1);
@@ -235,14 +236,14 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
         }
     }
 
-    public void testInvalidHostType() throws InterruptedException {
+    public void testInvalidHostType() {
         Settings nodeSettings = Settings.builder().put(AwsEc2Service.HOST_TYPE_SETTING.getKey(), "does_not_exist").build();
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> { buildDynamicHosts(nodeSettings, 1); });
         assertThat(exception.getMessage(), containsString("does_not_exist is unknown for discovery.ec2.host_type"));
     }
 
-    public void testFilterByTags() throws InterruptedException {
+    public void testFilterByTags() {
         int nodes = randomIntBetween(5, 10);
         Settings nodeSettings = Settings.builder().put(AwsEc2Service.TAG_SETTING.getKey() + "stage", "prod").build();
 
@@ -265,7 +266,7 @@ public class Ec2DiscoveryTests extends AbstractEC2MockAPITestCase {
         assertThat(dynamicHosts, hasSize(prodInstances));
     }
 
-    public void testFilterByMultipleTags() throws InterruptedException {
+    public void testFilterByMultipleTags() {
         int nodes = randomIntBetween(5, 10);
         Settings nodeSettings = Settings.builder().putList(AwsEc2Service.TAG_SETTING.getKey() + "stage", "prod", "preprod").build();
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Flush response stream in `Ec2DiscoveryTests` (#114101)