### PR TITLE
typo, "english" isn't a valid language code

### DIFF
--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -115,7 +115,7 @@ PUT _connector/my-connector
   "name": "My Connector",
   "description": "My Connector to sync data to Elastic index from Google Drive",
   "service_type": "google_drive",
-  "language": "english"
+  "language": "en"
 }
 ----
 


### PR DESCRIPTION
You get errors later if you try to run a sync after having set the language as `"english"`


