### PR TITLE
[8.x] [otel-data] Hide 10m and 60m aggregated metrics generated for the APM UI (#114042)

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/ecs-tsdb@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/ecs-tsdb@mappings.yaml
@@ -1,0 +1,19 @@
+version: ${xpack.oteldata.template.version}
+_meta:
+  description: |
+    Default mappings that can be changed by users for
+    the OpenTelemetry metrics index template installed by x-pack
+  managed: true
+template:
+  mappings:
+    dynamic_templates:
+      - ecs_ip:
+          mapping:
+            type: ip
+          path_match: [ "ip", "*.ip", "*_ip" ]
+          match_mapping_type: string
+      - all_strings_to_keywords:
+          mapping:
+            ignore_above: 1024
+            type: keyword
+          match_mapping_type: string

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.10m@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.10m@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-service_destination.10m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 10m
+          name:
+            type: constant_keyword
+            value: service_destination

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.1m@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.1m@template.yaml
@@ -1,11 +1,11 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
+index_patterns: ["metrics-service_destination.1m.otel-*"]
+priority: 130
 data_stream: {}
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +14,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +29,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 1m
+          name:
+            type: constant_keyword
+            value: service_destination

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.60m@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.60m@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-service_destination.60m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 60m
+          name:
+            type: constant_keyword
+            value: service_destination

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_summary.10m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_summary.10m.otel@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-service_summary.10m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 10m
+          name:
+            type: constant_keyword
+            value: service_summary

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_summary.1m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_summary.1m.otel@template.yaml
@@ -1,11 +1,11 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
+index_patterns: ["metrics-service_summary.1m.otel-*"]
+priority: 130
 data_stream: {}
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +14,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +29,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 1m
+          name:
+            type: constant_keyword
+            value: service_summary

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_summary.60m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_summary.60m.otel@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-service_summary.60m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 60m
+          name:
+            type: constant_keyword
+            value: service_summary

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_transaction.10m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_transaction.10m.otel@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-service_transaction.10m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 10m
+          name:
+            type: constant_keyword
+            value: service_transaction

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_transaction.1m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_transaction.1m.otel@template.yaml
@@ -1,11 +1,11 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
+index_patterns: ["metrics-service_transaction.1m.otel-*"]
+priority: 130
 data_stream: {}
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +14,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +29,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 1m
+          name:
+            type: constant_keyword
+            value: service_transaction

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_transaction.60m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_transaction.60m.otel@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-service_transaction.60m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 60m
+          name:
+            type: constant_keyword
+            value: service_transaction

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-transaction.10m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-transaction.10m.otel@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-transaction.10m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-10m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 10m
+          name:
+            type: constant_keyword
+            value: transaction

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-transaction.1m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-transaction.1m.otel@template.yaml
@@ -1,11 +1,11 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
+index_patterns: ["metrics-transaction.1m.otel-*"]
+priority: 130
 data_stream: {}
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +14,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-1m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +29,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 1m
+          name:
+            type: constant_keyword
+            value: transaction

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-transaction.60m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-transaction.60m.otel@template.yaml
@@ -1,11 +1,12 @@
 ---
 version: ${xpack.oteldata.template.version}
-index_patterns: ["metrics-*.otel-*"]
-priority: 120
-data_stream: {}
+index_patterns: ["metrics-transaction.60m.otel-*"]
+priority: 130
+data_stream:
+  hidden: true
 allow_auto_create: true
 _meta:
-  description: default OpenTelemetry metrics template installed by x-pack
+  description: aggregated APM metrics template installed by x-pack
   managed: true
 composed_of:
   - metrics@tsdb-settings
@@ -14,10 +15,12 @@ composed_of:
   - semconv-resource-to-ecs@mappings
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
   - ecs-tsdb@mappings
 ignore_missing_component_templates:
   - metrics@custom
   - metrics-otel@custom
+  - metrics-60m.otel@custom
 template:
   settings:
     index:
@@ -27,14 +30,11 @@ template:
       data_stream.type:
         type: constant_keyword
         value: metrics
-    dynamic_templates:
-      - ecs_ip:
-          mapping:
-            type: ip
-          path_match: [ "ip", "*.ip", "*_ip" ]
-          match_mapping_type: string
-      - all_strings_to_keywords:
-          mapping:
-            ignore_above: 1024
-            type: keyword
-          match_mapping_type: string
+      metricset:
+        properties:
+          interval:
+            type: constant_keyword
+            value: 60m
+          name:
+            type: constant_keyword
+            value: transaction

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 3
+version: 4
 
 component-templates:
   - otel@mappings
@@ -9,7 +9,20 @@ component-templates:
   - semconv-resource-to-ecs@mappings
   - metrics-otel@mappings
   - traces-otel@mappings
+  - ecs-tsdb@mappings
 index-templates:
   - logs-otel@template
   - metrics-otel@template
   - traces-otel@template
+  - metrics-transaction.60m.otel@template
+  - metrics-transaction.10m.otel@template
+  - metrics-transaction.1m.otel@template
+  - metrics-service_transaction.60m.otel@template
+  - metrics-service_transaction.10m.otel@template
+  - metrics-service_transaction.1m.otel@template
+  - metrics-service_summary.60m.otel@template
+  - metrics-service_summary.10m.otel@template
+  - metrics-service_summary.1m.otel@template
+  - metrics-service_destination.60m@template
+  - metrics-service_destination.10m@template
+  - metrics-service_destination.1m@template

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/30_aggregated_metrics_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/30_aggregated_metrics_tests.yml
@@ -1,0 +1,428 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_events: languid
+  - do:
+      cluster.put_component_template:
+        name: metrics-otel@custom
+        body:
+          template:
+            settings:
+              index:
+                routing_path: [unit, attributes.*, resource.attributes.*]
+                mode: time_series
+                time_series:
+                  start_time: 2024-07-01T13:03:08.138Z
+---
+"metrics-service_destination.10m must be hidden":
+  - do:
+      bulk:
+        index: metrics-service_destination.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_destination"},"resource":{"attributes":{ "metricset.interval": "10m"  } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-service_destination.10m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["service_destination"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["10m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-service_destination.10m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-service_destination.60m must be hidden":
+  - do:
+      bulk:
+        index: metrics-service_destination.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_destination" },"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-service_destination.60m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["service_destination"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["60m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-service_destination.60m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-service_summary.10m must be hidden":
+  - do:
+      bulk:
+        index: metrics-service_summary.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_summary"},"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-service_summary.10m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["service_summary"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["10m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-service_summary.10m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-service_summary.60m must be hidden":
+  - do:
+      bulk:
+        index: metrics-service_summary.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_summary" },"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-service_summary.60m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["service_summary"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["60m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-service_summary.60m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-service_transaction.10m must be hidden":
+  - do:
+      bulk:
+        index: metrics-service_transaction.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_transaction"  },"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-service_transaction.10m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["service_transaction"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["10m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-service_transaction.10m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-service_transaction.60m must be hidden":
+  - do:
+      bulk:
+        index: metrics-service_transaction.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_transaction"},"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-service_transaction.60m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["service_transaction"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["60m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-service_transaction.60m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-transaction.10m must be hidden":
+  - do:
+      bulk:
+        index: metrics-transaction.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "transaction"},"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-transaction.10m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["transaction"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["10m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-transaction.10m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"metrics-transaction.60m must be hidden":
+  - do:
+      bulk:
+        index: metrics-transaction.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "transaction"},"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-transaction.60m.otel-default
+        body:
+          fields: ["metricset.name", "metricset.interval"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.metricset\.name: ["transaction"] }
+  - match: { hits.hits.0.fields.metricset\.interval: ["60m"] }
+  - do:
+      indices.get_data_stream:
+        name: metrics-transaction.60m.otel-default
+  - match: { data_streams.0.hidden: true }
+---
+"Terms aggregation on metricset.interval from metrics-transaction must by default only contain 1m":
+  - do:
+      bulk:
+        index: metrics-transaction.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "transaction"},"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - do:
+      bulk:
+        index: metrics-transaction.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "transaction"},"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - do:
+      bulk:
+        index: metrics-transaction.1m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "transaction"},"resource":{"attributes":{ "metricset.interval": "1m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-*.otel-default
+        body: >
+          {
+
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 1 }
+  - match: { aggregations.intervals.buckets.0.key: "1m" }
+  - match: { aggregations.intervals.buckets.0.doc_count: 1 }
+  # With including hidden indices, 10m and 60m aggregation also show up
+  - do:
+      search:
+        index: metrics-*.otel-default
+        expand_wildcards: open,hidden
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 3 }
+---
+"Terms aggregation on metricset.interval from metrics-service_transaction must by default only contain 1m":
+  - do:
+      bulk:
+        index: metrics-service_transaction.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_transaction"},"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - do:
+      bulk:
+        index: metrics-service_transaction.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_transaction"},"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - do:
+      bulk:
+        index: metrics-service_transaction.1m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_transaction"},"resource":{"attributes":{ "metricset.interval": "1m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-*.otel-default
+        body: >
+          {
+
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 1 }
+  - match: { aggregations.intervals.buckets.0.key: "1m" }
+  - match: { aggregations.intervals.buckets.0.doc_count: 1 }
+  # With including hidden indices, 10m and 60m aggregation also show up
+  - do:
+      search:
+        index: metrics-*.otel-default
+        expand_wildcards: open,hidden
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 3 }
+---
+"Terms aggregation on metricset.interval from metrics-service_summary must by default only contain 1m":
+  - do:
+      bulk:
+        index: metrics-service_summary.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_summary"},"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - do:
+      bulk:
+        index: metrics-service_summary.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_summary"},"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - do:
+      bulk:
+        index: metrics-service_summary.1m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_summary"},"resource":{"attributes":{ "metricset.interval": "1m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-*.otel-default
+        body: >
+          {
+
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 1 }
+  - match: { aggregations.intervals.buckets.0.key: "1m" }
+  - match: { aggregations.intervals.buckets.0.doc_count: 1 }
+  # With including hidden indices, 10m and 60m aggregation also show up
+  - do:
+      search:
+        index: metrics-*.otel-default
+        expand_wildcards: open,hidden
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 3 }
+---
+"Terms aggregation on metricset.interval from metrics-service_destination must by default only contain 1m":
+  - do:
+      bulk:
+        index: metrics-service_destination.60m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_destination"},"resource":{"attributes":{ "metricset.interval": "60m" } } }'
+  - do:
+      bulk:
+        index: metrics-service_destination.10m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_destination"},"resource":{"attributes":{ "metricset.interval": "10m" } } }'
+  - do:
+      bulk:
+        index: metrics-service_destination.1m.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z" ,"attributes":{"processor.event":"metric","transaction.root":false, "metricset.name" : "service_destination"},"resource":{"attributes":{ "metricset.interval": "1m" } } }'
+  - is_false: errors
+  - do:
+      search:
+        index: metrics-*.otel-default
+        body: >
+          {
+
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 1 }
+  - match: { aggregations.intervals.buckets.0.key: "1m" }
+  - match: { aggregations.intervals.buckets.0.doc_count: 1 }
+  # With including hidden indices, 10m and 60m aggregation also show up
+  - do:
+      search:
+        index: metrics-*.otel-default
+        expand_wildcards: open,hidden
+        body: >
+          {
+            "size": 0,
+            "aggs": {
+              "intervals": {
+                "terms": {
+                  "field": "metricset.interval"
+                }
+              }
+            }
+          }
+  - length: { aggregations.intervals.buckets: 3 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [otel-data] Hide 10m and 60m aggregated metrics generated for the APM UI (#114042)