### PR TITLE
Set SlowLog logging to TRACE in tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexingSlowLog.java
@@ -9,13 +9,11 @@
 
 package org.elasticsearch.index;
 
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ESLogMessage;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -92,9 +90,6 @@ public final class IndexingSlowLog implements IndexingOperationListener {
     );
 
     private static final Logger indexLogger = LogManager.getLogger(INDEX_INDEXING_SLOWLOG_PREFIX + ".index");
-    static {
-        Loggers.setLevel(indexLogger, Level.TRACE);
-    }
 
     private final Index index;
 

--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -9,11 +9,9 @@
 
 package org.elasticsearch.index;
 
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.ESLogMessage;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.core.TimeValue;
@@ -46,11 +44,6 @@ public final class SearchSlowLog implements SearchOperationListener {
 
     private static final Logger queryLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
     private static final Logger fetchLogger = LogManager.getLogger(INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
-
-    static {
-        Loggers.setLevel(queryLogger, Level.TRACE);
-        Loggers.setLevel(fetchLogger, Level.TRACE);
-    }
 
     private final SlowLogFieldProvider slowLogFieldProvider;
 

--- a/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
@@ -58,18 +58,23 @@ public class IndexingSlowLogTests extends ESTestCase {
     static MockAppender appender;
     static Releasable appenderRelease;
     static Logger testLogger1 = LogManager.getLogger(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_PREFIX + ".index");
+    static Level origLogLevel = testLogger1.getLevel();
 
     @BeforeClass
     public static void init() throws IllegalAccessException {
         appender = new MockAppender("trace_appender");
         appender.start();
         Loggers.addAppender(testLogger1, appender);
+
+        Loggers.setLevel(testLogger1, Level.TRACE);
     }
 
     @AfterClass
     public static void cleanup() {
-        appender.stop();
         Loggers.removeAppender(testLogger1, appender);
+        appender.stop();
+
+        Loggers.setLevel(testLogger1, origLogLevel);
     }
 
     public void testLevelPrecedence() {

--- a/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -50,6 +50,8 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
     static MockAppender appender;
     static Logger queryLog = LogManager.getLogger(SearchSlowLog.INDEX_SEARCH_SLOWLOG_PREFIX + ".query");
     static Logger fetchLog = LogManager.getLogger(SearchSlowLog.INDEX_SEARCH_SLOWLOG_PREFIX + ".fetch");
+    static Level origQueryLogLevel = queryLog.getLevel();
+    static Level origFetchLogLevel = fetchLog.getLevel();
 
     @BeforeClass
     public static void init() throws IllegalAccessException {
@@ -57,13 +59,19 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
         appender.start();
         Loggers.addAppender(queryLog, appender);
         Loggers.addAppender(fetchLog, appender);
+
+        Loggers.setLevel(queryLog, Level.TRACE);
+        Loggers.setLevel(fetchLog, Level.TRACE);
     }
 
     @AfterClass
     public static void cleanup() {
-        appender.stop();
         Loggers.removeAppender(queryLog, appender);
         Loggers.removeAppender(fetchLog, appender);
+        appender.stop();
+
+        Loggers.setLevel(queryLog, origQueryLogLevel);
+        Loggers.setLevel(fetchLog, origFetchLogLevel);
     }
 
     @Override


### PR DESCRIPTION
The tests depend on the SlowLog loggers running at TRACE level but were not setting the level themselves. Instead they relied on the SlowLog setting the level to trace internally when it was created. If something else globally adjusted log levels between the time the SlowLog loggers were created and the tests ran, the tests could fail.

And in fact, `ScopedSettingsTest.testFallbackToLoggerLevel` was updating the root log level, which had the side effect of updating the SlowLog level. In #112183 SlowLog's log initialization was made static, which opened up its test to failure when ScopedSettingsTest ran before a SlowLog test in the same JVM.

I do not know if the intention of the SlowLog is that it overrides the global log level and should always be set at TRACE, in which case this fix is incorrect. It seems surprising, but I don't know why else SlowLog would explicitly initialize itself to TRACE. However, if that was the intention, the code was already at risk due to having no guard against being changed by Loggers.setLevel on an ancestor log. The change in this PR is at least not a regression in that behaviour. It does no longer start out at TRACE however, which is a change in behaviour.

I think removing the static TRACE initializer removes confusion and a potential footgun but reverting that bit of the change wouldn't affect the fix here.
