### PR TITLE
Scale from 0 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -226,7 +226,7 @@ public final class TrainedModelAssignment implements SimpleDiffable<TrainedModel
 
     public List<Tuple<String, Integer>> selectRandomNodesWeighedOnAllocationsForNRequestsAndState(
         int numberOfRequests,
-        RoutingState ... acceptableStates
+        RoutingState... acceptableStates
     ) {
         List<String> nodeIds = new ArrayList<>(nodeRoutingTable.size());
         List<Integer> cumulativeAllocations = new ArrayList<>(nodeRoutingTable.size());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -224,15 +224,15 @@ public final class TrainedModelAssignment implements SimpleDiffable<TrainedModel
         return nodeRoutingTable.values().stream().anyMatch(routeInfo -> routeInfo.getState() == RoutingState.STARTED);
     }
 
-    public List<Tuple<String, Integer>> selectRandomStartedNodesWeighedOnAllocationsForNRequests(
+    public List<Tuple<String, Integer>> selectRandomNodesWeighedOnAllocationsForNRequestsAndState(
         int numberOfRequests,
-        RoutingState requiredState
+        RoutingState ... acceptableStates
     ) {
         List<String> nodeIds = new ArrayList<>(nodeRoutingTable.size());
         List<Integer> cumulativeAllocations = new ArrayList<>(nodeRoutingTable.size());
         int allocationSum = 0;
         for (Map.Entry<String, RoutingInfo> routingEntry : nodeRoutingTable.entrySet()) {
-            if (routingEntry.getValue().getState() == requiredState) {
+            if (routingEntry.getValue().getState().isAnyOf(acceptableStates)) {
                 nodeIds.add(routingEntry.getKey());
                 allocationSum += routingEntry.getValue().getCurrentAllocations();
                 cumulativeAllocations.add(allocationSum);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
@@ -195,7 +195,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STOPPED, ""));
         TrainedModelAssignment assignment = builder.build();
 
-        assertThat(assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STARTED).isEmpty(), is(true));
+        assertThat(assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(1, RoutingState.STARTED).isEmpty(), is(true));
     }
 
     public void testselectRandomStartedNodeWeighedOnAllocationsForNRequests_GivenSingleStartedNode() {
@@ -203,7 +203,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-1", new RoutingInfo(4, 4, RoutingState.STARTED, ""));
         TrainedModelAssignment assignment = builder.build();
 
-        var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STARTED);
+        var nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(1, RoutingState.STARTED);
 
         assertThat(nodes, contains(new Tuple<>("node-1", 1)));
     }
@@ -213,7 +213,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-1", new RoutingInfo(4, 4, RoutingState.STARTED, ""));
         TrainedModelAssignment assignment = builder.build();
 
-        var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STOPPING);
+        var nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(1, RoutingState.STOPPING);
 
         assertThat(nodes, empty());
     }
@@ -223,7 +223,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-1", new RoutingInfo(4, 4, RoutingState.STOPPING, ""));
         TrainedModelAssignment assignment = builder.build();
 
-        var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STOPPING);
+        var nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(1, RoutingState.STOPPING);
 
         assertThat(nodes, contains(new Tuple<>("node-1", 1)));
     }
@@ -234,7 +234,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""));
         TrainedModelAssignment assignment = builder.build();
 
-        var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STARTED);
+        var nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(1, RoutingState.STARTED);
         assertThat(nodes, hasSize(1));
         assertEquals(nodes.get(0).v2(), Integer.valueOf(1));
     }
@@ -248,7 +248,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
 
         final int selectionCount = 10000;
         final CountAccumulator countsPerNodeAccumulator = new CountAccumulator();
-        var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(selectionCount, RoutingState.STARTED);
+        var nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(selectionCount, RoutingState.STARTED);
 
         assertThat(nodes, hasSize(3));
         assertThat(nodes.stream().mapToInt(Tuple::v2).sum(), equalTo(selectionCount));
@@ -269,7 +269,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-3", new RoutingInfo(0, 0, RoutingState.STARTED, ""));
         TrainedModelAssignment assignment = builder.build();
         final int selectionCount = 1000;
-        var nodeCounts = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(selectionCount, RoutingState.STARTED);
+        var nodeCounts = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(selectionCount, RoutingState.STARTED);
         assertThat(nodeCounts, hasSize(3));
 
         var selectedNodes = new HashSet<String>();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AdaptiveAllocationsScaleFromZeroIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AdaptiveAllocationsScaleFromZeroIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AdaptiveAllocationsScaleFromZeroIT extends PyTorchModelRestTestCase {
+
+    @Before
+    public void setShortScaleToZeroPeriod() throws IOException {
+        logger.info("setting time");
+        Request scaleToZeroTime = new Request("PUT", "_cluster/settings");
+        scaleToZeroTime.setJsonEntity("""
+            {
+              "persistent": {
+                "xpack.ml.adaptive_allocations_scale_to_zero": "2s"
+              }
+            }""");
+
+        client().performRequest(scaleToZeroTime);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testScaleFromZero() throws Exception {
+        String modelId = "test_scale_from_zero";
+        createPassThroughModel(modelId);
+        putModelDefinition(modelId, PyTorchModelIT.BASE_64_ENCODED_MODEL, PyTorchModelIT.RAW_MODEL_SIZE);
+        putVocabulary(List.of("Auto", "scale", "and", "infer"), modelId);
+
+        startDeployment(modelId, modelId, new AdaptiveAllocationsSettings(true, 0, 1));
+
+        var responseMap = entityAsMap(getTrainedModelStats(modelId));
+        List<Map<String, Object>> stats = (List<Map<String, Object>>) responseMap.get("trained_model_stats");
+        String statusState = (String) XContentMapValues.extractValue("deployment_stats.allocation_status.state", stats.get(0));
+        assertThat(responseMap.toString(), statusState, is(not(nullValue())));
+        Integer count = (Integer) XContentMapValues.extractValue("deployment_stats.allocation_status.allocation_count", stats.get(0));
+        assertThat(responseMap.toString(), count, is(1));
+
+        // wait for scale down. The scaler service will check every 10 seconds
+        assertBusy(() -> {
+            var statsMap = entityAsMap(getTrainedModelStats(modelId));
+            List<Map<String, Object>> innerStats = (List<Map<String, Object>>) statsMap.get("trained_model_stats");
+            Integer innerCount = (Integer) XContentMapValues.extractValue(
+                "deployment_stats.allocation_status.allocation_count",
+                innerStats.get(0)
+            );
+            assertThat(statsMap.toString(), innerCount, is(0));
+        }, 30, TimeUnit.SECONDS);
+
+        // infer will scale up
+        int inferenceCount = 10;
+        var latch = new CountDownLatch(inferenceCount);
+        for (int i = 0; i < inferenceCount; i++) {
+            asyncInfer("Auto scale and infer", modelId, TimeValue.timeValueSeconds(5), new ResponseListener() {
+                @Override
+                public void onSuccess(Response response) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception exception) {
+                    latch.countDown();
+                    fail(exception.getMessage());
+                }
+            });
+        }
+
+        latch.await();
+    }
+
+    // public void testMultipleDeploymentsWaiting() {
+    //
+    // }
+
+}

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -10,13 +10,20 @@ package org.elasticsearch.xpack.ml.integration;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseListener;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus;
 import org.elasticsearch.xpack.core.ml.inference.assignment.Priority;
 import org.elasticsearch.xpack.core.ml.integration.MlRestTestStateCleaner;
@@ -282,6 +289,32 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
         return client().performRequest(request);
     }
 
+    protected Response startDeployment(String modelId, String deploymentId, AdaptiveAllocationsSettings adaptiveAllocationsSettings)
+        throws IOException {
+        String endPoint = "/_ml/trained_models/"
+            + modelId
+            + "/deployment/_start"
+            + "?deployment_id="
+            + deploymentId
+            + "&threads_per_allocation=1";
+
+        ChunkedToXContentObject innerChunkedContent = params -> Iterators.concat(
+            ChunkedToXContentHelper.startObject(),
+            Iterators.single(((builder, p2) -> builder.field("adaptive_allocations", adaptiveAllocationsSettings))),
+            ChunkedToXContentHelper.endObject()
+        );
+
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        builder.field("adaptive_allocations", adaptiveAllocationsSettings);
+        builder.endObject();
+        var body = Strings.toString(builder);
+
+        Request request = new Request("POST", endPoint);
+        request.setJsonEntity(body);
+        return client().performRequest(request);
+    }
+
     protected void stopDeployment(String modelId) throws IOException {
         stopDeployment(modelId, false, false);
     }
@@ -323,6 +356,14 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
             {  "docs": [{"input":"%s"}] }
             """, input));
         return client().performRequest(request);
+    }
+
+    protected void asyncInfer(String input, String modelId, TimeValue timeout, ResponseListener responseListener) throws IOException {
+        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer?timeout=" + timeout.toString());
+        request.setJsonEntity(Strings.format("""
+            {  "docs": [{"input":"%s"}] }
+            """, input));
+        client().performRequestAsync(request, responseListener);
     }
 
     protected Response infer(String input, String modelId) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -766,6 +766,18 @@ public class MachineLearning extends Plugin
      */
     public static final int MAX_LOW_PRIORITY_MODELS_PER_NODE = 100;
 
+    /**
+     * The time interval without any requests that has to pass, before scaling down
+     * to zero allocations.
+     */
+    public static final Setting<TimeValue> ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME = Setting.timeSetting(
+        "xpack.ml.adaptive_allocations_scale_to_zero",
+        TimeValue.timeValueMinutes(15),
+        TimeValue.timeValueSeconds(1),
+        Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
     private static final Logger logger = LogManager.getLogger(MachineLearning.class);
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MachineLearning.class);
 
@@ -825,7 +837,8 @@ public class MachineLearning extends Plugin
             MAX_ML_NODE_SIZE,
             DELAYED_DATA_CHECK_FREQ,
             DUMMY_ENTITY_MEMORY,
-            DUMMY_ENTITY_PROCESSORS
+            DUMMY_ENTITY_PROCESSORS,
+            ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExternalInferModelAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
 import org.elasticsearch.xpack.ml.inference.adaptiveallocations.AdaptiveAllocationsScalerService;
@@ -29,7 +30,8 @@ public class TransportExternalInferModelAction extends TransportInternalInferMod
         XPackLicenseState licenseState,
         TrainedModelProvider trainedModelProvider,
         AdaptiveAllocationsScalerService adaptiveAllocationsScalerService,
-        TrainedModelAssignmentService assignmentService
+        TrainedModelAssignmentService assignmentService,
+        ThreadPool threadPool
     ) {
         super(
             InferModelAction.EXTERNAL_NAME,
@@ -41,7 +43,8 @@ public class TransportExternalInferModelAction extends TransportInternalInferMod
             licenseState,
             trainedModelProvider,
             adaptiveAllocationsScalerService,
-            assignmentService
+            assignmentService,
+            threadPool
         );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExternalInferModelAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
 import org.elasticsearch.xpack.ml.inference.adaptiveallocations.AdaptiveAllocationsScalerService;
+import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentService;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 
@@ -27,7 +28,8 @@ public class TransportExternalInferModelAction extends TransportInternalInferMod
         ClusterService clusterService,
         XPackLicenseState licenseState,
         TrainedModelProvider trainedModelProvider,
-        AdaptiveAllocationsScalerService adaptiveAllocationsScalerService
+        AdaptiveAllocationsScalerService adaptiveAllocationsScalerService,
+        TrainedModelAssignmentService assignmentService
     ) {
         super(
             InferModelAction.EXTERNAL_NAME,
@@ -38,7 +40,8 @@ public class TransportExternalInferModelAction extends TransportInternalInferMod
             clusterService,
             licenseState,
             trainedModelProvider,
-            adaptiveAllocationsScalerService
+            adaptiveAllocationsScalerService,
+            assignmentService
         );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -268,7 +268,10 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
 
         // We couldn't find any nodes in the started state so let's look for ones that are stopping in case we're shutting down some nodes
         if (nodes.isEmpty()) {
-            nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(request.numberOfDocuments(), RoutingState.STOPPING);
+            nodes = assignment.selectRandomNodesWeighedOnAllocationsForNRequestsAndState(
+                request.numberOfDocuments(),
+                RoutingState.STOPPING
+            );
         }
 
         if (nodes.isEmpty()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScaler.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScaler.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.ml.inference.adaptiveallocations;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.TimeValue;
-
-import static org.elasticsearch.xpack.ml.MachineLearning.ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME;
 
 /**
  * Processes measured requests counts and inference times and decides whether

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerService.java
@@ -41,7 +41,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+
+import static org.elasticsearch.xpack.ml.MachineLearning.ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME;
 
 /**
  * Periodically schedules adaptive allocations scaling. This process consists
@@ -212,6 +215,8 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
     private volatile Scheduler.Cancellable cancellable;
     private final AtomicBoolean busy;
 
+    private final AtomicLong scaleToZeroAfterNoRequestsSeconds = new AtomicLong();
+
     public AdaptiveAllocationsScalerService(
         ThreadPool threadPool,
         ClusterService clusterService,
@@ -247,6 +252,9 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
         scalers = new HashMap<>();
         metrics = new Metrics();
         busy = new AtomicBoolean(false);
+
+        setScaleToZeroPeriod(ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME.get(clusterService.getSettings()));
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME, this::setScaleToZeroPeriod);
     }
 
     public synchronized void start() {
@@ -290,14 +298,15 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
                 && assignment.getAdaptiveAllocationsSettings().getEnabled() == Boolean.TRUE) {
                 AdaptiveAllocationsScaler adaptiveAllocationsScaler = scalers.computeIfAbsent(
                     assignment.getDeploymentId(),
-                    key -> new AdaptiveAllocationsScaler(assignment.getDeploymentId(), assignment.totalTargetAllocations())
+                    key -> new AdaptiveAllocationsScaler(assignment.getDeploymentId(), assignment.totalTargetAllocations(),
+                        scaleToZeroAfterNoRequestsSeconds.get())
                 );
                 adaptiveAllocationsScaler.setMinMaxNumberOfAllocations(
                     assignment.getAdaptiveAllocationsSettings().getMinNumberOfAllocations(),
                     assignment.getAdaptiveAllocationsSettings().getMaxNumberOfAllocations()
                 );
             } else {
-                scalers.remove(assignment.getDeploymentId());
+                var scaler = scalers.remove(assignment.getDeploymentId());
                 lastInferenceStatsByDeploymentAndNode.remove(assignment.getDeploymentId());
             }
         }
@@ -330,6 +339,8 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
     }
 
     private void trigger() {
+        logger.info("trigger adaptive");
+
         if (busy.getAndSet(true)) {
             logger.debug("Skipping inference adaptive allocations scaling, because it's still busy.");
             return;
@@ -342,6 +353,7 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
     }
 
     private void getDeploymentStats(ActionListener<GetDeploymentStatsAction.Response> processDeploymentStats) {
+        logger.info("get deployment stats");
         String deploymentIds = String.join(",", scalers.keySet());
         ClientHelper.executeAsyncWithOrigin(
             client,
@@ -469,5 +481,10 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
                     );
             })
         );
+    }
+
+    private void setScaleToZeroPeriod(TimeValue timeValue) {
+        logger.info("setting scaler service to zero " + timeValue);
+        scaleToZeroAfterNoRequestsSeconds.set(timeValue.seconds());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -845,10 +845,9 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 return;
             }
         }
-        boolean hasUpdates = (numberOfAllocations != null
-            && Objects.equals(numberOfAllocations, existingAssignment.getTaskParams().getNumberOfAllocations()) == false)
-            || Objects.equals(adaptiveAllocationsSettings, existingAssignment.getAdaptiveAllocationsSettings()) == false;
+        boolean hasUpdates = hasUpdates(numberOfAllocations, adaptiveAllocationsSettingsUpdates, existingAssignment);
         if (hasUpdates == false) {
+            logger.info("no updates");
             listener.onResponse(existingAssignment);
             return;
         }
@@ -915,6 +914,17 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         );
 
         updateAssignment(clusterState, existingAssignment, numberOfAllocations, adaptiveAllocationsSettings, updatedStateListener);
+    }
+
+    static boolean hasUpdates(
+        Integer proposedNumberOfAllocations,
+        AdaptiveAllocationsSettings proposedAdaptiveSettings,
+        TrainedModelAssignment existingAssignment
+    ) {
+        return (proposedNumberOfAllocations != null
+            && Objects.equals(proposedNumberOfAllocations, existingAssignment.getTaskParams().getNumberOfAllocations()) == false)
+            || (proposedAdaptiveSettings != null
+                && Objects.equals(proposedAdaptiveSettings, existingAssignment.getAdaptiveAllocationsSettings()) == false);
     }
 
     private AdaptiveAllocationsSettings getAdaptiveAllocationsSettings(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/waitforallocations/ScalingInference.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/waitforallocations/ScalingInference.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus;
@@ -58,11 +57,10 @@ public class ScalingInference {
     }
 
     public synchronized void waitForAssignment(WaitingRequest request) {
-        logger.info("new wait for request");
         var p = queueRequests.computeIfAbsent(request.deploymentId(), k -> new LinkedBlockingQueue<>());
 
         if (p.isEmpty()) {
-            logger.info("will wait for condition");
+            logger.info("waitForAssignment will wait for condition");
             p.offer(request);
             assignmentService.waitForAssignmentCondition(
                 request.deploymentId(),
@@ -71,7 +69,7 @@ public class ScalingInference {
                 new WaitingListener(request.deploymentId())
             );
         } else {
-            logger.info("added to queue");
+            logger.info("waitForAssignment added to queue");
             p.offer(request);
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/waitforallocations/ScalingInference.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/waitforallocations/ScalingInference.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.waitforallocations;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.xpack.core.ml.action.InferModelAction;
+import org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus;
+import org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignment;
+import org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignmentMetadata;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentService;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.core.Strings.format;
+
+public class ScalingInference {
+
+    private static final Logger logger = LogManager.getLogger(ScalingInference.class);
+
+    private final Map<String, LinkedBlockingQueue<WaitingRequest>> queueRequests;
+
+    public record WaitingRequest(
+        InferModelAction.Request request,
+        InferModelAction.Response.Builder responseBuilder,
+        TaskId parentTaskId,
+        ActionListener<InferModelAction.Response> listener
+    ) {
+        public String deploymentId() {
+            return request.getId();
+        }
+    }
+
+    private final TrainedModelAssignmentService assignmentService;
+    private final BiConsumer<WaitingRequest, TrainedModelAssignment> queuedConsumer;
+
+    public ScalingInference(
+        TrainedModelAssignmentService assignmentService,
+        BiConsumer<WaitingRequest, TrainedModelAssignment> queuedConsumer
+    ) {
+        this.assignmentService = assignmentService;
+        this.queuedConsumer = queuedConsumer;
+        this.queueRequests = new ConcurrentHashMap<>();
+    }
+
+    public synchronized void waitForAssignment(WaitingRequest request) {
+        var p = queueRequests.computeIfAbsent(request.deploymentId(), k -> new LinkedBlockingQueue<>());
+
+        if (p.isEmpty()) {
+            p.offer(request);
+            assignmentService.waitForAssignmentCondition(
+                request.deploymentId(),
+                new DeploymentHasAtLeastOneAllocation(request.deploymentId()),
+                request.request().getInferenceTimeout(),
+                new WaitingListener(request.deploymentId())
+            );
+        } else {
+            p.offer(request);
+        }
+
+    }
+
+    private static class DeploymentHasAtLeastOneAllocation implements Predicate<ClusterState> {
+
+        private final String deploymentId;
+
+        DeploymentHasAtLeastOneAllocation(String deploymentId) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, "deployment_id");
+        }
+
+        @Override
+        public boolean test(ClusterState clusterState) {
+            TrainedModelAssignment trainedModelAssignment = TrainedModelAssignmentMetadata.assignmentForDeploymentId(
+                clusterState,
+                deploymentId
+            ).orElse(null);
+            if (trainedModelAssignment == null) {
+                logger.info(() -> format("[%s] assignment was null while waiting to scale up", deploymentId));
+                return true;
+            }
+
+            var allocationStatus = trainedModelAssignment.calculateAllocationStatus().orElse(null);
+            if (allocationStatus == null) {
+                return true;
+            }
+
+            var state = allocationStatus.calculateState();
+            return state.isAnyOf(AllocationStatus.State.STARTED, AllocationStatus.State.FULLY_ALLOCATED);
+        }
+    }
+
+    private class WaitingListener implements TrainedModelAssignmentService.WaitForAssignmentListener {
+
+        private final String deploymentId;
+
+        private WaitingListener(String deploymentId) {
+            this.deploymentId = deploymentId;
+        }
+
+        @Override
+        public void onResponse(TrainedModelAssignment assignment) {
+            // assignment is started, do inference
+            var queued = queueRequests.remove(deploymentId);
+            for (var request : queued) {
+                queuedConsumer.accept(request, assignment);
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            var queued = queueRequests.remove(deploymentId);
+            for (var request : queued) {
+                request.listener().onFailure(e);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerServiceTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
@@ -38,7 +40,10 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import static org.elasticsearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
+import static org.elasticsearch.xpack.ml.MachineLearning.ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -66,6 +71,10 @@ public class AdaptiveAllocationsScalerServiceTests extends ESTestCase {
             new ScalingExecutorBuilder(MachineLearning.UTILITY_THREAD_POOL_NAME, 0, 1, TimeValue.timeValueMinutes(10), false)
         );
         clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(
+            new ClusterSettings(Settings.EMPTY, Set.of(ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME))
+        );
         client = mock(Client.class);
         inferenceAuditor = mock(InferenceAuditor.class);
         meterRegistry = mock(MeterRegistry.class);
@@ -167,6 +176,8 @@ public class AdaptiveAllocationsScalerServiceTests extends ESTestCase {
 
         verify(clusterService).state();
         verify(clusterService).addListener(same(service));
+        verify(clusterService).getSettings();
+        verify(clusterService).getClusterSettings();
         verifyNoMoreInteractions(client, clusterService);
         reset(client, clusterService);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerServiceTests.java
@@ -41,8 +41,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.elasticsearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
 import static org.elasticsearch.xpack.ml.MachineLearning.ADAPTIVE_ALLOCATIONS_SCALE_TO_ZERO_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -251,4 +252,99 @@ public class AdaptiveAllocationsScalerServiceTests extends ESTestCase {
 
         service.stop();
     }
+
+    public void testMaybeStartAllocation() {
+        AdaptiveAllocationsScalerService service = new AdaptiveAllocationsScalerService(
+            threadPool,
+            clusterService,
+            client,
+            inferenceAuditor,
+            meterRegistry,
+            true,
+            1
+        );
+
+        when(client.threadPool()).thenReturn(threadPool);
+
+        // will not start when adaptive allocations are not enabled
+        assertFalse(service.maybeStartAllocation(TrainedModelAssignment.Builder.empty(taskParams(1), null).build()));
+        assertFalse(
+            service.maybeStartAllocation(
+                TrainedModelAssignment.Builder.empty(taskParams(1), new AdaptiveAllocationsSettings(Boolean.FALSE, 1, 2)).build()
+            )
+        );
+        // min allocations > 0
+        assertFalse(
+            service.maybeStartAllocation(
+                TrainedModelAssignment.Builder.empty(taskParams(0), new AdaptiveAllocationsSettings(Boolean.TRUE, 1, 2)).build()
+            )
+        );
+        assertTrue(
+            service.maybeStartAllocation(
+                TrainedModelAssignment.Builder.empty(taskParams(0), new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 2)).build()
+            )
+        );
+    }
+
+    public void testMaybeStartAllocation_BlocksMultipleRequests() throws Exception {
+        AdaptiveAllocationsScalerService service = new AdaptiveAllocationsScalerService(
+            threadPool,
+            clusterService,
+            client,
+            inferenceAuditor,
+            meterRegistry,
+            true,
+            1
+        );
+
+        var latch = new CountDownLatch(1);
+        var scalingUpRequestSent = new AtomicBoolean();
+
+        when(client.threadPool()).thenReturn(threadPool);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            var listener = (ActionListener<CreateTrainedModelAssignmentAction.Response>) invocationOnMock.getArguments()[2];
+            scalingUpRequestSent.set(true);
+            latch.await();
+            listener.onResponse(mock(CreateTrainedModelAssignmentAction.Response.class));
+            return Void.TYPE;
+        }).when(client).execute(eq(UpdateTrainedModelDeploymentAction.INSTANCE), any(), any());
+
+        threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
+            var starting = service.maybeStartAllocation(
+                TrainedModelAssignment.Builder.empty(taskParams(0), new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 2)).build()
+            );
+            assertTrue(starting);
+        });
+
+        // wait for the request to be sent
+        assertBusy(() -> assertTrue(scalingUpRequestSent.get()));
+
+        // Due to the inflight request this will not trigger an update request
+        assertTrue(
+            service.maybeStartAllocation(
+                TrainedModelAssignment.Builder.empty(taskParams(0), new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 2)).build()
+            )
+        );
+        // release the inflight request
+        latch.countDown();
+
+        verify(client, times(1)).execute(eq(UpdateTrainedModelDeploymentAction.INSTANCE), any(), any());
+    }
+
+    private StartTrainedModelDeploymentAction.TaskParams taskParams(int numAllocations) {
+        return new StartTrainedModelDeploymentAction.TaskParams(
+            "foo",
+            "foo",
+            1000L,
+            numAllocations,
+            1,
+            100,
+            null,
+            Priority.NORMAL,
+            100L,
+            100L
+        );
+    }
+
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerTests.java
@@ -7,7 +7,10 @@
 
 package org.elasticsearch.xpack.ml.inference.adaptiveallocations;
 
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
 import java.util.Random;
 
@@ -15,11 +18,21 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AdaptiveAllocationsScalerTests extends ESTestCase {
 
+    private ClusterService clusterService;
+
+    @Before
+    public void createMocks() throws Exception {
+        clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+    }
+
     public void testAutoscaling_scaleUpAndDown() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1, 60);
 
         // With 1 allocation the system can handle 500 requests * 0.020 sec/request.
         // To handle remaining requests the system should scale to 2 allocations.
@@ -47,7 +60,7 @@ public class AdaptiveAllocationsScalerTests extends ESTestCase {
     }
 
     public void testAutoscaling_noOscillating() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1, 60);
 
         // With 1 allocation the system can handle 880 requests * 0.010 sec/request.
         adaptiveAllocationsScaler.process(new AdaptiveAllocationsScalerService.Stats(880, 0, 0, 0.010), 10, 1);
@@ -75,7 +88,7 @@ public class AdaptiveAllocationsScalerTests extends ESTestCase {
     }
 
     public void testAutoscaling_respectMinMaxAllocations() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1, 60);
         adaptiveAllocationsScaler.setMinMaxNumberOfAllocations(2, 5);
 
         // Even though there are no requests, scale to the minimum of 2 allocations.
@@ -98,7 +111,7 @@ public class AdaptiveAllocationsScalerTests extends ESTestCase {
     }
 
     public void testEstimation_highVariance() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1, 60);
 
         Random random = new Random(42);
 
@@ -140,7 +153,7 @@ public class AdaptiveAllocationsScalerTests extends ESTestCase {
     }
 
     public void testAutoscaling_maxAllocationsSafeguard() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1, 60);
         adaptiveAllocationsScaler.process(new AdaptiveAllocationsScalerService.Stats(1_000_000, 10_000_000, 1, 0.05), 10, 1);
         assertThat(adaptiveAllocationsScaler.scale(), equalTo(32));
         adaptiveAllocationsScaler.setMinMaxNumberOfAllocations(2, 77);
@@ -148,7 +161,12 @@ public class AdaptiveAllocationsScalerTests extends ESTestCase {
     }
 
     public void testAutoscaling_scaleDownToZeroAllocations() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        int scaleDownAfterInactivitySeconds = 60 * 15; // scale down to 0 after 15 minutes
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler(
+            "test-deployment",
+            1,
+            scaleDownAfterInactivitySeconds
+        );
         // 1 hour with 1 request per 1 seconds, so don't scale.
         for (int i = 0; i < 3600; i++) {
             adaptiveAllocationsScaler.process(new AdaptiveAllocationsScalerService.Stats(1, 0, 0, 0.05), 1, 1);
@@ -178,7 +196,7 @@ public class AdaptiveAllocationsScalerTests extends ESTestCase {
     }
 
     public void testAutoscaling_dontScaleDownToZeroAllocationsWhenMinAllocationsIsSet() {
-        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1);
+        AdaptiveAllocationsScaler adaptiveAllocationsScaler = new AdaptiveAllocationsScaler("test-deployment", 1, 60);
         adaptiveAllocationsScaler.setMinMaxNumberOfAllocations(1, null);
 
         // 1 hour with no requests,


### PR DESCRIPTION
Changes `TransportInternalInferModelAction` to queue inference requests when an model deployment is scaling up from 0 allocations. Incoming inference requests are stored in a queue then send to the model once it is deployed on a node. 

Adds a setting to control the adaptive allocations scale to zero period for the purpose of running tests. 