### PR TITLE
ESQL: Improve error message in test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -345,9 +345,6 @@ tests:
 - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
   method: test {yaml=cluster.stats/30_ccs_stats/cross-cluster search stats search}
   issue: https://github.com/elastic/elasticsearch/issues/114371
-- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
-  method: testProfileOrdinalsGroupingOperator {SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/114380
 - class: org.elasticsearch.xpack.inference.services.cohere.CohereServiceTests
   method: testInfer_StreamRequest
   issue: https://github.com/elastic/elasticsearch/issues/114385

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
@@ -331,14 +332,13 @@ public class RestEsqlIT extends RestEsqlTestCase {
     }
 
     public void testProfileOrdinalsGroupingOperator() throws IOException {
+        assumeTrue("requires pragmas", Build.current().isSnapshot());
         indexTimestampData(1);
 
         RequestObjectBuilder builder = requestObjectBuilder().query(fromIndex() + " | STATS AVG(value) BY test.keyword");
         builder.profile(true);
-        if (Build.current().isSnapshot()) {
-            // Lock to shard level partitioning, so we get consistent profile output
-            builder.pragmas(Settings.builder().put("data_partitioning", "shard").build());
-        }
+        // Lock to shard level partitioning, so we get consistent profile output
+        builder.pragmas(Settings.builder().put("data_partitioning", "shard").build());
         Map<String, Object> result = runEsql(builder);
 
         List<List<String>> signatures = new ArrayList<>();
@@ -356,7 +356,7 @@ public class RestEsqlIT extends RestEsqlTestCase {
             signatures.add(sig);
         }
 
-        assertThat(signatures.get(0).get(2), equalTo("OrdinalsGroupingOperator[aggregators=[\"sum of longs\", \"count\"]]"));
+        assertThat(signatures, hasItem(hasItem("OrdinalsGroupingOperator[aggregators=[\"sum of longs\", \"count\"]]")));
     }
 
     public void testInlineStatsProfile() throws IOException {


### PR DESCRIPTION
Improve an error message in the test for `profile`ing the ordinals-based grouping operator. It's failed in the past with a rather cryptic error message. This will either keep it passing fully or give us a better error message when it does fail.

Closes #114380
