### PR TITLE
Avoid using `dynamic:strict` with `subobjects:false` at root

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -98,7 +98,22 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
         return new DataSourceResponse.ObjectMappingParametersGenerator(() -> {
             var parameters = new HashMap<String, Object>();
 
-            if (request.parentSubobjects() == ObjectMapper.Subobjects.DISABLED) {
+            // Changing subobjects from subobjects: false is not supported, but we can f.e. go from "true" to "false".
+            // TODO enable subobjects: auto
+            // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using
+            // copy_to.
+            if (ESTestCase.randomBoolean()) {
+                parameters.put(
+                    "subobjects",
+                    ESTestCase.randomValueOtherThan(
+                        ObjectMapper.Subobjects.AUTO,
+                        () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
+                    ).toString()
+                );
+            }
+
+            if (request.parentSubobjects() == ObjectMapper.Subobjects.DISABLED
+                || parameters.getOrDefault("subobjects", "true").equals("false")) {
                 // "enabled: false" is not compatible with subobjects: false
                 // changing "dynamic" from parent context is not compatible with subobjects: false
                 // changing subobjects value is not compatible with subobjects: false
@@ -114,19 +129,6 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             }
             if (ESTestCase.randomBoolean()) {
                 parameters.put("enabled", ESTestCase.randomFrom("true", "false"));
-            }
-            // Changing subobjects from subobjects: false is not supported, but we can f.e. go from "true" to "false".
-            // TODO enable subobjects: auto
-            // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using
-            // copy_to.
-            if (ESTestCase.randomBoolean()) {
-                parameters.put(
-                    "subobjects",
-                    ESTestCase.randomValueOtherThan(
-                        ObjectMapper.Subobjects.AUTO,
-                        () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
-                    ).toString()
-                );
             }
 
             if (ESTestCase.randomBoolean()) {


### PR DESCRIPTION
Fixes #114188