### PR TITLE
[8.15] Flush response stream in `EC2RetriesTests` (#114115)

### DIFF
--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
@@ -100,6 +100,7 @@ public class EC2RetriesTests extends AbstractEC2MockAPITestCase {
                     exchange.getResponseHeaders().set("Content-Type", "text/xml; charset=UTF-8");
                     exchange.sendResponseHeaders(HttpStatus.SC_OK, responseBody.length);
                     exchange.getResponseBody().write(responseBody);
+                    exchange.getResponseBody().flush();
                     return;
                 }
             }


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Flush response stream in `EC2RetriesTests` (#114115)