### PR TITLE
Fixing span gap builder tests (#114218)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -371,9 +371,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/114187
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   issue: https://github.com/elastic/elasticsearch/issues/114194
-- class: org.elasticsearch.index.query.SpanGapQueryBuilderTests
-  method: testToQuery
-  issue: https://github.com/elastic/elasticsearch/issues/114218
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/index/query/SpanGapQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanGapQueryBuilderTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.queries.spans.SpanNearQuery;
 import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.lucene.queries.SpanMatchNoDocsQuery;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -50,7 +51,9 @@ public class SpanGapQueryBuilderTests extends AbstractQueryTestCase<SpanNearQuer
     protected void doAssertLuceneQuery(SpanNearQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(
             query,
-            either(instanceOf(SpanNearQuery.class)).or(instanceOf(SpanTermQuery.class)).or(instanceOf(MatchAllQueryBuilder.class))
+            either(instanceOf(SpanNearQuery.class)).or(instanceOf(SpanTermQuery.class))
+                .or(instanceOf(MatchAllQueryBuilder.class))
+                .or(instanceOf(SpanMatchNoDocsQuery.class))
         );
         if (query instanceof SpanNearQuery spanNearQuery) {
             assertThat(spanNearQuery.getSlop(), equalTo(queryBuilder.slop()));


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/113251 having a `SpanMatchNoDocsQuery` is a valid response to the rewrite.

closes https://github.com/elastic/elasticsearch/issues/114218