### PR TITLE
[8.x] ES|QL: Ensure minimum capacity for PlanStreamInput caches (#114116)

### DIFF
--- a/docs/changelog/114116.yaml
+++ b/docs/changelog/114116.yaml
@@ -1,0 +1,5 @@
+pr: 114116
+summary: "ES|QL: Ensure minimum capacity for `PlanStreamInput` caches"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
@@ -209,7 +209,7 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput
     private void cacheAttribute(int id, Attribute attr) {
         assert id >= 0;
         if (id >= attributesCache.length) {
-            attributesCache = ArrayUtil.grow(attributesCache);
+            attributesCache = ArrayUtil.grow(attributesCache, id + 1);
         }
         attributesCache[id] = attr;
     }
@@ -252,7 +252,7 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput
     private void cacheEsField(int id, EsField field) {
         assert id >= 0;
         if (id >= esFieldsCache.length) {
-            esFieldsCache = ArrayUtil.grow(esFieldsCache);
+            esFieldsCache = ArrayUtil.grow(esFieldsCache, id + 1);
         }
         esFieldsCache[id] = field;
     }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ES|QL: Ensure minimum capacity for PlanStreamInput caches (#114116)