### PR TITLE
Remove empty queue conditional from slicing logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -291,7 +291,6 @@ final class DefaultSearchContext extends SearchContext {
         ToLongFunction<String> fieldCardinality
     ) {
         return executor instanceof ThreadPoolExecutor tpe
-            && tpe.getQueue().isEmpty()
             && isParallelCollectionSupportedForResults(resultsType, request.source(), fieldCardinality, enableQueryPhaseParallelCollection)
                 ? tpe.getMaximumPoolSize()
                 : 1;


### PR DESCRIPTION
With recent changes in Lucene around not forking execution when not necessary, we have removed the search worker thread pool in #111099. The worker thread pool had unlimited queue, and the fear was that we couuld have much more queueing on the search thread pool if we use it to parallelize execution across segments, because every shard would take up to a thread per slice when executing the query phase.

We have then introduced an additional conditional to stop parallelizing when there is a queue. That is perhaps a bit extreme, as it's a decision made when creating the searcher, while a queue may no longer be there once the search is executing. This has caused some benchmarks regressions, hence this commit removes the additional queue dependent conditional in order to perform additional benchmarks without it.