### PR TITLE
Add assertOnce to various cluster coordination listeners

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -135,7 +135,7 @@ public class JoinHelper {
             JoinRequest::new,
             (request, channel, task) -> joinHandler.accept(
                 request,
-                new ChannelActionListener<Empty>(channel).map(ignored -> Empty.INSTANCE)
+                ActionListener.assertOnce(new ChannelActionListener<Empty>(channel).map(ignored -> Empty.INSTANCE))
             )
         );
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
@@ -256,7 +256,7 @@ public abstract class Publication {
             }
             assert state == PublicationTargetState.NOT_STARTED : state + " -> " + PublicationTargetState.SENT_PUBLISH_REQUEST;
             state = PublicationTargetState.SENT_PUBLISH_REQUEST;
-            Publication.this.sendPublishRequest(discoveryNode, publishRequest, new PublishResponseHandler());
+            Publication.this.sendPublishRequest(discoveryNode, publishRequest, ActionListener.assertOnce(new PublishResponseHandler()));
             assert publicationCompletedIffAllTargetsInactiveOrCancelled();
         }
 


### PR DESCRIPTION
These listeners are all called (at most) once. This commit adds an
`assertOnce` wrapper to document this fact.