### PR TITLE
Backporting update for RankDocsRetrieverBuilderTests to account for inner retriever rewriting

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -298,9 +298,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/114376
-- class: org.elasticsearch.search.retriever.RankDocsRetrieverBuilderTests
-  method: testRewrite
-  issue: https://github.com/elastic/elasticsearch/issues/114467
 - class: org.elasticsearch.kibana.KibanaThreadPoolIT
   method: testBlockedThreadPoolsRejectUserRequests
   issue: https://github.com/elastic/elasticsearch/issues/113939


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/114502/ to `8.x`