### PR TITLE
Add node.stats.indices.shard_stats.total_count to monitoring-es-mb template

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -622,6 +622,13 @@
                             }
                           }
                         },
+                        "shard_stats": {
+                          "properties": {
+                            "total_count": {
+                              "type": "long"
+                            }
+                          }
+                        },
                         "store": {
                           "properties": {
                             "size": {


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/114470

Also as mentioned in https://github.com/elastic/elasticsearch/issues/114470:
> I can see there was this PR (#107471) and the ES side to add the field to the monitor mappings. However, I can see it was added as cluster_stats.indices.shards_stats.total_count, not elasticsearch.node.stats.indices.shard_stats.total_count. Is it a mistake?
> 
> I don't see this field (`cluster_stats.indices.shards_stats.total_count`) being used anywhere in the monitoring data.

and it seems to overlap with `cluster_stats.indices.shards.total`:
https://github.com/elastic/elasticsearch/blob/fd40f8b1cbfb5472ee9c9dd7a708b892fdc01baf/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json#L2366-L2385

If you can confirm that `cluster_stats.indices.shards_stats.total_count` is not used, I don't mind adding a commit to remove it.


