### PR TITLE
[TEST] Re-enable ScaledFloatFieldMapperTests.testSyntheticSourceKeepArrays

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -377,9 +377,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.services.cohere.CohereServiceTests
   method: testInfer_StreamRequest
   issue: https://github.com/elastic/elasticsearch/issues/114385
-- class: org.elasticsearch.index.mapper.extras.ScaledFloatFieldMapperTests
-  method: testSyntheticSourceKeepArrays
-  issue: https://github.com/elastic/elasticsearch/issues/114406
 
 # Examples:
 #


### PR DESCRIPTION
The issue was fixed in https://github.com/elastic/elasticsearch/pull/114391

Fixes #114363 