### PR TITLE
[8.x] Simplifying the way the simulate ingest API uses component template substitutions for pipeline lookup and mapping validation (#113908)

### DIFF
--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
@@ -606,3 +606,204 @@ setup:
   - match: { docs.0.doc._source.foo: "FOO" }
   - match: { docs.0.doc.executed_pipelines: [] }
   - not_exists: docs.0.doc.error
+
+---
+"Test ingest simulate with component template substitutions for data streams":
+  # In this test, we make sure that when the index template is a data stream template, simulte ingest works the same whether the data stream
+  # has been created or not -- either way, we expect it to use the template rather than the data stream / index mappings and settings.
+
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+
+  - requires:
+      cluster_features: ["simulate.component.template.substitutions"]
+      reason: "ingest simulate component template substitutions added in 8.16"
+
+  - do:
+      headers:
+        Content-Type: application/json
+      ingest.put_pipeline:
+        id: "foo-pipeline"
+        body:  >
+          {
+            "processors": [
+              {
+                "set": {
+                  "field": "foo",
+                  "value": true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      cluster.put_component_template:
+        name: mappings_template
+        body:
+          template:
+            mappings:
+              dynamic: strict
+              properties:
+                foo:
+                  type: keyword
+
+  - do:
+      cluster.put_component_template:
+        name: settings_template
+        body:
+          template:
+            settings:
+              index:
+                default_pipeline: "foo-pipeline"
+
+  - do:
+      allowed_warnings:
+        - "index template [test-composable-1] has index patterns [foo*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test-composable-1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: test-composable-1
+        body:
+          index_patterns:
+            - foo*
+          composed_of:
+            - mappings_template
+            - settings_template
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [simple-data-stream1]
+          composed_of:
+            - mappings_template
+            - settings_template
+          data_stream: {}
+
+  - do:
+      headers:
+        Content-Type: application/json
+      simulate.ingest:
+        index: simple-data-stream1
+        body: >
+          {
+            "docs": [
+              {
+                "_id": "asdf",
+                "_source": {
+                  "@timestamp": 1234,
+                  "foo": false
+                }
+              }
+            ],
+            "pipeline_substitutions": {
+              "foo-pipeline-2": {
+                "processors": [
+                  {
+                    "set": {
+                      "field": "foo",
+                      "value": "FOO"
+                    }
+                  }
+                ]
+              }
+            },
+            "component_template_substitutions": {
+              "settings_template": {
+                "template": {
+                  "settings": {
+                    "index": {
+                      "default_pipeline": "foo-pipeline-2"
+                    }
+                  }
+                }
+              },
+              "mappings_template": {
+                "template": {
+                  "mappings": {
+                    "dynamic": "strict",
+                    "properties": {
+                      "foo": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - length: { docs: 1 }
+  - match: { docs.0.doc._index: "simple-data-stream1" }
+  - match: { docs.0.doc._source.foo: "FOO" }
+  - match: { docs.0.doc.executed_pipelines: ["foo-pipeline-2"] }
+  - not_exists: docs.0.doc.error
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
+      headers:
+        Content-Type: application/json
+      simulate.ingest:
+        index: simple-data-stream1
+        body: >
+          {
+            "docs": [
+              {
+                "_id": "asdf",
+                "_source": {
+                  "@timestamp": 1234,
+                  "foo": false
+                }
+              }
+            ],
+            "pipeline_substitutions": {
+              "foo-pipeline-2": {
+                "processors": [
+                  {
+                    "set": {
+                      "field": "foo",
+                      "value": "FOO"
+                    }
+                  }
+                ]
+              }
+            },
+            "component_template_substitutions": {
+              "settings_template": {
+                "template": {
+                  "settings": {
+                    "index": {
+                      "default_pipeline": "foo-pipeline-2"
+                    }
+                  }
+                }
+              },
+              "mappings_template": {
+                "template": {
+                  "mappings": {
+                    "dynamic": "strict",
+                    "properties": {
+                      "foo": {
+                        "type": "keyword"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - length: { docs: 1 }
+  - match: { docs.0.doc._index: "simple-data-stream1" }
+  - match: { docs.0.doc._source.foo: "FOO" }
+  - match: { docs.0.doc.executed_pipelines: ["foo-pipeline-2"] }
+  - not_exists: docs.0.doc.error

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
-import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
@@ -157,8 +156,7 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
             xContentRegistry,
             indicesService,
             systemIndices,
-            indexSettingProviders,
-            Map.of()
+            indexSettingProviders
         );
 
         final Map<String, List<String>> overlapping = new HashMap<>();
@@ -235,8 +233,7 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
         final NamedXContentRegistry xContentRegistry,
         final IndicesService indicesService,
         final SystemIndices systemIndices,
-        Set<IndexSettingProvider> indexSettingProviders,
-        Map<String, ComponentTemplate> componentTemplateSubstitutions
+        Set<IndexSettingProvider> indexSettingProviders
     ) throws Exception {
         var metadata = simulatedState.getMetadata();
         Settings templateSettings = resolveSettings(simulatedState.metadata(), matchingTemplate);
@@ -266,7 +263,6 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
             null, // empty request mapping as the user can't specify any explicit mappings via the simulate api
             simulatedState,
             matchingTemplate,
-            componentTemplateSubstitutions,
             xContentRegistry,
             simulatedIndexName
         );

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
@@ -170,8 +170,7 @@ public class TransportSimulateTemplateAction extends TransportMasterNodeReadActi
             xContentRegistry,
             indicesService,
             systemIndices,
-            indexSettingProviders,
-            Map.of()
+            indexSettingProviders
         );
         if (request.includeDefaults()) {
             listener.onResponse(

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateBulkAction.java
@@ -51,6 +51,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -197,12 +198,33 @@ public class TransportSimulateBulkAction extends TransportAbstractBulkAction {
                  * path for when the index does not exist). And it does not deal with system indices since we do not intend for users to
                  * simulate writing to system indices.
                  */
-                // First, we remove the index from the cluster state if necessary (since we're going to use the templates)
-                ClusterState simulatedState = indexAbstraction == null
-                    ? state
-                    : new ClusterState.Builder(state).metadata(Metadata.builder(state.metadata()).remove(request.index()).build()).build();
+                ClusterState.Builder simulatedClusterStateBuilder = new ClusterState.Builder(state);
+                Metadata.Builder simulatedMetadata = Metadata.builder(state.metadata());
+                if (indexAbstraction != null) {
+                    /*
+                     * We remove the index or data stream from the cluster state so that we are forced to fall back to the templates to get
+                     * mappings.
+                     */
+                    String indexRequest = request.index();
+                    assert indexRequest != null : "Index requests cannot be null in a simulate bulk call";
+                    if (indexRequest != null) {
+                        simulatedMetadata.remove(indexRequest);
+                        simulatedMetadata.removeDataStream(indexRequest);
+                    }
+                }
+                if (componentTemplateSubstitutions.isEmpty() == false) {
+                    /*
+                     * We put the template substitutions into the cluster state. If they have the same name as an existing one, the
+                     * existing one is replaced.
+                     */
+                    Map<String, ComponentTemplate> updatedComponentTemplates = new HashMap<>();
+                    updatedComponentTemplates.putAll(state.metadata().componentTemplates());
+                    updatedComponentTemplates.putAll(componentTemplateSubstitutions);
+                    simulatedMetadata.componentTemplates(updatedComponentTemplates);
+                }
+                ClusterState simulatedState = simulatedClusterStateBuilder.metadata(simulatedMetadata).build();
 
-                String matchingTemplate = findV2Template(state.metadata(), request.index(), false);
+                String matchingTemplate = findV2Template(simulatedState.metadata(), request.index(), false);
                 if (matchingTemplate != null) {
                     final Template template = TransportSimulateIndexTemplateAction.resolveTemplate(
                         matchingTemplate,
@@ -212,8 +234,7 @@ public class TransportSimulateBulkAction extends TransportAbstractBulkAction {
                         xContentRegistry,
                         indicesService,
                         systemIndices,
-                        indexSettingProviders,
-                        componentTemplateSubstitutions
+                        indexSettingProviders
                     );
                     CompressedXContent mappings = template.mappings();
                     if (mappings != null) {
@@ -247,7 +268,7 @@ public class TransportSimulateBulkAction extends TransportAbstractBulkAction {
                         });
                     }
                 } else {
-                    List<IndexTemplateMetadata> matchingTemplates = findV1Templates(state.metadata(), request.index(), false);
+                    List<IndexTemplateMetadata> matchingTemplates = findV1Templates(simulatedState.metadata(), request.index(), false);
                     final Map<String, Object> mappingsMap = MetadataCreateIndexService.parseV1Mappings(
                         "{}",
                         matchingTemplates.stream().map(IndexTemplateMetadata::getMappings).collect(toList()),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -665,7 +665,6 @@ public class MetadataCreateIndexService {
             request.mappings(),
             currentState,
             templateName,
-            Map.of(),
             xContentRegistry,
             request.index()
         );
@@ -824,7 +823,6 @@ public class MetadataCreateIndexService {
         List<CompressedXContent> templateMappings = MetadataIndexTemplateService.collectMappings(
             composableIndexTemplate,
             componentTemplates,
-            Map.of(),
             indexName
         );
         return collectV2Mappings(null, templateMappings, xContentRegistry);
@@ -834,16 +832,10 @@ public class MetadataCreateIndexService {
         @Nullable final String requestMappings,
         final ClusterState currentState,
         final String templateName,
-        Map<String, ComponentTemplate> componentTemplateSubstitutions,
         final NamedXContentRegistry xContentRegistry,
         final String indexName
     ) throws Exception {
-        List<CompressedXContent> templateMappings = MetadataIndexTemplateService.collectMappings(
-            currentState,
-            templateName,
-            componentTemplateSubstitutions,
-            indexName
-        );
+        List<CompressedXContent> templateMappings = MetadataIndexTemplateService.collectMappings(currentState, templateName, indexName);
         return collectV2Mappings(requestMappings, templateMappings, xContentRegistry);
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -33,7 +33,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
-import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -271,30 +270,14 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         final IndexRequest indexRequest,
         final Metadata metadata
     ) {
-        resolvePipelinesAndUpdateIndexRequest(originalRequest, indexRequest, metadata, Map.of());
-    }
-
-    public static void resolvePipelinesAndUpdateIndexRequest(
-        final DocWriteRequest<?> originalRequest,
-        final IndexRequest indexRequest,
-        final Metadata metadata,
-        Map<String, ComponentTemplate> componentTemplateSubstitutions
-    ) {
-        resolvePipelinesAndUpdateIndexRequest(
-            originalRequest,
-            indexRequest,
-            metadata,
-            System.currentTimeMillis(),
-            componentTemplateSubstitutions
-        );
+        resolvePipelinesAndUpdateIndexRequest(originalRequest, indexRequest, metadata, System.currentTimeMillis());
     }
 
     static void resolvePipelinesAndUpdateIndexRequest(
         final DocWriteRequest<?> originalRequest,
         final IndexRequest indexRequest,
         final Metadata metadata,
-        final long epochMillis,
-        final Map<String, ComponentTemplate> componentTemplateSubstitutions
+        final long epochMillis
     ) {
         if (indexRequest.isPipelineResolved()) {
             return;
@@ -302,21 +285,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
         /*
          * Here we look for the pipelines associated with the index if the index exists. If the index does not exist we fall back to using
-         * templates to find the pipelines. But if a user has passed in component template substitutions, they want the settings from those
-         * used in place of the settings used to create any previous indices. So in that case we use the templates to find the pipelines --
-         * we don't fall back to the existing index if we don't find any because it is possible the user has intentionally removed the
-         * pipeline.
+         * templates to find the pipelines.
          */
-        final Pipelines pipelines;
-        if (componentTemplateSubstitutions.isEmpty()) {
-            pipelines = resolvePipelinesFromMetadata(originalRequest, indexRequest, metadata, epochMillis) //
-                .or(() -> resolvePipelinesFromIndexTemplates(indexRequest, metadata, Map.of()))
-                .orElse(Pipelines.NO_PIPELINES_DEFINED);
-        } else {
-            pipelines = resolvePipelinesFromIndexTemplates(indexRequest, metadata, componentTemplateSubstitutions).orElse(
-                Pipelines.NO_PIPELINES_DEFINED
-            );
-        }
+        final Pipelines pipelines = resolvePipelinesFromMetadata(originalRequest, indexRequest, metadata, epochMillis).or(
+            () -> resolvePipelinesFromIndexTemplates(indexRequest, metadata)
+        ).orElse(Pipelines.NO_PIPELINES_DEFINED);
 
         // The pipeline coming as part of the request always has priority over the resolved one from metadata or templates
         String requestPipeline = indexRequest.getPipeline();
@@ -1473,11 +1446,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return Optional.of(new Pipelines(IndexSettings.DEFAULT_PIPELINE.get(settings), IndexSettings.FINAL_PIPELINE.get(settings)));
     }
 
-    private static Optional<Pipelines> resolvePipelinesFromIndexTemplates(
-        IndexRequest indexRequest,
-        Metadata metadata,
-        Map<String, ComponentTemplate> componentTemplateSubstitutions
-    ) {
+    private static Optional<Pipelines> resolvePipelinesFromIndexTemplates(IndexRequest indexRequest, Metadata metadata) {
         if (indexRequest.index() == null) {
             return Optional.empty();
         }
@@ -1487,7 +1456,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         // precedence), or if a V2 template does not match, any V1 templates
         String v2Template = MetadataIndexTemplateService.findV2Template(metadata, indexRequest.index(), false);
         if (v2Template != null) {
-            final Settings settings = MetadataIndexTemplateService.resolveSettings(metadata, v2Template, componentTemplateSubstitutions);
+            final Settings settings = MetadataIndexTemplateService.resolveSettings(metadata, v2Template);
             return Optional.of(new Pipelines(IndexSettings.DEFAULT_PIPELINE.get(settings), IndexSettings.FINAL_PIPELINE.get(settings)));
         }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateActionTests.java
@@ -87,8 +87,7 @@ public class TransportSimulateIndexTemplateActionTests extends ESTestCase {
             xContentRegistry(),
             indicesService,
             systemIndices,
-            indexSettingsProviders,
-            Map.of()
+            indexSettingsProviders
         );
 
         assertThat(resolvedTemplate.settings().getAsInt("test-setting", -1), is(1));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -1074,7 +1074,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             .build();
         state = service.addIndexTemplateV2(state, true, "my-template", it);
 
-        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "my-template", Map.of(), "my-index");
+        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "my-template", "my-index");
 
         assertNotNull(mappings);
         assertThat(mappings.size(), equalTo(3));
@@ -1136,7 +1136,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             .build();
         state = service.addIndexTemplateV2(state, true, "my-template", it);
 
-        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "my-template", Map.of(), "my-index");
+        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "my-template", "my-index");
 
         assertNotNull(mappings);
         assertThat(mappings.size(), equalTo(3));
@@ -1190,7 +1190,6 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(
                 state,
                 "logs-data-stream-template",
-                Map.of(),
                 DataStream.getDefaultBackingIndexName("logs", 1L)
             );
 
@@ -1242,12 +1241,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
                 .build();
             state = service.addIndexTemplateV2(state, true, "timeseries-template", it);
 
-            List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(
-                state,
-                "timeseries-template",
-                Map.of(),
-                "timeseries"
-            );
+            List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "timeseries-template", "timeseries");
 
             assertNotNull(mappings);
             assertThat(mappings.size(), equalTo(2));
@@ -1269,7 +1263,6 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             mappings = MetadataIndexTemplateService.collectMappings(
                 state,
                 "timeseries-template",
-                Map.of(),
                 DataStream.getDefaultBackingIndexName("timeseries", 1L)
             );
 
@@ -1318,7 +1311,6 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(
                 state,
                 "logs-template",
-                Map.of(),
                 DataStream.getDefaultBackingIndexName("logs", 1L)
             );
 
@@ -1375,7 +1367,6 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(
                 state,
                 "timeseries-template",
-                Map.of(),
                 DataStream.getDefaultBackingIndexName("timeseries-template", 1L)
             );
 
@@ -2442,12 +2433,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             .build();
         state = service.addIndexTemplateV2(state, true, "composable-template", it);
 
-        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(
-            state,
-            "composable-template",
-            Map.of(),
-            "test-index"
-        );
+        List<CompressedXContent> mappings = MetadataIndexTemplateService.collectMappings(state, "composable-template", "test-index");
 
         assertNotNull(mappings);
         assertThat(mappings.size(), equalTo(2));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -32,20 +32,16 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
-import org.elasticsearch.cluster.metadata.ComponentTemplate;
-import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.Maps;
@@ -77,7 +73,6 @@ import org.junit.Before;
 import org.mockito.ArgumentMatcher;
 import org.mockito.invocation.InvocationOnMock;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -2591,7 +2586,7 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("<idx-{now/d}>");
-        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, epochMillis, Map.of());
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, epochMillis);
         assertTrue(hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
@@ -2918,83 +2913,6 @@ public class IngestServiceTests extends ESTestCase {
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
             assertThat(indexRequest.getFinalPipeline(), equalTo(NOOP_PIPELINE_NAME));
-        }
-    }
-
-    public void testResolvePipelinesAndUpdateIndexRequestWithComponentTemplateSubstitutions() throws IOException {
-        final String componentTemplateName = "test-component-template";
-        final String indexName = "my-index-1";
-        final String indexPipeline = "index-pipeline";
-        final String realTemplatePipeline = "template-pipeline";
-        final String substitutePipeline = "substitute-pipeline";
-
-        Metadata metadata;
-        {
-            // Build up cluster state metadata
-            IndexMetadata.Builder builder = IndexMetadata.builder(indexName)
-                .settings(settings(IndexVersion.current()))
-                .numberOfShards(1)
-                .numberOfReplicas(0);
-            ComponentTemplate realComponentTemplate = new ComponentTemplate(
-                new Template(
-                    Settings.builder().put("index.default_pipeline", realTemplatePipeline).build(),
-                    CompressedXContent.fromJSON("{}"),
-                    null
-                ),
-                null,
-                null
-            );
-            ComposableIndexTemplate composableIndexTemplate = ComposableIndexTemplate.builder()
-                .indexPatterns(List.of("my-index-*"))
-                .componentTemplates(List.of(componentTemplateName))
-                .build();
-            metadata = Metadata.builder()
-                .put(builder)
-                .indexTemplates(Map.of("my-index-template", composableIndexTemplate))
-                .componentTemplates(Map.of("test-component-template", realComponentTemplate))
-                .build();
-        }
-
-        Map<String, ComponentTemplate> componentTemplateSubstitutions;
-        {
-            ComponentTemplate simulatedComponentTemplate = new ComponentTemplate(
-                new Template(
-                    Settings.builder().put("index.default_pipeline", substitutePipeline).build(),
-                    CompressedXContent.fromJSON("{}"),
-                    null
-                ),
-                null,
-                null
-            );
-            componentTemplateSubstitutions = Map.of(componentTemplateName, simulatedComponentTemplate);
-        }
-
-        {
-            /*
-             * Here there is a pipeline in the request. This takes precedence over anything in the index or templates or component template
-             * substitutions.
-             */
-            IndexRequest indexRequest = new IndexRequest(indexName).setPipeline(indexPipeline);
-            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, 0, componentTemplateSubstitutions);
-            assertThat(indexRequest.getPipeline(), equalTo(indexPipeline));
-        }
-        {
-            /*
-             * Here there is no pipeline in the request, but there is one in the substitute component template. So it takes precedence.
-             */
-            IndexRequest indexRequest = new IndexRequest(indexName);
-            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, 0, componentTemplateSubstitutions);
-            assertThat(indexRequest.getPipeline(), equalTo(substitutePipeline));
-        }
-        {
-            /*
-             * This one is tricky. Since the index exists and there are no component template substitutions, we're going to use the actual
-             * index in this case rather than its template. The index does not have a default pipeline set, so it's "_none" instead of
-             * realTemplatePipeline.
-             */
-            IndexRequest indexRequest = new IndexRequest(indexName);
-            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, 0, Map.of());
-            assertThat(indexRequest.getPipeline(), equalTo("_none"));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Simplifying the way the simulate ingest API uses component template substitutions for pipeline lookup and mapping validation (#113908)