### PR TITLE
[8.x] [ML] Add Streaming Inference spec (#113812)

### DIFF
--- a/docs/changelog/113812.yaml
+++ b/docs/changelog/113812.yaml
@@ -1,0 +1,5 @@
+pr: 113812
+summary: Add Streaming Inference spec
+area: Machine Learning
+type: enhancement
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_inference.json
@@ -1,0 +1,49 @@
+{
+  "inference.stream_inference":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/post-stream-inference-api.html",
+      "description":"Perform streaming inference"
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "text/event-stream"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_inference/{inference_id}/_stream",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "inference_id":{
+              "type":"string",
+              "description":"The inference Id"
+            }
+          }
+        },
+        {
+          "path":"/_inference/{task_type}/{inference_id}/_stream",
+          "methods":[
+            "POST"
+          ],
+          "parts":{
+            "task_type":{
+              "type":"string",
+              "description":"The task type"
+            },
+            "inference_id":{
+              "type":"string",
+              "description":"The inference Id"
+            }
+          }
+        }
+      ]
+    },
+    "body":{
+      "description":"The inference payload"
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Add Streaming Inference spec (#113812)