### PR TITLE
Remove some easy/straightforward instances of UpdateForV9

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.XContentTestUtils.JsonMapView;
-import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 
 import java.util.Map;
 
@@ -87,25 +86,6 @@ public class SystemIndicesUpgradeIT extends AbstractRollingUpgradeTestCase {
                     throw new AssertionError(".tasks index does not exist yet");
                 }
             });
-
-            // If we are on 7.x create an alias that includes both a system index and a non-system index so we can be sure it gets
-            // upgraded properly. If we're already on 8.x, skip this part of the test.
-            if (clusterHasFeature(RestTestLegacyFeatures.SYSTEM_INDICES_REST_ACCESS_ENFORCED) == false) {
-                // Create an alias to make sure it gets upgraded properly
-                Request putAliasRequest = new Request("POST", "/_aliases");
-                putAliasRequest.setJsonEntity("""
-                    {
-                      "actions": [
-                        {"add":  {"index":  ".tasks", "alias": "test-system-alias"}},
-                        {"add":  {"index":  "test_index_reindex", "alias": "test-system-alias"}}
-                      ]
-                    }""");
-                putAliasRequest.setOptions(expectVersionSpecificWarnings(v -> {
-                    v.current(systemIndexWarning);
-                    v.compatible(systemIndexWarning);
-                }));
-                assertThat(client().performRequest(putAliasRequest).getStatusLine().getStatusCode(), is(200));
-            }
         } else if (isUpgradedCluster()) {
             assertBusy(() -> {
                 Request clusterStateRequest = new Request("GET", "/_cluster/state/metadata");

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -719,10 +719,6 @@ public abstract class ESRestTestCase extends ESTestCase {
      * all feature states, deleting system indices, system associated indices, and system data streams.
      */
     protected boolean resetFeatureStates() {
-        if (clusterHasFeature(RestTestLegacyFeatures.FEATURE_STATE_RESET_SUPPORTED) == false) {
-            return false;
-        }
-
         // ML reset fails when ML is disabled in versions before 8.7
         if (isMlEnabled() == false && clusterHasFeature(RestTestLegacyFeatures.ML_STATE_RESET_FALLBACK_ON_DISABLED) == false) {
             return false;
@@ -917,22 +913,10 @@ public abstract class ESRestTestCase extends ESTestCase {
                             .filter(name -> isXPackTemplate(name) == false)
                             .collect(Collectors.toList());
                         if (names.isEmpty() == false) {
-                            // Ideally we would want to check if the elected master node supports this feature and send the delete request
-                            // directly to that node, but node-specific feature checks is something we want to avoid if possible.
-                            if (clusterHasFeature(RestTestLegacyFeatures.DELETE_TEMPLATE_MULTIPLE_NAMES_SUPPORTED)) {
-                                try {
-                                    adminClient().performRequest(new Request("DELETE", "_index_template/" + String.join(",", names)));
-                                } catch (ResponseException e) {
-                                    logger.warn(() -> format("unable to remove multiple composable index templates %s", names), e);
-                                }
-                            } else {
-                                for (String name : names) {
-                                    try {
-                                        adminClient().performRequest(new Request("DELETE", "_index_template/" + name));
-                                    } catch (ResponseException e) {
-                                        logger.warn(() -> format("unable to remove composable index template %s", name), e);
-                                    }
-                                }
+                            try {
+                                adminClient().performRequest(new Request("DELETE", "_index_template/" + String.join(",", names)));
+                            } catch (ResponseException e) {
+                                logger.warn(() -> format("unable to remove multiple composable index templates %s", names), e);
                             }
                         }
                     } catch (Exception e) {
@@ -948,22 +932,10 @@ public abstract class ESRestTestCase extends ESTestCase {
                             .filter(name -> isXPackTemplate(name) == false)
                             .collect(Collectors.toList());
                         if (names.isEmpty() == false) {
-                            // Ideally we would want to check if the elected master node supports this feature and send the delete request
-                            // directly to that node, but node-specific feature checks is something we want to avoid if possible.
-                            if (clusterHasFeature(RestTestLegacyFeatures.DELETE_TEMPLATE_MULTIPLE_NAMES_SUPPORTED)) {
-                                try {
-                                    adminClient().performRequest(new Request("DELETE", "_component_template/" + String.join(",", names)));
-                                } catch (ResponseException e) {
-                                    logger.warn(() -> format("unable to remove multiple component templates %s", names), e);
-                                }
-                            } else {
-                                for (String componentTemplate : names) {
-                                    try {
-                                        adminClient().performRequest(new Request("DELETE", "_component_template/" + componentTemplate));
-                                    } catch (ResponseException e) {
-                                        logger.warn(() -> format("unable to remove component template %s", componentTemplate), e);
-                                    }
-                                }
+                            try {
+                                adminClient().performRequest(new Request("DELETE", "_component_template/" + String.join(",", names)));
+                            } catch (ResponseException e) {
+                                logger.warn(() -> format("unable to remove multiple component templates %s", names), e);
                             }
                         }
                     } catch (Exception e) {
@@ -1141,7 +1113,6 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected static void wipeAllIndices(boolean preserveSecurityIndices) throws IOException {
-        boolean includeHidden = clusterHasFeature(RestTestLegacyFeatures.HIDDEN_INDICES_SUPPORTED);
         try {
             // remove all indices except some history indices which can pop up after deleting all data streams but shouldn't interfere
             final List<String> indexPatterns = new ArrayList<>(
@@ -1151,7 +1122,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                 indexPatterns.add("-.security-*");
             }
             final Request deleteRequest = new Request("DELETE", Strings.collectionToCommaDelimitedString(indexPatterns));
-            deleteRequest.addParameter("expand_wildcards", "open,closed" + (includeHidden ? ",hidden" : ""));
+            deleteRequest.addParameter("expand_wildcards", "open,closed,hidden");
             final Response response = adminClient().performRequest(deleteRequest);
             try (InputStream is = response.getEntity().getContent()) {
                 assertTrue((boolean) XContentHelper.convertToMap(XContentType.JSON.xContent(), is, true).get("acknowledged"));
@@ -1320,9 +1291,8 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected void refreshAllIndices() throws IOException {
-        boolean includeHidden = clusterHasFeature(RestTestLegacyFeatures.HIDDEN_INDICES_SUPPORTED);
         Request refreshRequest = new Request("POST", "/_refresh");
-        refreshRequest.addParameter("expand_wildcards", "open" + (includeHidden ? ",hidden" : ""));
+        refreshRequest.addParameter("expand_wildcards", "open,hidden");
         // Allow system index deprecation warnings
         refreshRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
             if (warnings.isEmpty()) {
@@ -2488,18 +2458,6 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     private static XContentType randomSupportedContentType() {
-        if (clusterHasFeature(RestTestLegacyFeatures.SUPPORTS_TRUE_BINARY_RESPONSES) == false) {
-            // Very old versions encode binary stored fields using base64 in all formats, not just JSON, but we expect to see raw binary
-            // fields in non-JSON formats, so we stick to JSON in these cases.
-            return XContentType.JSON;
-        }
-
-        if (clusterHasFeature(RestTestLegacyFeatures.SUPPORTS_VENDOR_XCONTENT_TYPES) == false) {
-            // The VND_* formats were introduced part-way through the 7.x series for compatibility with 8.x, but are not supported by older
-            // 7.x versions.
-            return randomFrom(XContentType.JSON, XContentType.CBOR, XContentType.YAML, XContentType.SMILE);
-        }
-
         return randomFrom(XContentType.values());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
@@ -27,23 +27,8 @@ import static org.elasticsearch.cluster.ClusterState.VERSION_INTRODUCING_TRANSPO
 public class RestTestLegacyFeatures implements FeatureSpecification {
     public static final NodeFeature ML_STATE_RESET_FALLBACK_ON_DISABLED = new NodeFeature("ml.state_reset_fallback_on_disabled");
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature FEATURE_STATE_RESET_SUPPORTED = new NodeFeature("system_indices.feature_state_reset_supported");
-    public static final NodeFeature SYSTEM_INDICES_REST_ACCESS_ENFORCED = new NodeFeature("system_indices.rest_access_enforced");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature SYSTEM_INDICES_REST_ACCESS_DEPRECATED = new NodeFeature("system_indices.rest_access_deprecated");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature HIDDEN_INDICES_SUPPORTED = new NodeFeature("indices.hidden_supported");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     public static final NodeFeature COMPONENT_TEMPLATE_SUPPORTED = new NodeFeature("indices.component_template_supported");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature DELETE_TEMPLATE_MULTIPLE_NAMES_SUPPORTED = new NodeFeature(
-        "indices.delete_template_multiple_names_supported"
-    );
     public static final NodeFeature ML_NEW_MEMORY_FORMAT = new NodeFeature("ml.new_memory_format");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature SUPPORTS_VENDOR_XCONTENT_TYPES = new NodeFeature("rest.supports_vendor_xcontent_types");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature SUPPORTS_TRUE_BINARY_RESPONSES = new NodeFeature("rest.supports_true_binary_responses");
 
     /** These are "pure test" features: normally we would not need them, and test for TransportVersion/fallback to Version (see for example
      * {@code ESRestTestCase#minimumTransportVersion()}. However, some tests explicitly check and validate the content of a response, so
@@ -61,21 +46,6 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     public static final NodeFeature DESIRED_NODE_API_SUPPORTED = new NodeFeature("desired_node_supported");
     public static final NodeFeature SECURITY_UPDATE_API_KEY = new NodeFeature("security.api_key_update");
     public static final NodeFeature SECURITY_BULK_UPDATE_API_KEY = new NodeFeature("security.api_key_bulk_update");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature WATCHES_VERSION_IN_META = new NodeFeature("watcher.version_in_meta");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature SECURITY_ROLE_DESCRIPTORS_OPTIONAL = new NodeFeature("security.role_descriptors_optional");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM = new NodeFeature(
-        "search.aggregations.force_interval_selection_on_date_histogram"
-    );
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature TRANSFORM_NEW_API_ENDPOINT = new NodeFeature("transform.new_api_endpoint");
-    // Ref: https://github.com/elastic/elasticsearch/pull/65205
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature ML_INDICES_HIDDEN = new NodeFeature("ml.indices_hidden");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature ML_ANALYTICS_MAPPINGS = new NodeFeature("ml.analytics_mappings");
 
     public static final NodeFeature TSDB_NEW_INDEX_FORMAT = new NodeFeature("indices.tsdb_new_format");
     public static final NodeFeature TSDB_GENERALLY_AVAILABLE = new NodeFeature("indices.tsdb_supported");
@@ -104,13 +74,9 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     public static final NodeFeature REPLICATION_OF_CLOSED_INDICES = new NodeFeature("indices.closed_replication_supported");
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature TASK_INDEX_SYSTEM_INDEX = new NodeFeature("tasks.moved_to_system_index");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     public static final NodeFeature SOFT_DELETES_ENFORCED = new NodeFeature("indices.soft_deletes_enforced");
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     public static final NodeFeature NEW_TRANSPORT_COMPRESSED_SETTING = new NodeFeature("transport.new_compressed_setting");
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    public static final NodeFeature SHUTDOWN_SUPPORTED = new NodeFeature("shutdown.supported");
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
     public static final NodeFeature SERVICE_ACCOUNTS_SUPPORTED = new NodeFeature("auth.service_accounts_supported");
     @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
@@ -140,27 +106,14 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
         return Map.ofEntries(
-            entry(FEATURE_STATE_RESET_SUPPORTED, Version.V_7_13_0),
-            entry(SYSTEM_INDICES_REST_ACCESS_ENFORCED, Version.V_8_0_0),
-            entry(SYSTEM_INDICES_REST_ACCESS_DEPRECATED, Version.V_7_10_0),
-            entry(HIDDEN_INDICES_SUPPORTED, Version.V_7_7_0),
             entry(COMPONENT_TEMPLATE_SUPPORTED, Version.V_7_8_0),
-            entry(DELETE_TEMPLATE_MULTIPLE_NAMES_SUPPORTED, Version.V_7_13_0),
             entry(ML_STATE_RESET_FALLBACK_ON_DISABLED, Version.V_8_7_0),
             entry(SECURITY_UPDATE_API_KEY, Version.V_8_4_0),
             entry(SECURITY_BULK_UPDATE_API_KEY, Version.V_8_5_0),
             entry(ML_NEW_MEMORY_FORMAT, Version.V_8_11_0),
-            entry(SUPPORTS_VENDOR_XCONTENT_TYPES, Version.V_7_11_0),
-            entry(SUPPORTS_TRUE_BINARY_RESPONSES, Version.V_7_7_0),
             entry(TRANSPORT_VERSION_SUPPORTED, VERSION_INTRODUCING_TRANSPORT_VERSIONS),
             entry(STATE_REPLACED_TRANSPORT_VERSION_WITH_NODES_VERSION, Version.V_8_11_0),
             entry(ML_MEMORY_OVERHEAD_FIXED, Version.V_8_2_1),
-            entry(WATCHES_VERSION_IN_META, Version.V_7_13_0),
-            entry(SECURITY_ROLE_DESCRIPTORS_OPTIONAL, Version.V_7_3_0),
-            entry(SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM, Version.V_7_2_0),
-            entry(TRANSFORM_NEW_API_ENDPOINT, Version.V_7_5_0),
-            entry(ML_INDICES_HIDDEN, Version.V_7_7_0),
-            entry(ML_ANALYTICS_MAPPINGS, Version.V_7_3_0),
             entry(REST_ELASTIC_PRODUCT_HEADER_PRESENT, Version.V_8_0_1),
             entry(DESIRED_NODE_API_SUPPORTED, Version.V_8_1_0),
             entry(TSDB_NEW_INDEX_FORMAT, Version.V_8_2_0),
@@ -173,10 +126,8 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
             entry(INDEXING_SLOWLOG_LEVEL_SETTING_REMOVED, Version.V_8_0_0),
             entry(DEPRECATION_WARNINGS_LEAK_FIXED, Version.V_7_17_9),
             entry(REPLICATION_OF_CLOSED_INDICES, Version.V_7_2_0),
-            entry(TASK_INDEX_SYSTEM_INDEX, Version.V_7_10_0),
             entry(SOFT_DELETES_ENFORCED, Version.V_8_0_0),
             entry(NEW_TRANSPORT_COMPRESSED_SETTING, Version.V_7_14_0),
-            entry(SHUTDOWN_SUPPORTED, Version.V_7_15_0),
             entry(SERVICE_ACCOUNTS_SUPPORTED, Version.V_7_13_0),
             entry(TRANSFORM_SUPPORTED, Version.V_7_2_0),
             entry(SLM_SUPPORTED, Version.V_7_4_0),

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -371,14 +371,10 @@ public class DoSection implements ExecutableSection {
                 ? executionContext.getClientYamlTestCandidate().getTestPath()
                 : null;
 
-            // #84038 and #84089 mean that this assertion fails when running against < 7.17.2 and 8.0.0 released versions
-            // This is really difficult to express just with features, so I will break it down into 2 parts: version check for v7,
-            // and feature check for v8. This way the version check can be removed once we move to v9
-            @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-            var fixedInV7 = executionContext.clusterHasFeature("gte_v7.17.2", false)
-                && executionContext.clusterHasFeature("gte_v8.0.0", false) == false;
-            var fixedProductionHeader = fixedInV7
-                || executionContext.clusterHasFeature(RestTestLegacyFeatures.REST_ELASTIC_PRODUCT_HEADER_PRESENT.id(), false);
+            var fixedProductionHeader = executionContext.clusterHasFeature(
+                RestTestLegacyFeatures.REST_ELASTIC_PRODUCT_HEADER_PRESENT.id(),
+                false
+            );
             if (fixedProductionHeader) {
                 checkElasticProductHeader(response.getHeaders("X-elastic-product"));
             }

--- a/x-pack/plugin/shutdown/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/plugin/shutdown/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -14,18 +14,15 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
 import org.elasticsearch.upgrades.ParameterizedFullClusterRestartTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -86,13 +83,6 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             // account for delayed shards
             .put(ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "90s")
             .build();
-    }
-
-    @Before
-    public void checkClusterVersion() {
-        @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA) // always true
-        var originalClusterSupportsShutdown = oldClusterHasFeature(RestTestLegacyFeatures.SHUTDOWN_SUPPORTED);
-        assumeTrue("no shutdown in versions before 7.15", originalClusterSupportsShutdown);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -361,29 +361,10 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
                         )
                     )
             );
-            if (clusterHasFeature(RestTestLegacyFeatures.SECURITY_ROLE_DESCRIPTORS_OPTIONAL)) {
-                createApiKeyRequest.setJsonEntity("""
-                    {
-                       "name": "super_legacy_key"
-                    }""");
-            } else {
-                createApiKeyRequest.setJsonEntity("""
-                    {
-                       "name": "super_legacy_key",
-                       "role_descriptors": {
-                         "super": {
-                           "cluster": [ "all" ],
-                           "indices": [
-                             {
-                               "names": [ "*" ],
-                               "privileges": [ "all" ],
-                               "allow_restricted_indices": true
-                             }
-                           ]
-                         }
-                       }
-                    }""");
-            }
+            createApiKeyRequest.setJsonEntity("""
+                {
+                   "name": "super_legacy_key"
+                }""");
             final Map<String, Object> createApiKeyResponse = entityAsMap(client().performRequest(createApiKeyRequest));
             final byte[] keyBytes = (createApiKeyResponse.get("id") + ":" + createApiKeyResponse.get("api_key")).getBytes(
                 StandardCharsets.UTF_8
@@ -393,20 +374,6 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             final Request saveApiKeyRequest = new Request("PUT", "/api_keys/_doc/super_legacy_key");
             saveApiKeyRequest.setJsonEntity("{\"auth_header\":\"" + apiKeyAuthHeader + "\"}");
             assertOK(client().performRequest(saveApiKeyRequest));
-
-            if (clusterHasFeature(RestTestLegacyFeatures.SYSTEM_INDICES_REST_ACCESS_ENFORCED) == false) {
-                final Request indexRequest = new Request("POST", ".security/_doc");
-                indexRequest.setJsonEntity("""
-                    {
-                      "doc_type": "foo"
-                    }""");
-                if (clusterHasFeature(RestTestLegacyFeatures.SYSTEM_INDICES_REST_ACCESS_DEPRECATED)) {
-                    indexRequest.setOptions(systemIndexWarningHandlerOptions(".security-7").addHeader("Authorization", apiKeyAuthHeader));
-                } else {
-                    indexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", apiKeyAuthHeader));
-                }
-                assertOK(client().performRequest(indexRequest));
-            }
         } else {
             final Request getRequest = new Request("GET", "/api_keys/_doc/super_legacy_key");
             final Map<String, Object> getResponseMap = responseAsMap(client().performRequest(getRequest));
@@ -472,15 +439,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
             // create the rollup job
             final Request createRollupJobRequest = new Request("PUT", "/_rollup/job/rollup-job-test");
-
-            String intervalType;
-            if (clusterHasFeature(RestTestLegacyFeatures.SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM)) {
-                intervalType = "fixed_interval";
-            } else {
-                intervalType = "interval";
-            }
-
-            createRollupJobRequest.setJsonEntity(Strings.format("""
+            createRollupJobRequest.setJsonEntity("""
                 {
                   "index_pattern": "rollup-*",
                   "rollup_index": "results-rollup",
@@ -489,7 +448,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
                   "groups": {
                     "date_histogram": {
                       "field": "timestamp",
-                      "%s": "5m"
+                      "fixed_interval": "5m"
                     }
                   },
                   "metrics": [
@@ -498,7 +457,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
                       "metrics": [ "min", "max", "sum" ]
                     }
                   ]
-                }""", intervalType));
+                }""");
 
             Map<String, Object> createRollupJobResponse = entityAsMap(client().performRequest(createRollupJobRequest));
             assertThat(createRollupJobResponse.get("acknowledged"), equalTo(Boolean.TRUE));
@@ -550,11 +509,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             assertThat(createIndexResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
             // create a transform
-            String endpoint = clusterHasFeature(RestTestLegacyFeatures.TRANSFORM_NEW_API_ENDPOINT)
-                ? "_transform/transform-full-cluster-restart-test"
-                : "_data_frame/transforms/transform-full-cluster-restart-test";
-            final Request createTransformRequest = new Request("PUT", endpoint);
-
+            final Request createTransformRequest = new Request("PUT", "_transform/transform-full-cluster-restart-test");
             createTransformRequest.setJsonEntity("""
                 {
                   "source": {

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MlConfigIndexMappingsFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MlConfigIndexMappingsFullClusterRestartIT.java
@@ -28,8 +28,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class MlConfigIndexMappingsFullClusterRestartIT extends AbstractXpackFullClusterRestartTestCase {
 
@@ -62,13 +60,8 @@ public class MlConfigIndexMappingsFullClusterRestartIT extends AbstractXpackFull
         if (isRunningAgainstOldCluster()) {
             // trigger .ml-config index creation
             createAnomalyDetectorJob(OLD_CLUSTER_JOB_ID);
-            if (clusterHasFeature(RestTestLegacyFeatures.ML_ANALYTICS_MAPPINGS)) {
-                // .ml-config has mappings for analytics as the feature was introduced in 7.3.0
-                assertThat(getDataFrameAnalysisMappings().keySet(), hasItem("outlier_detection"));
-            } else {
-                // .ml-config does not yet have correct mappings, it will need an update after cluster is upgraded
-                assertThat(getDataFrameAnalysisMappings(), is(nullValue()));
-            }
+            // .ml-config has mappings for analytics as the feature was introduced in 7.3.0
+            assertThat(getDataFrameAnalysisMappings().keySet(), hasItem("outlier_detection"));
         } else {
             // trigger .ml-config index mappings update
             createAnomalyDetectorJob(NEW_CLUSTER_JOB_ID);

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
@@ -38,7 +38,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 public class MlHiddenIndicesFullClusterRestartIT extends AbstractXpackFullClusterRestartTestCase {
 
@@ -78,36 +77,6 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractXpackFullCluste
             // trigger ML indices creation
             createAnomalyDetectorJob(JOB_ID);
             openAnomalyDetectorJob(JOB_ID);
-
-            if (clusterHasFeature(RestTestLegacyFeatures.ML_INDICES_HIDDEN) == false) {
-                Map<String, Object> indexSettingsMap = contentAsMap(getMlIndicesSettings());
-                Map<String, Object> aliasesMap = contentAsMap(getMlAliases());
-
-                assertThat("Index settings map was: " + indexSettingsMap, indexSettingsMap, is(aMapWithSize(greaterThanOrEqualTo(4))));
-                for (Map.Entry<String, Object> e : indexSettingsMap.entrySet()) {
-                    String indexName = e.getKey();
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> settings = (Map<String, Object>) e.getValue();
-                    assertThat(settings, is(notNullValue()));
-                    assertThat(
-                        "Index " + indexName + " expected not to be hidden but was, settings = " + settings,
-                        XContentMapValues.extractValue(settings, "settings", "index", "hidden"),
-                        is(nullValue())
-                    );
-                }
-
-                for (Tuple<List<String>, String> indexAndAlias : EXPECTED_INDEX_ALIAS_PAIRS) {
-                    List<String> indices = indexAndAlias.v1();
-                    String alias = indexAndAlias.v2();
-                    for (String index : indices) {
-                        assertThat(
-                            indexAndAlias + " expected not be hidden but was, aliasesMap = " + aliasesMap,
-                            XContentMapValues.extractValue(aliasesMap, index, "aliases", alias, "is_hidden"),
-                            is(nullValue())
-                        );
-                    }
-                }
-            }
         } else {
             // The 5 operations in MlInitializationService.makeMlInternalIndicesHidden() run sequentially, so might
             // not all be finished when this test runs. The desired state should exist within a few seconds of startup,

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/WatcherMappingUpdateIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/WatcherMappingUpdateIT.java
@@ -76,12 +76,7 @@ public class WatcherMappingUpdateIT extends AbstractXpackFullClusterRestartTestC
                 """);
             client().performRequest(putWatchRequest);
 
-            if (clusterHasFeature(RestTestLegacyFeatures.WATCHES_VERSION_IN_META)) {
-                assertMappingVersion(".watches", getOldClusterVersion());
-            } else {
-                // watches indices from before 7.10 do not have mapping versions in _meta
-                assertNoMappingVersion(".watches");
-            }
+            assertMappingVersion(".watches", getOldClusterVersion());
         } else {
             assertMappingVersion(".watches", Build.current().version());
         }
@@ -101,9 +96,7 @@ public class WatcherMappingUpdateIT extends AbstractXpackFullClusterRestartTestC
         assertBusy(() -> {
             Request mappingRequest = new Request("GET", index + "/_mappings");
             assert isRunningAgainstOldCluster();
-            if (clusterHasFeature(RestTestLegacyFeatures.SYSTEM_INDICES_REST_ACCESS_DEPRECATED)) {
-                mappingRequest.setOptions(getWarningHandlerOptions(index));
-            }
+            mappingRequest.setOptions(getWarningHandlerOptions(index));
             Response response = client().performRequest(mappingRequest);
             String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             assertThat(responseBody, not(containsString("\"version\":\"")));

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractUpgradeTestCase.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.upgrades;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.io.Streams;
@@ -15,7 +14,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Booleans;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.test.SecuritySettingsSourceField;
 import org.junit.Before;
@@ -47,16 +45,6 @@ public abstract class AbstractUpgradeTestCase extends ESRestTestCase {
      */
     protected static boolean isOriginalClusterCurrent() {
         return UPGRADE_FROM_VERSION.equals(Build.current().version());
-    }
-
-    @Deprecated(forRemoval = true)
-    @UpdateForV9(owner = UpdateForV9.Owner.CORE_INFRA)
-    // Tests should be reworked to rely on features from the current cluster (old, mixed or upgraded).
-    // Version test against the original cluster will be removed
-    protected static boolean isOriginalClusterVersionAtLeast(Version supportedVersion) {
-        // Always assume non-semantic versions are OK: this method will be removed in V9, we are testing the pre-upgrade cluster version,
-        // and non-semantic versions are always V8+
-        return parseLegacyVersion(UPGRADE_FROM_VERSION).map(x -> x.onOrAfter(supportedVersion)).orElse(true);
     }
 
     @Override

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -8,13 +8,11 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Strings;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
 import org.junit.Before;
@@ -101,11 +99,6 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     public void testTrainedModelDeployment() throws Exception {
-        @UpdateForV9(owner = UpdateForV9.Owner.MACHINE_LEARNING) // upgrade will always be from v8, condition can be removed
-        var originalClusterAtLeastV8 = isOriginalClusterVersionAtLeast(Version.V_8_0_0);
-        // These tests assume the original cluster is v8 - testing for features on the _current_ cluster will break for NEW
-        assumeTrue("NLP model deployments added in 8.0", originalClusterAtLeastV8);
-
         final String modelId = "upgrade-deployment-test";
 
         switch (CLUSTER_TYPE) {
@@ -140,11 +133,6 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     public void testTrainedModelDeploymentStopOnMixedCluster() throws Exception {
-        @UpdateForV9(owner = UpdateForV9.Owner.MACHINE_LEARNING) // upgrade will always be from v8, condition can be removed
-        var originalClusterAtLeastV8 = isOriginalClusterVersionAtLeast(Version.V_8_0_0);
-        // These tests assume the original cluster is v8 - testing for features on the _current_ cluster will break for NEW
-        assumeTrue("NLP model deployments added in 8.0", originalClusterAtLeastV8);
-
         final String modelId = "upgrade-deployment-test-stop-mixed-cluster";
 
         switch (CLUSTER_TYPE) {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -7,14 +7,12 @@
 
 package org.elasticsearch.upgrades;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Strings;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
@@ -71,10 +69,6 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101926")
     public void testMlAssignmentPlannerUpgrade() throws Exception {
-        @UpdateForV9(owner = UpdateForV9.Owner.MACHINE_LEARNING) // upgrade will always be from v8, condition can be removed
-        var originalClusterAtLeastV8 = isOriginalClusterVersionAtLeast(Version.V_8_0_0);
-        // These tests assume the original cluster is v8 - testing for features on the _current_ cluster will break for NEW
-        assumeTrue("NLP model deployments added in 8.0", originalClusterAtLeastV8);
         assumeFalse("This test deploys multiple models which cannot be accommodated on a single processor", IS_SINGLE_PROCESSOR_TEST);
 
         logger.info("Starting testMlAssignmentPlannerUpgrade, model size {}", RAW_MODEL_SIZE);


### PR DESCRIPTION
Mostly remove things that we don't need going forward - e.g. because we do not support features (or missing features) from v7, or we do not need to support them in BwC tests.