### PR TITLE
[8.x] Handle InternalSendException inline for non-forking handlers (#114375)

### DIFF
--- a/docs/changelog/114375.yaml
+++ b/docs/changelog/114375.yaml
@@ -1,0 +1,5 @@
+pr: 114375
+summary: Handle `InternalSendException` inline for non-forking handlers
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1060,8 +1060,9 @@ public class TransportService extends AbstractLifecycleComponent
         if (lifecycle.stoppedOrClosed()) {
             // too late to try and dispatch anywhere else, let's just use the calling thread
             return EsExecutors.DIRECT_EXECUTOR_SERVICE;
-        } else if (handlerExecutor == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
-            // if the handler is non-forking then dispatch to GENERIC to avoid a possible stack overflow
+        } else if (handlerExecutor == EsExecutors.DIRECT_EXECUTOR_SERVICE && enableStackOverflowAvoidance) {
+            // If the handler is non-forking and stack overflow protection is enabled then dispatch to GENERIC
+            // Otherwise we let the handler deal with any potential stack overflow (this is the default)
             return threadPool.generic();
         } else {
             return handlerExecutor;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Handle InternalSendException inline for non-forking handlers (#114375)