### PR TITLE
Run fail formatting yaml test with 1 shard (#114214)

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
@@ -3,6 +3,8 @@ setup:
       indices.create:
           index: test_date
           body:
+            settings:
+              number_of_shards: 1
             mappings:
               properties:
                 date_field:


### PR DESCRIPTION
manual backport of https://github.com/elastic/elasticsearch/pull/114214