### PR TITLE
Remove unnecessary test overrides

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -61,31 +61,6 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
     );
 
     @Override
-    public void testCreateSnapshot() {
-        super.testCreateSnapshot();
-    }
-
-    @Override
-    public void testIndexLatest() throws Exception {
-        super.testIndexLatest();
-    }
-
-    @Override
-    public void testListChildren() {
-        super.testListChildren();
-    }
-
-    @Override
-    public void testCleanup() throws Exception {
-        super.testCleanup();
-    }
-
-    @Override
-    public void testReadFromPositionWithLength() {
-        super.testReadFromPositionWithLength();
-    }
-
-    @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return pluginList(AzureRepositoryPlugin.class);
     }


### PR DESCRIPTION
These test overrides were introduced so that we had somewhere to hang an
`@AwaitsFix` annotation, but now the tests are unmuted again there's no
need for the overrides.

Relates #108336