### PR TITLE
[CI] Add workaround for no space left on device failures

### DIFF
--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -7,7 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
-      diskSizeGb: 350
+      diskSizeGb: 500
   - wait
   # The hadoop build depends on the ES artifact
   # So let's trigger the hadoop build any time we build a new staging artifact


### PR DESCRIPTION
We see no space left on device likely caused by just adding another docker flavour. this is a quick workaround until we start removing docker images again