### PR TITLE
Fix synonyms CI tests timeout

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -351,15 +351,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.services.cohere.CohereServiceTests
   method: testInfer_StreamRequest
   issue: https://github.com/elastic/elasticsearch/issues/114385
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/60_synonym_rule_get/Synonym set not found}
-  issue: https://github.com/elastic/elasticsearch/issues/114432
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/60_synonym_rule_get/Get a synonym rule}
-  issue: https://github.com/elastic/elasticsearch/issues/114443
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/60_synonym_rule_get/Synonym rule not found}
-  issue: https://github.com/elastic/elasticsearch/issues/114444
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/114412

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
@@ -15,7 +15,8 @@ setup:
               id: "test-id-3"
   - do:
       cluster.health:
-        index: .synonyms-2
+        index: .synonyms
+        timeout: 1m
         wait_for_status: green
 
 ---


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/114432
Closes https://github.com/elastic/elasticsearch/issues/114443
Closes https://github.com/elastic/elasticsearch/issues/114444

Increase timeout in health check for cluster, introduced in https://github.com/elastic/elasticsearch/pull/114400.

Health checks on synonyms index is failing with a timeout before it reaches green status. There's no reason for the index not to reach it, and other tests that use cluster health have an increased timeout for cluster health check. 