### PR TITLE
[8.x] Correctly inject subobjects parameter in logsdb tests (#113643)

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/DataGenerationHelper.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/logsdb/qa/DataGenerationHelper.java
@@ -12,25 +12,18 @@ package org.elasticsearch.datastreams.logsdb.qa;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.Mapper;
-import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.logsdb.datageneration.DataGenerator;
 import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.logsdb.datageneration.FieldDataGenerator;
-import org.elasticsearch.logsdb.datageneration.datasource.DataSourceHandler;
-import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
-import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.logsdb.datageneration.fields.PredefinedField;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 public class DataGenerationHelper {
-    private final ObjectMapper.Subobjects subobjects;
     private final boolean keepArraySource;
 
     private final DataGenerator dataGenerator;
@@ -40,44 +33,10 @@ public class DataGenerationHelper {
     }
 
     public DataGenerationHelper(Consumer<DataGeneratorSpecification.Builder> builderConfigurator) {
-        // TODO enable subobjects: auto
-        // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using copy_to.
-        this.subobjects = ESTestCase.randomValueOtherThan(
-            ObjectMapper.Subobjects.AUTO,
-            () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
-        );
         this.keepArraySource = ESTestCase.randomBoolean();
 
-        var specificationBuilder = DataGeneratorSpecification.builder().withFullyDynamicMapping(ESTestCase.randomBoolean());
-        if (subobjects != ObjectMapper.Subobjects.ENABLED) {
-            specificationBuilder = specificationBuilder.withNestedFieldsLimit(0);
-        }
-
-        specificationBuilder.withDataSourceHandlers(List.of(new DataSourceHandler() {
-            @Override
-            public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
-                if (subobjects == ObjectMapper.Subobjects.ENABLED) {
-                    // Use default behavior
-                    return null;
-                }
-
-                assert request.isNested() == false;
-
-                // "enabled: false" is not compatible with subobjects: false
-                // "dynamic: false/strict/runtime" is not compatible with subobjects: false
-                return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
-                    var parameters = new HashMap<String, Object>();
-                    parameters.put("subobjects", subobjects.toString());
-                    if (ESTestCase.randomBoolean()) {
-                        parameters.put("dynamic", "true");
-                    }
-                    if (ESTestCase.randomBoolean()) {
-                        parameters.put("enabled", "true");
-                    }
-                    return parameters;
-                });
-            }
-        }))
+        var specificationBuilder = DataGeneratorSpecification.builder()
+            .withFullyDynamicMapping(ESTestCase.randomBoolean())
             .withPredefinedFields(
                 List.of(
                     // Customized because it always needs doc_values for aggregations.
@@ -136,11 +95,7 @@ public class DataGenerationHelper {
     }
 
     void standardMapping(XContentBuilder builder) throws IOException {
-        if (subobjects != ObjectMapper.Subobjects.ENABLED) {
-            dataGenerator.writeMapping(builder, Map.of("subobjects", subobjects.toString()));
-        } else {
-            dataGenerator.writeMapping(builder);
-        }
+        dataGenerator.writeMapping(builder);
     }
 
     void logsDbSettings(Settings.Builder builder) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -63,7 +63,7 @@ public class ObjectMapper extends Mapper {
             this.printedValue = printedValue;
         }
 
-        static Subobjects from(Object node) {
+        public static Subobjects from(Object node) {
             if (node instanceof Boolean value) {
                 return value ? Subobjects.ENABLED : Subobjects.DISABLED;
             }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DataSourceRequest.java
@@ -9,10 +9,10 @@
 
 package org.elasticsearch.logsdb.datageneration.datasource;
 
+import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.logsdb.datageneration.FieldType;
 import org.elasticsearch.logsdb.datageneration.fields.DynamicMapping;
-import org.elasticsearch.test.ESTestCase;
 
 import java.util.Set;
 
@@ -116,15 +116,11 @@ public interface DataSourceRequest<TResponse extends DataSourceResponse> {
         }
     }
 
-    record ObjectMappingParametersGenerator(boolean isRoot, boolean isNested)
+    record ObjectMappingParametersGenerator(boolean isRoot, boolean isNested, ObjectMapper.Subobjects parentSubobjects)
         implements
             DataSourceRequest<DataSourceResponse.ObjectMappingParametersGenerator> {
         public DataSourceResponse.ObjectMappingParametersGenerator accept(DataSourceHandler handler) {
             return handler.handle(this);
-        }
-
-        public String syntheticSourceKeepValue() {
-            return isRoot() ? ESTestCase.randomFrom("none", "arrays") : ESTestCase.randomFrom("none", "arrays", "all");
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.logsdb.datageneration.datasource;
 
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.logsdb.datageneration.fields.DynamicMapping;
 import org.elasticsearch.test.ESTestCase;
 
@@ -78,8 +79,11 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
     @Override
     public DataSourceResponse.ObjectMappingParametersGenerator handle(DataSourceRequest.ObjectMappingParametersGenerator request) {
         if (request.isNested()) {
+            assert request.parentSubobjects() != ObjectMapper.Subobjects.DISABLED;
+
             return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
                 var parameters = new HashMap<String, Object>();
+
                 if (ESTestCase.randomBoolean()) {
                     parameters.put("dynamic", ESTestCase.randomFrom("true", "false", "strict"));
                 }
@@ -93,14 +97,41 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
 
         return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
             var parameters = new HashMap<String, Object>();
+
+            if (request.parentSubobjects() == ObjectMapper.Subobjects.DISABLED) {
+                // "enabled: false" is not compatible with subobjects: false
+                // changing "dynamic" from parent context is not compatible with subobjects: false
+                // changing subobjects value is not compatible with subobjects: false
+                if (ESTestCase.randomBoolean()) {
+                    parameters.put("enabled", "true");
+                }
+
+                return parameters;
+            }
+
             if (ESTestCase.randomBoolean()) {
                 parameters.put("dynamic", ESTestCase.randomFrom("true", "false", "strict", "runtime"));
             }
             if (ESTestCase.randomBoolean()) {
                 parameters.put("enabled", ESTestCase.randomFrom("true", "false"));
             }
+            // Changing subobjects from subobjects: false is not supported, but we can f.e. go from "true" to "false".
+            // TODO enable subobjects: auto
+            // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using
+            // copy_to.
             if (ESTestCase.randomBoolean()) {
-                parameters.put(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, request.syntheticSourceKeepValue());
+                parameters.put(
+                    "subobjects",
+                    ESTestCase.randomValueOtherThan(
+                        ObjectMapper.Subobjects.AUTO,
+                        () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
+                    ).toString()
+                );
+            }
+
+            if (ESTestCase.randomBoolean()) {
+                var value = request.isRoot() ? ESTestCase.randomFrom("none", "arrays") : ESTestCase.randomFrom("none", "arrays", "all");
+                parameters.put(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, value);
             }
 
             return parameters;

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/Context.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/Context.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.logsdb.datageneration.fields;
 
+import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceResponse;
@@ -31,9 +32,14 @@ class Context {
     private final AtomicInteger nestedFieldsCount;
     private final Set<String> eligibleCopyToDestinations;
     private final DynamicMapping parentDynamicMapping;
+    private final ObjectMapper.Subobjects currentSubobjectsConfig;
 
-    Context(DataGeneratorSpecification specification, DynamicMapping parentDynamicMapping) {
-        this(specification, "", 0, new AtomicInteger(0), new HashSet<>(), parentDynamicMapping);
+    Context(
+        DataGeneratorSpecification specification,
+        DynamicMapping parentDynamicMapping,
+        ObjectMapper.Subobjects currentSubobjectsConfig
+    ) {
+        this(specification, "", 0, new AtomicInteger(0), new HashSet<>(), parentDynamicMapping, currentSubobjectsConfig);
     }
 
     private Context(
@@ -42,7 +48,8 @@ class Context {
         int objectDepth,
         AtomicInteger nestedFieldsCount,
         Set<String> eligibleCopyToDestinations,
-        DynamicMapping parentDynamicMapping
+        DynamicMapping parentDynamicMapping,
+        ObjectMapper.Subobjects currentSubobjectsConfig
     ) {
         this.specification = specification;
         this.childFieldGenerator = specification.dataSource().get(new DataSourceRequest.ChildFieldGenerator(specification));
@@ -52,6 +59,7 @@ class Context {
         this.nestedFieldsCount = nestedFieldsCount;
         this.eligibleCopyToDestinations = eligibleCopyToDestinations;
         this.parentDynamicMapping = parentDynamicMapping;
+        this.currentSubobjectsConfig = currentSubobjectsConfig;
     }
 
     public DataGeneratorSpecification specification() {
@@ -66,21 +74,30 @@ class Context {
         return specification.dataSource().get(new DataSourceRequest.FieldTypeGenerator(dynamicMapping));
     }
 
-    public Context subObject(String name, DynamicMapping dynamicMapping) {
+    public Context subObject(String name, DynamicMapping dynamicMapping, ObjectMapper.Subobjects subobjects) {
         return new Context(
             specification,
             pathToField(name),
             objectDepth + 1,
             nestedFieldsCount,
             eligibleCopyToDestinations,
-            dynamicMapping
+            dynamicMapping,
+            subobjects
         );
     }
 
-    public Context nestedObject(String name, DynamicMapping dynamicMapping) {
+    public Context nestedObject(String name, DynamicMapping dynamicMapping, ObjectMapper.Subobjects subobjects) {
         nestedFieldsCount.incrementAndGet();
         // copy_to can't be used across nested documents so all currently eligible fields are not eligible inside nested document.
-        return new Context(specification, pathToField(name), objectDepth + 1, nestedFieldsCount, new HashSet<>(), dynamicMapping);
+        return new Context(
+            specification,
+            pathToField(name),
+            objectDepth + 1,
+            nestedFieldsCount,
+            new HashSet<>(),
+            dynamicMapping,
+            subobjects
+        );
     }
 
     public boolean shouldAddDynamicObjectField(DynamicMapping dynamicMapping) {
@@ -99,10 +116,11 @@ class Context {
         return childFieldGenerator.generateRegularSubObject();
     }
 
-    public boolean shouldAddNestedField() {
+    public boolean shouldAddNestedField(ObjectMapper.Subobjects subobjects) {
         if (objectDepth >= specification.maxObjectDepth()
             || nestedFieldsCount.get() >= specification.nestedFieldsLimit()
-            || parentDynamicMapping == DynamicMapping.FORCED) {
+            || parentDynamicMapping == DynamicMapping.FORCED
+            || subobjects == ObjectMapper.Subobjects.DISABLED) {
             return false;
         }
 
@@ -131,6 +149,14 @@ class Context {
         return dynamicParameter.equals("strict") ? DynamicMapping.FORBIDDEN : DynamicMapping.SUPPORTED;
     }
 
+    public ObjectMapper.Subobjects determineSubobjects(Map<String, Object> mappingParameters) {
+        if (currentSubobjectsConfig == ObjectMapper.Subobjects.DISABLED) {
+            return ObjectMapper.Subobjects.DISABLED;
+        }
+
+        return ObjectMapper.Subobjects.from(mappingParameters.getOrDefault("subobjects", "true"));
+    }
+
     public Set<String> getEligibleCopyToDestinations() {
         return eligibleCopyToDestinations;
     }
@@ -141,5 +167,9 @@ class Context {
 
     private String pathToField(String field) {
         return path.isEmpty() ? field : path + "." + field;
+    }
+
+    public ObjectMapper.Subobjects getCurrentSubobjectsConfig() {
+        return currentSubobjectsConfig;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/NestedFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/NestedFieldDataGenerator.java
@@ -28,13 +28,14 @@ public class NestedFieldDataGenerator implements FieldDataGenerator {
 
         this.mappingParameters = context.specification()
             .dataSource()
-            .get(new DataSourceRequest.ObjectMappingParametersGenerator(false, true))
+            .get(new DataSourceRequest.ObjectMappingParametersGenerator(false, true, context.getCurrentSubobjectsConfig()))
             .mappingGenerator()
             .get();
         var dynamicMapping = context.determineDynamicMapping(mappingParameters);
+        var subobjects = context.determineSubobjects(mappingParameters);
 
         var genericGenerator = new GenericSubObjectFieldDataGenerator(context);
-        this.childFields = genericGenerator.generateChildFields(dynamicMapping);
+        this.childFields = genericGenerator.generateChildFields(dynamicMapping, subobjects);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/ObjectFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/ObjectFieldDataGenerator.java
@@ -28,13 +28,14 @@ public class ObjectFieldDataGenerator implements FieldDataGenerator {
 
         this.mappingParameters = context.specification()
             .dataSource()
-            .get(new DataSourceRequest.ObjectMappingParametersGenerator(false, false))
+            .get(new DataSourceRequest.ObjectMappingParametersGenerator(false, false, context.getCurrentSubobjectsConfig()))
             .mappingGenerator()
             .get();
         var dynamicMapping = context.determineDynamicMapping(mappingParameters);
+        var subobjects = context.determineSubobjects(mappingParameters);
 
         var genericGenerator = new GenericSubObjectFieldDataGenerator(context);
-        this.childFields = genericGenerator.generateChildFields(dynamicMapping);
+        this.childFields = genericGenerator.generateChildFields(dynamicMapping, subobjects);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/TopLevelObjectFieldDataGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/fields/TopLevelObjectFieldDataGenerator.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.logsdb.datageneration.fields;
 
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.logsdb.datageneration.DataGeneratorSpecification;
 import org.elasticsearch.logsdb.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -37,7 +38,12 @@ public class TopLevelObjectFieldDataGenerator {
             this.mappingParameters = Map.of();
         } else {
             this.mappingParameters = new HashMap<>(
-                specification.dataSource().get(new DataSourceRequest.ObjectMappingParametersGenerator(true, false)).mappingGenerator().get()
+                // Value of subobjects here is for a parent of this object.
+                // Since there is no parent we pass ENABLED to allow to set subobjects to any value at top level.
+                specification.dataSource()
+                    .get(new DataSourceRequest.ObjectMappingParametersGenerator(true, false, ObjectMapper.Subobjects.ENABLED))
+                    .mappingGenerator()
+                    .get()
             );
             // Top-level object can't be disabled because @timestamp is a required field in data streams.
             this.mappingParameters.remove("enabled");
@@ -46,11 +52,15 @@ public class TopLevelObjectFieldDataGenerator {
                 ? DynamicMapping.FORBIDDEN
                 : DynamicMapping.SUPPORTED;
         }
-        this.context = new Context(specification, dynamicMapping);
+        var subobjects = ObjectMapper.Subobjects.from(mappingParameters.getOrDefault("subobjects", "true"));
+
+        // Value of subobjects here is for a parent of this object.
+        // Since there is no parent we pass ENABLED to allow to set subobjects to any value at top level.
+        this.context = new Context(specification, dynamicMapping, ObjectMapper.Subobjects.ENABLED);
         var genericGenerator = new GenericSubObjectFieldDataGenerator(context);
 
         this.predefinedFields = genericGenerator.generateChildFields(specification.predefinedFields());
-        this.generatedChildFields = genericGenerator.generateChildFields(dynamicMapping);
+        this.generatedChildFields = genericGenerator.generateChildFields(dynamicMapping, subobjects);
     }
 
     public CheckedConsumer<XContentBuilder, IOException> mappingWriter(Map<String, Object> customMappingParameters) {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Correctly inject subobjects parameter in logsdb tests (#113643)