### PR TITLE
#111893 Add Warnings For Missing Index Templates

### DIFF
--- a/docs/reference/data-streams/promote-data-stream-api.asciidoc
+++ b/docs/reference/data-streams/promote-data-stream-api.asciidoc
@@ -20,6 +20,7 @@ be rolled over in the local cluster.
 
 NOTE: When promoting a data stream, ensure the local cluster has a data stream enabled index template that matches the data stream.
 If this is missing, the data stream will not be able to roll over until a matching index template is created.
+This will affect the lifecycle management of the data stream and interfere with the data stream size and retention.
 
 [source,console]
 ----

--- a/docs/reference/data-streams/promote-data-stream-api.asciidoc
+++ b/docs/reference/data-streams/promote-data-stream-api.asciidoc
@@ -18,6 +18,9 @@ available, the data stream in the local cluster can be promoted
 to a regular data stream, which allows these data streams to
 be rolled over in the local cluster.
 
+NOTE: When promoting a data stream, ensure the local cluster has a data stream enabled index template that matches the data stream.
+If this is missing, the data stream will not be able to roll over until a matching index template is created.
+
 [source,console]
 ----
 POST /_data_stream/_promote/my-data-stream

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -49,6 +49,7 @@ Snapshots don't contain or back up:
 * <<security-files,Security configuration files>>
 
 NOTE: When restoring a data stream, if the target cluster does not have an index template that matches the data stream, the data stream will not be able to roll over until a matching index template is created.
+This will affect the lifecycle management of the data stream and interfere with the data stream size and retention.
 
 [discrete]
 [[feature-state]]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -48,6 +48,8 @@ Snapshots don't contain or back up:
 * Node configuration files
 * <<security-files,Security configuration files>>
 
+NOTE: When restoring a data stream, if the target cluster does not have an index template that matches the data stream, the data stream will not be able to roll over until a matching index template is created.
+
 [discrete]
 [[feature-state]]
 === Feature states

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -1362,7 +1362,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertAcked(
             client.execute(
                 DeleteDataStreamAction.INSTANCE,
-                new DeleteDataStreamAction.Request(TEST_REQUEST_TIMEOUT, datastreamName, "other-ds", "with-fs")
+                new DeleteDataStreamAction.Request(TEST_REQUEST_TIMEOUT, datastreamName, "other-ds")
             )
         );
 
@@ -1370,13 +1370,6 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
             client.execute(
                 TransportDeleteComposableIndexTemplateAction.TYPE,
                 new TransportDeleteComposableIndexTemplateAction.Request(TEMPLATE_1_ID)
-            ).get()
-        );
-
-        assertAcked(
-            client.execute(
-                TransportDeleteComposableIndexTemplateAction.TYPE,
-                new TransportDeleteComposableIndexTemplateAction.Request(TEMPLATE_2_ID)
             ).get()
         );
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/PromoteDataStreamTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/PromoteDataStreamTransportAction.java
@@ -86,7 +86,7 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
 
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    return promoteDataStream(currentState, request, clusterService);
+                    return promoteDataStream(currentState, request);
                 }
 
                 @Override
@@ -104,8 +104,7 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
 
     static ClusterState promoteDataStream(
         ClusterState currentState,
-        PromoteDataStreamAction.Request request,
-        ClusterService clusterService
+        PromoteDataStreamAction.Request request
     ) {
         DataStream dataStream = currentState.getMetadata().dataStreams().get(request.getName());
 
@@ -113,7 +112,7 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
             throw new ResourceNotFoundException("data stream [" + request.getName() + "] does not exist");
         }
 
-        warnIfTemplateMissingForDatastream(dataStream, clusterService);
+        warnIfTemplateMissingForDatastream(dataStream, currentState);
 
         DataStream promotedDataStream = dataStream.promoteDataStream();
         Metadata.Builder metadata = Metadata.builder(currentState.metadata());
@@ -121,10 +120,10 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
         return ClusterState.builder(currentState).metadata(metadata).build();
     }
 
-    private static void warnIfTemplateMissingForDatastream(DataStream dataStream, ClusterService clusterService) {
+    private static void warnIfTemplateMissingForDatastream(DataStream dataStream, ClusterState currentState) {
         var datastreamName = dataStream.getName();
 
-        var matchingIndex = clusterService.state()
+        var matchingIndex = currentState
             .metadata()
             .templatesV2()
             .values()

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/PromoteDataStreamTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/PromoteDataStreamTransportAction.java
@@ -102,10 +102,7 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
         clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
-    static ClusterState promoteDataStream(
-        ClusterState currentState,
-        PromoteDataStreamAction.Request request
-    ) {
+    static ClusterState promoteDataStream(ClusterState currentState, PromoteDataStreamAction.Request request) {
         DataStream dataStream = currentState.getMetadata().dataStreams().get(request.getName());
 
         if (dataStream == null) {
@@ -123,8 +120,7 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
     private static void warnIfTemplateMissingForDatastream(DataStream dataStream, ClusterState currentState) {
         var datastreamName = dataStream.getName();
 
-        var matchingIndex = currentState
-            .metadata()
+        var matchingIndex = currentState.metadata()
             .templatesV2()
             .values()
             .stream()

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/PromoteDataStreamTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/PromoteDataStreamTransportAction.java
@@ -42,7 +42,6 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
     private static final Logger logger = LogManager.getLogger(PromoteDataStreamTransportAction.class);
 
     private final SystemIndices systemIndices;
-    private final ClusterService clusterService;
 
     @Inject
     public PromoteDataStreamTransportAction(
@@ -64,7 +63,6 @@ public class PromoteDataStreamTransportAction extends AcknowledgedTransportMaste
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.systemIndices = systemIndices;
-        this.clusterService = clusterService;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -52,6 +52,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -398,6 +399,8 @@ public final class RestoreService implements ClusterStateApplier {
         Map<String, DataStream> dataStreamsToRestore = result.v1();
         Map<String, DataStreamAlias> dataStreamAliasesToRestore = result.v2();
 
+        validateDatastreamTemplatesExistAndWarnIfMissing(dataStreamsToRestore, snapshotInfo);
+
         // Remove the data streams from the list of requested indices
         requestIndices.removeAll(dataStreamsToRestore.keySet());
 
@@ -508,6 +511,30 @@ public final class RestoreService implements ClusterStateApplier {
                 listener
             )
         );
+    }
+
+    private void validateDatastreamTemplatesExistAndWarnIfMissing(Map<String, DataStream> dataStreamsToRestore, SnapshotInfo snapshotInfo) {
+        var templatePatterns = clusterService.state()
+            .metadata()
+            .templatesV2()
+            .values()
+            .stream()
+            .filter(cit -> cit.getDataStreamTemplate() != null)
+            .flatMap(cit -> cit.indexPatterns().stream())
+            .collect(Collectors.toSet());
+
+        for (String name : dataStreamsToRestore.keySet()) {
+            if (templatePatterns.stream().noneMatch(pattern -> Regex.simpleMatch(pattern, name))) {
+                String warningMessage = format(
+                    "Snapshot [%s] contains data stream [%s] but custer does not have a matching index template. This will cause"
+                        + " rollover to fail until a matching index template is created",
+                    snapshotInfo.snapshotId(),
+                    name
+                );
+                logger.warn(() -> warningMessage);
+                HeaderWarning.addWarning(warningMessage);
+            }
+        }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -916,7 +916,7 @@ public class ElasticsearchAssertions {
         ActionRequestBuilder<?, T> requestBuilder,
         Matcher<? super List<String>> matcher
     ) throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(2);
+        CountDownLatch latch = new CountDownLatch(1);
         requestBuilder.execute(new ActionListener<>() {
             @Override
             public void onResponse(T response) {
@@ -937,7 +937,6 @@ public class ElasticsearchAssertions {
                 }
             }
         });
-        latch.countDown();
         if (latch.await(10, TimeUnit.SECONDS) == false) {
             fail("Did not receive request response before timeout");
         }

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.WarningFailureException;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
@@ -1118,6 +1119,115 @@ public class AutoFollowIT extends ESCCRRestTestCase {
             cleanUpLeader(List.of(regularIndex, mountedIndex), List.of(), List.of());
             cleanUpFollower(List.of(regularIndex), List.of(), List.of(autoFollowPattern));
         }
+    }
+
+    public void testNoWarningOnPromoteDatastreamWhenTemplateExistsOnFollower() throws Exception {
+        if ("follow".equals(targetCluster) == false) {
+            return;
+        }
+        testDatastreamPromotionWarnings(true);
+    }
+
+    public void testWarningOnPromoteDatastreamWhenTemplateDoesNotExistsOnFollower() {
+        if ("follow".equals(targetCluster) == false) {
+            return;
+        }
+        WarningFailureException exception = assertThrows(WarningFailureException.class, () -> testDatastreamPromotionWarnings(false));
+        assertThat(
+            exception.getMessage(),
+            containsString(
+                "does not have a matching index template. " + "This will cause rollover to fail until a matching index template is created]"
+            )
+        );
+    }
+
+    private void testDatastreamPromotionWarnings(Boolean createFollowerTemplate) throws Exception {
+        final int numDocs = 64;
+        final String dataStreamName = getTestName().toLowerCase(Locale.ROOT) + "-dopromo";
+        final String autoFollowPatternName = getTestName().toLowerCase(Locale.ROOT);
+
+        int initialNumberOfSuccessfulFollowedIndices = getNumberOfSuccessfulFollowedIndices();
+        List<String> backingIndexNames = null;
+        try {
+            // Create index template
+            Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/" + getTestName().toLowerCase(Locale.ROOT));
+            putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\":[\"" + dataStreamName + "*\"],\"data_stream\":{}}");
+
+            if (createFollowerTemplate) {
+                assertOK(client().performRequest(putComposableIndexTemplateRequest));
+            }
+
+            // Create auto follow pattern
+            createAutoFollowPattern(client(), autoFollowPatternName, dataStreamName + "*", "leader_cluster", null);
+
+            // Create data stream and ensure that it is auto followed
+            try (var leaderClient = buildLeaderClient()) {
+                assertOK(leaderClient.performRequest(putComposableIndexTemplateRequest));
+
+                for (int i = 0; i < numDocs; i++) {
+                    var indexRequest = new Request("POST", "/" + dataStreamName + "/_doc");
+                    indexRequest.addParameter("refresh", "true");
+                    indexRequest.setJsonEntity("{\"@timestamp\": \"" + DATE_FORMAT.format(new Date()) + "\",\"message\":\"abc\"}");
+                    assertOK(leaderClient.performRequest(indexRequest));
+                }
+                verifyDataStream(leaderClient, dataStreamName, backingIndexName(dataStreamName, 1));
+                verifyDocuments(leaderClient, dataStreamName, numDocs);
+            }
+            assertBusy(() -> {
+                assertThat(getNumberOfSuccessfulFollowedIndices(), equalTo(initialNumberOfSuccessfulFollowedIndices + 1));
+                verifyDataStream(client(), dataStreamName, backingIndexName(dataStreamName, 1));
+                ensureYellow(dataStreamName);
+                verifyDocuments(client(), dataStreamName, numDocs);
+            });
+
+            // Rollover in leader cluster and ensure second backing index is replicated:
+            try (var leaderClient = buildLeaderClient()) {
+                var rolloverRequest = new Request("POST", "/" + dataStreamName + "/_rollover");
+                assertOK(leaderClient.performRequest(rolloverRequest));
+                verifyDataStream(leaderClient, dataStreamName, backingIndexName(dataStreamName, 1), backingIndexName(dataStreamName, 2));
+
+                var indexRequest = new Request("POST", "/" + dataStreamName + "/_doc");
+                indexRequest.addParameter("refresh", "true");
+                indexRequest.setJsonEntity("{\"@timestamp\": \"" + DATE_FORMAT.format(new Date()) + "\",\"message\":\"abc\"}");
+                assertOK(leaderClient.performRequest(indexRequest));
+                verifyDocuments(leaderClient, dataStreamName, numDocs + 1);
+            }
+            assertBusy(() -> {
+                assertThat(getNumberOfSuccessfulFollowedIndices(), equalTo(initialNumberOfSuccessfulFollowedIndices + 2));
+                verifyDataStream(client(), dataStreamName, backingIndexName(dataStreamName, 1), backingIndexName(dataStreamName, 2));
+                ensureYellow(dataStreamName);
+                verifyDocuments(client(), dataStreamName, numDocs + 1);
+            });
+
+            backingIndexNames = verifyDataStream(
+                client(),
+                dataStreamName,
+                backingIndexName(dataStreamName, 1),
+                backingIndexName(dataStreamName, 2)
+            );
+
+            // Promote local data stream
+            var promoteRequest = new Request("POST", "/_data_stream/_promote/" + dataStreamName);
+            Response response = client().performRequest(promoteRequest);
+            assertOK(response);
+        } finally {
+            if (backingIndexNames == null) {
+                // we failed to compute the actual backing index names in the test because we failed earlier on, guessing them on a
+                // best-effort basis
+                backingIndexNames = List.of(backingIndexName(dataStreamName, 1), backingIndexName(dataStreamName, 2));
+            }
+
+            cleanUpFollower(backingIndexNames, List.of(dataStreamName), List.of(autoFollowPatternName));
+            cleanUpLeader(backingIndexNames.subList(0, 1), List.of(dataStreamName), List.of());
+            Request deleteTemplateRequest = new Request("DELETE", "/_index_template/" + getTestName().toLowerCase(Locale.ROOT));
+            if (createFollowerTemplate) {
+                assertOK(client().performRequest(deleteTemplateRequest));
+            }
+            try (var leaderClient = buildLeaderClient()) {
+                assertOK(leaderClient.performRequest(deleteTemplateRequest));
+            }
+        }
+
     }
 
     private int getNumberOfSuccessfulFollowedIndices() throws IOException {

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -1125,23 +1125,23 @@ public class AutoFollowIT extends ESCCRRestTestCase {
         if ("follow".equals(targetCluster) == false) {
             return;
         }
-        testDatastreamPromotionWarnings(true);
+        testDataStreamPromotionWarnings(true);
     }
 
     public void testWarningOnPromoteDatastreamWhenTemplateDoesNotExistsOnFollower() {
         if ("follow".equals(targetCluster) == false) {
             return;
         }
-        WarningFailureException exception = assertThrows(WarningFailureException.class, () -> testDatastreamPromotionWarnings(false));
+        WarningFailureException exception = assertThrows(WarningFailureException.class, () -> testDataStreamPromotionWarnings(false));
         assertThat(
             exception.getMessage(),
             containsString(
-                "does not have a matching index template. " + "This will cause rollover to fail until a matching index template is created]"
+                "does not have a matching index template. This will cause rollover to fail until a matching index template is created]"
             )
         );
     }
 
-    private void testDatastreamPromotionWarnings(Boolean createFollowerTemplate) throws Exception {
+    private void testDataStreamPromotionWarnings(Boolean createFollowerTemplate) throws Exception {
         final int numDocs = 64;
         final String dataStreamName = getTestName().toLowerCase(Locale.ROOT) + "-dopromo";
         final String autoFollowPatternName = getTestName().toLowerCase(Locale.ROOT);

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -1217,6 +1217,8 @@ public class AutoFollowIT extends ESCCRRestTestCase {
                 backingIndexNames = List.of(backingIndexName(dataStreamName, 1), backingIndexName(dataStreamName, 2));
             }
 
+            // These cleanup methods are copied from the finally block of other Data Stream tests in this class however
+            // they may no longer be required but have been included for completeness
             cleanUpFollower(backingIndexNames, List.of(dataStreamName), List.of(autoFollowPatternName));
             cleanUpLeader(backingIndexNames.subList(0, 1), List.of(dataStreamName), List.of());
             Request deleteTemplateRequest = new Request("DELETE", "/_index_template/" + getTestName().toLowerCase(Locale.ROOT));


### PR DESCRIPTION
Fixes [ES#111893 - Data stream restoration/promotion without a matching template](https://github.com/elastic/elasticsearch/issues/111893)

This PR adds warnings headers and log messages for the following conditions:

* Promoting a CCR replicated data stream wihout a matching index template for the data stream
* Restoring a snapshot of a data stream without a matching index template for the data stream

In both these senarios, the action will succede however future rollovers of the data stream will fail due to the missing templates. By adding a warning header and log, we make the user explicitly aware of this pending failure.

Documentation for both these actions has also been updated to warn of this scenario
