### PR TITLE
Add name to role mappings in cluster state

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -239,6 +239,7 @@ public class TransportVersions {
     public static final TransportVersion TEXT_SIMILARITY_RERANKER_QUERY_REWRITE = def(8_763_00_0);
     public static final TransportVersion SIMULATE_INDEX_TEMPLATES_SUBSTITUTIONS = def(8_764_00_0);
     public static final TransportVersion RETRIEVERS_TELEMETRY_ADDED = def(8_765_00_0);
+    public static final TransportVersion ADD_VERSION_TO_ROLE_MAPPING_METADATA = def(8_766_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
@@ -243,17 +243,16 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
         }
     }
 
+    public static ExpressionRoleMapping parse(XContentParser parser) throws IOException {
+        return parse(null, parser);
+    }
+
     /**
      * Parse an {@link ExpressionRoleMapping} from the provided <em>XContent</em>
      */
     public static ExpressionRoleMapping parse(String name, XContentParser parser) throws IOException {
         try {
-            final Builder builder = PARSER.parse(parser, name);
-            if (builder.name == null) {
-                return builder.build("name_not_available_after_deserialization");
-            } else {
-                return builder.build();
-            }
+            return PARSER.parse(parser, name).build();
         } catch (IllegalArgumentException | IllegalStateException e) {
             throw new ParsingException(parser.getTokenLocation(), e.getMessage(), e);
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -125,7 +125,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
             roleMappings,
             containsInAnyOrder(
                 new ExpressionRoleMapping(
-                    "name_not_available_after_deserialization",
+                    "everyone_kibana_alone",
                     new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                     List.of("kibana_user"),
                     List.of(),
@@ -133,7 +133,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                     true
                 ),
                 new ExpressionRoleMapping(
-                    "name_not_available_after_deserialization",
+                    "everyone_fleet_alone",
                     new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                     List.of("fleet_user"),
                     List.of(),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1203,7 +1203,7 @@ public class Security extends Plugin
             new SecurityUsageServices(realms, allRolesStore, nativeRoleMappingStore, ipFilter.get(), profileService, apiKeyService)
         );
 
-        reservedRoleMappingAction.set(new ReservedRoleMappingAction());
+        reservedRoleMappingAction.set(new ReservedRoleMappingAction(featureService));
 
         cacheInvalidatorRegistry.validate();
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
@@ -17,13 +17,14 @@ import java.util.Set;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MIGRATION_FRAMEWORK;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_PROFILE_ORIGIN_FEATURE;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_ROLES_METADATA_FLATTENED;
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_ROLE_MAPPING_NAME_FIELD;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.VERSION_SECURITY_PROFILE_ORIGIN;
 
 public class SecurityFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of(SECURITY_ROLES_METADATA_FLATTENED, SECURITY_MIGRATION_FRAMEWORK);
+        return Set.of(SECURITY_ROLE_MAPPING_NAME_FIELD, SECURITY_ROLES_METADATA_FLATTENED, SECURITY_MIGRATION_FRAMEWORK);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/ReservedRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/ReservedRoleMappingAction.java
@@ -54,8 +54,8 @@ public class ReservedRoleMappingAction implements ReservedClusterStateHandler<Li
         // RoleMappingMetadata is written to cluster state, so make sure all nodes can parse the new format (with name), if they
         // can't, write the old format (exclude name)
         RoleMappingMetadata newRoleMappingMetadata = featureService.clusterHasFeature(prevState.state(), SECURITY_ROLE_MAPPING_NAME_FIELD)
-            ? new RoleMappingMetadata(roleMappings)
-            : new RoleMappingMetadata(roleMappings, false);
+            ? new RoleMappingMetadata(roleMappings, )
+            : new RoleMappingMetadata(roleMappings);
 
         if (newRoleMappingMetadata.equals(RoleMappingMetadata.getFromClusterState(prevState.state()))) {
             return prevState;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -61,6 +61,7 @@ public class SecuritySystemIndices {
     public static final NodeFeature SECURITY_PROFILE_ORIGIN_FEATURE = new NodeFeature("security.security_profile_origin");
     public static final NodeFeature SECURITY_MIGRATION_FRAMEWORK = new NodeFeature("security.migration_framework");
     public static final NodeFeature SECURITY_ROLES_METADATA_FLATTENED = new NodeFeature("security.roles_metadata_flattened");
+    public static final NodeFeature SECURITY_ROLE_MAPPING_NAME_FIELD = new NodeFeature("security.role_mapping_name_field");
 
     /**
      * Security managed index mappings used to be updated based on the product version. They are now updated based on per-index mappings

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/reservedstate/ReservedRoleMappingActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/reservedstate/ReservedRoleMappingActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.security.action.reservedstate;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.reservedstate.TransformState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -21,6 +22,7 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests that the ReservedRoleMappingAction does validation, can add and remove role mappings
@@ -37,7 +39,7 @@ public class ReservedRoleMappingActionTests extends ESTestCase {
     public void testValidation() {
         ClusterState state = ClusterState.builder(new ClusterName("elasticsearch")).build();
         TransformState prevState = new TransformState(state, Collections.emptySet());
-        ReservedRoleMappingAction action = new ReservedRoleMappingAction();
+        ReservedRoleMappingAction action = new ReservedRoleMappingAction(mock(FeatureService.class));
         String badPolicyJSON = """
             {
                "everyone_kibana": {
@@ -66,7 +68,7 @@ public class ReservedRoleMappingActionTests extends ESTestCase {
     public void testAddRemoveRoleMapping() throws Exception {
         ClusterState state = ClusterState.builder(new ClusterName("elasticsearch")).build();
         TransformState prevState = new TransformState(state, Collections.emptySet());
-        ReservedRoleMappingAction action = new ReservedRoleMappingAction();
+        ReservedRoleMappingAction action = new ReservedRoleMappingAction(mock(FeatureService.class));
         String emptyJSON = "";
 
         TransformState updatedState = processJSON(action, prevState, emptyJSON);


### PR DESCRIPTION
This PR is prerequisite to https://github.com/elastic/elasticsearch/pull/114305. 

This will write the `ExpressionRoleMapping::name` field as part of the `RoleMappingMetadata` persisted in cluster state. The idea is that this PR will be merged after the PR <INSERT LINK> that ensures that `settings.json` is reloaded on every restart. When `settings.json` is loaded, the `RoleMappingMetadata` will be rewritten to cluster state with each mapping containing the new name field. 

`RoleMappingMetadata` will be written to cluster state and persisted for all contexts, that means `SNAPSHOT`, `GATEWAY` and `API`. 

- `GATEWAY` - This is persisted across master node restarts, so I've added a new node feature to make sure that all nodes have the new parser before writing.
- `SNAPSHOT` - This is persisted for snapshot purposes. Since [you can’t restore an index to an earlier version of Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html#snapshot-index-compatibility) persisting the new field if all nodes have the parser, should guarantee that it can be parsed after restore. 
- `API` - This is persisted in the cluster state API. No additional work is needed to support this.