### PR TITLE
improve AbstractHash performance

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/AbstractHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractHash.java
@@ -12,52 +12,53 @@ package org.elasticsearch.common.util;
 import org.elasticsearch.core.Releasables;
 
 /**
- * Base implementation for {@link BytesRefHash} and {@link LongHash}, or any class that
- * needs to map values to dense ords. This class is not thread-safe.
+ * Base implementation for {@link BytesRefHash},{@link LongHash}, {@link LongLongHash} and {@link Int3Hash}
+ * or any class that needs to map values to dense ords. This class is not thread-safe.
  */
-// IDs are internally stored as id + 1 so that 0 encodes for an empty slot
 abstract class AbstractHash extends AbstractPagedHashMap {
 
     LongArray ids;
 
     AbstractHash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);
-        ids = bigArrays.newLongArray(capacity(), true);
+        ids = bigArrays.newLongArray(capacity(), false);
+        ids.fill(0L, capacity(), -1L);
     }
 
     /**
      * Get the id associated with key at <code>0 &lt;= index &lt;= capacity()</code> or -1 if this slot is unused.
      */
-    public long id(long index) {
-        return ids.get(index) - 1;
+    public final long id(long index) {
+        return ids.get(index);
     }
 
     /**
      * Set the id provided key at <code>0 &lt;= index &lt;= capacity()</code> .
      */
     protected final void setId(long index, long id) {
-        ids.set(index, id + 1);
-    }
-
-    /**
-     * Set the id provided key at <code>0 &lt;= index &lt;= capacity()</code>  and get the previous value or -1 if this slot is unused.
-     */
-    protected final long getAndSetId(long index, long id) {
-        return ids.getAndSet(index, id + 1) - 1;
-    }
-
-    @Override
-    protected void resize(long capacity) {
-        ids = bigArrays.resize(ids, capacity);
-    }
-
-    @Override
-    protected boolean used(long bucket) {
-        return id(bucket) >= 0;
+        ids.set(index, id);
     }
 
     @Override
     public void close() {
         Releasables.close(ids);
     }
+
+    @Override
+    protected final void rehash(long buckets, long newBuckets) {
+        // grow and reset all ids to -1
+        ids = bigArrays.resize(ids, newBuckets);
+        ids.fill(0L, newBuckets, -1L);
+        // rehash all elements
+        final long size = size();
+        for (long i = 0; i < size; ++i) {
+            rehash(i);
+        }
+    }
+
+    /**
+     * rehash the id.
+     */
+    protected abstract void rehash(long id);
+
 }

--- a/server/src/main/java/org/elasticsearch/common/util/AbstractObjectHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractObjectHash.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.util;
+
+/**
+ * Base implementation for {@link LongObjectPagedHashMap} and {@link ObjectObjectPagedHashMap}.
+ */
+public abstract class AbstractObjectHash extends AbstractPagedHashMap {
+
+    AbstractObjectHash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
+        super(capacity, maxLoadFactor, bigArrays);
+    }
+
+    /** Is the current buckets used */
+    protected abstract boolean used(long bucket);
+
+    /** Remove the entry at the given index and add it back */
+    protected abstract void removeAndAdd(long index);
+
+    /** Resize to the given capacity. */
+    protected abstract void resize(long capacity);
+
+    @Override
+    protected final void rehash(long buckets, long newBuckets) {
+        // Resize arrays
+        resize(newBuckets);
+        for (long i = 0; i < buckets; ++i) {
+            if (used(i)) {
+                removeAndAdd(i);
+            }
+        }
+        // The only entries which have not been put in their final position in the previous loop are those that were stored in a slot that
+        // is < slot(key, mask). This only happens when slot(key, mask) returned a slot that was close to the end of the array and collision
+        // resolution has put it back in the first slots. This time, collision resolution will have put them at the beginning of the newly
+        // allocated slots. Let's re-add them to make sure they are in the right slot. This 2nd loop will typically exit very early.
+        for (long i = buckets; i < newBuckets; ++i) {
+            if (used(i)) {
+                removeAndAdd(i); // add it back
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/util/AbstractObjectHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractObjectHash.java
@@ -12,7 +12,7 @@ package org.elasticsearch.common.util;
 /**
  * Base implementation for {@link LongObjectPagedHashMap} and {@link ObjectObjectPagedHashMap}.
  */
-public abstract class AbstractObjectHash extends AbstractPagedHashMap {
+abstract class AbstractObjectHash extends AbstractPagedHashMap {
 
     AbstractObjectHash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -222,9 +222,7 @@ public final class BytesRefHash extends AbstractHash implements Accountable {
     }
 
     @Override
-    protected void removeAndAdd(long index) {
-        final long id = getAndSetId(index, -1);
-        assert id >= 0;
+    protected void rehash(long id) {
         final int code = hashes.get(id);
         reset(code, id);
     }

--- a/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
@@ -99,7 +99,8 @@ public final class Int3Hash extends AbstractHash {
         keys.set(keyOffset + 2, key3);
     }
 
-    private void reset(long id) {
+    @Override
+    protected void rehash(long id) {
         final IntArray keys = this.keys;
         final long keyOffset = id * 3;
         final int key1 = keys.get(keyOffset);
@@ -127,13 +128,6 @@ public final class Int3Hash extends AbstractHash {
         }
         assert size < maxSize;
         return set(key1, key2, key3, size);
-    }
-
-    @Override
-    protected void removeAndAdd(long index) {
-        final long id = getAndSetId(index, -1);
-        assert id >= 0;
-        reset(id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/LongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongHash.java
@@ -82,7 +82,8 @@ public final class LongHash extends AbstractHash {
         keys.set(id, key);
     }
 
-    private void reset(long id) {
+    @Override
+    protected void rehash(long id) {
         final long key = keys.get(id);
         final long slot = slot(hash(key), mask);
         for (long index = slot;; index = nextSlot(index, mask)) {
@@ -105,13 +106,6 @@ public final class LongHash extends AbstractHash {
         }
         assert size < maxSize;
         return set(key, size);
-    }
-
-    @Override
-    protected void removeAndAdd(long index) {
-        final long id = getAndSetId(index, -1);
-        assert id >= 0;
-        reset(id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -104,7 +104,8 @@ public final class LongLongHash extends AbstractHash {
         keys.set(keyOffset + 1, key2);
     }
 
-    private void reset(long id) {
+    @Override
+    protected void rehash(long id) {
         final LongArray keys = this.keys;
         final long keyOffset = id * 2;
         final long key1 = keys.get(keyOffset);
@@ -131,13 +132,6 @@ public final class LongLongHash extends AbstractHash {
         }
         assert size < maxSize;
         return set(key1, key2, size);
-    }
-
-    @Override
-    protected void removeAndAdd(long index) {
-        final long id = getAndSetId(index, -1);
-        assert id >= 0;
-        reset(id);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -18,7 +18,7 @@ import java.util.NoSuchElementException;
  * A hash table from native longs to objects. This implementation resolves collisions
  * using open-addressing and does not support null values. This class is not thread-safe.
  */
-public final class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements Iterable<LongObjectPagedHashMap.Cursor<T>> {
+public final class LongObjectPagedHashMap<T> extends AbstractObjectHash implements Iterable<LongObjectPagedHashMap.Cursor<T>> {
 
     private LongArray keys;
     private ObjectArray<T> values;

--- a/server/src/main/java/org/elasticsearch/common/util/ObjectObjectPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ObjectObjectPagedHashMap.java
@@ -22,7 +22,7 @@ import java.util.NoSuchElementException;
  *  Note that this class does not track either the actual keys or values. It is responsibility of
  *  the caller to release those objects if necessary.
  */
-public final class ObjectObjectPagedHashMap<K, V> extends AbstractPagedHashMap implements Iterable<ObjectObjectPagedHashMap.Cursor<K, V>> {
+public final class ObjectObjectPagedHashMap<K, V> extends AbstractObjectHash implements Iterable<ObjectObjectPagedHashMap.Cursor<K, V>> {
 
     private ObjectArray<K> keys;
     private ObjectArray<V> values;


### PR DESCRIPTION
The recent changes in removeAndAdd has shown we can do much better in AbstractHash when rehasing. We are just replaying all the hashes so it will be much efficient to delete the ids in one go and play back the hashes than what we are doing now that we delete hashes one by one.

To do that we introduce an `AbstractObjectHash` that keeps the current rehasing logic for Object like implementations.  For abstract hash we are now deleting all hashes from id using the more efficinet method `LongArray#fill` and then replaying the hashes. This allow as well to properly encode -1 in the ids and remove the need to add/subtract 1 when getting/setting ids.

Microbenchmarks shows a better write performance of about 10%.