### PR TITLE
[8.x] Use ELSER By Default For Semantic Text (#113563)

### DIFF
--- a/docs/changelog/113563.yaml
+++ b/docs/changelog/113563.yaml
@@ -1,0 +1,5 @@
+pr: 113563
+summary: Use ELSER By Default For Semantic Text
+area: Mapping
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper;
 import org.elasticsearch.xpack.inference.rank.random.RandomRankRetrieverBuilder;
 import org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -22,12 +23,15 @@ public class InferenceFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of(
-            TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_RETRIEVER_SUPPORTED,
-            RandomRankRetrieverBuilder.RANDOM_RERANKER_RETRIEVER_SUPPORTED,
-            SemanticTextFieldMapper.SEMANTIC_TEXT_SEARCH_INFERENCE_ID,
-            TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_COMPOSITION_SUPPORTED
-        );
+        var features = new HashSet<NodeFeature>();
+        features.add(TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_RETRIEVER_SUPPORTED);
+        features.add(RandomRankRetrieverBuilder.RANDOM_RERANKER_RETRIEVER_SUPPORTED);
+        features.add(SemanticTextFieldMapper.SEMANTIC_TEXT_SEARCH_INFERENCE_ID);
+        features.add(TextSimilarityRankRetrieverBuilder.TEXT_SIMILARITY_RERANKER_COMPOSITION_SUPPORTED);
+        if (DefaultElserFeatureFlag.isEnabled()) {
+            features.add(SemanticTextFieldMapper.SEMANTIC_TEXT_DEFAULT_ELSER_2);
+        }
+        return Set.copyOf(features);
     }
 
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextField.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextField.java
@@ -58,6 +58,7 @@ public record SemanticTextField(String fieldName, List<String> originalValues, I
     static final String TEXT_FIELD = "text";
     static final String INFERENCE_FIELD = "inference";
     static final String INFERENCE_ID_FIELD = "inference_id";
+    static final String SEARCH_INFERENCE_ID_FIELD = "search_inference_id";
     static final String CHUNKS_FIELD = "chunks";
     static final String CHUNKED_EMBEDDINGS_FIELD = "embeddings";
     static final String CHUNKED_TEXT_FIELD = "text";

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ml.inference.results.MlTextEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+import org.elasticsearch.xpack.inference.DefaultElserFeatureFlag;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -71,18 +72,23 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKS_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.INFERENCE_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.INFERENCE_ID_FIELD;
+import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.MODEL_SETTINGS_FIELD;
+import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.SEARCH_INFERENCE_ID_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.TEXT_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getChunksFieldName;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getEmbeddingsFieldName;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getOriginalTextFieldName;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.DEFAULT_ELSER_ID;
 
 /**
  * A {@link FieldMapper} for semantic text fields.
  */
 public class SemanticTextFieldMapper extends FieldMapper implements InferenceFieldMapper {
     public static final NodeFeature SEMANTIC_TEXT_SEARCH_INFERENCE_ID = new NodeFeature("semantic_text.search_inference_id");
+    public static final NodeFeature SEMANTIC_TEXT_DEFAULT_ELSER_2 = new NodeFeature("semantic_text.default_elser_2");
 
     public static final String CONTENT_TYPE = "semantic_text";
+    public static final String DEFAULT_ELSER_2_INFERENCE_ID = DEFAULT_ELSER_ID;
 
     private final IndexSettings indexSettings;
 
@@ -96,25 +102,37 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         private final IndexSettings indexSettings;
 
         private final Parameter<String> inferenceId = Parameter.stringParam(
-            "inference_id",
+            INFERENCE_ID_FIELD,
             false,
             mapper -> ((SemanticTextFieldType) mapper.fieldType()).inferenceId,
-            null
+            DefaultElserFeatureFlag.isEnabled() ? DEFAULT_ELSER_2_INFERENCE_ID : null
         ).addValidator(v -> {
             if (Strings.isEmpty(v)) {
-                throw new IllegalArgumentException("field [inference_id] must be specified");
+                // If the default ELSER feature flag is enabled, the only way we get here is if the user explicitly sets the param to an
+                // empty value. However, if the feature flag is disabled, we can get here if the user didn't set the param.
+                // Adjust the error message appropriately.
+                String message = DefaultElserFeatureFlag.isEnabled()
+                    ? "[" + INFERENCE_ID_FIELD + "] on mapper [" + leafName() + "] of type [" + CONTENT_TYPE + "] must not be empty"
+                    : "[" + INFERENCE_ID_FIELD + "] on mapper [" + leafName() + "] of type [" + CONTENT_TYPE + "] must be specified";
+                throw new IllegalArgumentException(message);
             }
         });
 
         private final Parameter<String> searchInferenceId = Parameter.stringParam(
-            "search_inference_id",
+            SEARCH_INFERENCE_ID_FIELD,
             true,
             mapper -> ((SemanticTextFieldType) mapper.fieldType()).searchInferenceId,
             null
-        ).acceptsNull();
+        ).acceptsNull().addValidator(v -> {
+            if (v != null && Strings.isEmpty(v)) {
+                throw new IllegalArgumentException(
+                    "[" + SEARCH_INFERENCE_ID_FIELD + "] on mapper [" + leafName() + "] of type [" + CONTENT_TYPE + "] must not be empty"
+                );
+            }
+        });
 
         private final Parameter<SemanticTextField.ModelSettings> modelSettings = new Parameter<>(
-            "model_settings",
+            MODEL_SETTINGS_FIELD,
             true,
             () -> null,
             (n, c, o) -> SemanticTextField.parseModelSettingsFromMap(o),
@@ -204,6 +222,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             }
             var childContext = context.createChildContext(leafName(), ObjectMapper.Dynamic.FALSE);
             final ObjectMapper inferenceField = inferenceFieldBuilder.apply(childContext);
+
             return new SemanticTextFieldMapper(
                 leafName(),
                 new SemanticTextFieldType(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.QueryBitSetProducer;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -58,6 +59,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.inference.DefaultElserFeatureFlag;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.model.TestModel;
 import org.junit.AssumptionViolatedException;
@@ -77,8 +79,10 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKS_
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.INFERENCE_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.INFERENCE_ID_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.MODEL_SETTINGS_FIELD;
+import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.SEARCH_INFERENCE_ID_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getChunksFieldName;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getEmbeddingsFieldName;
+import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_ELSER_2_INFERENCE_ID;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldTests.randomSemanticText;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -92,7 +96,10 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void minimalMapping(XContentBuilder b) throws IOException {
-        b.field("type", "semantic_text").field("inference_id", "test_model");
+        b.field("type", "semantic_text");
+        if (DefaultElserFeatureFlag.isEnabled() == false) {
+            b.field("inference_id", "test_model");
+        }
     }
 
     @Override
@@ -155,8 +162,16 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
     }
 
     public void testDefaults() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
-        assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());
+        final String fieldName = "field";
+        final XContentBuilder fieldMapping = fieldMapping(this::minimalMapping);
+
+        MapperService mapperService = createMapperService(fieldMapping);
+        DocumentMapper mapper = mapperService.documentMapper();
+        assertEquals(Strings.toString(fieldMapping), mapper.mappingSource().toString());
+        assertSemanticTextField(mapperService, fieldName, false);
+        if (DefaultElserFeatureFlag.isEnabled()) {
+            assertInferenceEndpoints(mapperService, fieldName, DEFAULT_ELSER_2_INFERENCE_ID, DEFAULT_ELSER_2_INFERENCE_ID);
+        }
 
         ParsedDocument doc1 = mapper.parse(source(this::writeField));
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
@@ -172,12 +187,80 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         assertTrue(fieldType.fieldHasValue(fieldInfos));
     }
 
-    public void testInferenceIdNotPresent() {
-        Exception e = expectThrows(
-            MapperParsingException.class,
-            () -> createMapperService(fieldMapping(b -> b.field("type", "semantic_text")))
-        );
-        assertThat(e.getMessage(), containsString("field [inference_id] must be specified"));
+    public void testSetInferenceEndpoints() throws IOException {
+        final String fieldName = "field";
+        final String inferenceId = "foo";
+        final String searchInferenceId = "bar";
+
+        CheckedBiConsumer<XContentBuilder, MapperService, IOException> assertSerialization = (expectedMapping, mapperService) -> {
+            DocumentMapper mapper = mapperService.documentMapper();
+            assertEquals(Strings.toString(expectedMapping), mapper.mappingSource().toString());
+        };
+
+        {
+            final XContentBuilder fieldMapping = fieldMapping(b -> b.field("type", "semantic_text").field(INFERENCE_ID_FIELD, inferenceId));
+            final MapperService mapperService = createMapperService(fieldMapping);
+            assertSemanticTextField(mapperService, fieldName, false);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, inferenceId);
+            assertSerialization.accept(fieldMapping, mapperService);
+        }
+        {
+            if (DefaultElserFeatureFlag.isEnabled()) {
+                final XContentBuilder fieldMapping = fieldMapping(
+                    b -> b.field("type", "semantic_text").field(SEARCH_INFERENCE_ID_FIELD, searchInferenceId)
+                );
+                final MapperService mapperService = createMapperService(fieldMapping);
+                assertSemanticTextField(mapperService, fieldName, false);
+                assertInferenceEndpoints(mapperService, fieldName, DEFAULT_ELSER_2_INFERENCE_ID, searchInferenceId);
+                assertSerialization.accept(fieldMapping, mapperService);
+            }
+        }
+        {
+            final XContentBuilder fieldMapping = fieldMapping(
+                b -> b.field("type", "semantic_text")
+                    .field(INFERENCE_ID_FIELD, inferenceId)
+                    .field(SEARCH_INFERENCE_ID_FIELD, searchInferenceId)
+            );
+            MapperService mapperService = createMapperService(fieldMapping);
+            assertSemanticTextField(mapperService, fieldName, false);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, searchInferenceId);
+            assertSerialization.accept(fieldMapping, mapperService);
+        }
+    }
+
+    public void testInvalidInferenceEndpoints() {
+        {
+            Exception e = expectThrows(
+                MapperParsingException.class,
+                () -> createMapperService(fieldMapping(b -> b.field("type", "semantic_text").field(INFERENCE_ID_FIELD, (String) null)))
+            );
+            assertThat(
+                e.getMessage(),
+                containsString("[inference_id] on mapper [field] of type [semantic_text] must not have a [null] value")
+            );
+        }
+        {
+            final String expectedMessage = DefaultElserFeatureFlag.isEnabled()
+                ? "[inference_id] on mapper [field] of type [semantic_text] must not be empty"
+                : "[inference_id] on mapper [field] of type [semantic_text] must be specified";
+            Exception e = expectThrows(
+                MapperParsingException.class,
+                () -> createMapperService(fieldMapping(b -> b.field("type", "semantic_text").field(INFERENCE_ID_FIELD, "")))
+            );
+            assertThat(e.getMessage(), containsString(expectedMessage));
+        }
+        {
+            if (DefaultElserFeatureFlag.isEnabled()) {
+                Exception e = expectThrows(
+                    MapperParsingException.class,
+                    () -> createMapperService(fieldMapping(b -> b.field("type", "semantic_text").field(SEARCH_INFERENCE_ID_FIELD, "")))
+                );
+                assertThat(
+                    e.getMessage(),
+                    containsString("[search_inference_id] on mapper [field] of type [semantic_text] must not be empty")
+                );
+            }
+        }
     }
 
     public void testCannotBeUsedInMultiFields() {
@@ -221,7 +304,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                 new SemanticTextField.ModelSettings(TaskType.SPARSE_EMBEDDING, null, null, null)
             );
             assertSemanticTextField(mapperService, fieldName, true);
-            assertSearchInferenceId(mapperService, fieldName, inferenceId);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, inferenceId);
         }
 
         {
@@ -232,7 +315,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                 new SemanticTextField.ModelSettings(TaskType.SPARSE_EMBEDDING, null, null, null)
             );
             assertSemanticTextField(mapperService, fieldName, true);
-            assertSearchInferenceId(mapperService, fieldName, searchInferenceId);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, searchInferenceId);
         }
     }
 
@@ -331,19 +414,19 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
             String fieldName = randomFieldName(depth);
             MapperService mapperService = createMapperService(buildMapping.apply(fieldName, null));
             assertSemanticTextField(mapperService, fieldName, false);
-            assertSearchInferenceId(mapperService, fieldName, inferenceId);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, inferenceId);
 
             merge(mapperService, buildMapping.apply(fieldName, searchInferenceId1));
             assertSemanticTextField(mapperService, fieldName, false);
-            assertSearchInferenceId(mapperService, fieldName, searchInferenceId1);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, searchInferenceId1);
 
             merge(mapperService, buildMapping.apply(fieldName, searchInferenceId2));
             assertSemanticTextField(mapperService, fieldName, false);
-            assertSearchInferenceId(mapperService, fieldName, searchInferenceId2);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, searchInferenceId2);
 
             merge(mapperService, buildMapping.apply(fieldName, null));
             assertSemanticTextField(mapperService, fieldName, false);
-            assertSearchInferenceId(mapperService, fieldName, inferenceId);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, inferenceId);
 
             mapperService = mapperServiceForFieldWithModelSettings(
                 fieldName,
@@ -351,19 +434,19 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                 new SemanticTextField.ModelSettings(TaskType.SPARSE_EMBEDDING, null, null, null)
             );
             assertSemanticTextField(mapperService, fieldName, true);
-            assertSearchInferenceId(mapperService, fieldName, inferenceId);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, inferenceId);
 
             merge(mapperService, buildMapping.apply(fieldName, searchInferenceId1));
             assertSemanticTextField(mapperService, fieldName, true);
-            assertSearchInferenceId(mapperService, fieldName, searchInferenceId1);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, searchInferenceId1);
 
             merge(mapperService, buildMapping.apply(fieldName, searchInferenceId2));
             assertSemanticTextField(mapperService, fieldName, true);
-            assertSearchInferenceId(mapperService, fieldName, searchInferenceId2);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, searchInferenceId2);
 
             merge(mapperService, buildMapping.apply(fieldName, null));
             assertSemanticTextField(mapperService, fieldName, true);
-            assertSearchInferenceId(mapperService, fieldName, inferenceId);
+            assertInferenceEndpoints(mapperService, fieldName, inferenceId, inferenceId);
         }
     }
 
@@ -409,11 +492,17 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         }
     }
 
-    private static void assertSearchInferenceId(MapperService mapperService, String fieldName, String expectedSearchInferenceId) {
+    private static void assertInferenceEndpoints(
+        MapperService mapperService,
+        String fieldName,
+        String expectedInferenceId,
+        String expectedSearchInferenceId
+    ) {
         var fieldType = mapperService.fieldType(fieldName);
         assertNotNull(fieldType);
         assertThat(fieldType, instanceOf(SemanticTextFieldMapper.SemanticTextFieldType.class));
         SemanticTextFieldMapper.SemanticTextFieldType semanticTextFieldType = (SemanticTextFieldMapper.SemanticTextFieldType) fieldType;
+        assertEquals(expectedInferenceId, semanticTextFieldType.getInferenceId());
         assertEquals(expectedSearchInferenceId, semanticTextFieldType.getSearchInferenceId());
     }
 
@@ -433,9 +522,19 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
             MapperService mapperService = createMapperService(mapping);
             assertSemanticTextField(mapperService, fieldName1, false);
-            assertSearchInferenceId(mapperService, fieldName1, setSearchInferenceId ? searchInferenceId : model1.getInferenceEntityId());
+            assertInferenceEndpoints(
+                mapperService,
+                fieldName1,
+                model1.getInferenceEntityId(),
+                setSearchInferenceId ? searchInferenceId : model1.getInferenceEntityId()
+            );
             assertSemanticTextField(mapperService, fieldName2, false);
-            assertSearchInferenceId(mapperService, fieldName2, setSearchInferenceId ? searchInferenceId : model2.getInferenceEntityId());
+            assertInferenceEndpoints(
+                mapperService,
+                fieldName2,
+                model2.getInferenceEntityId(),
+                setSearchInferenceId ? searchInferenceId : model2.getInferenceEntityId()
+            );
 
             DocumentMapper documentMapper = mapperService.documentMapper();
             ParsedDocument doc = documentMapper.parse(

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
@@ -547,3 +547,34 @@ setup:
   - match: { _source.dense_field.text: "another updated inference test" }
   - match: { _source.dense_field.inference.chunks.0.text: "another updated inference test" }
   - exists: _source.dense_field.inference.chunks.0.embeddings
+
+---
+"Calculates embeddings using the default ELSER 2 endpoint":
+  - requires:
+      cluster_features: "semantic_text.default_elser_2"
+      reason: semantic_text default ELSER 2 inference ID introduced in 8.16.0
+
+  - do:
+      indices.create:
+        index: test-elser-2-default-index
+        body:
+          mappings:
+            properties:
+              sparse_field:
+                type: semantic_text
+
+  - do:
+      index:
+        index: test-elser-2-default-index
+        id: doc_1
+        body:
+          sparse_field: "inference test"
+
+  - do:
+      get:
+        index: test-elser-2-default-index
+        id: doc_1
+
+  - match: { _source.sparse_field.text: "inference test" }
+  - exists: _source.sparse_field.inference.chunks.0.embeddings
+  - match: { _source.sparse_field.inference.chunks.0.text: "inference test" }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/40_semantic_text_query.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/40_semantic_text_query.yml
@@ -839,3 +839,38 @@ setup:
 
   - match: { error.type: "resource_not_found_exception" }
   - match: { error.reason: "Inference endpoint not found [invalid-inference-id]" }
+
+---
+"Query a field that uses the default ELSER 2 endpoint":
+  - requires:
+      cluster_features: "semantic_text.default_elser_2"
+      reason: semantic_text default ELSER 2 inference ID introduced in 8.16.0
+
+  - do:
+      indices.create:
+        index: test-elser-2-default-index
+        body:
+          mappings:
+            properties:
+              sparse_field:
+                type: semantic_text
+
+  - do:
+      index:
+        index: test-elser-2-default-index
+        id: doc_1
+        body:
+          sparse_field: "inference test"
+        refresh: true
+
+  - do:
+      search:
+        index: test-elser-2-default-index
+        body:
+          query:
+            semantic:
+              field: "sparse_field"
+              query: "inference test"
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc_1" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use ELSER By Default For Semantic Text (#113563)](https://github.com/elastic/elasticsearch/pull/113563)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)