### PR TITLE
Add role mapping cleanup task

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -211,8 +211,6 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_AMAZON_BEDROCK_ADDED = def(8_702_00_0);
     public static final TransportVersion ENTERPRISE_GEOIP_DOWNLOADER_BACKPORT_8_15 = def(8_702_00_1);
     public static final TransportVersion FIX_VECTOR_SIMILARITY_INNER_HITS_BACKPORT_8_15 = def(8_702_00_2);
-
-    public static final TransportVersion ADD_ROLE_MAPPING_CLEANUP_TASK = def(8_702_00_3);
     /**
      * This is the squash of two backports:
      * <ul>
@@ -226,6 +224,7 @@ public class TransportVersions {
      * </ul>
      */
     public static final TransportVersion ESQL_ATTRIBUTE_CACHED_SERIALIZATION_8_15 = def(8_702_00_3);
+    public static final TransportVersion ADD_ROLE_MAPPING_CLEANUP_TASK = def(8_702_00_4);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -211,6 +211,8 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_AMAZON_BEDROCK_ADDED = def(8_702_00_0);
     public static final TransportVersion ENTERPRISE_GEOIP_DOWNLOADER_BACKPORT_8_15 = def(8_702_00_1);
     public static final TransportVersion FIX_VECTOR_SIMILARITY_INNER_HITS_BACKPORT_8_15 = def(8_702_00_2);
+
+    public static final TransportVersion ADD_ROLE_MAPPING_CLEANUP_TASK = def(8_703_00_3);
     /**
      * This is the squash of two backports:
      * <ul>

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -212,7 +212,7 @@ public class TransportVersions {
     public static final TransportVersion ENTERPRISE_GEOIP_DOWNLOADER_BACKPORT_8_15 = def(8_702_00_1);
     public static final TransportVersion FIX_VECTOR_SIMILARITY_INNER_HITS_BACKPORT_8_15 = def(8_702_00_2);
 
-    public static final TransportVersion ADD_ROLE_MAPPING_CLEANUP_TASK = def(8_703_00_3);
+    public static final TransportVersion ADD_ROLE_MAPPING_CLEANUP_TASK = def(8_702_00_3);
     /**
      * This is the squash of two backports:
      * <ul>

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -89,6 +89,7 @@ import org.elasticsearch.xpack.core.security.authz.permission.RemoteClusterPermi
 import org.elasticsearch.xpack.core.security.authz.permission.RemoteClusterPermissions;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
+import org.elasticsearch.xpack.core.security.support.RoleMappingCleanupTaskParams;
 import org.elasticsearch.xpack.core.security.support.SecurityMigrationTaskParams;
 import org.elasticsearch.xpack.core.slm.SLMFeatureSetUsage;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
@@ -304,6 +305,11 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, SearchPlu
                 PersistentTaskParams.class,
                 SecurityMigrationTaskParams.TASK_NAME,
                 SecurityMigrationTaskParams::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                PersistentTaskParams.class,
+                RoleMappingCleanupTaskParams.TASK_NAME,
+                RoleMappingCleanupTaskParams::new
             )
         ).filter(Objects::nonNull).toList();
     }
@@ -381,6 +387,11 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, SearchPlu
                 PersistentTaskParams.class,
                 new ParseField(SecurityMigrationTaskParams.TASK_NAME),
                 SecurityMigrationTaskParams::fromXContent
+            ),
+            new NamedXContentRegistry.Entry(
+                PersistentTaskParams.class,
+                new ParseField(RoleMappingCleanupTaskParams.TASK_NAME),
+                RoleMappingCleanupTaskParams::fromXContent
             ),
             new NamedXContentRegistry.Entry(
                 Metadata.Custom.class,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
@@ -108,8 +108,7 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
     }
 
     public static RoleMappingMetadata fromXContent(XContentParser parser) throws IOException {
-        RoleMappingMetadata roleMappingMetadata = PARSER.apply(parser, null);
-        return roleMappingMetadata;
+        return PARSER.apply(parser, null);
     }
 
     public int getVersion() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
@@ -40,6 +40,8 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
     public static final String TYPE = "role_mappings";
     public static int ROLE_MAPPING_METADATA_VERSION = 1;
 
+    private static final ParseField VERSION_PARSE_FIELD = new ParseField("version");
+
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<RoleMappingMetadata, Void> PARSER = new ConstructingObjectParser<>(
         TYPE,
@@ -57,7 +59,7 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
             (p, c) -> ExpressionRoleMapping.parse("name_not_available_after_deserialization", p),
             new ParseField(TYPE)
         );
-        PARSER.declareIntOrNull(optionalConstructorArg(), 0, new ParseField("version"));
+        PARSER.declareIntOrNull(optionalConstructorArg(), 0, VERSION_PARSE_FIELD);
     }
 
     private static final RoleMappingMetadata EMPTY = new RoleMappingMetadata(Set.of(), 0);
@@ -104,7 +106,12 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         // role mappings are serialized without their names
-        return Iterators.concat(ChunkedToXContentHelper.startArray(TYPE), roleMappings.iterator(), ChunkedToXContentHelper.endArray());
+        return Iterators.concat(
+            ChunkedToXContentHelper.field(VERSION_PARSE_FIELD.getPreferredName(), version),
+            ChunkedToXContentHelper.startArray(TYPE),
+            roleMappings.iterator(),
+            ChunkedToXContentHelper.endArray()
+        );
     }
 
     public static RoleMappingMetadata fromXContent(XContentParser parser) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
@@ -64,12 +64,16 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
 
     private final Set<ExpressionRoleMapping> roleMappings;
 
+    private final int version;
+
     public RoleMappingMetadata(Set<ExpressionRoleMapping> roleMappings) {
+        this.version = 0;
         this.roleMappings = roleMappings;
     }
 
     public RoleMappingMetadata(StreamInput input) throws IOException {
         this.roleMappings = input.readCollectionAsSet(ExpressionRoleMapping::new);
+        this.version = input.readOptionalInt();
     }
 
     public Set<ExpressionRoleMapping> getRoleMappings() {
@@ -100,7 +104,13 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
     }
 
     public static RoleMappingMetadata fromXContent(XContentParser parser) throws IOException {
-        return PARSER.apply(parser, null);
+        RoleMappingMetadata roleMappingMetadata = PARSER.apply(parser, null);
+        return roleMappingMetadata;
+    }
+
+    // TODO Implement rewrite of this to cluster state!
+    public int getVersion() {
+        return this.version;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RoleMappingCleanupTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RoleMappingCleanupTaskParams.java
@@ -12,29 +12,20 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.persistent.PersistentTaskParams;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-
 public class RoleMappingCleanupTaskParams implements PersistentTaskParams {
     public static final String TASK_NAME = "role-mapping-cleanup";
 
-    public static final ConstructingObjectParser<RoleMappingCleanupTaskParams, Void> PARSER = new ConstructingObjectParser<>(
+    public static final ObjectParser<RoleMappingCleanupTaskParams, Void> PARSER = new ObjectParser<>(
         TASK_NAME,
         true,
-        (arr) -> new RoleMappingCleanupTaskParams()
+        RoleMappingCleanupTaskParams::new
     );
-
-    static {
-        PARSER.declareInt(constructorArg(), new ParseField("migration_version"));
-        PARSER.declareBoolean(optionalConstructorArg(), new ParseField("migration_needed"));
-    }
 
     public RoleMappingCleanupTaskParams() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RoleMappingCleanupTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RoleMappingCleanupTaskParams.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.support;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.persistent.PersistentTaskParams;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class RoleMappingCleanupTaskParams implements PersistentTaskParams {
+    public static final String TASK_NAME = "role-mapping-cleanup";
+
+    public static final ConstructingObjectParser<RoleMappingCleanupTaskParams, Void> PARSER = new ConstructingObjectParser<>(
+        TASK_NAME,
+        true,
+        (arr) -> new RoleMappingCleanupTaskParams()
+    );
+
+    static {
+        PARSER.declareInt(constructorArg(), new ParseField("migration_version"));
+        PARSER.declareBoolean(optionalConstructorArg(), new ParseField("migration_needed"));
+    }
+
+    public RoleMappingCleanupTaskParams() {}
+
+    public RoleMappingCleanupTaskParams(StreamInput in) throws IOException {}
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {}
+
+    @Override
+    public String getWriteableName() {
+        return TASK_NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersions.ADD_METADATA_FLATTENED_TO_ROLES;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.endObject();
+        return builder;
+    }
+
+    public static RoleMappingCleanupTaskParams fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RoleMappingCleanupTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/RoleMappingCleanupTaskParams.java
@@ -41,7 +41,7 @@ public class RoleMappingCleanupTaskParams implements PersistentTaskParams {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.ADD_METADATA_FLATTENED_TO_ROLES;
+        return TransportVersions.ADD_ROLE_MAPPING_CLEANUP_TASK;
     }
 
     @Override

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/jwt/JwtRoleMappingsIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/jwt/JwtRoleMappingsIntegTests.java
@@ -446,7 +446,7 @@ public final class JwtRoleMappingsIntegTests extends SecurityIntegTestCase {
     }
 
     private void publishRoleMappings(Set<ExpressionRoleMapping> roleMappings) throws InterruptedException {
-        RoleMappingMetadata roleMappingMetadata = new RoleMappingMetadata(roleMappings);
+        RoleMappingMetadata roleMappingMetadata = new RoleMappingMetadata(roleMappings, 0);
         List<ClusterService> clusterServices = new ArrayList<>();
         internalCluster().getInstances(ClusterService.class).forEach(clusterServices::add);
         CountDownLatch publishedClusterState = new CountDownLatch(clusterServices.size());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -796,14 +796,6 @@ public class Security extends Plugin
                 SecurityMigrations.MIGRATIONS_BY_VERSION
             )
         );
-        this.roleMappingCleanupExecutor.set(
-            new RoleMappingCleanupExecutor(
-                clusterService,
-                RoleMappingCleanupTaskParams.TASK_NAME,
-                threadPool.executor(ThreadPool.Names.MANAGEMENT),
-                client
-            )
-        );
         this.persistentTasksService.set(persistentTasksService);
 
         systemIndices.getMainIndexManager().addStateListener((oldState, newState) -> {
@@ -863,6 +855,15 @@ public class Security extends Plugin
             client,
             systemIndices.getMainIndexManager(),
             scriptService
+        );
+        this.roleMappingCleanupExecutor.set(
+            new RoleMappingCleanupExecutor(
+                clusterService,
+                RoleMappingCleanupTaskParams.TASK_NAME,
+                threadPool.executor(ThreadPool.Names.MANAGEMENT),
+                nativeRoleMappingStore,
+                systemIndices.getMainIndexManager()
+            )
         );
         final ClusterStateRoleMapper clusterStateRoleMapper = new ClusterStateRoleMapper(settings, scriptService, clusterService);
         final UserRoleMapper userRoleMapper = new CompositeRoleMapper(nativeRoleMappingStore, clusterStateRoleMapper);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -2361,7 +2361,7 @@ public class Security extends Plugin
         if (this.securityMigrationExecutor.get() != null) {
             executors.add(this.securityMigrationExecutor.get());
         }
-        if (this.securityMigrationExecutor.get() != null) {
+        if (this.roleMappingCleanupExecutor.get() != null) {
             executors.add(this.roleMappingCleanupExecutor.get());
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/RoleMappingCleanupExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/RoleMappingCleanupExecutor.java
@@ -119,10 +119,11 @@ public class RoleMappingCleanupExecutor extends PersistentTasksExecutor<RoleMapp
 
     @Override
     public void accept(SecurityIndexManager.State oldState, SecurityIndexManager.State newState) {
-        if (cleanupInProgress.compareAndSet(false, true)
-            && securityIndexManager.isAvailable(SecurityIndexManager.Availability.SEARCH_SHARDS)) {
-            securityIndexManager.removeStateListener(this);
-            doCleanup();
+        if (securityIndexManager.isAvailable(SecurityIndexManager.Availability.SEARCH_SHARDS)) {
+            if (cleanupInProgress.compareAndSet(false, true)) {
+                securityIndexManager.removeStateListener(this);
+                doCleanup();
+            }
         }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/RoleMappingCleanupExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/RoleMappingCleanupExecutor.java
@@ -9,30 +9,121 @@ package org.elasticsearch.xpack.security.support;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
+import org.elasticsearch.xpack.core.security.authz.RoleMappingMetadata;
 import org.elasticsearch.xpack.core.security.support.RoleMappingCleanupTaskParams;
+import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
-public class RoleMappingCleanupExecutor extends PersistentTasksExecutor<RoleMappingCleanupTaskParams> {
+public class RoleMappingCleanupExecutor extends PersistentTasksExecutor<RoleMappingCleanupTaskParams>
+    implements
+        BiConsumer<SecurityIndexManager.State, SecurityIndexManager.State> {
 
     private static final Logger logger = LogManager.getLogger(RoleMappingCleanupExecutor.class);
-    private final Client client;
+    private final NativeRoleMappingStore roleMappingStore;
 
     private final ClusterService clusterService;
+    private AllocatedPersistentTask currentTask = null;
+    private final SecurityIndexManager securityIndexManager;
+    private final AtomicBoolean cleanupInProgress = new AtomicBoolean(false);
 
-    public RoleMappingCleanupExecutor(ClusterService clusterService, String taskName, Executor executor, Client client) {
+    public RoleMappingCleanupExecutor(
+        ClusterService clusterService,
+        String taskName,
+        Executor executor,
+        NativeRoleMappingStore roleMappingStore,
+        SecurityIndexManager securityIndexManager
+    ) {
         super(taskName, executor);
         this.clusterService = clusterService;
-        this.client = client;
+        this.roleMappingStore = roleMappingStore;
+        this.securityIndexManager = securityIndexManager;
     }
 
     @Override
     protected void nodeOperation(AllocatedPersistentTask task, RoleMappingCleanupTaskParams params, PersistentTaskState state) {
-        logger.info("RUNNING NOOP MIGRATION!! YAY");
+        currentTask = task;
+        if (securityIndexManager.isAvailable(SecurityIndexManager.Availability.SEARCH_SHARDS) == false) {
+            logger.info("Security index not available, waiting...");
+            securityIndexManager.addStateListener(this);
+        } else {
+            doCleanup();
+        }
+    }
+
+    private void doCleanup() {
+        getRoleMappingBothInClusterStateAndIndex(
+            clusterService.state(),
+            ActionListener.wrap(roleMappings -> disableRoleMappings(roleMappings, ActionListener.wrap(response -> {
+                markAsCompleted();
+            }, this::markAsFailed)), this::markAsFailed)
+        );
+    }
+
+    private void markAsCompleted() {
+        currentTask.markAsCompleted();
+        logger.info("Successfully cleaned up role mappings");
+        cleanupInProgress.set(false);
+    }
+
+    private void markAsFailed(Exception exception) {
+        currentTask.markAsFailed(exception);
+        logger.warn("Role mapping clean up failed: " + exception);
+        cleanupInProgress.set(false);
+    }
+
+    private void getRoleMappingBothInClusterStateAndIndex(ClusterState state, ActionListener<List<ExpressionRoleMapping>> listener) {
+        RoleMappingMetadata roleMappingMetadata = RoleMappingMetadata.getFromClusterState(state);
+        Set<String> roleMappingNames = roleMappingMetadata.getRoleMappings()
+            .stream()
+            .map(ExpressionRoleMapping::getName)
+            .collect(Collectors.toSet());
+
+        if (roleMappingNames.isEmpty()) {
+            listener.onResponse(List.of());
+            return;
+        }
+        roleMappingStore.getRoleMappings(roleMappingNames, listener);
+    }
+
+    private void disableRoleMappings(List<ExpressionRoleMapping> roleMappings, ActionListener<Collection<Void>> listener) {
+        GroupedActionListener<Void> groupedActionListener = new GroupedActionListener<>(roleMappings.size(), listener);
+        for (ExpressionRoleMapping roleMapping : roleMappings) {
+            var request = new PutRoleMappingRequest();
+            request.setName(roleMapping.getName());
+            request.setEnabled(false);
+            request.setRoles(roleMapping.getRoles());
+            request.setRoleTemplates(roleMapping.getRoleTemplates());
+            request.setRules(roleMapping.getExpression());
+            request.setMetadata(roleMapping.getMetadata());
+            roleMappingStore.putRoleMapping(
+                request,
+                ActionListener.wrap(response -> groupedActionListener.onResponse(null), groupedActionListener::onFailure)
+            );
+        }
+    }
+
+    @Override
+    public void accept(SecurityIndexManager.State oldState, SecurityIndexManager.State newState) {
+        if (cleanupInProgress.compareAndSet(false, true)
+            && securityIndexManager.isAvailable(SecurityIndexManager.Availability.SEARCH_SHARDS)) {
+            securityIndexManager.removeStateListener(this);
+            doCleanup();
+        }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/RoleMappingCleanupExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/RoleMappingCleanupExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.support;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTaskState;
+import org.elasticsearch.persistent.PersistentTasksExecutor;
+import org.elasticsearch.xpack.core.security.support.RoleMappingCleanupTaskParams;
+
+import java.util.concurrent.Executor;
+
+public class RoleMappingCleanupExecutor extends PersistentTasksExecutor<RoleMappingCleanupTaskParams> {
+
+    private static final Logger logger = LogManager.getLogger(RoleMappingCleanupExecutor.class);
+    private final Client client;
+
+    private final ClusterService clusterService;
+
+    public RoleMappingCleanupExecutor(ClusterService clusterService, String taskName, Executor executor, Client client) {
+        super(taskName, executor);
+        this.clusterService = clusterService;
+        this.client = client;
+    }
+
+    @Override
+    protected void nodeOperation(AllocatedPersistentTask task, RoleMappingCleanupTaskParams params, PersistentTaskState state) {
+        logger.info("RUNNING NOOP MIGRATION!! YAY");
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/reservedstate/ReservedRoleMappingActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/reservedstate/ReservedRoleMappingActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.security.action.reservedstate;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.reservedstate.TransformState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -22,6 +23,7 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests that the ReservedRoleMappingAction does validation, can add and remove role mappings
@@ -40,7 +42,7 @@ public class ReservedRoleMappingActionTests extends ESTestCase {
     public void testValidation() {
         ClusterState state = ClusterState.builder(new ClusterName("elasticsearch")).build();
         TransformState prevState = new TransformState(state, Collections.emptySet());
-        ReservedRoleMappingAction action = new ReservedRoleMappingAction();
+        ReservedRoleMappingAction action = new ReservedRoleMappingAction(mock(PersistentTasksService.class));
         String badPolicyJSON = """
             {
                "everyone_kibana": {
@@ -69,7 +71,7 @@ public class ReservedRoleMappingActionTests extends ESTestCase {
     public void testAddRemoveRoleMapping() throws Exception {
         ClusterState state = ClusterState.builder(new ClusterName("elasticsearch")).build();
         TransformState prevState = new TransformState(state, Collections.emptySet());
-        ReservedRoleMappingAction action = new ReservedRoleMappingAction();
+        ReservedRoleMappingAction action = new ReservedRoleMappingAction(mock(PersistentTasksService.class));
         String emptyJSON = "";
 
         TransformState updatedState = processJSON(action, prevState, emptyJSON);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RoleMappingMetadataTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RoleMappingMetadataTests.java
@@ -33,7 +33,7 @@ public class RoleMappingMetadataTests extends AbstractWireSerializingTestCase<Ro
 
     @Override
     protected RoleMappingMetadata createTestInstance() {
-        return new RoleMappingMetadata(randomSet(0, 3, () -> randomRoleMapping(true)));
+        return new RoleMappingMetadata(randomSet(0, 3, () -> randomRoleMapping(true)), 0);
     }
 
     @Override
@@ -47,7 +47,7 @@ public class RoleMappingMetadataTests extends AbstractWireSerializingTestCase<Ro
         if (randomBoolean() || mutated == false) {
             mutatedRoleMappings.add(randomRoleMapping(true));
         }
-        return new RoleMappingMetadata(mutatedRoleMappings);
+        return new RoleMappingMetadata(mutatedRoleMappings, 0);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class RoleMappingMetadataTests extends AbstractWireSerializingTestCase<Ro
     }
 
     public void testSerializationBWC() throws IOException {
-        RoleMappingMetadata original = new RoleMappingMetadata(randomSet(0, 3, () -> randomRoleMapping(true)));
+        RoleMappingMetadata original = new RoleMappingMetadata(randomSet(0, 3, () -> randomRoleMapping(true)), 0);
         TransportVersion version = TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_7_2_0, null);
         BytesStreamOutput output = new BytesStreamOutput();
         output.setTransportVersion(version);
@@ -79,8 +79,8 @@ public class RoleMappingMetadataTests extends AbstractWireSerializingTestCase<Ro
         Set<ExpressionRoleMapping> roleMappings1 = randomSet(0, 3, () -> randomRoleMapping(true));
         Set<ExpressionRoleMapping> roleMappings2 = randomSet(0, 3, () -> randomRoleMapping(true));
         assumeFalse("take 2 different role mappings", roleMappings1.equals(roleMappings2));
-        assertThat(new RoleMappingMetadata(roleMappings1).equals(new RoleMappingMetadata(roleMappings2)), is(false));
-        assertThat(new RoleMappingMetadata(roleMappings1).equals(new RoleMappingMetadata(roleMappings1)), is(true));
-        assertThat(new RoleMappingMetadata(roleMappings2).equals(new RoleMappingMetadata(roleMappings2)), is(true));
+        assertThat(new RoleMappingMetadata(roleMappings1, 0).equals(new RoleMappingMetadata(roleMappings2, 0)), is(false));
+        assertThat(new RoleMappingMetadata(roleMappings1, 0).equals(new RoleMappingMetadata(roleMappings1, 0)), is(true));
+        assertThat(new RoleMappingMetadata(roleMappings2, 0).equals(new RoleMappingMetadata(roleMappings2, 0)), is(true));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RoleMappingMetadataXContentSerializationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RoleMappingMetadataXContentSerializationTests.java
@@ -31,7 +31,7 @@ public class RoleMappingMetadataXContentSerializationTests extends AbstractChunk
 
     @Override
     protected RoleMappingMetadata createTestInstance() {
-        return new RoleMappingMetadata(randomSet(0, 3, () -> randomRoleMapping(true)));
+        return new RoleMappingMetadata(randomSet(0, 3, () -> randomRoleMapping(true)), 0);
     }
 
     @Override
@@ -45,7 +45,7 @@ public class RoleMappingMetadataXContentSerializationTests extends AbstractChunk
         if (randomBoolean() || mutated == false) {
             mutatedRoleMappings.add(randomRoleMapping(true));
         }
-        return new RoleMappingMetadata(mutatedRoleMappings);
+        return new RoleMappingMetadata(mutatedRoleMappings, 0);
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapperTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapperTests.java
@@ -82,7 +82,7 @@ public class ClusterStateRoleMapperTests extends ESTestCase {
         ExpressionRoleMapping mapping1 = mockExpressionRoleMapping(false, Set.of("role1"), expressionModel);
         ExpressionRoleMapping mapping2 = mockExpressionRoleMapping(true, Set.of("role2"));
         ExpressionRoleMapping mapping3 = mockExpressionRoleMapping(true, Set.of("role3"), expressionModel);
-        RoleMappingMetadata roleMappingMetadata = new RoleMappingMetadata(Set.of(mapping1, mapping2, mapping3));
+        RoleMappingMetadata roleMappingMetadata = new RoleMappingMetadata(Set.of(mapping1, mapping2, mapping3), 0);
         ClusterState state = roleMappingMetadata.updateClusterState(ClusterState.builder(new ClusterName("elasticsearch")).build());
         when(clusterService.state()).thenReturn(state);
         {
@@ -123,19 +123,19 @@ public class ClusterStateRoleMapperTests extends ESTestCase {
         ExpressionRoleMapping mapping2 = mockExpressionRoleMapping(true, Set.of("role"), model2);
         ExpressionRoleMapping mapping3 = mockExpressionRoleMapping(true, Set.of("role3"), model2);
         ClusterState emptyState = ClusterState.builder(new ClusterName("elasticsearch")).build();
-        RoleMappingMetadata roleMappingMetadata1 = new RoleMappingMetadata(Set.of(mapping1));
+        RoleMappingMetadata roleMappingMetadata1 = new RoleMappingMetadata(Set.of(mapping1), 0);
         ClusterState state1 = roleMappingMetadata1.updateClusterState(emptyState);
         roleMapper.clusterChanged(new ClusterChangedEvent("test", emptyState, state1));
         verify(mockRealm, times(1)).expireAll();
-        RoleMappingMetadata roleMappingMetadata2 = new RoleMappingMetadata(Set.of(mapping2));
+        RoleMappingMetadata roleMappingMetadata2 = new RoleMappingMetadata(Set.of(mapping2), 0);
         ClusterState state2 = roleMappingMetadata2.updateClusterState(state1);
         roleMapper.clusterChanged(new ClusterChangedEvent("test", state1, state2));
         verify(mockRealm, times(2)).expireAll();
-        RoleMappingMetadata roleMappingMetadata3 = new RoleMappingMetadata(Set.of(mapping3));
+        RoleMappingMetadata roleMappingMetadata3 = new RoleMappingMetadata(Set.of(mapping3), 0);
         ClusterState state3 = roleMappingMetadata3.updateClusterState(state2);
         roleMapper.clusterChanged(new ClusterChangedEvent("test", state2, state3));
         verify(mockRealm, times(3)).expireAll();
-        RoleMappingMetadata roleMappingMetadata4 = new RoleMappingMetadata(Set.of(mapping2, mapping3));
+        RoleMappingMetadata roleMappingMetadata4 = new RoleMappingMetadata(Set.of(mapping2, mapping3), 0);
         ClusterState state4 = roleMappingMetadata4.updateClusterState(state3);
         roleMapper.clusterChanged(new ClusterChangedEvent("test", state3, state4));
         verify(mockRealm, times(4)).expireAll();


### PR DESCRIPTION
This PR adds a one-time cleanup task for role mapping duplicates both in cluster state and the `.security` index. The cleanup task is triggered once, the first time the `settings.json` is reloaded after this PR has been deployed. The task compares the names of the role mappings in the operator-defined `settings.json` and the names of the role mappings in the `.security` index and removes or disables (TBD which one) the one in the .security index. It also adds the name field to the serialization of the role mapping, since the name is needed for the GET Role Mappings API. 

## Issue
This cleanup is done because there was a bug (fixed [here](https://github.com/elastic/elasticsearch/pull/114337)) that caused ECK customers to have the same role mappings with the same names present both in cluster state and the `.security` index. The effective role mapping is the combination of the `.security` index mapping and the cluster state one. After the bug [fix](https://github.com/elastic/elasticsearch/pull/114337), if the mapping in cluster state is modified (through `setting.json`), the `.security` index will still contain the old mapping and this could lead to unintended behaviour.

## Open Questions
- Before this is merged we need to make sure file based settings (`settings.json`) is re-loaded on every master node restart (draft PR <link>)
- Should we disable or delete roles. The REST API returns disabled roles (with `enabled: false`) which could be confusing since they're not active during role mapping in the auth/authz flow. Deleting them means users can't recover if the cleanup does something wrong.  
- We probably want to separate the mapping serialization change to a separate PR too. Open question is if this should be a new field or just new metadata? 

## Risks
1. Role mappings might be intended to be defined both in the `.security` index and the cluster state and will be removed by this PR (minimal since before 8.15 it wasn't possible to this)
2. Role mappings modified in the `.security` index to workaround the bug fixed [here](https://github.com/elastic/elasticsearch/pull/114337) will be removed and all changes might not be reflected in the `settings.json` role mappings (Only reported by a few customers)
3. This might not trigger for a very long time, increasing the risk of (1) and (2) (mitigated by coupling this with forcing a reload of file settings on master restart)

## Dependencies
- link to file setting reload on master restart PR

## TODO
- Add new serialization/deserialization to include mapping name
- Add testing
- Figure out snapshot restore flow with new format
- Figure out mixed cluster behaviour
