### PR TITLE
[8.x] Don't generate invalid combination of subobjects parameter in logsdb tests (#114265)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/logsdb/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -102,18 +102,12 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             // TODO enable subobjects: auto
             // It is disabled because it currently does not have auto flattening and that results in asserts being triggered when using
             // copy_to.
-            if (ESTestCase.randomBoolean()) {
-                parameters.put(
-                    "subobjects",
-                    ESTestCase.randomValueOtherThan(
-                        ObjectMapper.Subobjects.AUTO,
-                        () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
-                    ).toString()
-                );
-            }
+            var subobjects = ESTestCase.randomValueOtherThan(
+                ObjectMapper.Subobjects.AUTO,
+                () -> ESTestCase.randomFrom(ObjectMapper.Subobjects.values())
+            );
 
-            if (request.parentSubobjects() == ObjectMapper.Subobjects.DISABLED
-                || parameters.getOrDefault("subobjects", "true").equals("false")) {
+            if (request.parentSubobjects() == ObjectMapper.Subobjects.DISABLED || subobjects == ObjectMapper.Subobjects.DISABLED) {
                 // "enabled: false" is not compatible with subobjects: false
                 // changing "dynamic" from parent context is not compatible with subobjects: false
                 // changing subobjects value is not compatible with subobjects: false
@@ -124,6 +118,9 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
                 return parameters;
             }
 
+            if (ESTestCase.randomBoolean()) {
+                parameters.put("subobjects", subobjects.toString());
+            }
             if (ESTestCase.randomBoolean()) {
                 parameters.put("dynamic", ESTestCase.randomFrom("true", "false", "strict", "runtime"));
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Don&#x27;t generate invalid combination of subobjects parameter in logsdb tests (#114265)](https://github.com/elastic/elasticsearch/pull/114265)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)