### PR TITLE
[8.x] Fixing span gap builder tests (#114218) (#114219)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/SpanGapQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanGapQueryBuilderTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.queries.spans.SpanNearQuery;
 import org.apache.lucene.queries.spans.SpanQuery;
 import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.lucene.queries.SpanMatchNoDocsQuery;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -50,7 +51,9 @@ public class SpanGapQueryBuilderTests extends AbstractQueryTestCase<SpanNearQuer
     protected void doAssertLuceneQuery(SpanNearQueryBuilder queryBuilder, Query query, SearchExecutionContext context) throws IOException {
         assertThat(
             query,
-            either(instanceOf(SpanNearQuery.class)).or(instanceOf(SpanTermQuery.class)).or(instanceOf(MatchAllQueryBuilder.class))
+            either(instanceOf(SpanNearQuery.class)).or(instanceOf(SpanTermQuery.class))
+                .or(instanceOf(MatchAllQueryBuilder.class))
+                .or(instanceOf(SpanMatchNoDocsQuery.class))
         );
         if (query instanceof SpanNearQuery spanNearQuery) {
             assertThat(spanNearQuery.getSlop(), equalTo(queryBuilder.slop()));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fixing span gap builder tests (#114218) (#114219)](https://github.com/elastic/elasticsearch/pull/114219)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)