### PR TITLE
Speed up XPackRestIT a little

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -242,9 +242,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_force_delete/Test force deleting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/113327
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/top_metrics/sort by scaled float field}
-  issue: https://github.com/elastic/elasticsearch/issues/113340
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
   issue: https://github.com/elastic/elasticsearch/issues/113343

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
@@ -29,7 +29,7 @@ setup:
 
   - do:
       bulk:
-        refresh: wait_for
+        refresh: true
         body:
           - {"create": {"_index": "profiling-events-all"}}
           - {"Stacktrace.count": [1], "profiling.project.id": ["100"], "os.kernel": ["9.9.9-0"], "tags": ["environment:qa", "region:eu-west-1"], "host.ip": ["192.168.1.2"], "@timestamp": ["1700504427"], "container.name": ["instance-0000000010"], "ecs.version": ["1.12.0"], "Stacktrace.id": ["S07KmaoGhvNte78xwwRbZQ"], "agent.version": ["head-be593ef3-1688111067"], "host.name": ["ip-192-168-1-2"], "host.id": ["8457605156473051743"], "process.thread.name": ["497295213074376"]}


### PR DESCRIPTION
This speeds up all of the `profiling` tests in `XPackRestIT` by replacing a "wait for refresh" with a "refresh as fast as you can". It'll only be a few seconds of speed up, but it's something.

While I'm here I'm reenabling one of our tests that doesn't seem to be causing the slow down.

Closes #113340
