### PR TITLE
[8.x] Unmute ComparisonTests (#114248)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -74,9 +74,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=rollup/security_tests/Index-based access}
   issue: https://github.com/elastic/elasticsearch/issues/111631
-- class: org.elasticsearch.tdigest.ComparisonTests
-  method: testSparseGaussianDistribution
-  issue: https://github.com/elastic/elasticsearch/issues/111721
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testSnapshotRestore {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/111777


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Unmute ComparisonTests (#114248)