### PR TITLE
[8.x] Improve exception message for bad environment variable placeholders in settings (#114552)

### DIFF
--- a/docs/changelog/114552.yaml
+++ b/docs/changelog/114552.yaml
@@ -1,0 +1,5 @@
+pr: 114552
+summary: Improve exception message for bad environment variable placeholders in settings
+area: Infra/Settings
+type: enhancement
+issues: [110858]

--- a/server/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
+++ b/server/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
@@ -54,7 +54,11 @@ public class InternalSettingsPreparer {
         loadOverrides(output, properties);
         output.put(input);
         replaceForcedSettings(output);
-        output.replacePropertyPlaceholders();
+        try {
+            output.replacePropertyPlaceholders();
+        } catch (Exception e) {
+            throw new SettingsException("Failed to replace property placeholders from [" + configFile.getFileName() + "]", e);
+        }
         ensureSpecialSettingsExist(output, defaultNodeName);
 
         return new Environment(output.build(), configDir);

--- a/server/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
+++ b/server/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
@@ -86,6 +86,20 @@ public class InternalSettingsPreparerTests extends ESTestCase {
         }
     }
 
+    public void testReplacePlaceholderFailure() {
+        try {
+            InternalSettingsPreparer.prepareEnvironment(
+                Settings.builder().put(baseEnvSettings).put("cluster.name", "${ES_CLUSTER_NAME}").build(),
+                emptyMap(),
+                null,
+                () -> "default_node_name"
+            );
+            fail("Expected SettingsException");
+        } catch (SettingsException e) {
+            assertEquals("Failed to replace property placeholders from [elasticsearch.yml]", e.getMessage());
+        }
+    }
+
     public void testSecureSettings() {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("foo", "secret");


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Improve exception message for bad environment variable placeholders in settings (#114552)