### PR TITLE
[8.x] Add postal_code support to the City and Enterprise databases (#114193)

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -40,7 +40,8 @@ enum Database {
             Property.REGION_NAME,
             Property.CITY_NAME,
             Property.TIMEZONE,
-            Property.LOCATION
+            Property.LOCATION,
+            Property.POSTAL_CODE
         ),
         Set.of(
             Property.COUNTRY_ISO_CODE,
@@ -108,7 +109,8 @@ enum Database {
             Property.MOBILE_COUNTRY_CODE,
             Property.MOBILE_NETWORK_CODE,
             Property.USER_TYPE,
-            Property.CONNECTION_TYPE
+            Property.CONNECTION_TYPE,
+            Property.POSTAL_CODE
         ),
         Set.of(
             Property.COUNTRY_ISO_CODE,
@@ -228,7 +230,8 @@ enum Database {
         MOBILE_NETWORK_CODE,
         CONNECTION_TYPE,
         USER_TYPE,
-        TYPE;
+        TYPE,
+        POSTAL_CODE;
 
         /**
          * Parses a string representation of a property into an actual Property instance. Not all properties that exist are

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
@@ -23,6 +23,7 @@ import com.maxmind.geoip2.model.EnterpriseResponse;
 import com.maxmind.geoip2.model.IspResponse;
 import com.maxmind.geoip2.record.Continent;
 import com.maxmind.geoip2.record.Location;
+import com.maxmind.geoip2.record.Postal;
 import com.maxmind.geoip2.record.Subdivision;
 
 import org.elasticsearch.common.network.InetAddresses;
@@ -139,6 +140,7 @@ final class MaxmindIpDataLookups {
             Location location = response.getLocation();
             Continent continent = response.getContinent();
             Subdivision subdivision = response.getMostSpecificSubdivision();
+            Postal postal = response.getPostal();
 
             Map<String, Object> data = new HashMap<>();
             for (Database.Property property : this.properties) {
@@ -204,6 +206,11 @@ final class MaxmindIpDataLookups {
                             locationObject.put("lat", latitude);
                             locationObject.put("lon", longitude);
                             data.put("location", locationObject);
+                        }
+                    }
+                    case POSTAL_CODE -> {
+                        if (postal != null && postal.getCode() != null) {
+                            data.put("postal_code", postal.getCode());
                         }
                     }
                 }
@@ -324,6 +331,7 @@ final class MaxmindIpDataLookups {
             Location location = response.getLocation();
             Continent continent = response.getContinent();
             Subdivision subdivision = response.getMostSpecificSubdivision();
+            Postal postal = response.getPostal();
 
             Long asn = response.getTraits().getAutonomousSystemNumber();
             String organizationName = response.getTraits().getAutonomousSystemOrganization();
@@ -411,6 +419,11 @@ final class MaxmindIpDataLookups {
                             locationObject.put("lat", latitude);
                             locationObject.put("lon", longitude);
                             data.put("location", locationObject);
+                        }
+                    }
+                    case POSTAL_CODE -> {
+                        if (postal != null && postal.getCode() != null) {
+                            data.put("postal_code", postal.getCode());
                         }
                     }
                     case ASN -> {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -274,7 +274,8 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             e.getMessage(),
             equalTo(
                 "[properties] illegal property value [invalid]. valid values are [IP, COUNTRY_ISO_CODE, "
-                    + "COUNTRY_NAME, CONTINENT_CODE, CONTINENT_NAME, REGION_ISO_CODE, REGION_NAME, CITY_NAME, TIMEZONE, LOCATION]"
+                    + "COUNTRY_NAME, CONTINENT_CODE, CONTINENT_NAME, REGION_ISO_CODE, REGION_NAME, CITY_NAME, TIMEZONE, "
+                    + "LOCATION, POSTAL_CODE]"
             )
         );
 

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -222,7 +222,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData, notNullValue());
-        assertThat(geoData.size(), equalTo(10));
+        assertThat(geoData.size(), equalTo(11));
         assertThat(geoData.get("ip"), equalTo(ip));
         assertThat(geoData.get("country_iso_code"), equalTo("US"));
         assertThat(geoData.get("country_name"), equalTo("United States"));
@@ -233,6 +233,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("city_name"), equalTo("Homestead"));
         assertThat(geoData.get("timezone"), equalTo("America/New_York"));
         assertThat(geoData.get("location"), equalTo(Map.of("lat", 25.4573d, "lon", -80.4572d)));
+        assertThat(geoData.get("postal_code"), equalTo("33035"));
     }
 
     public void testCityWithMissingLocation() throws Exception {
@@ -470,7 +471,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData, notNullValue());
-        assertThat(geoData.size(), equalTo(24));
+        assertThat(geoData.size(), equalTo(25));
         assertThat(geoData.get("ip"), equalTo(ip));
         assertThat(geoData.get("country_iso_code"), equalTo("US"));
         assertThat(geoData.get("country_name"), equalTo("United States"));
@@ -481,6 +482,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("city_name"), equalTo("Chatham"));
         assertThat(geoData.get("timezone"), equalTo("America/New_York"));
         assertThat(geoData.get("location"), equalTo(Map.of("lat", 42.3478, "lon", -73.5549)));
+        assertThat(geoData.get("postal_code"), equalTo("12037"));
         assertThat(geoData.get("asn"), equalTo(14671L));
         assertThat(geoData.get("organization_name"), equalTo("FairPoint Communications"));
         assertThat(geoData.get("network"), equalTo("74.209.16.0/20"));

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MaxMindSupportTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MaxMindSupportTests.java
@@ -84,7 +84,8 @@ public class MaxMindSupportTests extends ESTestCase {
         "location.longitude",
         "location.timeZone",
         "mostSpecificSubdivision.isoCode",
-        "mostSpecificSubdivision.name"
+        "mostSpecificSubdivision.name",
+        "postal.code"
     );
     private static final Set<String> CITY_UNSUPPORTED_FIELDS = Set.of(
         "city.confidence",
@@ -109,7 +110,6 @@ public class MaxMindSupportTests extends ESTestCase {
         "mostSpecificSubdivision.confidence",
         "mostSpecificSubdivision.geoNameId",
         "mostSpecificSubdivision.names",
-        "postal.code",
         "postal.confidence",
         "registeredCountry.confidence",
         "registeredCountry.geoNameId",
@@ -223,6 +223,7 @@ public class MaxMindSupportTests extends ESTestCase {
         "location.timeZone",
         "mostSpecificSubdivision.isoCode",
         "mostSpecificSubdivision.name",
+        "postal.code",
         "traits.anonymous",
         "traits.anonymousVpn",
         "traits.autonomousSystemNumber",
@@ -263,7 +264,6 @@ public class MaxMindSupportTests extends ESTestCase {
         "mostSpecificSubdivision.confidence",
         "mostSpecificSubdivision.geoNameId",
         "mostSpecificSubdivision.names",
-        "postal.code",
         "postal.confidence",
         "registeredCountry.confidence",
         "registeredCountry.geoNameId",


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add postal_code support to the City and Enterprise databases (#114193)