### PR TITLE
[8.x] Change read-only suffix for file based role mappings (#114205)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -359,9 +359,9 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
             containsInAnyOrder(
                 "everyone_kibana",
-                "everyone_kibana " + RESERVED_ROLE_MAPPING_SUFFIX,
+                "everyone_kibana" + RESERVED_ROLE_MAPPING_SUFFIX,
                 "_everyone_kibana",
-                "everyone_fleet " + RESERVED_ROLE_MAPPING_SUFFIX,
+                "everyone_fleet" + RESERVED_ROLE_MAPPING_SUFFIX,
                 "zzz_mapping",
                 "123_mapping"
             )
@@ -377,6 +377,16 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
 
         // it's possible to delete overlapping native role mapping
         assertTrue(client().execute(DeleteRoleMappingAction.INSTANCE, deleteRequest("everyone_kibana")).actionGet().isFound());
+
+        // Fetch a specific file based role
+        request = new GetRoleMappingsRequest();
+        request.setNames("everyone_kibana" + RESERVED_ROLE_MAPPING_SUFFIX);
+        response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
+        assertTrue(response.hasMappings());
+        assertThat(
+            Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
+            containsInAnyOrder("everyone_kibana" + RESERVED_ROLE_MAPPING_SUFFIX)
+        );
 
         savedClusterState = setupClusterStateListenerForCleanup(internalCluster().getMasterName());
         writeJSONFile(internalCluster().getMasterName(), emptyJSON, logger, versionCounter);
@@ -556,9 +566,7 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         assertThat(
             Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
             containsInAnyOrder(
-                Arrays.stream(mappings)
-                    .map(mapping -> mapping + (readOnly ? " " + RESERVED_ROLE_MAPPING_SUFFIX : ""))
-                    .toArray(String[]::new)
+                Arrays.stream(mappings).map(mapping -> mapping + (readOnly ? RESERVED_ROLE_MAPPING_SUFFIX : "")).toArray(String[]::new)
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleAction.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -17,6 +18,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleRequest;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleResponse;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authz.ReservedRoleNameChecker;
 import org.elasticsearch.xpack.security.authz.store.NativeRolesStore;
 
@@ -25,16 +27,20 @@ public class TransportDeleteRoleAction extends TransportAction<DeleteRoleRequest
     private final NativeRolesStore rolesStore;
     private final ReservedRoleNameChecker reservedRoleNameChecker;
 
+    private final ClusterStateRoleMapper clusterStateRoleMapper;
+
     @Inject
     public TransportDeleteRoleAction(
         ActionFilters actionFilters,
         NativeRolesStore rolesStore,
         TransportService transportService,
-        ReservedRoleNameChecker reservedRoleNameChecker
+        ReservedRoleNameChecker reservedRoleNameChecker,
+        ClusterStateRoleMapper clusterStateRoleMapper
     ) {
         super(DeleteRoleAction.NAME, actionFilters, transportService.getTaskManager(), EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.rolesStore = rolesStore;
         this.reservedRoleNameChecker = reservedRoleNameChecker;
+        this.clusterStateRoleMapper = clusterStateRoleMapper;
     }
 
     @Override
@@ -45,7 +51,19 @@ public class TransportDeleteRoleAction extends TransportAction<DeleteRoleRequest
         }
 
         try {
-            rolesStore.deleteRole(request, listener.safeMap(DeleteRoleResponse::new));
+            rolesStore.deleteRole(request, listener.safeMap((found) -> {
+                if (clusterStateRoleMapper.hasMapping(request.name())) {
+                    // Allow to delete a mapping with the same name in the native role mapping store as the file_settings namespace, but
+                    // add a warning header to signal to the caller that this could be a problem.
+                    HeaderWarning.addWarning(
+                        "A read only role mapping with the same name ["
+                            + request.name()
+                            + "] has been previously been defined in a configuration file. "
+                            + "The read only role mapping will still be active."
+                    );
+                }
+                return new DeleteRoleResponse(found);
+            }));
         } catch (Exception e) {
             logger.error((Supplier<?>) () -> "failed to delete role [" + request.name() + "]", e);
             listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapper.java
@@ -47,7 +47,7 @@ public class ClusterStateRoleMapper extends AbstractRoleMapperClearRealmCache im
      * </ul>
      */
     public static final String CLUSTER_STATE_ROLE_MAPPINGS_ENABLED = "xpack.security.authc.cluster_state_role_mappings.enabled";
-    public static final String RESERVED_ROLE_MAPPING_SUFFIX = "(read only)";
+    public static final String RESERVED_ROLE_MAPPING_SUFFIX = "-read-only-operator-config";
     private static final Logger logger = LogManager.getLogger(ClusterStateRoleMapper.class);
 
     private final ScriptService scriptService;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.core.security.action.role.DeleteRoleRequest;
 import org.elasticsearch.xpack.core.security.action.role.DeleteRoleResponse;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authz.ReservedRoleNameChecker;
 import org.elasticsearch.xpack.security.authz.store.NativeRolesStore;
 import org.junit.BeforeClass;
@@ -66,7 +67,8 @@ public class TransportDeleteRoleActionTests extends ESTestCase {
             mock(ActionFilters.class),
             rolesStore,
             transportService,
-            new ReservedRoleNameChecker.Default()
+            new ReservedRoleNameChecker.Default(),
+            mock(ClusterStateRoleMapper.class)
         );
 
         DeleteRoleRequest request = new DeleteRoleRequest();
@@ -115,7 +117,8 @@ public class TransportDeleteRoleActionTests extends ESTestCase {
             mock(ActionFilters.class),
             rolesStore,
             transportService,
-            new ReservedRoleNameChecker.Default()
+            new ReservedRoleNameChecker.Default(),
+            mock(ClusterStateRoleMapper.class)
         );
 
         DeleteRoleRequest request = new DeleteRoleRequest();
@@ -168,7 +171,8 @@ public class TransportDeleteRoleActionTests extends ESTestCase {
             mock(ActionFilters.class),
             rolesStore,
             transportService,
-            new ReservedRoleNameChecker.Default()
+            new ReservedRoleNameChecker.Default(),
+            mock(ClusterStateRoleMapper.class)
         );
 
         DeleteRoleRequest request = new DeleteRoleRequest();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingActionTests.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper.RESERVED_ROLE_MAPPING_SUFFIX;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -97,12 +98,18 @@ public class TransportPutRoleMappingActionTests extends ESTestCase {
         final FieldExpression expression = new FieldExpression("username", Collections.singletonList(new FieldExpression.FieldValue("*")));
         IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> put("anarchy (read only)", expression, "superuser", Collections.singletonMap("dumb", true))
+            () -> put("anarchy" + RESERVED_ROLE_MAPPING_SUFFIX, expression, "superuser", Collections.singletonMap("dumb", true))
         );
 
         assertThat(
             illegalArgumentException.getMessage(),
-            equalTo("Invalid mapping name [anarchy (read only)]. [(read only)] is not an allowed suffix")
+            equalTo(
+                "Invalid mapping name [anarchy"
+                    + RESERVED_ROLE_MAPPING_SUFFIX
+                    + "]. ["
+                    + RESERVED_ROLE_MAPPING_SUFFIX
+                    + "] is not an allowed suffix"
+            )
         );
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Change read-only suffix for file based role mappings (#114205)](https://github.com/elastic/elasticsearch/pull/114205)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)