### PR TITLE
Cleanup BucketsAggregator#rewriteBuckets

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -111,7 +111,6 @@ public abstract class BucketsAggregator extends AggregatorBase {
         try {
             docCounts = bigArrays().newLongArray(newNumBuckets, true);
             success = true;
-            docCounts.fill(0, newNumBuckets, 0);
             for (long i = 0; i < oldDocCounts.size(); i++) {
                 long docCount = oldDocCounts.get(i);
 


### PR DESCRIPTION
The array is initialized with the flag `clearOnResize` set to true so we don't need to set the values to 0 again.