### PR TITLE
[Inference API] Add parameters to perform inference API as alias to task_settings

### DIFF
--- a/docs/changelog/114329.yaml
+++ b/docs/changelog/114329.yaml
@@ -1,0 +1,5 @@
+pr: 114329
+summary: "[Inference API] Add parameters to perform inference API as alias to `task_settings`"
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -59,6 +59,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
         public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(30);
         public static final ParseField INPUT = new ParseField("input");
         public static final ParseField TASK_SETTINGS = new ParseField("task_settings");
+        public static final ParseField PARAMETERS = new ParseField("parameters");
         public static final ParseField QUERY = new ParseField("query");
         public static final ParseField TIMEOUT = new ParseField("timeout");
 
@@ -66,6 +67,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
         static {
             PARSER.declareStringArray(Request.Builder::setInput, INPUT);
             PARSER.declareObject(Request.Builder::setTaskSettings, (p, c) -> p.mapOrdered(), TASK_SETTINGS);
+            PARSER.declareObject(Request.Builder::setTaskSettings, (p, c) -> p.mapOrdered(), PARAMETERS);
             PARSER.declareString(Request.Builder::setQuery, QUERY);
             PARSER.declareString(Builder::setInferenceTimeout, TIMEOUT);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -73,6 +73,77 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         }
     }
 
+    public void testParsingWithTaskSettings() throws IOException {
+        String requestText = """
+            {
+              "input": "single text input",
+                "task_settings": {
+                    "foo": "bar"
+                }
+            }
+            """;
+        try (var parser = createParser(JsonXContent.jsonXContent, requestText)) {
+            var request = InferenceAction.Request.parseRequest("model_id", TaskType.SPARSE_EMBEDDING, parser).build();
+            assertThat(request.getInput(), contains("single text input"));
+            assertThat(request.getTaskSettings(), is(Map.of("foo", "bar")));
+        }
+    }
+
+    public void testParsingWithParameters() throws IOException {
+        String requestText = """
+            {
+              "input": "single text input",
+                "parameters": {
+                    "foo": "bar"
+                }
+            }
+            """;
+        try (var parser = createParser(JsonXContent.jsonXContent, requestText)) {
+            var request = InferenceAction.Request.parseRequest("model_id", TaskType.SPARSE_EMBEDDING, parser).build();
+            assertThat(request.getInput(), contains("single text input"));
+            assertThat(request.getTaskSettings(), is(Map.of("foo", "bar")));
+        }
+    }
+
+    public void testParsingWithTaskSettingsAndParameters() throws IOException {
+        {
+            String singleInputRequest = """
+                {
+                  "input": "single text input",
+                  "parameters": {
+                        "foo": "bar"
+                    },
+                  "task_settings": {
+                        "food": "bard"
+                  }
+                }
+                """;
+            try (var parser = createParser(JsonXContent.jsonXContent, singleInputRequest)) {
+                var request = InferenceAction.Request.parseRequest("model_id", TaskType.SPARSE_EMBEDDING, parser).build();
+                assertThat(request.getInput(), contains("single text input"));
+                assertThat(request.getTaskSettings(), is(Map.of("food", "bard")));
+            }
+        }
+        {
+            String singleInputRequest = """
+                {
+                  "input": "single text input",
+                  "task_settings": {
+                        "food": "bard"
+                  },
+                  "parameters": {
+                        "foo": "bar"
+                  }
+                }
+                """;
+            try (var parser = createParser(JsonXContent.jsonXContent, singleInputRequest)) {
+                var request = InferenceAction.Request.parseRequest("model_id", TaskType.SPARSE_EMBEDDING, parser).build();
+                assertThat(request.getInput(), contains("single text input"));
+                assertThat(request.getTaskSettings(), is(Map.of("foo", "bar")));
+            }
+        }
+    }
+
     public void testValidation_TextEmbedding() {
         InferenceAction.Request request = new InferenceAction.Request(
             TaskType.TEXT_EMBEDDING,


### PR DESCRIPTION
Alias task_settings as parameters in the perform inference API.

## examples:
### Put the endpoint
``` json
  {
  "service": "cohere",
  "service_settings": {
    "model_id": "rerank-english-v3.0",
    "api_key": "<REDACTED>"
  },
  "task_settings": {
    "return_documents": true
  }
  }
```

### perform inference with task settings:
request:
``` json
{
    "input": ["test1", "test2", "test3"],
    "query": "test",
    "task_settings":{
        "return_documents":true,
        "top_n": 1
    }
}
```

response:
``` json 
{
    "rerank": [
        {
            "index": 0,
            "relevance_score": 9.927262E-4,
            "text": "test1"
        }
    ]
}
```

### perform inference with parameters:
request:
``` json
{
    "input": ["test1", "test2", "test3"],
    "query": "test",
    "parameters":{
        "return_documents":true,
        "top_n": 1
    }
}
```

response:
``` json
{
    "rerank": [
        {
            "index": 0,
            "relevance_score": 9.927262E-4,
            "text": "test1"
        }
    ]
}
```

### without parameters or task_settings:
request:
``` json
{
    "input": ["test1", "test2", "test3"],
    "query": "test"
}
```
response:
``` json
{
    "rerank": [
        {
            "index": 0,
            "relevance_score": 9.927262E-4,
            "text": "test1"
        },
        {
            "index": 1,
            "relevance_score": 7.1802974E-4,
            "text": "test2"
        },
        {
            "index": 2,
            "relevance_score": 2.1152887E-4,
            "text": "test3"
        }
    ]
}
```

### with both parameters and task settings (the latter one is used)
request:
``` json
{
    "input": ["test1", "test2", "test3"],
    "query": "test",
    "parameters":{
        "top_n": 1
    },
    "task_settings":{
        "top_n": 2
    }
}
```

response:
``` json
{
    "rerank": [
        {
            "index": 0,
            "relevance_score": 9.927262E-4,
            "text": "test1"
        },
        {
            "index": 1,
            "relevance_score": 7.1802974E-4,
            "text": "test2"
        }
    ]
}
```

