### PR TITLE
ES|QL: Ensure minimum capacity for PlanStreamInput caches

### DIFF
--- a/docs/changelog/114116.yaml
+++ b/docs/changelog/114116.yaml
@@ -1,0 +1,5 @@
+pr: 114116
+summary: "ES|QL: Ensure minimum capacity for `PlanStreamInput` caches"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
@@ -209,7 +209,7 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput
     private void cacheAttribute(int id, Attribute attr) {
         assert id >= 0;
         if (id >= attributesCache.length) {
-            attributesCache = ArrayUtil.grow(attributesCache);
+            attributesCache = ArrayUtil.grow(attributesCache, id + 1);
         }
         attributesCache[id] = attr;
     }
@@ -252,7 +252,7 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput
     private void cacheEsField(int id, EsField field) {
         assert id >= 0;
         if (id >= esFieldsCache.length) {
-            esFieldsCache = ArrayUtil.grow(esFieldsCache);
+            esFieldsCache = ArrayUtil.grow(esFieldsCache, id + 1);
         }
         esFieldsCache[id] = field;
     }


### PR DESCRIPTION
Ensure that attribute caches have enough capacity before inserting a new element.
Especially for very deeply nested attributes, `ArrayUtil.grow()` could not grow the array enough by default, so we'll pass the minimum capacity needed.

Fixes: https://github.com/elastic/elasticsearch/issues/114018