### PR TITLE
[8.x] Improve performance of LongLongHash#removeAndAdd (#114230)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -104,13 +104,16 @@ public final class LongLongHash extends AbstractHash {
         keys.set(keyOffset + 1, key2);
     }
 
-    private void reset(long key1, long key2, long id) {
+    private void reset(long id) {
+        final LongArray keys = this.keys;
+        final long keyOffset = id * 2;
+        final long key1 = keys.get(keyOffset);
+        final long key2 = keys.get(keyOffset + 1);
         final long slot = slot(hash(key1, key2), mask);
         for (long index = slot;; index = nextSlot(index, mask)) {
             final long curId = id(index);
             if (curId == -1) { // means unset
                 setId(index, id);
-                append(id, key1, key2);
                 break;
             }
         }
@@ -134,10 +137,7 @@ public final class LongLongHash extends AbstractHash {
     protected void removeAndAdd(long index) {
         final long id = getAndSetId(index, -1);
         assert id >= 0;
-        long keyOffset = id * 2;
-        final long key1 = keys.getAndSet(keyOffset, 0);
-        final long key2 = keys.getAndSet(keyOffset + 1, 0);
-        reset(key1, key2, id);
+        reset(id);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Improve performance of LongLongHash#removeAndAdd (#114230)