### PR TITLE
Fix issue with releasing resources in bulk tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -194,7 +194,7 @@ public class IncrementalBulkService {
                         releasables.clear();
                         // We do not need to set this back to false as this will be the last request.
                         bulkInProgress = true;
-                        client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
+                        client.bulk(bulkRequest, ActionListener.runBefore(new ActionListener<>() {
 
                             private final boolean isFirstRequest = incrementalRequestSubmitted == false;
 


### PR DESCRIPTION
A recent commit incidentally changed a release resources call from
doBefore to doAfter. Several tests depending on resources being released
synchronously which requires doBefore.

Closes #114181
Closes #114182