### PR TITLE
[8.15] Default enable cluster state role mapper (#114337)

### DIFF
--- a/docs/changelog/114337.yaml
+++ b/docs/changelog/114337.yaml
@@ -1,5 +1,0 @@
-pr: 114337
-summary: "Enables cluster state role mapper, to include ECK operator-defined role mappings in role resolution"
-area: Authentication
-type: bug
-issues: []

--- a/docs/changelog/114337.yaml
+++ b/docs/changelog/114337.yaml
@@ -1,0 +1,5 @@
+pr: 114337
+summary: "Enables cluster state role mapper, to include ECK operator-defined role mappings in role resolution"
+area: Authentication
+type: bug
+issues: []

--- a/docs/changelog/114421.yaml
+++ b/docs/changelog/114421.yaml
@@ -1,5 +1,5 @@
 pr: 114421
-summary: "[8.15] Default enable cluster state role mapper"
+summary: "Enables cluster state role mapper, to include ECK operator-defined role mappings in role resolution"
 area: Authentication
 type: bug
 issues: []

--- a/docs/changelog/114421.yaml
+++ b/docs/changelog/114421.yaml
@@ -1,5 +1,0 @@
-pr: 114421
-summary: "Enables cluster state role mapper, to include ECK operator-defined role mappings in role resolution"
-area: Authentication
-type: bug
-issues: []

--- a/docs/changelog/114421.yaml
+++ b/docs/changelog/114421.yaml
@@ -1,5 +1,0 @@
-pr: 114421
-summary: "[8.15] Default enable cluster state role mapper"
-area: Authentication
-type: bug
-issues: []

--- a/docs/changelog/114421.yaml
+++ b/docs/changelog/114421.yaml
@@ -1,0 +1,5 @@
+pr: 114421
+summary: "[8.15] Default enable cluster state role mapper"
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -148,15 +148,6 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
              }
         }""";
 
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        Settings.Builder builder = Settings.builder()
-            .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            // some tests make use of cluster-state based role mappings
-            .put("xpack.security.authc.cluster_state_role_mappings.enabled", true);
-        return builder.build();
-    }
-
     @After
     public void cleanUp() {
         updateClusterSettings(Settings.builder().putNull("indices.recovery.max_bytes_per_sec"));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/jwt/JwtRoleMappingsIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/jwt/JwtRoleMappingsIntegTests.java
@@ -78,8 +78,6 @@ public final class JwtRoleMappingsIntegTests extends SecurityIntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         Settings.Builder builder = Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            // some tests make use of cluster-state based role mappings
-            .put("xpack.security.authc.cluster_state_role_mappings.enabled", true)
             .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), randomBoolean())
             // 1st JWT realm
             .put("xpack.security.authc.realms.jwt.jwt0.order", 10)

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapper.java
@@ -31,9 +31,9 @@ import static org.elasticsearch.xpack.core.security.SecurityExtension.SecurityCo
 public final class ClusterStateRoleMapper extends AbstractRoleMapperClearRealmCache implements ClusterStateListener {
 
     /**
-     * This setting is never registered by the xpack security plugin - in order to enable the
+     * This setting is never registered by the xpack security plugin - in order to disable the
      * cluster-state based role mapper another plugin must register it as a boolean setting
-     * and set it to `true`.
+     * and set it to `false`.
      * If this setting is set to <code>true</code> then:
      * <ul>
      *     <li>Realms that make use role mappings (all realms but file and native) will,
@@ -54,8 +54,8 @@ public final class ClusterStateRoleMapper extends AbstractRoleMapperClearRealmCa
     public ClusterStateRoleMapper(Settings settings, ScriptService scriptService, ClusterService clusterService) {
         this.scriptService = scriptService;
         this.clusterService = clusterService;
-        // this role mapper is disabled by default and only code in other plugins can enable it
-        this.enabled = settings.getAsBoolean(CLUSTER_STATE_ROLE_MAPPINGS_ENABLED, false);
+        // this role mapper is enabled by default and only code in other plugins can disable it
+        this.enabled = settings.getAsBoolean(CLUSTER_STATE_ROLE_MAPPINGS_ENABLED, true);
         if (this.enabled) {
             clusterService.addListener(this);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -403,7 +403,7 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         );
         public static final Setting<Boolean> CLUSTER_STATE_ROLE_MAPPINGS_ENABLED = Setting.boolSetting(
             "xpack.security.authc.cluster_state_role_mappings.enabled",
-            false,
+            true,
             Setting.Property.NodeScope
         );
         public static final Setting<Boolean> NATIVE_ROLES_ENABLED = Setting.boolSetting(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapperTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ClusterStateRoleMapperTests.java
@@ -56,12 +56,12 @@ public class ClusterStateRoleMapperTests extends ESTestCase {
             () -> 1L
         );
         clusterService = mock(ClusterService.class);
-        enabledSettings = Settings.builder().put("xpack.security.authc.cluster_state_role_mappings.enabled", true).build();
+        disabledSettings = Settings.builder().put("xpack.security.authc.cluster_state_role_mappings.enabled", false).build();
         if (randomBoolean()) {
-            disabledSettings = Settings.builder().put("xpack.security.authc.cluster_state_role_mappings.enabled", false).build();
+            enabledSettings = Settings.builder().put("xpack.security.authc.cluster_state_role_mappings.enabled", true).build();
         } else {
-            // the cluster state role mapper is disabled by default
-            disabledSettings = Settings.EMPTY;
+            // the cluster state role mapper is enabled by default
+            enabledSettings = Settings.EMPTY;
         }
     }
 


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/114337 with following commits:
- 3e06625fd79edc30fb1fb3a49e56d88297d14249