### PR TITLE
[8.x] [CI] Switch to local ssds for DRA workflow pipeline (#114147)

### DIFF
--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -6,8 +6,8 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
-      buildDirectory: /dev/shm/bk
-      diskSizeGb: 350
+      localSsds: 1
+      localSsdInterface: nvme
   - wait
   # The hadoop build depends on the ES artifact
   # So let's trigger the hadoop build any time we build a new staging artifact


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[CI] Switch to local ssds for DRA workflow pipeline (#114147)](https://github.com/elastic/elasticsearch/pull/114147)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)