### PR TITLE
[8.x] Adding support for registered country fields for maxmind geoip databases (#114521)

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -43,7 +43,10 @@ enum Database {
             Property.TIMEZONE,
             Property.LOCATION,
             Property.POSTAL_CODE,
-            Property.ACCURACY_RADIUS
+            Property.ACCURACY_RADIUS,
+            Property.REGISTERED_COUNTRY_IN_EUROPEAN_UNION,
+            Property.REGISTERED_COUNTRY_ISO_CODE,
+            Property.REGISTERED_COUNTRY_NAME
         ),
         Set.of(
             Property.COUNTRY_ISO_CODE,
@@ -62,7 +65,10 @@ enum Database {
             Property.CONTINENT_NAME,
             Property.COUNTRY_NAME,
             Property.COUNTRY_IN_EUROPEAN_UNION,
-            Property.COUNTRY_ISO_CODE
+            Property.COUNTRY_ISO_CODE,
+            Property.REGISTERED_COUNTRY_IN_EUROPEAN_UNION,
+            Property.REGISTERED_COUNTRY_ISO_CODE,
+            Property.REGISTERED_COUNTRY_NAME
         ),
         Set.of(Property.CONTINENT_NAME, Property.COUNTRY_NAME, Property.COUNTRY_ISO_CODE)
     ),
@@ -124,7 +130,10 @@ enum Database {
             Property.CONNECTION_TYPE,
             Property.POSTAL_CODE,
             Property.POSTAL_CONFIDENCE,
-            Property.ACCURACY_RADIUS
+            Property.ACCURACY_RADIUS,
+            Property.REGISTERED_COUNTRY_IN_EUROPEAN_UNION,
+            Property.REGISTERED_COUNTRY_ISO_CODE,
+            Property.REGISTERED_COUNTRY_NAME
         ),
         Set.of(
             Property.COUNTRY_ISO_CODE,
@@ -181,6 +190,10 @@ enum Database {
             Property.POSTAL_CODE
         ),
         Set.of(Property.COUNTRY_ISO_CODE, Property.REGION_NAME, Property.CITY_NAME, Property.LOCATION)
+    ),
+    CountryV2(
+        Set.of(Property.IP, Property.CONTINENT_CODE, Property.CONTINENT_NAME, Property.COUNTRY_NAME, Property.COUNTRY_ISO_CODE),
+        Set.of(Property.CONTINENT_NAME, Property.COUNTRY_NAME, Property.COUNTRY_ISO_CODE)
     ),
     PrivacyDetection(
         Set.of(Property.IP, Property.HOSTING, Property.PROXY, Property.RELAY, Property.TOR, Property.VPN, Property.SERVICE),
@@ -272,7 +285,10 @@ enum Database {
         PROXY,
         RELAY,
         VPN,
-        SERVICE;
+        SERVICE,
+        REGISTERED_COUNTRY_IN_EUROPEAN_UNION,
+        REGISTERED_COUNTRY_ISO_CODE,
+        REGISTERED_COUNTRY_NAME;
 
         /**
          * Parses a string representation of a property into an actual Property instance. Not all properties that exist are

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/MaxmindIpDataLookups.java
@@ -142,6 +142,7 @@ final class MaxmindIpDataLookups {
         @Override
         protected Map<String, Object> transform(final CityResponse response) {
             com.maxmind.geoip2.record.Country country = response.getCountry();
+            com.maxmind.geoip2.record.Country registeredCountry = response.getRegisteredCountry();
             com.maxmind.geoip2.record.City city = response.getCity();
             Location location = response.getLocation();
             Continent continent = response.getContinent();
@@ -231,6 +232,22 @@ final class MaxmindIpDataLookups {
                             data.put("postal_code", postal.getCode());
                         }
                     }
+                    case REGISTERED_COUNTRY_IN_EUROPEAN_UNION -> {
+                        if (registeredCountry.getIsoCode() != null) {
+                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
+                            data.put("registered_country_in_european_union", registeredCountry.isInEuropeanUnion());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_ISO_CODE -> {
+                        if (registeredCountry.getIsoCode() != null) {
+                            data.put("registered_country_iso_code", registeredCountry.getIsoCode());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_NAME -> {
+                        if (registeredCountry.getName() != null) {
+                            data.put("registered_country_name", registeredCountry.getName());
+                        }
+                    }
                 }
             }
             return data;
@@ -273,6 +290,7 @@ final class MaxmindIpDataLookups {
         @Override
         protected Map<String, Object> transform(final CountryResponse response) {
             com.maxmind.geoip2.record.Country country = response.getCountry();
+            com.maxmind.geoip2.record.Country registeredCountry = response.getRegisteredCountry();
             Continent continent = response.getContinent();
 
             Map<String, Object> data = new HashMap<>();
@@ -307,6 +325,22 @@ final class MaxmindIpDataLookups {
                         String continentName = continent.getName();
                         if (continentName != null) {
                             data.put("continent_name", continentName);
+                        }
+                    }
+                    case REGISTERED_COUNTRY_IN_EUROPEAN_UNION -> {
+                        if (registeredCountry.getIsoCode() != null) {
+                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
+                            data.put("registered_country_in_european_union", registeredCountry.isInEuropeanUnion());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_ISO_CODE -> {
+                        if (registeredCountry.getIsoCode() != null) {
+                            data.put("registered_country_iso_code", registeredCountry.getIsoCode());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_NAME -> {
+                        if (registeredCountry.getName() != null) {
+                            data.put("registered_country_name", registeredCountry.getName());
                         }
                     }
                 }
@@ -351,6 +385,7 @@ final class MaxmindIpDataLookups {
         @Override
         protected Map<String, Object> transform(final EnterpriseResponse response) {
             com.maxmind.geoip2.record.Country country = response.getCountry();
+            com.maxmind.geoip2.record.Country registeredCountry = response.getRegisteredCountry();
             com.maxmind.geoip2.record.City city = response.getCity();
             Location location = response.getLocation();
             Continent continent = response.getContinent();
@@ -546,6 +581,22 @@ final class MaxmindIpDataLookups {
                     case CONNECTION_TYPE -> {
                         if (connectionType != null) {
                             data.put("connection_type", connectionType.toString());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_IN_EUROPEAN_UNION -> {
+                        if (registeredCountry.getIsoCode() != null) {
+                            // isInEuropeanUnion is a boolean so it can't be null. But it really only makes sense if we have a country
+                            data.put("registered_country_in_european_union", registeredCountry.isInEuropeanUnion());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_ISO_CODE -> {
+                        if (registeredCountry.getIsoCode() != null) {
+                            data.put("registered_country_iso_code", registeredCountry.getIsoCode());
+                        }
+                    }
+                    case REGISTERED_COUNTRY_NAME -> {
+                        if (registeredCountry.getName() != null) {
+                            data.put("registered_country_name", registeredCountry.getName());
                         }
                     }
                 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -196,7 +196,8 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             equalTo(
                 "[properties] illegal property value ["
                     + asnProperty
-                    + "]. valid values are [IP, COUNTRY_IN_EUROPEAN_UNION, COUNTRY_ISO_CODE, COUNTRY_NAME, CONTINENT_CODE, CONTINENT_NAME]"
+                    + "]. valid values are [IP, COUNTRY_IN_EUROPEAN_UNION, COUNTRY_ISO_CODE, COUNTRY_NAME, CONTINENT_CODE, "
+                    + "CONTINENT_NAME, REGISTERED_COUNTRY_IN_EUROPEAN_UNION, REGISTERED_COUNTRY_ISO_CODE, REGISTERED_COUNTRY_NAME]"
             )
         );
     }
@@ -276,7 +277,8 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
             equalTo(
                 "[properties] illegal property value [invalid]. valid values are [IP, COUNTRY_IN_EUROPEAN_UNION, COUNTRY_ISO_CODE, "
                     + "COUNTRY_NAME, CONTINENT_CODE, CONTINENT_NAME, REGION_ISO_CODE, REGION_NAME, CITY_NAME, TIMEZONE, "
-                    + "LOCATION, POSTAL_CODE, ACCURACY_RADIUS]"
+                    + "LOCATION, POSTAL_CODE, ACCURACY_RADIUS, REGISTERED_COUNTRY_IN_EUROPEAN_UNION, REGISTERED_COUNTRY_ISO_CODE, "
+                    + "REGISTERED_COUNTRY_NAME]"
             )
         );
 

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -108,7 +108,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData, notNullValue());
-        assertThat(geoData.size(), equalTo(9));
+        assertThat(geoData.size(), equalTo(12));
         assertThat(geoData.get("ip"), equalTo(ip));
         assertThat(geoData.get("country_in_european_union"), equalTo(false));
         assertThat(geoData.get("country_iso_code"), equalTo("US"));
@@ -117,6 +117,9 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("continent_name"), equalTo("North America"));
         assertThat(geoData.get("timezone"), equalTo("America/Chicago"));
         assertThat(geoData.get("location"), equalTo(Map.of("lat", 37.751d, "lon", -97.822d)));
+        assertThat(geoData.get("registered_country_in_european_union"), equalTo(false));
+        assertThat(geoData.get("registered_country_iso_code"), equalTo("US"));
+        assertThat(geoData.get("registered_country_name"), equalTo("United States"));
     }
 
     public void testNullValueWithIgnoreMissing() throws Exception {
@@ -230,7 +233,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData, notNullValue());
-        assertThat(geoData.size(), equalTo(13));
+        assertThat(geoData.size(), equalTo(16));
         assertThat(geoData.get("ip"), equalTo(ip));
         assertThat(geoData.get("country_in_european_union"), equalTo(false));
         assertThat(geoData.get("country_iso_code"), equalTo("US"));
@@ -244,6 +247,9 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("location"), equalTo(Map.of("lat", 25.4573d, "lon", -80.4572d)));
         assertThat(geoData.get("accuracy_radius"), equalTo(50));
         assertThat(geoData.get("postal_code"), equalTo("33035"));
+        assertThat(geoData.get("registered_country_in_european_union"), equalTo(false));
+        assertThat(geoData.get("registered_country_iso_code"), equalTo("US"));
+        assertThat(geoData.get("registered_country_name"), equalTo("United States"));
     }
 
     public void testCityWithMissingLocation() throws Exception {
@@ -300,13 +306,16 @@ public class GeoIpProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData, notNullValue());
-        assertThat(geoData.size(), equalTo(6));
+        assertThat(geoData.size(), equalTo(9));
         assertThat(geoData.get("ip"), equalTo(ip));
         assertThat(geoData.get("country_in_european_union"), equalTo(true));
         assertThat(geoData.get("country_iso_code"), equalTo("NL"));
         assertThat(geoData.get("country_name"), equalTo("Netherlands"));
         assertThat(geoData.get("continent_code"), equalTo("EU"));
         assertThat(geoData.get("continent_name"), equalTo("Europe"));
+        assertThat(geoData.get("registered_country_in_european_union"), equalTo(true));
+        assertThat(geoData.get("registered_country_iso_code"), equalTo("NL"));
+        assertThat(geoData.get("registered_country_name"), equalTo("Netherlands"));
     }
 
     public void testCountryWithMissingLocation() throws Exception {
@@ -490,7 +499,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> geoData = (Map<String, Object>) ingestDocument.getSourceAndMetadata().get("target_field");
         assertThat(geoData, notNullValue());
-        assertThat(geoData.size(), equalTo(30));
+        assertThat(geoData.size(), equalTo(33));
         assertThat(geoData.get("ip"), equalTo(ip));
         assertThat(geoData.get("country_confidence"), equalTo(99));
         assertThat(geoData.get("country_in_european_union"), equalTo(false));
@@ -521,6 +530,9 @@ public class GeoIpProcessorTests extends ESTestCase {
         assertThat(geoData.get("isp_organization_name"), equalTo("Fairpoint Communications"));
         assertThat(geoData.get("user_type"), equalTo("residential"));
         assertThat(geoData.get("connection_type"), equalTo("Cable/DSL"));
+        assertThat(geoData.get("registered_country_in_european_union"), equalTo(false));
+        assertThat(geoData.get("registered_country_iso_code"), equalTo("US"));
+        assertThat(geoData.get("registered_country_name"), equalTo("United States"));
     }
 
     public void testIsp() throws Exception {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/IpinfoIpDataLookupsTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/IpinfoIpDataLookupsTests.java
@@ -79,6 +79,10 @@ public class IpinfoIpDataLookupsTests extends ESTestCase {
         // the second City variant database is like a version of the ordinary City database but lacking many fields
         assertThat(Sets.difference(Database.CityV2.properties(), Database.City.properties()), is(empty()));
         assertThat(Sets.difference(Database.CityV2.defaultProperties(), Database.City.defaultProperties()), is(empty()));
+
+        // the second Country variant database is like a version of the ordinary Country database but lacking come fields
+        assertThat(Sets.difference(Database.CountryV2.properties(), Database.CountryV2.properties()), is(empty()));
+        assertThat(Database.CountryV2.defaultProperties(), equalTo(Database.Country.defaultProperties()));
     }
 
     public void testParseAsn() {
@@ -219,7 +223,7 @@ public class IpinfoIpDataLookupsTests extends ESTestCase {
 
         // this is the 'free' Country database (sample)
         try (DatabaseReaderLazyLoader loader = configDatabases.getDatabase("ip_country_sample.mmdb")) {
-            IpDataLookup lookup = new IpinfoIpDataLookups.Country(Database.Country.properties());
+            IpDataLookup lookup = new IpinfoIpDataLookups.Country(Database.CountryV2.properties());
             Map<String, Object> data = lookup.getData(loader, "4.221.143.168");
             assertThat(
                 data,

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MaxMindSupportTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/MaxMindSupportTests.java
@@ -87,7 +87,10 @@ public class MaxMindSupportTests extends ESTestCase {
         "location.timeZone",
         "mostSpecificSubdivision.isoCode",
         "mostSpecificSubdivision.name",
-        "postal.code"
+        "postal.code",
+        "registeredCountry.inEuropeanUnion",
+        "registeredCountry.isoCode",
+        "registeredCountry.name"
     );
     private static final Set<String> CITY_UNSUPPORTED_FIELDS = Set.of(
         "city.confidence",
@@ -113,9 +116,6 @@ public class MaxMindSupportTests extends ESTestCase {
         "postal.confidence",
         "registeredCountry.confidence",
         "registeredCountry.geoNameId",
-        "registeredCountry.inEuropeanUnion",
-        "registeredCountry.isoCode",
-        "registeredCountry.name",
         "registeredCountry.names",
         "representedCountry.confidence",
         "representedCountry.geoNameId",
@@ -162,7 +162,10 @@ public class MaxMindSupportTests extends ESTestCase {
         "country.inEuropeanUnion",
         "country.isoCode",
         "continent.code",
-        "country.name"
+        "country.name",
+        "registeredCountry.inEuropeanUnion",
+        "registeredCountry.isoCode",
+        "registeredCountry.name"
     );
     private static final Set<String> COUNTRY_UNSUPPORTED_FIELDS = Set.of(
         "continent.geoNameId",
@@ -173,9 +176,6 @@ public class MaxMindSupportTests extends ESTestCase {
         "maxMind",
         "registeredCountry.confidence",
         "registeredCountry.geoNameId",
-        "registeredCountry.inEuropeanUnion",
-        "registeredCountry.isoCode",
-        "registeredCountry.name",
         "registeredCountry.names",
         "representedCountry.confidence",
         "representedCountry.geoNameId",
@@ -229,6 +229,9 @@ public class MaxMindSupportTests extends ESTestCase {
         "mostSpecificSubdivision.name",
         "postal.code",
         "postal.confidence",
+        "registeredCountry.inEuropeanUnion",
+        "registeredCountry.isoCode",
+        "registeredCountry.name",
         "traits.anonymous",
         "traits.anonymousVpn",
         "traits.autonomousSystemNumber",
@@ -267,9 +270,6 @@ public class MaxMindSupportTests extends ESTestCase {
         "mostSpecificSubdivision.names",
         "registeredCountry.confidence",
         "registeredCountry.geoNameId",
-        "registeredCountry.inEuropeanUnion",
-        "registeredCountry.isoCode",
-        "registeredCountry.name",
         "registeredCountry.names",
         "representedCountry.confidence",
         "representedCountry.geoNameId",
@@ -364,6 +364,7 @@ public class MaxMindSupportTests extends ESTestCase {
     private static final Set<Database> KNOWN_UNSUPPORTED_DATABASE_VARIANTS = Set.of(
         Database.AsnV2,
         Database.CityV2,
+        Database.CountryV2,
         Database.PrivacyDetection
     );
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Adding support for registered country fields for maxmind geoip databases (#114521)