### PR TITLE
[8.x] [CI] Only trigger DRA workflow on intake for main branches (#114077)

### DIFF
--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -76,6 +76,7 @@ steps:
   - trigger: elasticsearch-dra-workflow
     label: Trigger DRA snapshot workflow
     async: true
+    branches: "main 8.* 7.17"
     build:
       branch: "$BUILDKITE_BRANCH"
       commit: "$BUILDKITE_COMMIT"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[CI] Only trigger DRA workflow on intake for main branches (#114077)](https://github.com/elastic/elasticsearch/pull/114077)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)