### PR TITLE
[8.x] Don't validate internal stats if they are empty (#113846)

### DIFF
--- a/docs/changelog/113846.yaml
+++ b/docs/changelog/113846.yaml
@@ -1,0 +1,6 @@
+pr: 113846
+summary: Don't validate internal stats if they are empty
+area: Aggregations
+type: bug
+issues:
+ - 113811

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -76,7 +76,7 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     }
 
     private void verifyFormattingStats() {
-        if (format != DocValueFormat.RAW) {
+        if (format != DocValueFormat.RAW && count != 0) {
             verifyFormattingStat(Fields.MIN, format, min);
             verifyFormattingStat(Fields.MAX, format, max);
             verifyFormattingStat(Fields.AVG, format, getAvg());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
@@ -18,7 +18,9 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
@@ -63,6 +65,30 @@ public class StatsAggregatorTests extends AggregatorTestCase {
 
     public void testEmpty() throws IOException {
         final MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG);
+        testCase(stats("_name").field(ft.name()), iw -> {}, stats -> {
+            assertEquals(0d, stats.getCount(), 0);
+            assertEquals(0d, stats.getSum(), 0);
+            assertEquals(Float.NaN, stats.getAvg(), 0);
+            assertEquals(Double.POSITIVE_INFINITY, stats.getMin(), 0);
+            assertEquals(Double.NEGATIVE_INFINITY, stats.getMax(), 0);
+            assertFalse(AggregationInspectionHelper.hasValue(stats));
+        }, ft);
+    }
+
+    public void testEmptyDate() throws IOException {
+        DateFormatter.forPattern("epoch_millis");
+        final MappedFieldType ft = new DateFieldMapper.DateFieldType(
+            "field",
+            true,
+            true,
+            false,
+            true,
+            DateFormatter.forPattern("epoch_millis"),
+            DateFieldMapper.Resolution.MILLISECONDS,
+            null,
+            null,
+            Map.of()
+        );
         testCase(stats("_name").field(ft.name()), iw -> {}, stats -> {
             assertEquals(0d, stats.getCount(), 0);
             assertEquals(0d, stats.getSum(), 0);


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Don't validate internal stats if they are empty (#113846)