### PR TITLE
Flush response stream in `EC2RetriesTests`

### DIFF
--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
@@ -101,6 +101,7 @@ public class EC2RetriesTests extends AbstractEC2MockAPITestCase {
                     exchange.getResponseHeaders().set("Content-Type", "text/xml; charset=UTF-8");
                     exchange.sendResponseHeaders(HttpStatus.SC_OK, responseBody.length);
                     exchange.getResponseBody().write(responseBody);
+                    exchange.getResponseBody().flush();
                     return;
                 }
             }


### PR DESCRIPTION
This is apparently necessary when running with JDK23.

Relates #114101
Closes #114078