### PR TITLE
Verify Maxmind database types in the geoip processor

### DIFF
--- a/docs/changelog/114527.yaml
+++ b/docs/changelog/114527.yaml
@@ -1,0 +1,5 @@
+pr: 114527
+summary: Verify Maxmind database types in the geoip processor
+area: Ingest Node
+type: enhancement
+issues: []

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.ingest.geoip.GeoIpProcessor.GEOIP_TYPE;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDatabase;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDefaultDatabases;
 import static org.hamcrest.Matchers.equalTo;
@@ -66,7 +67,7 @@ public class ReloadingDatabasesWhilePerformingGeoLookupsIT extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
         DatabaseNodeService databaseNodeService = createRegistry(geoIpConfigDir, geoIpTmpDir, clusterService);
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         copyDatabase("GeoLite2-City-Test.mmdb", geoIpTmpDir.resolve("GeoLite2-City.mmdb"));
         copyDatabase("GeoLite2-City-Test.mmdb", geoIpTmpDir.resolve("GeoLite2-City-Test.mmdb"));
         databaseNodeService.updateDatabase("GeoLite2-City.mmdb", "md5", geoIpTmpDir.resolve("GeoLite2-City.mmdb"));

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -296,8 +296,8 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
             return false;
         }
 
-        if (processor.containsKey(GeoIpProcessor.TYPE)) {
-            Map<String, Object> processorConfig = (Map<String, Object>) processor.get(GeoIpProcessor.TYPE);
+        if (processor.containsKey(GeoIpProcessor.GEOIP_TYPE)) {
+            Map<String, Object> processorConfig = (Map<String, Object>) processor.get(GeoIpProcessor.GEOIP_TYPE);
             return downloadDatabaseOnPipelineCreation(processorConfig) == downloadDatabaseOnPipelineCreation;
         }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.ingest.geoip.GeoIpDownloader.DATABASES_INDEX;
 import static org.elasticsearch.ingest.geoip.GeoIpDownloader.GEOIP_DOWNLOADER;
 import static org.elasticsearch.ingest.geoip.GeoIpProcessor.Factory.downloadDatabaseOnPipelineCreation;
+import static org.elasticsearch.ingest.geoip.GeoIpProcessor.GEOIP_TYPE;
 
 /**
  * Persistent task executor that is responsible for starting {@link GeoIpDownloader} after task is allocated by master node.
@@ -296,9 +297,9 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
             return false;
         }
 
-        if (processor.containsKey(GeoIpProcessor.GEOIP_TYPE)) {
-            Map<String, Object> processorConfig = (Map<String, Object>) processor.get(GeoIpProcessor.GEOIP_TYPE);
-            return downloadDatabaseOnPipelineCreation(processorConfig) == downloadDatabaseOnPipelineCreation;
+        if (processor.containsKey(GEOIP_TYPE)) {
+            Map<String, Object> processorConfig = (Map<String, Object>) processor.get(GEOIP_TYPE);
+            return downloadDatabaseOnPipelineCreation(GEOIP_TYPE, processorConfig, null) == downloadDatabaseOnPipelineCreation;
         }
 
         return isProcessorWithOnFailureGeoIpProcessor(processor, downloadDatabaseOnPipelineCreation)

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -297,8 +297,8 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
             return false;
         }
 
-        if (processor.containsKey(GEOIP_TYPE)) {
-            Map<String, Object> processorConfig = (Map<String, Object>) processor.get(GEOIP_TYPE);
+        final Map<String, Object> processorConfig = (Map<String, Object>) processor.get(GEOIP_TYPE);
+        if (processorConfig != null) {
             return downloadDatabaseOnPipelineCreation(GEOIP_TYPE, processorConfig, null) == downloadDatabaseOnPipelineCreation;
         }
 
@@ -337,11 +337,9 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
      */
     @SuppressWarnings("unchecked")
     private static boolean isForeachProcessorWithGeoipProcessor(Map<String, Object> processor, boolean downloadDatabaseOnPipelineCreation) {
-        return processor.containsKey("foreach")
-            && hasAtLeastOneGeoipProcessor(
-                ((Map<String, Map<String, Object>>) processor.get("foreach")).get("processor"),
-                downloadDatabaseOnPipelineCreation
-            );
+        final Map<String, Object> processorConfig = (Map<String, Object>) processor.get("foreach");
+        return processorConfig != null
+            && hasAtLeastOneGeoipProcessor((Map<String, Object>) processorConfig.get("processor"), downloadDatabaseOnPipelineCreation);
     }
 
     private void startTask(Runnable onFailure) {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -233,7 +233,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
             // Validating the download_database_on_pipeline_creation even if the result
             // is not used directly by the factory.
-            downloadDatabaseOnPipelineCreation(config, processorTag);
+            downloadDatabaseOnPipelineCreation(type, config, processorTag);
 
             // noop, should be removed in 9.0
             Object value = config.remove("fallback_to_default_databases");
@@ -312,13 +312,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
             );
         }
 
-        public static boolean downloadDatabaseOnPipelineCreation(Map<String, Object> config) {
-            return downloadDatabaseOnPipelineCreation(config, null);
-        }
-
-        public static boolean downloadDatabaseOnPipelineCreation(Map<String, Object> config, String processorTag) {
-            // note: we're relying on the "geoip" TYPE here, ideally that would be abstracted away
-            return readBooleanProperty(GEOIP_TYPE, processorTag, config, "download_database_on_pipeline_creation", true);
+        public static boolean downloadDatabaseOnPipelineCreation(String type, Map<String, Object> config, String processorTag) {
+            return readBooleanProperty(type, processorTag, config, "download_database_on_pipeline_creation", true);
         }
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -37,7 +37,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
     static final String DEFAULT_DATABASES_DEPRECATION_MESSAGE = "the [fallback_to_default_databases] has been deprecated, because "
         + "Elasticsearch no longer includes the default Maxmind geoip databases. This setting will be removed in Elasticsearch 9.0";
 
-    public static final String TYPE = "geoip";
+    public static final String GEOIP_TYPE = "geoip";
 
     private final String field;
     private final Supplier<Boolean> isValid;
@@ -146,7 +146,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     @Override
     public String getType() {
-        return TYPE;
+        return GEOIP_TYPE;
     }
 
     String getField() {
@@ -215,12 +215,12 @@ public final class GeoIpProcessor extends AbstractProcessor {
             final String description,
             final Map<String, Object> config
         ) throws IOException {
-            String ipField = readStringProperty(TYPE, processorTag, config, "field");
-            String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "geoip");
-            String databaseFile = readStringProperty(TYPE, processorTag, config, "database_file", "GeoLite2-City.mmdb");
-            List<String> propertyNames = readOptionalList(TYPE, processorTag, config, "properties");
-            boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
-            boolean firstOnly = readBooleanProperty(TYPE, processorTag, config, "first_only", true);
+            String ipField = readStringProperty(GEOIP_TYPE, processorTag, config, "field");
+            String targetField = readStringProperty(GEOIP_TYPE, processorTag, config, "target_field", "geoip");
+            String databaseFile = readStringProperty(GEOIP_TYPE, processorTag, config, "database_file", "GeoLite2-City.mmdb");
+            List<String> propertyNames = readOptionalList(GEOIP_TYPE, processorTag, config, "properties");
+            boolean ignoreMissing = readBooleanProperty(GEOIP_TYPE, processorTag, config, "ignore_missing", false);
+            boolean firstOnly = readBooleanProperty(GEOIP_TYPE, processorTag, config, "first_only", true);
 
             // Validating the download_database_on_pipeline_creation even if the result
             // is not used directly by the factory.
@@ -248,14 +248,14 @@ public final class GeoIpProcessor extends AbstractProcessor {
             try {
                 factory = IpDataLookupFactories.get(databaseType, databaseFile);
             } catch (IllegalArgumentException e) {
-                throw newConfigurationException(TYPE, processorTag, "database_file", e.getMessage());
+                throw newConfigurationException(GEOIP_TYPE, processorTag, "database_file", e.getMessage());
             }
 
             final IpDataLookup ipDataLookup;
             try {
                 ipDataLookup = factory.create(propertyNames);
             } catch (IllegalArgumentException e) {
-                throw newConfigurationException(TYPE, processorTag, "properties", e.getMessage());
+                throw newConfigurationException(GEOIP_TYPE, processorTag, "properties", e.getMessage());
             }
 
             return new GeoIpProcessor(
@@ -277,7 +277,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         }
 
         public static boolean downloadDatabaseOnPipelineCreation(Map<String, Object> config, String processorTag) {
-            return readBooleanProperty(TYPE, processorTag, config, "download_database_on_pipeline_creation", true);
+            // note: we're relying on the "geoip" TYPE here, ideally that would be abstracted away
+            return readBooleanProperty(GEOIP_TYPE, processorTag, config, "download_database_on_pipeline_creation", true);
         }
     }
 
@@ -298,7 +299,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
         @Override
         public String getType() {
-            return TYPE;
+            return GEOIP_TYPE;
         }
 
         public String getDatabaseName() {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -202,9 +202,11 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     public static final class Factory implements Processor.Factory {
 
+        private final String type; // currently always just "geoip"
         private final IpDatabaseProvider ipDatabaseProvider;
 
-        public Factory(IpDatabaseProvider ipDatabaseProvider) {
+        public Factory(String type, IpDatabaseProvider ipDatabaseProvider) {
+            this.type = type;
             this.ipDatabaseProvider = ipDatabaseProvider;
         }
 
@@ -215,12 +217,12 @@ public final class GeoIpProcessor extends AbstractProcessor {
             final String description,
             final Map<String, Object> config
         ) throws IOException {
-            String ipField = readStringProperty(GEOIP_TYPE, processorTag, config, "field");
-            String targetField = readStringProperty(GEOIP_TYPE, processorTag, config, "target_field", "geoip");
-            String databaseFile = readStringProperty(GEOIP_TYPE, processorTag, config, "database_file", "GeoLite2-City.mmdb");
-            List<String> propertyNames = readOptionalList(GEOIP_TYPE, processorTag, config, "properties");
-            boolean ignoreMissing = readBooleanProperty(GEOIP_TYPE, processorTag, config, "ignore_missing", false);
-            boolean firstOnly = readBooleanProperty(GEOIP_TYPE, processorTag, config, "first_only", true);
+            String ipField = readStringProperty(type, processorTag, config, "field");
+            String targetField = readStringProperty(type, processorTag, config, "target_field", "geoip");
+            String databaseFile = readStringProperty(type, processorTag, config, "database_file", "GeoLite2-City.mmdb");
+            List<String> propertyNames = readOptionalList(type, processorTag, config, "properties");
+            boolean ignoreMissing = readBooleanProperty(type, processorTag, config, "ignore_missing", false);
+            boolean firstOnly = readBooleanProperty(type, processorTag, config, "first_only", true);
 
             // Validating the download_database_on_pipeline_creation even if the result
             // is not used directly by the factory.
@@ -248,14 +250,14 @@ public final class GeoIpProcessor extends AbstractProcessor {
             try {
                 factory = IpDataLookupFactories.get(databaseType, databaseFile);
             } catch (IllegalArgumentException e) {
-                throw newConfigurationException(GEOIP_TYPE, processorTag, "database_file", e.getMessage());
+                throw newConfigurationException(type, processorTag, "database_file", e.getMessage());
             }
 
             final IpDataLookup ipDataLookup;
             try {
                 ipDataLookup = factory.create(propertyNames);
             } catch (IllegalArgumentException e) {
-                throw newConfigurationException(GEOIP_TYPE, processorTag, "properties", e.getMessage());
+                throw newConfigurationException(type, processorTag, "properties", e.getMessage());
             }
 
             return new GeoIpProcessor(

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -277,9 +277,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
         }
 
         public static boolean downloadDatabaseOnPipelineCreation(Map<String, Object> config, String processorTag) {
-            return readBooleanProperty(GeoIpProcessor.TYPE, processorTag, config, "download_database_on_pipeline_creation", true);
+            return readBooleanProperty(TYPE, processorTag, config, "download_database_on_pipeline_creation", true);
         }
-
     }
 
     static class DatabaseUnavailableProcessor extends AbstractProcessor {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -129,7 +129,7 @@ public class IngestGeoIpPlugin extends Plugin
             parameters.ingestService.getClusterService()
         );
         databaseRegistry.set(registry);
-        return Map.of(GeoIpProcessor.TYPE, new GeoIpProcessor.Factory(registry));
+        return Map.of(GeoIpProcessor.GEOIP_TYPE, new GeoIpProcessor.Factory(registry));
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -129,7 +129,7 @@ public class IngestGeoIpPlugin extends Plugin
             parameters.ingestService.getClusterService()
         );
         databaseRegistry.set(registry);
-        return Map.of(GeoIpProcessor.GEOIP_TYPE, new GeoIpProcessor.Factory(registry));
+        return Map.of(GeoIpProcessor.GEOIP_TYPE, new GeoIpProcessor.Factory(GeoIpProcessor.GEOIP_TYPE, registry));
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpinfoIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IpinfoIpDataLookups.java
@@ -39,6 +39,10 @@ final class IpinfoIpDataLookups {
 
     private static final Logger logger = LogManager.getLogger(IpinfoIpDataLookups.class);
 
+    // the actual prefix from the metadata is cased like the literal string, and
+    // prefix dispatch and checks case-insensitive, so that works out nicely
+    static final String IPINFO_PREFIX = "ipinfo";
+
     /**
      * Lax-ly parses a string that (ideally) looks like 'AS123' into a Long like 123L (or null, if such parsing isn't possible).
      * @param asn a potentially empty (or null) ASN string that is expected to contain 'AS' and then a parsable long

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,6 +46,11 @@ final class MaxmindIpDataLookups {
     private MaxmindIpDataLookups() {
         // utility class
     }
+
+    // the actual prefixes from the metadata are cased like the literal strings, but
+    // prefix dispatch and checks case-insensitive, so the actual constants are lowercase
+    static final String GEOIP2_PREFIX = "GeoIP2".toLowerCase(Locale.ROOT);
+    static final String GEOLITE2_PREFIX = "GeoLite2".toLowerCase(Locale.ROOT);
 
     static class AnonymousIp extends AbstractBase<AnonymousIpResponse> {
         AnonymousIp(final Set<Database.Property> properties) {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -43,6 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.ingest.geoip.GeoIpProcessor.GEOIP_TYPE;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.DEFAULT_DATABASES;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDatabase;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDefaultDatabases;
@@ -88,7 +89,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildDefaults() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -104,7 +105,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testSetIgnoreMissing() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -121,7 +122,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testCountryBuildDefaults() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -139,7 +140,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testAsnBuildDefaults() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -157,7 +158,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildTargetField() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("target_field", "_field");
@@ -168,7 +169,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildDbFile() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-Country.mmdb");
@@ -181,7 +182,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildWithCountryDbAndAsnFields() {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-Country.mmdb");
@@ -201,7 +202,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildWithAsnDbAndCityFields() {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-ASN.mmdb");
@@ -219,7 +220,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     public void testBuildNonExistingDbFile() throws Exception {
         copyDatabase("GeoLite2-City-Test.mmdb", geoipTmpDir.resolve("GeoLite2-City.mmdb"));
         databaseNodeService.updateDatabase("GeoLite2-City.mmdb", "md5", geoipTmpDir.resolve("GeoLite2-City.mmdb"));
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -229,7 +230,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildBuiltinDatabaseMissing() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         cleanDatabases(geoIpConfigDir, configDatabases);
 
         Map<String, Object> config = new HashMap<>();
@@ -240,7 +241,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildFields() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Set<Property> properties = new HashSet<>();
         List<String> fieldNames = new ArrayList<>();
@@ -264,7 +265,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildIllegalFieldOption() {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config1 = new HashMap<>();
         config1.put("field", "_field");
@@ -293,7 +294,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         IpDatabaseProvider provider = mock(IpDatabaseProvider.class);
         when(provider.getDatabase(anyString())).thenReturn(database);
 
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(provider);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, provider);
 
         Map<String, Object> config1 = new HashMap<>();
         config1.put("field", "_field");
@@ -312,7 +313,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         IpDatabaseProvider provider = mock(IpDatabaseProvider.class);
         when(provider.getDatabase(anyString())).thenReturn(database);
 
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(provider);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, provider);
 
         Map<String, Object> config1 = new HashMap<>();
         config1.put("field", "_field");
@@ -341,7 +342,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             Runnable::run,
             clusterService
         );
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         for (DatabaseReaderLazyLoader lazyLoader : configDatabases.getConfigDatabases().values()) {
             assertNull(lazyLoader.databaseReader.get());
         }
@@ -410,7 +411,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             clusterService
         );
         databaseNodeService.initialize("nodeId", resourceWatcherService, mock(IngestService.class));
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         for (DatabaseReaderLazyLoader lazyLoader : configDatabases.getConfigDatabases().values()) {
             assertNull(lazyLoader.databaseReader.get());
         }
@@ -433,7 +434,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testFallbackUsingDefaultDatabases() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "source_field");
         config.put("fallback_to_default_databases", randomBoolean());
@@ -442,7 +443,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testDownloadDatabaseOnPipelineCreation() throws IOException {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", randomIdentifier());
         config.put("download_database_on_pipeline_creation", randomBoolean());
@@ -460,7 +461,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             .metadata(Metadata.builder().putCustom(PersistentTasksCustomMetadata.TYPE, tasks))
             .build();
         when(clusterService.state()).thenReturn(clusterState);
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -472,7 +473,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testUpdateDatabaseWhileIngesting() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "source_field");
         GeoIpProcessor processor = (GeoIpProcessor) factory.create(null, null, null, config);
@@ -511,7 +512,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testDatabaseNotReadyYet() throws Exception {
-        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, databaseNodeService);
         cleanDatabases(geoIpConfigDir, configDatabases);
 
         {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -344,6 +344,22 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         );
     }
 
+    public void testLaxMaxmindSupport() throws Exception {
+        IpDatabase database = mock(IpDatabase.class);
+        when(database.getDatabaseType()).thenReturn("some_custom_database.mmdb-City");
+        IpDatabaseProvider provider = mock(IpDatabaseProvider.class);
+        when(provider.getDatabase(anyString())).thenReturn(database);
+
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(GEOIP_TYPE, provider);
+
+        Map<String, Object> config1 = new HashMap<>();
+        config1.put("database_file", "some-custom-database.mmdb");
+        config1.put("field", "_field");
+        config1.put("properties", List.of("ip"));
+        factory.create(null, null, null, config1);
+        assertWarnings(GeoIpProcessor.UNSUPPORTED_DATABASE_DEPRECATION_MESSAGE.replaceAll("\\{}", "some_custom_database.mmdb-City"));
+    }
+
     public void testLazyLoading() throws Exception {
         final Path configDir = createTempDir();
         final Path geoIpConfigDir = configDir.resolve("ingest-geoip");

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocument;
+import static org.elasticsearch.ingest.geoip.GeoIpProcessor.GEOIP_TYPE;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDatabase;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -85,6 +86,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testCity() throws Exception {
         String ip = "8.8.8.8";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -119,6 +121,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNullValueWithIgnoreMissing() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -141,6 +144,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNonExistentWithIgnoreMissing() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -160,6 +164,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNullWithoutIgnoreMissing() {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -182,6 +187,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNonExistentWithoutIgnoreMissing() {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -202,6 +208,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testCity_withIpV6() throws Exception {
         String ip = "2602:306:33d3:8000::3257:9652";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -242,6 +249,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testCityWithMissingLocation() throws Exception {
         String ip = "80.231.5.0";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -270,6 +278,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testCountry() throws Exception {
         String ip = "82.170.213.79";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -303,6 +312,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testCountryWithMissingLocation() throws Exception {
         String ip = "80.231.5.0";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -331,6 +341,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testAsn() throws Exception {
         String ip = "82.171.64.0";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -362,6 +373,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testAnonymmousIp() throws Exception {
         String ip = "81.2.69.1";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -396,6 +408,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testConnectionType() throws Exception {
         String ip = "214.78.120.5";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -425,6 +438,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testDomain() throws Exception {
         String ip = "69.219.64.2";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -454,6 +468,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testEnterprise() throws Exception {
         String ip = "74.209.24.4";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -511,6 +526,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testIsp() throws Exception {
         String ip = "149.101.100.1";
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -545,6 +561,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testAddressIsNotInTheDatabase() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -569,6 +586,7 @@ public class GeoIpProcessorTests extends ESTestCase {
      */
     public void testInvalid() {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -590,6 +608,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testListAllValid() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -617,6 +636,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testListPartiallyValid() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -644,6 +664,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testListNoMatches() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -667,7 +688,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     public void testListDatabaseReferenceCounting() throws Exception {
         AtomicBoolean closeCheck = new AtomicBoolean(false);
         var loader = loader("GeoLite2-City.mmdb", closeCheck);
-        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", () -> {
+        GeoIpProcessor processor = new GeoIpProcessor(GEOIP_TYPE, randomAlphaOfLength(10), null, "source_field", () -> {
             loader.preLookup();
             return loader;
         }, () -> true, "target_field", ipDataLookupAll(Database.City), false, false, "filename");
@@ -692,6 +713,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testListFirstOnly() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -717,6 +739,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testListFirstOnlyNoMatches() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -739,6 +762,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testInvalidDatabase() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -762,6 +786,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNoDatabase() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",
@@ -785,6 +810,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNoDatabase_ignoreMissing() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
             randomAlphaOfLength(10),
             null,
             "source_field",


### PR DESCRIPTION
The `geoip` processor has always expected to work with database files from Maxmind. This PR adds active checking of that -- if you configure a `geoip` processor to work with a file from a known-different-provider, then we'll reject the configuration at pipeline/processor creation time.

This is somewhat lax, however, so it should not break any existing configurations that are currently working (such configurations will get a deprecation message, but not a failure).