### PR TITLE
Investigate and Address Dense Vector Mapper Parsing Issue

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
@@ -867,7 +867,7 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    protected RandomIndexWriter indexWriterForSyntheticSource(Directory directory) throws IOException {
+    protected RandomIndexWriter indexWriterForSyntheticSource(Directory directory, MapperService mapperService) throws IOException {
         // MockAnalyzer is "too good" and produces random payloads every time
         // which then leads to failures during assertReaderEquals.
         return new RandomIndexWriter(random(), directory, new StandardAnalyzer());

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ES815BitFlatVectorFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ES815BitFlatVectorFormat.java
@@ -45,4 +45,5 @@ public class ES815BitFlatVectorFormat extends KnnVectorsFormat {
     public String toString() {
         return NAME;
     }
+
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1463,19 +1463,26 @@ public abstract class FieldMapper extends Mapper {
                 }
             }
             String type = (String) fieldNode.remove("type");
-            for (Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().iterator(); iterator.hasNext();) {
+
+            List<String> order = Arrays.stream(params).map(p -> p.name).toList();
+            Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().stream().sorted((e1, e2) -> {
+                int i1 = order.indexOf(e1.getKey());
+                int i2 = order.indexOf(e2.getKey());
+                return Integer.compare(i1, i2);
+            }).iterator();
+            while (iterator.hasNext()) {
                 Map.Entry<String, Object> entry = iterator.next();
                 final String propName = entry.getKey();
                 final Object propNode = entry.getValue();
                 switch (propName) {
                     case "fields" -> {
                         TypeParsers.parseMultiField(multiFieldsBuilder::add, name, parserContext, propName, propNode);
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                     case "copy_to" -> {
                         copyTo = copyTo.withAddedFields(TypeParsers.parseCopyFields(propNode));
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                     case "boost" -> {
@@ -1488,12 +1495,12 @@ public abstract class FieldMapper extends Mapper {
                             "Parameter [boost] on field [{}] is deprecated and has no effect",
                             name
                         );
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                     case SYNTHETIC_SOURCE_KEEP_PARAM -> {
                         sourceKeepMode = Optional.of(SourceKeepMode.from(XContentMapValues.nodeStringValue(propNode)));
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                 }
@@ -1514,7 +1521,7 @@ public abstract class FieldMapper extends Mapper {
                     if (parserContext.indexVersionCreated().isLegacyIndexVersion()) {
                         // ignore unknown parameters on legacy indices
                         handleUnknownParamOnLegacyIndex(propName, propNode);
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                     if (isDeprecatedParameter(propName, parserContext.indexVersionCreated())) {
@@ -1525,7 +1532,7 @@ public abstract class FieldMapper extends Mapper {
                             propName,
                             type
                         );
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                     if (parserContext.isFromDynamicTemplate() && parserContext.indexVersionCreated().before(IndexVersions.V_8_0_0)) {
@@ -1539,7 +1546,7 @@ public abstract class FieldMapper extends Mapper {
                             propName,
                             type
                         );
-                        iterator.remove();
+                        fieldNode.remove(propName);
                         continue;
                     }
                     throw new MapperParsingException(
@@ -1560,7 +1567,7 @@ public abstract class FieldMapper extends Mapper {
                     );
                 }
                 parameter.parse(name, parserContext, propNode);
-                iterator.remove();
+                fieldNode.remove(propName);
             }
             validate();
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1463,26 +1463,19 @@ public abstract class FieldMapper extends Mapper {
                 }
             }
             String type = (String) fieldNode.remove("type");
-
-            List<String> order = Arrays.stream(params).map(p -> p.name).toList();
-            Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().stream().sorted((e1, e2) -> {
-                int i1 = order.indexOf(e1.getKey());
-                int i2 = order.indexOf(e2.getKey());
-                return Integer.compare(i1, i2);
-            }).iterator();
-            while (iterator.hasNext()) {
+            for (Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 final String propName = entry.getKey();
                 final Object propNode = entry.getValue();
                 switch (propName) {
                     case "fields" -> {
                         TypeParsers.parseMultiField(multiFieldsBuilder::add, name, parserContext, propName, propNode);
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                     case "copy_to" -> {
                         copyTo = copyTo.withAddedFields(TypeParsers.parseCopyFields(propNode));
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                     case "boost" -> {
@@ -1495,12 +1488,12 @@ public abstract class FieldMapper extends Mapper {
                             "Parameter [boost] on field [{}] is deprecated and has no effect",
                             name
                         );
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                     case SYNTHETIC_SOURCE_KEEP_PARAM -> {
                         sourceKeepMode = Optional.of(SourceKeepMode.from(XContentMapValues.nodeStringValue(propNode)));
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                 }
@@ -1521,7 +1514,7 @@ public abstract class FieldMapper extends Mapper {
                     if (parserContext.indexVersionCreated().isLegacyIndexVersion()) {
                         // ignore unknown parameters on legacy indices
                         handleUnknownParamOnLegacyIndex(propName, propNode);
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                     if (isDeprecatedParameter(propName, parserContext.indexVersionCreated())) {
@@ -1532,7 +1525,7 @@ public abstract class FieldMapper extends Mapper {
                             propName,
                             type
                         );
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                     if (parserContext.isFromDynamicTemplate() && parserContext.indexVersionCreated().before(IndexVersions.V_8_0_0)) {
@@ -1546,7 +1539,7 @@ public abstract class FieldMapper extends Mapper {
                             propName,
                             type
                         );
-                        fieldNode.remove(propName);
+                        iterator.remove();
                         continue;
                     }
                     throw new MapperParsingException(
@@ -1567,7 +1560,7 @@ public abstract class FieldMapper extends Mapper {
                     );
                 }
                 parameter.parse(name, parserContext, propNode);
-                fieldNode.remove(propName);
+                iterator.remove();
             }
             validate();
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2039,10 +2039,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         private void mapping(XContentBuilder b) throws IOException {
             b.field("type", "dense_vector");
-            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (elementType == ElementType.BYTE || elementType == ElementType.BIT || randomBoolean()) {
                 b.field("element_type", elementType.toString());
             }
+            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (indexed) {
                 b.field("index", true);
                 b.field("similarity", "l2_norm");

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2039,10 +2039,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         private void mapping(XContentBuilder b) throws IOException {
             b.field("type", "dense_vector");
+            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (elementType == ElementType.BYTE || elementType == ElementType.BIT || randomBoolean()) {
                 b.field("element_type", elementType.toString());
             }
-            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (indexed) {
                 b.field("index", true);
                 b.field("similarity", "l2_norm");

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2022,7 +2022,6 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
     private static class DenseVectorSyntheticSourceSupport implements SyntheticSourceSupport {
         private final int dims = between(512, 1000);
-//        private final int dims = between(5, 512);
         private final ElementType elementType = randomFrom(ElementType.BIT);
         private final boolean indexed = randomBoolean();
         private final boolean indexOptionsSet = indexed && randomBoolean();
@@ -2030,8 +2029,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         @Override
         public SyntheticSourceExample example(int maxValues) throws IOException {
             Object value = switch (elementType) {
-                case BYTE, BIT: yield randomList(dims, dims, ESTestCase::randomByte);
-                case FLOAT: yield randomList(dims, dims, ESTestCase::randomFloat);
+                case BYTE, BIT:
+                    yield randomList(dims, dims, ESTestCase::randomByte);
+                case FLOAT:
+                    yield randomList(dims, dims, ESTestCase::randomFloat);
             };
             return new SyntheticSourceExample(value, value, this::mapping);
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -955,6 +955,14 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         );
     }
 
+    public void testLargeDimsBit() throws IOException {
+        createMapperService(fieldMapping(b -> {
+            b.field("type", "dense_vector");
+            b.field("dims", 1024 * Byte.SIZE);
+            b.field("element_type", ElementType.BIT.toString());
+        }));
+    }
+
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "dense_vector").field("dims", 3)));
 
@@ -2021,8 +2029,8 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     }
 
     private static class DenseVectorSyntheticSourceSupport implements SyntheticSourceSupport {
-        private final int dims = between(512, 1000);
-        private final ElementType elementType = randomFrom(ElementType.BIT);
+        private final int dims = between(5, 1000);
+        private final ElementType elementType = randomFrom(ElementType.BYTE, ElementType.BIT, ElementType.FLOAT);
         private final boolean indexed = randomBoolean();
         private final boolean indexOptionsSet = indexed && randomBoolean();
 
@@ -2039,10 +2047,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         private void mapping(XContentBuilder b) throws IOException {
             b.field("type", "dense_vector");
+            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (elementType == ElementType.BYTE || elementType == ElementType.BIT || randomBoolean()) {
                 b.field("element_type", elementType.toString());
             }
-            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (indexed) {
                 b.field("index", true);
                 b.field("similarity", "l2_norm");

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2021,9 +2021,9 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     }
 
     private static class DenseVectorSyntheticSourceSupport implements SyntheticSourceSupport {
-//        private final int dims = between(5, 1000);
-        private final int dims = between(5, 512);
-        private final ElementType elementType = randomFrom(ElementType.BYTE, ElementType.BIT, ElementType.FLOAT);
+        private final int dims = between(512, 1000);
+//        private final int dims = between(5, 512);
+        private final ElementType elementType = randomFrom(ElementType.BIT);
         private final boolean indexed = randomBoolean();
         private final boolean indexOptionsSet = indexed && randomBoolean();
 
@@ -2038,10 +2038,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         private void mapping(XContentBuilder b) throws IOException {
             b.field("type", "dense_vector");
-            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (elementType == ElementType.BYTE || elementType == ElementType.BIT || randomBoolean()) {
                 b.field("element_type", elementType.toString());
             }
+            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
             if (indexed) {
                 b.field("index", true);
                 b.field("similarity", "l2_norm");

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -2021,23 +2021,25 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
     }
 
     private static class DenseVectorSyntheticSourceSupport implements SyntheticSourceSupport {
-        private final int dims = between(5, 1000);
-        private final ElementType elementType = randomFrom(ElementType.BYTE, ElementType.FLOAT);
+//        private final int dims = between(5, 1000);
+        private final int dims = between(5, 512);
+        private final ElementType elementType = randomFrom(ElementType.BYTE, ElementType.BIT, ElementType.FLOAT);
         private final boolean indexed = randomBoolean();
         private final boolean indexOptionsSet = indexed && randomBoolean();
 
         @Override
         public SyntheticSourceExample example(int maxValues) throws IOException {
-            Object value = elementType == ElementType.BYTE
-                ? randomList(dims, dims, ESTestCase::randomByte)
-                : randomList(dims, dims, ESTestCase::randomFloat);
+            Object value = switch (elementType) {
+                case BYTE, BIT: yield randomList(dims, dims, ESTestCase::randomByte);
+                case FLOAT: yield randomList(dims, dims, ESTestCase::randomFloat);
+            };
             return new SyntheticSourceExample(value, value, this::mapping);
         }
 
         private void mapping(XContentBuilder b) throws IOException {
             b.field("type", "dense_vector");
-            b.field("dims", dims);
-            if (elementType == ElementType.BYTE || randomBoolean()) {
+            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
+            if (elementType == ElementType.BYTE || elementType == ElementType.BIT || randomBoolean()) {
                 b.field("element_type", elementType.toString());
             }
             if (indexed) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -67,6 +67,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -717,7 +718,7 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
     }
 
     public void testIgnoredSourceFilteringIntegration() throws Exception {
-        DocumentMapper mapper = createMapperService(
+        MapperService mapperService = createMapperService(
             Settings.builder()
                 .put("index.mapping.total_fields.limit", 1)
                 .put("index.mapping.total_fields.ignore_dynamic_beyond_limit", true)
@@ -725,10 +726,11 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
             syntheticSourceMapping(b -> {
                 b.startObject("foo").field("type", "keyword").endObject();
             })
-        ).documentMapper();
+        );
+        DocumentMapper mapper = mapperService.documentMapper();
 
         try (Directory directory = newDirectory()) {
-            RandomIndexWriter iw = indexWriterForSyntheticSource(directory);
+            RandomIndexWriter iw = indexWriterForSyntheticSource(directory, mapperService);
             ParsedDocument doc = mapper.parse(source(b -> {
                 b.field("fieldA", "testA");
                 b.field("fieldB", "testB");


### PR DESCRIPTION
### Description:

This PR is created to investigate and address the issue related to the `DenseVectorFieldMapper` parsing. The current implementation has led to some parsing inconsistencies, which need to be resolved in a more elegant manner.

### Example Issue:

Consider the following example:

```
PUT test
{
  "mappings": {
    "properties": {
      "vector": {
        "type": "dense_vector",
        "dims": 8000,
        "index": false,
        "element_type": "bit"
      }
    }
  }
}
```

This request results in the following error:

```json
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "The number of dimensions for field [vector] should be in the range [1, 4096] but was [8000]"
      }
    ],
    "type": "mapper_parsing_exception",
    "reason": "Failed to parse mapping: The number of dimensions for field [vector] should be in the range [1, 4096] but was [8000]",
    "caused_by": {
      "type": "mapper_parsing_exception",
      "reason": "The number of dimensions for field [vector] should be in the range [1, 4096] but was [8000]"
    }
  },
  "status": 400
}
```

This issue highlights the need for better validation and parsing logic within the `DenseVectorFieldMapper`.

### Proposed Changes:

- **Investigate the Root Cause:** Conduct a thorough investigation to understand the root cause of the parsing inconsistencies.
- **Update Validations:** Instead of changing the parsing order, update the validations within the `DenseVectorFieldMapper` to ensure that all necessary fields are correctly parsed and validated.
- **Add Tests:** Introduce additional tests to cover edge cases and ensure that the parsing logic is robust and reliable.

### Rationale:

The goal is to find a more elegant and sustainable solution to the parsing issue without fundamentally changing how all mappers iterate values. This approach aligns with the feedback received and aims to improve the overall reliability of the `DenseVectorFieldMapper`.

### Next Steps:

- Review the proposed investigation and validation updates.
- Discuss potential impacts and further improvements.
- Implement the agreed-upon changes and validate through comprehensive testing.