### PR TITLE
[8.x] Ensure green step in synonyms rule yaml test (#114400)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
@@ -13,7 +13,10 @@ setup:
               id: "test-id-2"
             - synonyms: "test => check"
               id: "test-id-3"
-
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        wait_for_status: green
 
 ---
 "Get a synonym rule":


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Ensure green step in synonyms rule yaml test (#114400)