### PR TITLE
Improve performance of LongHash#removeAndAdd

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/AbstractHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractHash.java
@@ -32,7 +32,17 @@ abstract class AbstractHash extends AbstractPagedHashMap {
         return ids.get(index) - 1;
     }
 
-    protected final long id(long index, long id) {
+    /**
+     * Set the id provided key at <code>0 &lt;= index &lt;= capacity()</code> .
+     */
+    protected final void setId(long index, long id) {
+        ids.set(index, id + 1);
+    }
+
+    /**
+     * Set the id provided key at <code>0 &lt;= index &lt;= capacity()</code>  and get the previous value or -1 if this slot is unused.
+     */
+    protected final long getAndSetId(long index, long id) {
         return ids.getAndSet(index, id + 1) - 1;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -169,7 +169,7 @@ public final class BytesRefHash extends AbstractHash implements Accountable {
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 append(id, key, code);
                 ++size;
                 return id;
@@ -197,7 +197,7 @@ public final class BytesRefHash extends AbstractHash implements Accountable {
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 break;
             }
         }
@@ -223,7 +223,7 @@ public final class BytesRefHash extends AbstractHash implements Accountable {
 
     @Override
     protected void removeAndAdd(long index) {
-        final long id = id(index, -1);
+        final long id = getAndSetId(index, -1);
         assert id >= 0;
         final int code = hashes.get(id);
         reset(code, id);

--- a/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
@@ -79,7 +79,7 @@ public final class Int3Hash extends AbstractHash {
         while (true) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 append(id, key1, key2, key3);
                 ++size;
                 return id;
@@ -106,7 +106,7 @@ public final class Int3Hash extends AbstractHash {
         while (true) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 append(id, key1, key2, key3);
                 break;
             }
@@ -130,7 +130,7 @@ public final class Int3Hash extends AbstractHash {
 
     @Override
     protected void removeAndAdd(long index) {
-        final long id = id(index, -1);
+        final long id = getAndSetId(index, -1);
         assert id >= 0;
         long keyOffset = id * 3;
         final int key1 = keys.getAndSet(keyOffset, 0);

--- a/server/src/main/java/org/elasticsearch/common/util/LongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongHash.java
@@ -67,7 +67,7 @@ public final class LongHash extends AbstractHash {
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 append(id, key);
                 ++size;
                 return id;
@@ -82,13 +82,13 @@ public final class LongHash extends AbstractHash {
         keys.set(id, key);
     }
 
-    private void reset(long key, long id) {
+    private void reset(long id) {
+        final long key = keys.get(id);
         final long slot = slot(hash(key), mask);
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
-                append(id, key);
+                setId(index, id);
                 break;
             }
         }
@@ -109,10 +109,9 @@ public final class LongHash extends AbstractHash {
 
     @Override
     protected void removeAndAdd(long index) {
-        final long id = id(index, -1);
+        final long id = getAndSetId(index, -1);
         assert id >= 0;
-        final long key = keys.getAndSet(id, 0);
-        reset(key, id);
+        reset(id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -84,7 +84,7 @@ public final class LongLongHash extends AbstractHash {
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 append(id, key1, key2);
                 ++size;
                 return id;
@@ -109,7 +109,7 @@ public final class LongLongHash extends AbstractHash {
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
-                id(index, id);
+                setId(index, id);
                 append(id, key1, key2);
                 break;
             }
@@ -132,7 +132,7 @@ public final class LongLongHash extends AbstractHash {
 
     @Override
     protected void removeAndAdd(long index) {
-        final long id = id(index, -1);
+        final long id = getAndSetId(index, -1);
         assert id >= 0;
         long keyOffset = id * 2;
         final long key1 = keys.getAndSet(keyOffset, 0);


### PR DESCRIPTION
I noticed that in LongHash#removeAndAdd we are setting the key to 0 via `keys.getAndSet(id, 0)` to then later updated to the same value via ` append(id, key)`. This is unnecessary so we can remove it and remove some array manipulation in that method. 

In addition I am updating the semantics of AbstractHash to take advantage of the changes in https://github.com/elastic/elasticsearch/pull/109878 where we add getAndSet implementations to some BigArrays implementations.