### PR TITLE
Docs: ESQL doesn't preserve `null`s in a list (#114335)

### DIFF
--- a/docs/reference/esql/multivalued-fields.asciidoc
+++ b/docs/reference/esql/multivalued-fields.asciidoc
@@ -167,6 +167,37 @@ POST /_query
 ----
 
 [discrete]
+[[esql-multivalued-nulls]]
+==== `null` in a list
+
+`null` values in a list are not preserved at the storage layer:
+
+[source,console,id=esql-multivalued-fields-multivalued-nulls]
+----
+POST /mv/_doc?refresh
+{ "a": [2, null, 1] }
+
+POST /_query
+{
+  "query": "FROM mv | LIMIT 1"
+}
+----
+
+[source,console-result]
+----
+{
+  "took": 28,
+  "columns": [
+    { "name": "a", "type": "long"},
+  ],
+  "values": [
+    [[1, 2]],
+  ]
+}
+----
+// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
+
+[discrete]
 [[esql-multivalued-fields-functions]]
 ==== Functions
 

--- a/docs/reference/esql/multivalued-fields.asciidoc
+++ b/docs/reference/esql/multivalued-fields.asciidoc
@@ -186,7 +186,6 @@ POST /_query
 [source,console-result]
 ----
 {
-  "took": 28,
   "columns": [
     { "name": "a", "type": "long"},
   ],
@@ -195,7 +194,6 @@ POST /_query
   ]
 }
 ----
-// TESTRESPONSE[s/"took": 28/"took": "$body.took"/]
 
 [discrete]
 [[esql-multivalued-fields-functions]]


### PR DESCRIPTION
The doc values don't preserve `null`s in a list so ESQL doesn't either.

Closes #114324
