### PR TITLE
Rename methods in o.e.x.c.security.support.Automatons

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
@@ -53,7 +53,7 @@ public final class ApplicationPermission {
                 return new PermissionEntry(
                     appPriv,
                     Sets.union(existing.resourceNames, resourceNames),
-                    Automatons.unionAndMinimize(Arrays.asList(existing.resourceAutomaton, patterns))
+                    Automatons.unionAndDeterminize(Arrays.asList(existing.resourceAutomaton, patterns))
                 );
             }
         }));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ClusterPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ClusterPermission.java
@@ -137,7 +137,7 @@ public class ClusterPermission {
             }
             List<PermissionCheck> checks = this.permissionChecks;
             if (false == actionAutomatons.isEmpty()) {
-                final Automaton mergedAutomaton = Automatons.unionAndMinimize(this.actionAutomatons);
+                final Automaton mergedAutomaton = Automatons.unionAndDeterminize(this.actionAutomatons);
                 checks = new ArrayList<>(this.permissionChecks.size() + 1);
                 checks.add(new AutomatonPermissionCheck(mergedAutomaton));
                 checks.addAll(this.permissionChecks);
@@ -156,7 +156,7 @@ public class ClusterPermission {
             } else {
                 final Automaton allowedAutomaton = Automatons.patterns(allowedActionPatterns);
                 final Automaton excludedAutomaton = Automatons.patterns(excludeActionPatterns);
-                return Automatons.minusAndMinimize(allowedAutomaton, excludedAutomaton);
+                return Automatons.minusAndDeterminize(allowedAutomaton, excludedAutomaton);
             }
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
@@ -147,7 +147,7 @@ public final class FieldPermissions implements Accountable, CacheKey {
         List<Automaton> automatonList = groups.stream()
             .map(g -> FieldPermissions.buildPermittedFieldsAutomaton(g.getGrantedFields(), g.getExcludedFields()))
             .collect(Collectors.toList());
-        return Automatons.unionAndMinimize(automatonList);
+        return Automatons.unionAndDeterminize(automatonList);
     }
 
     /**
@@ -189,7 +189,7 @@ public final class FieldPermissions implements Accountable, CacheKey {
             );
         }
 
-        grantedFieldsAutomaton = Automatons.minusAndMinimize(grantedFieldsAutomaton, deniedFieldsAutomaton);
+        grantedFieldsAutomaton = Automatons.minusAndDeterminize(grantedFieldsAutomaton, deniedFieldsAutomaton);
         return grantedFieldsAutomaton;
     }
 
@@ -206,7 +206,7 @@ public final class FieldPermissions implements Accountable, CacheKey {
     public FieldPermissions limitFieldPermissions(FieldPermissions limitedBy) {
         if (hasFieldLevelSecurity() && limitedBy != null && limitedBy.hasFieldLevelSecurity()) {
             // TODO: cache the automaton computation with FieldPermissionsCache
-            Automaton _permittedFieldsAutomaton = Automatons.intersectAndMinimize(getIncludeAutomaton(), limitedBy.getIncludeAutomaton());
+            Automaton _permittedFieldsAutomaton = Automatons.intersectAndDeterminize(getIncludeAutomaton(), limitedBy.getIncludeAutomaton());
             return new FieldPermissions(
                 CollectionUtils.concatLists(fieldPermissionsDefinitions, limitedBy.fieldPermissionsDefinitions),
                 _permittedFieldsAutomaton

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissions.java
@@ -206,7 +206,10 @@ public final class FieldPermissions implements Accountable, CacheKey {
     public FieldPermissions limitFieldPermissions(FieldPermissions limitedBy) {
         if (hasFieldLevelSecurity() && limitedBy != null && limitedBy.hasFieldLevelSecurity()) {
             // TODO: cache the automaton computation with FieldPermissionsCache
-            Automaton _permittedFieldsAutomaton = Automatons.intersectAndDeterminize(getIncludeAutomaton(), limitedBy.getIncludeAutomaton());
+            Automaton _permittedFieldsAutomaton = Automatons.intersectAndDeterminize(
+                getIncludeAutomaton(),
+                limitedBy.getIncludeAutomaton()
+            );
             return new FieldPermissions(
                 CollectionUtils.concatLists(fieldPermissionsDefinitions, limitedBy.fieldPermissionsDefinitions),
                 _permittedFieldsAutomaton

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissionsCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissionsCache.java
@@ -107,7 +107,7 @@ public final class FieldPermissionsCache {
                     List<Automaton> automatonList = fieldPermissionsCollection.stream()
                         .map(FieldPermissions::getIncludeAutomaton)
                         .collect(Collectors.toList());
-                    return new FieldPermissions(key, Automatons.unionAndMinimize(automatonList));
+                    return new FieldPermissions(key, Automatons.unionAndDeterminize(automatonList));
                 });
             } catch (ExecutionException e) {
                 throw new ElasticsearchException("unable to compute field permissions", e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -283,14 +283,14 @@ public final class IndicesPermission {
         for (String forIndexPattern : checkForIndexPatterns) {
             Automaton checkIndexAutomaton = Automatons.patterns(forIndexPattern);
             if (false == allowRestrictedIndices && false == isConcreteRestrictedIndex(forIndexPattern)) {
-                checkIndexAutomaton = Automatons.minusAndMinimize(checkIndexAutomaton, restrictedIndices.getAutomaton());
+                checkIndexAutomaton = Automatons.minusAndDeterminize(checkIndexAutomaton, restrictedIndices.getAutomaton());
             }
             if (false == Operations.isEmpty(checkIndexAutomaton)) {
                 Automaton allowedIndexPrivilegesAutomaton = null;
                 for (var indexAndPrivilegeAutomaton : indexGroupAutomatons.entrySet()) {
                     if (Automatons.subsetOf(checkIndexAutomaton, indexAndPrivilegeAutomaton.getValue())) {
                         if (allowedIndexPrivilegesAutomaton != null) {
-                            allowedIndexPrivilegesAutomaton = Automatons.unionAndMinimize(
+                            allowedIndexPrivilegesAutomaton = Automatons.unionAndDeterminize(
                                 Arrays.asList(allowedIndexPrivilegesAutomaton, indexAndPrivilegeAutomaton.getKey())
                             );
                         } else {
@@ -342,7 +342,7 @@ public final class IndicesPermission {
                 automatonList.add(group.privilege.getAutomaton());
             }
         }
-        return automatonList.isEmpty() ? Automatons.EMPTY : Automatons.unionAndMinimize(automatonList);
+        return automatonList.isEmpty() ? Automatons.EMPTY : Automatons.unionAndDeterminize(automatonList);
     }
 
     /**
@@ -704,7 +704,7 @@ public final class IndicesPermission {
             Automaton indexAutomaton = group.getIndexMatcherAutomaton();
             allAutomatons.compute(
                 group.privilege().getAutomaton(),
-                (key, value) -> value == null ? indexAutomaton : Automatons.unionAndMinimize(List.of(value, indexAutomaton))
+                (key, value) -> value == null ? indexAutomaton : Automatons.unionAndDeterminize(List.of(value, indexAutomaton))
             );
             if (combine) {
                 List<Tuple<Automaton, Automaton>> combinedAutomatons = new ArrayList<>();
@@ -714,7 +714,7 @@ public final class IndicesPermission {
                         group.privilege().getAutomaton()
                     );
                     if (Operations.isEmpty(intersectingPrivileges) == false) {
-                        Automaton indexPatternAutomaton = Automatons.unionAndMinimize(
+                        Automaton indexPatternAutomaton = Automatons.unionAndDeterminize(
                             List.of(indexAndPrivilegeAutomatons.getValue(), indexAutomaton)
                         );
                         combinedAutomatons.add(new Tuple<>(intersectingPrivileges, indexPatternAutomaton));
@@ -723,7 +723,7 @@ public final class IndicesPermission {
                 combinedAutomatons.forEach(
                     automatons -> allAutomatons.compute(
                         automatons.v1(),
-                        (key, value) -> value == null ? automatons.v2() : Automatons.unionAndMinimize(List.of(value, automatons.v2()))
+                        (key, value) -> value == null ? automatons.v2() : Automatons.unionAndDeterminize(List.of(value, automatons.v2()))
                     )
                 );
             }
@@ -768,7 +768,7 @@ public final class IndicesPermission {
                 this.indexNameMatcher = StringMatcher.of(indices).and(name -> restrictedIndices.isRestricted(name) == false);
                 this.indexNameAutomaton = () -> indexNameAutomatonMemo.computeIfAbsent(
                     indices,
-                    k -> Automatons.minusAndMinimize(Automatons.patterns(indices), restrictedIndices.getAutomaton())
+                    k -> Automatons.minusAndDeterminize(Automatons.patterns(indices), restrictedIndices.getAutomaton())
                 );
             }
             this.fieldPermissions = Objects.requireNonNull(fieldPermissions);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
@@ -212,7 +212,7 @@ public final class LimitedRole implements Role {
     public Automaton allowedActionsMatcher(String index) {
         final Automaton allowedMatcher = baseRole.allowedActionsMatcher(index);
         final Automaton limitedByMatcher = limitedByRole.allowedActionsMatcher(index);
-        return Automatons.intersectAndMinimize(allowedMatcher, limitedByMatcher);
+        return Automatons.intersectAndDeterminize(allowedMatcher, limitedByMatcher);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -57,7 +57,7 @@ import java.util.stream.Stream;
 
 import static java.util.Map.entry;
 import static org.elasticsearch.xpack.core.security.support.Automatons.patterns;
-import static org.elasticsearch.xpack.core.security.support.Automatons.unionAndMinimize;
+import static org.elasticsearch.xpack.core.security.support.Automatons.unionAndDeterminize;
 
 /**
  * The name of an index related action always being with `indices:` followed by a sequence of slash-separated terms
@@ -110,7 +110,7 @@ public final class IndexPrivilege extends Privilege {
     private static final Automaton DELETE_AUTOMATON = patterns("indices:data/write/delete*", "indices:data/write/bulk*");
     private static final Automaton WRITE_AUTOMATON = patterns("indices:data/write/*", TransportAutoPutMappingAction.TYPE.name());
     private static final Automaton MONITOR_AUTOMATON = patterns("indices:monitor/*");
-    private static final Automaton MANAGE_AUTOMATON = unionAndMinimize(
+    private static final Automaton MANAGE_AUTOMATON = unionAndDeterminize(
         Arrays.asList(
             MONITOR_AUTOMATON,
             patterns("indices:admin/*", TransportFieldCapabilitiesAction.NAME + "*", GetRollupIndexCapsAction.NAME + "*")
@@ -303,7 +303,7 @@ public final class IndexPrivilege extends Privilege {
         if (actions.isEmpty() == false) {
             automata.add(patterns(actions));
         }
-        return new IndexPrivilege(name, unionAndMinimize(automata));
+        return new IndexPrivilege(name, unionAndDeterminize(automata));
     }
 
     static Map<String, IndexPrivilege> values() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
@@ -112,7 +112,7 @@ public final class Automatons {
 
     private static Automaton buildAutomaton(Collection<String> patterns) {
         if (patterns.size() == 1) {
-            return minimize(pattern(patterns.iterator().next()));
+            return determinize(pattern(patterns.iterator().next()));
         }
 
         final Function<Collection<String>, Automaton> build = strings -> {
@@ -121,7 +121,7 @@ public final class Automatons {
                 final Automaton patternAutomaton = pattern(pattern);
                 automata.add(patternAutomaton);
             }
-            return unionAndMinimize(automata);
+            return unionAndDeterminize(automata);
         };
 
         // We originally just compiled each automaton separately and then unioned them all.
@@ -188,7 +188,7 @@ public final class Automatons {
         if (misc.isEmpty() == false) {
             automata.add(build.apply(misc));
         }
-        return unionAndMinimize(automata);
+        return unionAndDeterminize(automata);
     }
 
     /**
@@ -277,22 +277,22 @@ public final class Automatons {
         return Operations.determinize(concatenate(automata), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
     }
 
-    public static Automaton unionAndMinimize(Collection<Automaton> automata) {
+    public static Automaton unionAndDeterminize(Collection<Automaton> automata) {
         Automaton res = automata.size() == 1 ? automata.iterator().next() : union(automata);
-        return minimize(res);
+        return determinize(res);
     }
 
-    public static Automaton minusAndMinimize(Automaton a1, Automaton a2) {
+    public static Automaton minusAndDeterminize(Automaton a1, Automaton a2) {
         Automaton res = minus(a1, a2, maxDeterminizedStates);
-        return minimize(res);
+        return determinize(res);
     }
 
-    public static Automaton intersectAndMinimize(Automaton a1, Automaton a2) {
+    public static Automaton intersectAndDeterminize(Automaton a1, Automaton a2) {
         Automaton res = intersection(a1, a2);
-        return minimize(res);
+        return determinize(res);
     }
 
-    private static Automaton minimize(Automaton automaton) {
+    private static Automaton determinize(Automaton automaton) {
         return Operations.determinize(automaton, maxDeterminizedStates);
     }
 


### PR DESCRIPTION
Lucene 10 stopped relying in on automaton minimization and moved the underlying Hopcroft algorithm to test code (for reasoning see https://github.com/apache/lucene/pull/528). With the upgrade to Lucene 10 we currently also only determinize automata. The security Automatons utility class currently contains several methods that sound like they would minimize the automaton, but this has changed so this PR also changes the method names accordingly.
