### PR TITLE
[8.15] Fix analyzed wildcard query in simple_query_string when disjunctions is empty (#114264)

### DIFF
--- a/docs/changelog/114264.yaml
+++ b/docs/changelog/114264.yaml
@@ -1,0 +1,5 @@
+pr: 114264
+summary: "Fix analyzed wildcard query in simple_query_string when disjunctions is empty"
+area: Search
+type: bug
+issues: [114185]

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -581,6 +581,32 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         });
     }
 
+    public void testSimpleQueryStringWithAnalysisStopWords() throws Exception {
+        String mapping = Strings.toString(
+            XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("properties")
+                .startObject("body")
+                .field("type", "text")
+                .field("analyzer", "stop")
+                .endObject()
+                .endObject()
+                .endObject()
+        );
+
+        CreateIndexRequestBuilder mappingRequest = indicesAdmin().prepareCreate("test1").setMapping(mapping);
+        mappingRequest.get();
+        indexRandom(true, prepareIndex("test1").setId("1").setSource("body", "Some Text"));
+        refresh();
+
+        assertHitCount(
+            prepareSearch().setQuery(
+                simpleQueryStringQuery("the* text*").analyzeWildcard(true).defaultOperator(Operator.AND).field("body")
+            ),
+            1
+        );
+    }
+
     private void assertHits(SearchHits hits, String... ids) {
         assertThat(hits.getTotalHits().value, equalTo((long) ids.length));
         Set<String> hitIds = new HashSet<>();

--- a/server/src/main/java/org/elasticsearch/index/search/SimpleQueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/SimpleQueryStringQueryParser.java
@@ -198,6 +198,9 @@ public class SimpleQueryStringQueryParser extends SimpleQueryParser {
         if (disjuncts.size() == 1) {
             return disjuncts.get(0);
         }
+        if (disjuncts.size() == 0) {
+            return null;
+        }
         return new DisjunctionMaxQuery(disjuncts, 1.0f);
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Fix analyzed wildcard query in simple_query_string when disjunctions is empty (#114264)](https://github.com/elastic/elasticsearch/pull/114264)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)