### PR TITLE
[8.x] fix typo - "english" is not a valid language code (#114166)

### DIFF
--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -116,7 +116,7 @@ PUT _connector/my-connector
   "name": "My Connector",
   "description": "My Connector to sync data to Elastic index from Google Drive",
   "service_type": "google_drive",
-  "language": "english"
+  "language": "en"
 }
 ----
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - fix typo - "english" is not a valid language code (#114166)