### PR TITLE
[8.x] Enable pushing Sort/Filter by ReferenceAttribute down to Lucene, and thereby optimize Sort by ST_DISTANCE (#112938)

### DIFF
--- a/docs/changelog/112938.yaml
+++ b/docs/changelog/112938.yaml
@@ -1,0 +1,35 @@
+pr: 112938
+summary: Enhance SORT push-down to Lucene to cover references to fields and ST_DISTANCE function
+area: ES|QL
+type: enhancement
+issues:
+ - 109973
+highlight:
+  title: Enhance SORT push-down to Lucene to cover references to fields and ST_DISTANCE function
+  body: |-
+    The most used and likely most valuable geospatial search query in Elasticsearch is the sorted proximity search,
+    finding items within a certain distance of a point of interest and sorting the results by distance.
+    This has been possible in ES|QL since 8.15.0, but the sorting was done in-memory, not pushed down to Lucene.
+    Now the sorting is pushed down to Lucene, which results in a significant performance improvement.
+
+    Queries that perform both filtering and sorting on distance are supported. For example:
+
+    [source,esql]
+    ----
+    FROM test
+    | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(37.7749, -122.4194)"))
+    | WHERE distance < 1000000
+    | SORT distance ASC, name DESC
+    | LIMIT 10
+    ----
+
+    In addition, the support for sorting on EVAL expressions has been extended to cover references to fields:
+
+    [source,esql]
+    ----
+    FROM test
+    | EVAL ref = field
+    | SORT ref ASC
+    | LIMIT 10
+    ----
+  notable: false

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -166,7 +166,7 @@ public class HeapAttackIT extends ESRestTestCase {
                     "error",
                     matchesMap().extraOk()
                         .entry("bytes_wanted", greaterThan(1000))
-                        .entry("reason", matchesRegex("\\[request] Data too large, data for \\[(topn|esql_block_factory)] would .+"))
+                        .entry("reason", matchesRegex("\\[request] Data too large, data for \\[.+] would be .+"))
                         .entry("durability", "TRANSIENT")
                         .entry("type", "circuit_breaking_exception")
                         .entry("bytes_limit", greaterThan(1000))

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -423,10 +423,8 @@ public class RestEsqlIT extends RestEsqlTestCase {
                     .item("ProjectOperator")
                     .item("OutputOperator"),
                 // Second pass read and join via eval
-                matchesList().item("LuceneSourceOperator")
+                matchesList().item("LuceneTopNSourceOperator")
                     .item("EvalOperator")
-                    .item("ValuesSourceReaderOperator")
-                    .item("TopNOperator")
                     .item("ValuesSourceReaderOperator")
                     .item("ProjectOperator")
                     .item("ExchangeSinkOperator"),
@@ -591,6 +589,16 @@ public class RestEsqlIT extends RestEsqlTestCase {
             case "TopNOperator" -> matchesMap().entry("occupied_rows", 0)
                 .entry("ram_used", instanceOf(String.class))
                 .entry("ram_bytes_used", greaterThan(0));
+            case "LuceneTopNSourceOperator" -> matchesMap().entry("pages_emitted", greaterThan(0))
+                .entry("current", greaterThan(0))
+                .entry("processed_slices", greaterThan(0))
+                .entry("processed_shards", List.of("rest-esql-test:0"))
+                .entry("total_slices", greaterThan(0))
+                .entry("slice_max", 0)
+                .entry("slice_min", 0)
+                .entry("processing_nanos", greaterThan(0))
+                .entry("processed_queries", List.of("*:*"))
+                .entry("slice_index", 0);
             default -> throw new AssertionError("unexpected status: " + o);
         };
         MapMatcher expectedOp = matchesMap().entry("operator", startsWith(name));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -1116,7 +1116,145 @@ count:long | country:k
 1          | Poland
 ;
 
+airportsWithinEvalDistanceBandCopenhagenTrainStationCount
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+| WHERE distance < 600000 AND distance > 400000
+| STATS count=COUNT() BY country
+| SORT count DESC, country ASC
+;
+
+count:long | country:k
+3          | Sweden
+2          | Norway
+1          | Germany
+1          | Lithuania
+1          | Poland
+;
+
+airportsWithinEvalDistanceBandCopenhagenTrainStationKeepDistance
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")), importance = 10 - scalerank
+| WHERE distance < 500000 AND distance > 400000
+| STATS count=COUNT() BY distance, importance
+| SORT distance ASC, importance DESC, count DESC
+;
+
+count:long | distance:double   | importance:integer
+1          | 402611.1308019835 | 4
+1          | 433987.3301951482 | 3
+;
+
+airportsWithinEvalDistanceBandCopenhagenTrainStationCountNonPushableEval
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")), position = location::keyword
+| WHERE distance < 600000 AND distance > 400000 AND SUBSTRING(position, 1, 5) == "POINT"
+| STATS count=COUNT() BY country
+| SORT count DESC, country ASC
+;
+
+count:long | country:k
+3          | Sweden
+2          | Norway
+1          | Germany
+1          | Lithuania
+1          | Poland
+;
+
+airportsWithinEvalDistanceBandCopenhagenTrainStationCountNonPushableWhereConjunctive
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+| WHERE distance < 500000 AND 0.5*distance < 300000
+| STATS count=COUNT() BY country
+| SORT count DESC, country ASC
+;
+
+count:long | country:k
+3          | Germany
+3          | Sweden
+1          | Denmark
+1          | Poland
+;
+
+airportsWithinEvalDistanceBandCopenhagenTrainStationCountNonPushableWhereDisjunctive
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+| WHERE distance < 500000 OR 0.5*distance < 300000
+| STATS count=COUNT() BY country
+| SORT count DESC, country ASC
+;
+
+count:long | country:k
+5          | Sweden
+4          | Germany
+2          | Norway
+1          | Denmark
+1          | Lithuania
+1          | Poland
+;
+
+airportsSortCityName
+FROM airports
+| SORT abbrev
+| LIMIT 5
+| KEEP abbrev, name, location, country, city
+;
+
+abbrev:keyword  |  name:text                     |  location:geo_point                          |  country:keyword  |  city:keyword
+ABJ             |  Abidjan Port Bouet            |  POINT(-3.93221929167636 5.2543984451492)    |  Côte d'Ivoire    |  Abidjan
+ABQ             |  Albuquerque Int'l             |  POINT(-106.6166851616 35.0491578018276)     |  United States    |  Albuquerque
+ABV             |  Abuja Int'l                   |  POINT(7.27025993974356 9.00437659781094)    |  Nigeria          |  Abuja
+ACA             |  General Juan N Alvarez Int'l  |  POINT(-99.7545085619681 16.76196735278)     |  Mexico           |  Acapulco de Juárez
+ACC             |  Kotoka Int'l                  |  POINT(-0.171402855660817 5.60698152381193)  |  Ghana            |  Accra
+;
+
 airportsSortDistanceFromCopenhagenTrainStation
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+| SORT distance ASC
+| LIMIT 5
+| KEEP abbrev, name, location, country, city
+;
+
+abbrev:k | name:text               | location:geo_point                       | country:k | city:k    
+CPH      | Copenhagen              | POINT(12.6493508684508 55.6285017221528) | Denmark   | Copenhagen
+GOT      | Gothenburg              | POINT(12.2938269092573 57.6857493534879) | Sweden    | Gothenburg
+HAM      | Hamburg                 | POINT(10.005647830925 53.6320011640866)  | Germany   | Norderstedt
+TXL      | Berlin-Tegel Int'l      | POINT(13.2903090925074 52.5544287044101) | Germany   | Hohen Neuendorf
+BRE      | Bremen                  | POINT(8.7858617703132 53.052287104156)   | Germany   | Bremen
+;
+
+airportsSortDistanceFromCopenhagenTrainStationInline
+required_capability: st_distance
+required_capability: spatial_distance_pushdown_enhancements
+
+FROM airports
+| SORT ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")) ASC
+| LIMIT 5
+| KEEP abbrev, name, location, country, city
+;
+
+abbrev:k | name:text               | location:geo_point                       | country:k | city:k    
+CPH      | Copenhagen              | POINT(12.6493508684508 55.6285017221528) | Denmark   | Copenhagen
+GOT      | Gothenburg              | POINT(12.2938269092573 57.6857493534879) | Sweden    | Gothenburg
+HAM      | Hamburg                 | POINT(10.005647830925 53.6320011640866)  | Germany   | Norderstedt
+TXL      | Berlin-Tegel Int'l      | POINT(13.2903090925074 52.5544287044101) | Germany   | Hohen Neuendorf
+BRE      | Bremen                  | POINT(8.7858617703132 53.052287104156)   | Germany   | Bremen
+;
+
+airportsSortDistanceFromCopenhagenTrainStationDetails
 required_capability: st_distance
 
 FROM airports
@@ -1134,6 +1272,26 @@ GOT      | Gothenburg              | POINT(12.2938269092573 57.6857493534879) | 
 HAM      | Hamburg                 | POINT(10.005647830925 53.6320011640866)  | Germany   | Norderstedt     | POINT(10.0103 53.7064)  | 280.34     | 273.42
 TXL      | Berlin-Tegel Int'l      | POINT(13.2903090925074 52.5544287044101) | Germany   | Hohen Neuendorf | POINT(13.2833 52.6667)  | 349.97     | 337.53
 BRE      | Bremen                  | POINT(8.7858617703132 53.052287104156)   | Germany   | Bremen          | POINT(8.8 53.0833)      | 380.5      | 377.22
+;
+
+airportsSortDistanceFromCopenhagenTrainStationDetailsAndNonPushableEval
+required_capability: st_distance
+
+FROM airports
+| EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")), position = location::keyword
+| WHERE distance < 600000 AND SUBSTRING(position, 1, 5) == "POINT"
+| SORT distance ASC
+| LIMIT 5
+| EVAL distance = ROUND(distance/1000,2)
+| KEEP abbrev, name, position, distance
+;
+
+abbrev:k | name:text               | position:keyword                          | distance:d
+CPH      | Copenhagen              | POINT (12.6493508684508 55.6285017221528) | 7.24
+GOT      | Gothenburg              | POINT (12.2938269092573 57.6857493534879) | 224.42
+HAM      | Hamburg                 | POINT (10.005647830925 53.6320011640866)  | 280.34
+TXL      | Berlin-Tegel Int'l      | POINT (13.2903090925074 52.5544287044101) | 349.97
+BRE      | Bremen                  | POINT (8.7858617703132 53.052287104156)   | 380.5
 ;
 
 airportsSortDistanceFromAirportToCity

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -134,3 +134,37 @@ Otmar             |Herbst           |[-8.19, -1.9, -0.32]        |[-0.32, -1.90,
 null              |Swan             |-8.46                       |-8.46                        |-8                   |10034          
 Sanjiv            |Zschoche         |[-7.67, -3.25]              |[-3.25, -7.67]               |[-3, -8]             |10053
 ;
+
+sortingOnSwappedFields
+FROM employees
+| EVAL name = last_name, last_name = first_name, first_name = name
+| WHERE first_name > "B" AND last_name IS NOT NULL
+| SORT name
+| LIMIT 10
+| KEEP name, last_name, first_name
+;
+
+name:keyword | last_name:keyword | first_name:keyword
+Baek         | Premal            | Baek
+Bamford      | Parto             | Bamford
+Bernatsky    | Mokhtar           | Bernatsky
+Bernini      | Brendon           | Bernini
+Berztiss     | Yongqiao          | Berztiss
+Bierman      | Margareta         | Bierman
+Billingsley  | Breannda          | Billingsley
+Bouloucos    | Cristinel         | Bouloucos
+Brattka      | Charlene          | Brattka
+Bridgland    | Patricio          | Bridgland
+;
+
+sortingOnSwappedFieldsNoKeep
+// Note that this test requires all fields to be returned in order to test a specific code path in physical planning
+FROM employees
+| EVAL name = first_name, first_name = last_name, last_name = name
+| WHERE first_name == "Bernini" AND last_name == "Brendon"
+| SORT name
+;
+
+avg_worked_seconds:long | birth_date:date      | emp_no:i | gender:k | height:d | height.float:d     | height.half_float:d | height.scaled_float:d | hire_date:date       | is_rehired:bool      | job_positions:k     | languages:i | languages.byte:i | languages.long:l | languages.short:short | salary:i | salary_change:d | salary_change.int:i | salary_change.keyword:k | salary_change.long:l | still_hired:bool | name:k  | first_name:k | last_name:k
+349086555               | 1961-09-01T00:00:00Z | 10056    | F        | 1.57     | 1.5700000524520874 | 1.5703125           | 1.57                  | 1990-02-01T00:00:00Z | [false, false, true] | [Senior Team Lead]  | 2           | 2                | 2                | 2                     | 33370    | [-5.17, 10.99]  | [-5, 10]            | [-5.17, 10.99]          | [-5, 10]             | true             | Brendon | Bernini      | Brendon
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -166,6 +166,11 @@ public class EsqlCapabilities {
         SPATIAL_PREDICATES_SUPPORT_MULTIVALUES,
 
         /**
+         * Support a number of fixes and enhancements to spatial distance pushdown. Done in #112938.
+         */
+        SPATIAL_DISTANCE_PUSHDOWN_ENHANCEMENTS,
+
+        /**
          * Fix to GROK and DISSECT that allows extracting attributes with the same name as the input
          * https://github.com/elastic/elasticsearch/issues/110184
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -552,10 +552,9 @@ public class Verifier {
      */
     private static void checkForSortOnSpatialTypes(LogicalPlan p, Set<Failure> localFailures) {
         if (p instanceof OrderBy ob) {
-            ob.forEachExpression(Attribute.class, attr -> {
-                DataType dataType = attr.dataType();
-                if (DataType.isSpatial(dataType)) {
-                    localFailures.add(fail(attr, "cannot sort on " + dataType.typeName()));
+            ob.order().forEach(order -> {
+                if (DataType.isSpatial(order.dataType())) {
+                    localFailures.add(fail(order, "cannot sort on " + order.dataType().typeName()));
                 }
             });
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
@@ -78,6 +79,29 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
         out.writeNamedWriteable(right());
         // The doc-values fields are only used on data nodes local planning, and therefor never serialized
         // The CRS type is re-resolved from the combination of left and right fields, and also not necessary to serialize
+    }
+
+    /**
+     * Mark the function as expecting the specified fields to arrive as doc-values.
+     */
+    public abstract BinarySpatialFunction withDocValues(boolean foundLeft, boolean foundRight);
+
+    @Override
+    public int hashCode() {
+        // NB: the hashcode is currently used for key generation so
+        // to avoid clashes between aggs with the same arguments, add the class name as variation
+        return Objects.hash(getClass(), children(), leftDocValues, rightDocValues);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (super.equals(obj)) {
+            BinarySpatialFunction other = (BinarySpatialFunction) obj;
+            return Objects.equals(other.children(), children())
+                && Objects.equals(other.leftDocValues, leftDocValues)
+                && Objects.equals(other.rightDocValues, rightDocValues);
+        }
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
@@ -26,7 +26,6 @@ import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -38,7 +37,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
@@ -198,10 +196,10 @@ public class SpatialContains extends SpatialRelatesFunction {
     }
 
     @Override
-    public SpatialContains withDocValues(Set<FieldAttribute> attributes) {
+    public SpatialContains withDocValues(boolean foundLeft, boolean foundRight) {
         // Only update the docValues flags if the field is found in the attributes
-        boolean leftDV = leftDocValues || foundField(left(), attributes);
-        boolean rightDV = rightDocValues || foundField(right(), attributes);
+        boolean leftDV = leftDocValues || foundLeft;
+        boolean rightDV = rightDocValues || foundRight;
         return new SpatialContains(source(), left(), right(), leftDV, rightDV);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
@@ -23,7 +23,6 @@ import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -35,7 +34,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
@@ -113,10 +111,10 @@ public class SpatialDisjoint extends SpatialRelatesFunction {
     }
 
     @Override
-    public SpatialDisjoint withDocValues(Set<FieldAttribute> attributes) {
+    public SpatialDisjoint withDocValues(boolean foundLeft, boolean foundRight) {
         // Only update the docValues flags if the field is found in the attributes
-        boolean leftDV = leftDocValues || foundField(left(), attributes);
-        boolean rightDV = rightDocValues || foundField(right(), attributes);
+        boolean leftDV = leftDocValues || foundLeft;
+        boolean rightDV = rightDocValues || foundRight;
         return new SpatialDisjoint(source(), left(), right(), leftDV, rightDV);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
@@ -23,7 +23,6 @@ import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -35,7 +34,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
@@ -111,10 +109,10 @@ public class SpatialIntersects extends SpatialRelatesFunction {
     }
 
     @Override
-    public SpatialIntersects withDocValues(Set<FieldAttribute> attributes) {
+    public SpatialIntersects withDocValues(boolean foundLeft, boolean foundRight) {
         // Only update the docValues flags if the field is found in the attributes
-        boolean leftDV = leftDocValues || foundField(left(), attributes);
-        boolean rightDV = rightDocValues || foundField(right(), attributes);
+        boolean leftDV = leftDocValues || foundLeft;
+        boolean rightDV = rightDocValues || foundRight;
         return new SpatialIntersects(source(), left(), right(), leftDV, rightDV);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -22,7 +22,6 @@ import org.elasticsearch.lucene.spatial.Component2DVisitor;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
@@ -30,9 +29,6 @@ import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asGeometryDocValueReader;
 import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asLuceneComponent2D;
@@ -58,47 +54,6 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
     }
 
     /**
-     * Mark the function as expecting the specified fields to arrive as doc-values.
-     */
-    public abstract SpatialRelatesFunction withDocValues(Set<FieldAttribute> attributes);
-
-    /**
-     * Push-down to Lucene is only possible if one field is an indexed spatial field, and the other is a constant spatial or string column.
-     */
-    public boolean canPushToSource(Predicate<FieldAttribute> isAggregatable) {
-        // The use of foldable here instead of SpatialEvaluatorFieldKey.isConstant is intentional to match the behavior of the
-        // Lucene pushdown code in EsqlTranslationHandler::SpatialRelatesTranslator
-        // We could enhance both places to support ReferenceAttributes that refer to constants, but that is a larger change
-        return isPushableFieldAttribute(left(), isAggregatable) && right().foldable()
-            || isPushableFieldAttribute(right(), isAggregatable) && left().foldable();
-    }
-
-    private static boolean isPushableFieldAttribute(Expression exp, Predicate<FieldAttribute> isAggregatable) {
-        return exp instanceof FieldAttribute fa
-            && fa.getExactInfo().hasExact()
-            && isAggregatable.test(fa)
-            && DataType.isSpatial(fa.dataType());
-    }
-
-    @Override
-    public int hashCode() {
-        // NB: the hashcode is currently used for key generation so
-        // to avoid clashes between aggs with the same arguments, add the class name as variation
-        return Objects.hash(getClass(), children(), leftDocValues, rightDocValues);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (super.equals(obj)) {
-            SpatialRelatesFunction other = (SpatialRelatesFunction) obj;
-            return Objects.equals(other.children(), children())
-                && Objects.equals(other.leftDocValues, leftDocValues)
-                && Objects.equals(other.rightDocValues, rightDocValues);
-        }
-        return false;
-    }
-
-    /**
      * Produce a map of rules defining combinations of incoming types to the evaluator factory that should be used.
      */
     abstract Map<SpatialEvaluatorFactory.SpatialEvaluatorKey, SpatialEvaluatorFactory<?, ?>> evaluatorRules();
@@ -113,19 +68,6 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
     @Override
     public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
         return SpatialEvaluatorFactory.makeSpatialEvaluator(this, evaluatorRules(), toEvaluator);
-    }
-
-    /**
-     * When performing local physical plan optimization, it is necessary to know if this function has a field attribute.
-     * This is because the planner might push down a spatial aggregation to lucene, which results in the field being provided
-     * as doc-values instead of source values, and this function needs to know if it should use doc-values or not.
-     */
-    public boolean hasFieldAttribute(Set<FieldAttribute> foundAttributes) {
-        return foundField(left(), foundAttributes) || foundField(right(), foundAttributes);
-    }
-
-    protected boolean foundField(Expression expression, Set<FieldAttribute> foundAttributes) {
-        return expression instanceof FieldAttribute field && foundAttributes.contains(field);
     }
 
     protected static class SpatialRelations extends BinarySpatialComparator<Boolean> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
@@ -23,7 +23,6 @@ import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -36,7 +35,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
@@ -113,10 +111,10 @@ public class SpatialWithin extends SpatialRelatesFunction implements SurrogateEx
     }
 
     @Override
-    public SpatialWithin withDocValues(Set<FieldAttribute> attributes) {
+    public SpatialWithin withDocValues(boolean foundLeft, boolean foundRight) {
         // Only update the docValues flags if the field is found in the attributes
-        boolean leftDV = leftDocValues || foundField(left(), attributes);
-        boolean rightDV = rightDocValues || foundField(right(), attributes);
+        boolean leftDV = leftDocValues || foundLeft;
+        boolean rightDV = rightDocValues || foundRight;
         return new SpatialWithin(source(), left(), right(), leftDV, rightDV);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
@@ -149,6 +149,14 @@ public class StDistance extends BinarySpatialFunction implements EvaluatorMapper
     }
 
     @Override
+    public StDistance withDocValues(boolean foundLeft, boolean foundRight) {
+        // Only update the docValues flags if the field is found in the attributes
+        boolean leftDV = leftDocValues || foundLeft;
+        boolean rightDV = rightDocValues || foundRight;
+        return new StDistance(source(), left(), right(), leftDV, rightDV);
+    }
+
+    @Override
     public String getWriteableName() {
         return ENTRY.name;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/EnableSpatialDistancePushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/EnableSpatialDistancePushdown.java
@@ -12,8 +12,14 @@ import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -25,17 +31,42 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Esq
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.splitAnd;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource.canPushSpatialFunctionToSource;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource.canPushToSource;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushFiltersToSource.getAliasReplacedBy;
 
 /**
  * When a spatial distance predicate can be pushed down to lucene, this is done by capturing the distance within the same function.
  * In principle this is like re-writing the predicate:
  * <pre>WHERE ST_DISTANCE(field, TO_GEOPOINT("POINT(0 0)")) &lt;= 10000</pre>
  * as:
- * <pre>WHERE ST_INTERSECTS(field, TO_GEOSHAPE("CIRCLE(0,0,10000)"))</pre>
+ * <pre>WHERE ST_INTERSECTS(field, TO_GEOSHAPE("CIRCLE(0,0,10000)"))</pre>.
+ * <p>
+ * In addition, since the distance could be calculated in a preceding <code>EVAL</code> command, we also need to consider the case:
+ * <pre>
+ *     FROM index
+ *     | EVAL distance = ST_DISTANCE(field, TO_GEOPOINT("POINT(0 0)"))
+ *     | WHERE distance &lt;= 10000
+ * </pre>
+ * And re-write that as:
+ * <pre>
+ *     FROM index
+ *     | WHERE ST_INTERSECTS(field, TO_GEOSHAPE("CIRCLE(0,0,10000)"))
+ *     | EVAL distance = ST_DISTANCE(field, TO_GEOPOINT("POINT(0 0)"))
+ * </pre>
+ * Note that the WHERE clause is both rewritten to an intersection and pushed down closer to the <code>EsQueryExec</code>,
+ * which allows the predicate to be pushed down to Lucene in a later rule, <code>PushFiltersToSource</code>.
  */
 public class EnableSpatialDistancePushdown extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
     FilterExec,
@@ -44,23 +75,121 @@ public class EnableSpatialDistancePushdown extends PhysicalOptimizerRules.Parame
     @Override
     protected PhysicalPlan rule(FilterExec filterExec, LocalPhysicalOptimizerContext ctx) {
         PhysicalPlan plan = filterExec;
-        if (filterExec.child() instanceof EsQueryExec) {
-            // Find and rewrite any binary comparisons that involve a distance function and a literal
-            var rewritten = filterExec.condition().transformDown(EsqlBinaryComparison.class, comparison -> {
-                ComparisonType comparisonType = ComparisonType.from(comparison.getFunctionType());
-                if (comparison.left() instanceof StDistance dist && comparison.right().foldable()) {
-                    return rewriteComparison(comparison, dist, comparison.right(), comparisonType);
-                } else if (comparison.right() instanceof StDistance dist && comparison.left().foldable()) {
-                    return rewriteComparison(comparison, dist, comparison.left(), ComparisonType.invert(comparisonType));
-                }
-                return comparison;
-            });
-            if (rewritten.equals(filterExec.condition()) == false) {
-                plan = new FilterExec(filterExec.source(), filterExec.child(), rewritten);
-            }
+        if (filterExec.child() instanceof EsQueryExec esQueryExec) {
+            plan = rewrite(filterExec, esQueryExec);
+        } else if (filterExec.child() instanceof EvalExec evalExec && evalExec.child() instanceof EsQueryExec esQueryExec) {
+            plan = rewriteBySplittingFilter(filterExec, evalExec, esQueryExec);
         }
 
         return plan;
+    }
+
+    private FilterExec rewrite(FilterExec filterExec, EsQueryExec esQueryExec) {
+        // Find and rewrite any binary comparisons that involve a distance function and a literal
+        var rewritten = filterExec.condition().transformDown(EsqlBinaryComparison.class, comparison -> {
+            ComparisonType comparisonType = ComparisonType.from(comparison.getFunctionType());
+            if (comparison.left() instanceof StDistance dist && comparison.right().foldable()) {
+                return rewriteComparison(comparison, dist, comparison.right(), comparisonType);
+            } else if (comparison.right() instanceof StDistance dist && comparison.left().foldable()) {
+                return rewriteComparison(comparison, dist, comparison.left(), ComparisonType.invert(comparisonType));
+            }
+            return comparison;
+        });
+        if (rewritten.equals(filterExec.condition()) == false) {
+            return new FilterExec(filterExec.source(), esQueryExec, rewritten);
+        }
+        return filterExec;
+    }
+
+    /**
+     * This version of the rewrite will try to split the filter into two parts, one that can be pushed down to the source and
+     * one that needs to be kept after the EVAL.
+     * For example:
+     * <pre>
+     *     FROM index
+     *     | EVAL distance = ST_DISTANCE(field, TO_GEOPOINT("POINT(0 0)")), other = scale * 2
+     *     | WHERE distance &lt;= 10000 AND distance &gt; 5000 AND other &gt; 10
+     * </pre>
+     * Should be rewritten as:
+     * <pre>
+     *     FROM index
+     *     | WHERE ST_INTERSECTS(field, TO_GEOSHAPE("CIRCLE(0,0,10000)"))
+     *         AND ST_DISJOINT(field, TO_GEOSHAPE("CIRCLE(0,0,5000)"))
+     *     | EVAL distance = ST_DISTANCE(field, TO_GEOPOINT("POINT(0 0)")), other = scale * 2
+     *     | WHERE other &gt; 10
+     * </pre>
+     */
+    private PhysicalPlan rewriteBySplittingFilter(FilterExec filterExec, EvalExec evalExec, EsQueryExec esQueryExec) {
+        // Find all pushable distance functions in the EVAL
+        Map<NameId, StDistance> distances = getPushableDistances(evalExec.fields());
+
+        // Don't do anything if there are no distances to push down
+        if (distances.isEmpty()) {
+            return filterExec;
+        }
+
+        // Process the EVAL to get all aliases that might be needed in the filter rewrite
+        AttributeMap<Attribute> aliasReplacedBy = getAliasReplacedBy(evalExec);
+
+        // First we split the filter into multiple AND'd expressions, and then we evaluate each individually for distance rewrites
+        List<Expression> pushable = new ArrayList<>();
+        List<Expression> nonPushable = new ArrayList<>();
+        for (Expression exp : splitAnd(filterExec.condition())) {
+            Expression resExp = exp.transformUp(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
+            // Find and rewrite any binary comparisons that involve a distance function and a literal
+            var rewritten = rewriteDistanceFilters(resExp, distances);
+            // If all pushable StDistance functions were found and re-written, we need to re-write the FILTER/EVAL combination
+            if (rewritten.equals(resExp) == false && canPushToSource(rewritten, x -> false)) {
+                pushable.add(rewritten);
+            } else {
+                nonPushable.add(exp);
+            }
+        }
+
+        // If nothing pushable was rewritten, we can return the original filter
+        if (pushable.isEmpty()) {
+            return filterExec;
+        }
+
+        // Move the rewritten pushable filters below the EVAL
+        var distanceFilter = new FilterExec(filterExec.source(), esQueryExec, Predicates.combineAnd(pushable));
+        var newEval = new EvalExec(evalExec.source(), distanceFilter, evalExec.fields());
+        if (nonPushable.isEmpty()) {
+            // No other filters found, we can just return the original eval with the new filter as child
+            return newEval;
+        } else {
+            // Some other filters found, we need to return two filters with the eval in between
+            return new FilterExec(filterExec.source(), newEval, Predicates.combineAnd(nonPushable));
+        }
+    }
+
+    private Map<NameId, StDistance> getPushableDistances(List<Alias> aliases) {
+        Map<NameId, StDistance> distances = new LinkedHashMap<>();
+        aliases.forEach(alias -> {
+            if (alias.child() instanceof StDistance distance && canPushSpatialFunctionToSource(distance)) {
+                distances.put(alias.id(), distance);
+            } else if (alias.child() instanceof ReferenceAttribute ref && distances.containsKey(ref.id())) {
+                StDistance distance = distances.get(ref.id());
+                distances.put(alias.id(), distance);
+            }
+        });
+        return distances;
+    }
+
+    private Expression rewriteDistanceFilters(Expression expr, Map<NameId, StDistance> distances) {
+        return expr.transformDown(EsqlBinaryComparison.class, comparison -> {
+            ComparisonType comparisonType = ComparisonType.from(comparison.getFunctionType());
+            if (comparison.left() instanceof ReferenceAttribute r && distances.containsKey(r.id()) && comparison.right().foldable()) {
+                StDistance dist = distances.get(r.id());
+                return rewriteComparison(comparison, dist, comparison.right(), comparisonType);
+            } else if (comparison.right() instanceof ReferenceAttribute r
+                && distances.containsKey(r.id())
+                && comparison.left().foldable()) {
+                    StDistance dist = distances.get(r.id());
+                    return rewriteComparison(comparison, dist, comparison.left(), ComparisonType.invert(comparisonType));
+                }
+            return comparison;
+        });
     }
 
     private Expression rewriteComparison(
@@ -117,7 +246,7 @@ public class EnableSpatialDistancePushdown extends PhysicalOptimizerRules.Parame
     /**
      * This enum captures the key differences between various inequalities as perceived from the spatial distance function.
      * In particular, we need to know which direction the inequality points, with lt=true meaning the left is expected to be smaller
-     * than the right. And eq=true meaning we expect euality as well. We currently don't support Equals and NotEquals, so the third
+     * than the right. And eq=true meaning we expect equality as well. We currently don't support Equals and NotEquals, so the third
      * field disables those.
      */
     enum ComparisonType {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -8,10 +8,14 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Range;
@@ -30,6 +34,7 @@ import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.core.util.Queries;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.FullTextFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.ip.CIDRMatch;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.BinarySpatialFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
@@ -43,6 +48,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Not
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
@@ -53,6 +59,7 @@ import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.splitAnd;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushDownUtils.isAggregatable;
 
 public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<FilterExec, LocalPhysicalOptimizerContext> {
 
@@ -60,38 +67,86 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
     protected PhysicalPlan rule(FilterExec filterExec, LocalPhysicalOptimizerContext ctx) {
         PhysicalPlan plan = filterExec;
         if (filterExec.child() instanceof EsQueryExec queryExec) {
-            List<Expression> pushable = new ArrayList<>();
-            List<Expression> nonPushable = new ArrayList<>();
-            for (Expression exp : splitAnd(filterExec.condition())) {
-                (canPushToSource(exp, x -> LucenePushDownUtils.hasIdenticalDelegate(x, ctx.searchStats())) ? pushable : nonPushable).add(
-                    exp
-                );
-            }
-            // Combine GT, GTE, LT and LTE in pushable to Range if possible
-            List<Expression> newPushable = combineEligiblePushableToRange(pushable);
-            if (newPushable.size() > 0) { // update the executable with pushable conditions
-                Query queryDSL = PlannerUtils.TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(newPushable));
-                QueryBuilder planQuery = queryDSL.asBuilder();
-                var query = Queries.combine(Queries.Clause.FILTER, asList(queryExec.query(), planQuery));
-                queryExec = new EsQueryExec(
-                    queryExec.source(),
-                    queryExec.index(),
-                    queryExec.indexMode(),
-                    queryExec.output(),
-                    query,
-                    queryExec.limit(),
-                    queryExec.sorts(),
-                    queryExec.estimatedRowSize()
-                );
-                if (nonPushable.size() > 0) { // update filter with remaining non-pushable conditions
-                    plan = new FilterExec(filterExec.source(), queryExec, Predicates.combineAnd(nonPushable));
-                } else { // prune Filter entirely
-                    plan = queryExec;
-                }
-            } // else: nothing changes
+            plan = planFilterExec(filterExec, queryExec, ctx);
+        } else if (filterExec.child() instanceof EvalExec evalExec && evalExec.child() instanceof EsQueryExec queryExec) {
+            plan = planFilterExec(filterExec, evalExec, queryExec, ctx);
         }
-
         return plan;
+    }
+
+    private static PhysicalPlan planFilterExec(FilterExec filterExec, EsQueryExec queryExec, LocalPhysicalOptimizerContext ctx) {
+        List<Expression> pushable = new ArrayList<>();
+        List<Expression> nonPushable = new ArrayList<>();
+        for (Expression exp : splitAnd(filterExec.condition())) {
+            (canPushToSource(exp, x -> LucenePushDownUtils.hasIdenticalDelegate(x, ctx.searchStats())) ? pushable : nonPushable).add(exp);
+        }
+        return rewrite(filterExec, queryExec, pushable, nonPushable, List.of());
+    }
+
+    private static PhysicalPlan planFilterExec(
+        FilterExec filterExec,
+        EvalExec evalExec,
+        EsQueryExec queryExec,
+        LocalPhysicalOptimizerContext ctx
+    ) {
+        AttributeMap<Attribute> aliasReplacedBy = getAliasReplacedBy(evalExec);
+        List<Expression> pushable = new ArrayList<>();
+        List<Expression> nonPushable = new ArrayList<>();
+        for (Expression exp : splitAnd(filterExec.condition())) {
+            Expression resExp = exp.transformUp(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
+            (canPushToSource(resExp, x -> LucenePushDownUtils.hasIdenticalDelegate(x, ctx.searchStats())) ? pushable : nonPushable).add(
+                exp
+            );
+        }
+        // Replace field references with their actual field attributes
+        pushable.replaceAll(e -> e.transformDown(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r)));
+        return rewrite(filterExec, queryExec, pushable, nonPushable, evalExec.fields());
+    }
+
+    static AttributeMap<Attribute> getAliasReplacedBy(EvalExec evalExec) {
+        AttributeMap.Builder<Attribute> aliasReplacedByBuilder = AttributeMap.builder();
+        evalExec.fields().forEach(alias -> {
+            if (alias.child() instanceof Attribute attr) {
+                aliasReplacedByBuilder.put(alias.toAttribute(), attr);
+            }
+        });
+        return aliasReplacedByBuilder.build();
+    }
+
+    private static PhysicalPlan rewrite(
+        FilterExec filterExec,
+        EsQueryExec queryExec,
+        List<Expression> pushable,
+        List<Expression> nonPushable,
+        List<Alias> evalFields
+    ) {
+        // Combine GT, GTE, LT and LTE in pushable to Range if possible
+        List<Expression> newPushable = combineEligiblePushableToRange(pushable);
+        if (newPushable.size() > 0) { // update the executable with pushable conditions
+            Query queryDSL = PlannerUtils.TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(newPushable));
+            QueryBuilder planQuery = queryDSL.asBuilder();
+            var query = Queries.combine(Queries.Clause.FILTER, asList(queryExec.query(), planQuery));
+            queryExec = new EsQueryExec(
+                queryExec.source(),
+                queryExec.index(),
+                queryExec.indexMode(),
+                queryExec.output(),
+                query,
+                queryExec.limit(),
+                queryExec.sorts(),
+                queryExec.estimatedRowSize()
+            );
+            // If the eval contains other aliases, not just field attributes, we need to keep them in the plan
+            PhysicalPlan plan = evalFields.isEmpty() ? queryExec : new EvalExec(filterExec.source(), queryExec, evalFields);
+            if (nonPushable.size() > 0) {
+                // update filter with remaining non-pushable conditions
+                return new FilterExec(filterExec.source(), plan, Predicates.combineAnd(nonPushable));
+            } else {
+                // prune Filter entirely
+                return plan;
+            }
+        } // else: nothing changes
+        return filterExec;
     }
 
     private static List<Expression> combineEligiblePushableToRange(List<Expression> pushable) {
@@ -189,8 +244,8 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
             }
         } else if (exp instanceof CIDRMatch cidrMatch) {
             return isAttributePushable(cidrMatch.ipField(), cidrMatch, hasIdenticalDelegate) && Expressions.foldable(cidrMatch.matches());
-        } else if (exp instanceof SpatialRelatesFunction bc) {
-            return bc.canPushToSource(LucenePushDownUtils::isAggregatable);
+        } else if (exp instanceof SpatialRelatesFunction spatial) {
+            return canPushSpatialFunctionToSource(spatial);
         } else if (exp instanceof MatchQueryPredicate mqp) {
             return mqp.field() instanceof FieldAttribute && DataType.isString(mqp.field().dataType());
         } else if (exp instanceof StringQueryPredicate) {
@@ -199,6 +254,20 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
             return true;
         }
         return false;
+    }
+
+    /**
+     * Push-down to Lucene is only possible if one field is an indexed spatial field, and the other is a constant spatial or string column.
+     */
+    public static boolean canPushSpatialFunctionToSource(BinarySpatialFunction s) {
+        // The use of foldable here instead of SpatialEvaluatorFieldKey.isConstant is intentional to match the behavior of the
+        // Lucene pushdown code in EsqlTranslationHandler::SpatialRelatesTranslator
+        // We could enhance both places to support ReferenceAttributes that refer to constants, but that is a larger change
+        return isPushableSpatialAttribute(s.left()) && s.right().foldable() || isPushableSpatialAttribute(s.right()) && s.left().foldable();
+    }
+
+    private static boolean isPushableSpatialAttribute(Expression exp) {
+        return exp instanceof FieldAttribute fa && fa.getExactInfo().hasExact() && isAggregatable(fa) && DataType.isSpatial(fa.dataType());
     }
 
     private static boolean isAttributePushable(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSource.java
@@ -7,55 +7,217 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.BinarySpatialFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDistance;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.function.Predicate;
 
+/**
+ * We handle two main scenarios here:
+ * <ol>
+ *     <li>
+ *         Queries like `FROM index | SORT field` will be pushed to the source if the field is an indexed field.
+ *     </li>
+ *     <li>
+ *         Queries like `FROM index | EVAL ref = ... | SORT ref` will be pushed to the source if the reference function is pushable,
+ *         which can happen under two conditions:
+ *         <ul>
+ *             <li>
+ *                 The reference refers linearly to an indexed field.
+ *                 For example: `FROM index | EVAL ref = field | SORT ref`
+ *             </li>
+ *             <li>
+ *                 The reference refers to a distance function that refers to an indexed field and a constant expression.
+ *                 For example `FROM index | EVAL distance = ST_DISTANCE(field, POINT(0, 0)) | SORT distance`.
+ *                 As with the previous condition, both the attribute and the constant can be further aliased.
+ *             </li>
+ *         </ul>
+ *     </li>
+ *     <li>
+ *     </li>
+ * </ol>
+ */
 public class PushTopNToSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<TopNExec, LocalPhysicalOptimizerContext> {
     @Override
     protected PhysicalPlan rule(TopNExec topNExec, LocalPhysicalOptimizerContext ctx) {
-        PhysicalPlan plan = topNExec;
-        PhysicalPlan child = topNExec.child();
-        if (canPushSorts(child)
-            && canPushDownOrders(topNExec.order(), x -> LucenePushDownUtils.hasIdenticalDelegate(x, ctx.searchStats()))) {
+        Pushable pushable = evaluatePushable(topNExec, x -> LucenePushDownUtils.hasIdenticalDelegate(x, ctx.searchStats()));
+        return pushable.rewrite(topNExec);
+    }
+
+    /**
+     * Multiple scenarios for pushing down TopN to Lucene source. Each involve checking a combination of conditions and then
+     * performing an associated rewrite specific to that scenario. This interface should be extended by each scenario, and
+     * include the appropriate rewrite logic.
+     */
+    interface Pushable {
+        PhysicalPlan rewrite(TopNExec topNExec);
+    }
+
+    private static final Pushable NO_OP = new NoOpPushable();
+
+    record NoOpPushable() implements Pushable {
+        public PhysicalPlan rewrite(TopNExec topNExec) {
+            return topNExec;
+        }
+    }
+
+    /**
+     * TODO: Consider deleting this case entirely. We do not know if this is ever hit.
+     */
+    record PushableExchangeExec(ExchangeExec exchangeExec, EsQueryExec queryExec) implements Pushable {
+        public PhysicalPlan rewrite(TopNExec topNExec) {
             var sorts = buildFieldSorts(topNExec.order());
             var limit = topNExec.limit();
+            return exchangeExec.replaceChild(queryExec.withSorts(sorts).withLimit(limit));
+        }
+    }
 
-            if (child instanceof ExchangeExec exchangeExec && exchangeExec.child() instanceof EsQueryExec queryExec) {
-                plan = exchangeExec.replaceChild(queryExec.withSorts(sorts).withLimit(limit));
-            } else {
-                plan = ((EsQueryExec) child).withSorts(sorts).withLimit(limit);
+    record PushableQueryExec(EsQueryExec queryExec) implements Pushable {
+        public PhysicalPlan rewrite(TopNExec topNExec) {
+            var sorts = buildFieldSorts(topNExec.order());
+            var limit = topNExec.limit();
+            return queryExec.withSorts(sorts).withLimit(limit);
+        }
+    }
+
+    record PushableGeoDistance(FieldAttribute fieldAttribute, Order order, Point point) {
+        private EsQueryExec.Sort sort() {
+            return new EsQueryExec.GeoDistanceSort(fieldAttribute.exactAttribute(), order.direction(), point.getLat(), point.getLon());
+        }
+
+        private static PushableGeoDistance from(StDistance distance, Order order) {
+            if (distance.left() instanceof Attribute attr && distance.right().foldable()) {
+                return from(attr, distance.right(), order);
+            } else if (distance.right() instanceof Attribute attr && distance.left().foldable()) {
+                return from(attr, distance.left(), order);
+            }
+            return null;
+        }
+
+        private static PushableGeoDistance from(Attribute attr, Expression foldable, Order order) {
+            if (attr instanceof FieldAttribute fieldAttribute) {
+                Geometry geometry = SpatialRelatesUtils.makeGeometryFromLiteral(foldable);
+                if (geometry instanceof Point point) {
+                    return new PushableGeoDistance(fieldAttribute, order, point);
+                }
+            }
+            return null;
+        }
+    }
+
+    record PushableCompoundExec(EvalExec evalExec, EsQueryExec queryExec, List<EsQueryExec.Sort> pushableSorts) implements Pushable {
+        public PhysicalPlan rewrite(TopNExec topNExec) {
+            // We need to keep the EVAL in place because the coordinator will have its own TopNExec so we need to keep the distance
+            return evalExec.replaceChild(queryExec.withSorts(pushableSorts).withLimit(topNExec.limit()));
+        }
+    }
+
+    private static Pushable evaluatePushable(TopNExec topNExec, Predicate<FieldAttribute> hasIdenticalDelegate) {
+        PhysicalPlan child = topNExec.child();
+        if (child instanceof EsQueryExec queryExec
+            && queryExec.canPushSorts()
+            && canPushDownOrders(topNExec.order(), hasIdenticalDelegate)) {
+            // With the simplest case of `FROM index | SORT ...` we only allow pushing down if the sort is on a field
+            return new PushableQueryExec(queryExec);
+        }
+        if (child instanceof ExchangeExec exchangeExec
+            && exchangeExec.child() instanceof EsQueryExec queryExec
+            && queryExec.canPushSorts()
+            && canPushDownOrders(topNExec.order(), hasIdenticalDelegate)) {
+            // When we have an exchange between the FROM and the SORT, we also only allow pushing down if the sort is on a field
+            return new PushableExchangeExec(exchangeExec, queryExec);
+        }
+        if (child instanceof EvalExec evalExec && evalExec.child() instanceof EsQueryExec queryExec && queryExec.canPushSorts()) {
+            // When we have an EVAL between the FROM and the SORT, we consider pushing down if the sort is on a field and/or
+            // a distance function defined in the EVAL. We also move the EVAL to after the SORT.
+            List<Order> orders = topNExec.order();
+            List<Alias> fields = evalExec.fields();
+            LinkedHashMap<NameId, StDistance> distances = new LinkedHashMap<>();
+            AttributeMap.Builder<Attribute> aliasReplacedByBuilder = AttributeMap.builder();
+            fields.forEach(alias -> {
+                // TODO: can we support CARTESIAN also?
+                if (alias.child() instanceof StDistance distance && distance.crsType() == BinarySpatialFunction.SpatialCrsType.GEO) {
+                    distances.put(alias.id(), distance);
+                } else if (alias.child() instanceof Attribute attr) {
+                    aliasReplacedByBuilder.put(alias.toAttribute(), attr.toAttribute());
+                }
+            });
+            AttributeMap<Attribute> aliasReplacedBy = aliasReplacedByBuilder.build();
+
+            List<EsQueryExec.Sort> pushableSorts = new ArrayList<>();
+            for (Order order : orders) {
+                if (LucenePushDownUtils.isPushableFieldAttribute(order.child(), hasIdenticalDelegate)) {
+                    pushableSorts.add(
+                        new EsQueryExec.FieldSort(
+                            ((FieldAttribute) order.child()).exactAttribute(),
+                            order.direction(),
+                            order.nullsPosition()
+                        )
+                    );
+                } else if (order.child() instanceof ReferenceAttribute referenceAttribute) {
+                    Attribute resolvedAttribute = aliasReplacedBy.resolve(referenceAttribute, referenceAttribute);
+                    if (distances.containsKey(resolvedAttribute.id())) {
+                        StDistance distance = distances.get(resolvedAttribute.id());
+                        StDistance d = (StDistance) distance.transformDown(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
+                        PushableGeoDistance pushableGeoDistance = PushableGeoDistance.from(d, order);
+                        if (pushableGeoDistance != null) {
+                            pushableSorts.add(pushableGeoDistance.sort());
+                        } else {
+                            // As soon as we see a non-pushable sort, we know we need a final SORT command
+                            break;
+                        }
+                    } else if (aliasReplacedBy.resolve(referenceAttribute, referenceAttribute) instanceof FieldAttribute fieldAttribute
+                        && LucenePushDownUtils.isPushableFieldAttribute(fieldAttribute, hasIdenticalDelegate)) {
+                            // If the SORT refers to a reference to a pushable field, we can push it down
+                            pushableSorts.add(
+                                new EsQueryExec.FieldSort(fieldAttribute.exactAttribute(), order.direction(), order.nullsPosition())
+                            );
+                        } else {
+                            // If the SORT refers to a non-pushable reference function, the EVAL must remain before the SORT,
+                            // and we can no longer push down anything
+                            break;
+                        }
+                } else {
+                    // As soon as we see a non-pushable sort, we know we need a final SORT command
+                    break;
+                }
+            }
+            // TODO: We can push down partial sorts where `pushableSorts.size() < orders.size()`, but that should involve benchmarks
+            if (pushableSorts.size() > 0 && pushableSorts.size() == orders.size()) {
+                return new PushableCompoundExec(evalExec, queryExec, pushableSorts);
             }
         }
-        return plan;
+        return NO_OP;
     }
 
-    private static boolean canPushSorts(PhysicalPlan plan) {
-        if (plan instanceof EsQueryExec queryExec) {
-            return queryExec.canPushSorts();
-        }
-        if (plan instanceof ExchangeExec exchangeExec && exchangeExec.child() instanceof EsQueryExec queryExec) {
-            return queryExec.canPushSorts();
-        }
-        return false;
-    }
-
-    private boolean canPushDownOrders(List<Order> orders, Predicate<FieldAttribute> hasIdenticalDelegate) {
+    private static boolean canPushDownOrders(List<Order> orders, Predicate<FieldAttribute> hasIdenticalDelegate) {
         // allow only exact FieldAttributes (no expressions) for sorting
         return orders.stream().allMatch(o -> LucenePushDownUtils.isPushableFieldAttribute(o.child(), hasIdenticalDelegate));
     }
 
-    private List<EsQueryExec.FieldSort> buildFieldSorts(List<Order> orders) {
-        List<EsQueryExec.FieldSort> sorts = new ArrayList<>(orders.size());
+    private static List<EsQueryExec.Sort> buildFieldSorts(List<Order> orders) {
+        List<EsQueryExec.Sort> sorts = new ArrayList<>(orders.size());
         for (Order o : orders) {
             sorts.add(new EsQueryExec.FieldSort(((FieldAttribute) o.child()).exactAttribute(), o.direction(), o.nullsPosition()));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialDocValuesExtraction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SpatialDocValuesExtraction.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialAggregateFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.BinarySpatialFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesFunction;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -26,6 +28,41 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * This rule is responsible for marking spatial fields to be extracted from doc-values instead of source values.
+ * This is a very specific optimization that is only used in the context of spatial aggregations.
+ * Normally spatial fields are extracted from source values because this maintains original precision, but is very slow.
+ * Simply loading from doc-values loses precision for points, and loses the geometry topological information for shapes.
+ * For this reason we only consider loading from doc values under very specific conditions:
+ * <ul>
+ *     <li>The spatial data is consumed by a spatial aggregation (eg. <code>ST_CENTROIDS_AGG</code>, negating the need for precision.</li>
+ *     <li>This aggregation is planned to run on the data node, so the doc-values Blocks are never transmit to the coordinator node.</li>
+ *     <li>The data node index in question has doc-values stored for the field in question.</li>
+ * </ul>
+ * While we do not support transmitting spatial doc-values to the coordinator node, it is still important on the data node to ensure
+ * that all spatial functions that will receive these doc-values are aware of this fact. For this reason, if the above conditions are met,
+ * we need to make four edits to the local physical plan to consistently support spatial doc-values:
+ * <ul>
+ *     <li>The spatial aggregation function itself is marked using <code>withDocValues()</code> to enable its
+ *     <code>toEvaluator()</code> method to produce the correct doc-values aware <code>Evaluator</code> functions.</li>
+ *     <li>Any spatial functions called within <code>EVAL</code> commands before the doc-values are consumed by the aggregation
+ *     also need to be marked using <code>withDocValues()</code> so their evaluators are correct.</li>
+ *     <li>Any spatial functions used within filters, <code>WHERE</code> commands, are similarly marked for the same reason.</li>
+ *     <li>The <code>FieldExtractExec</code> that will extract the field is marked with <code>withDocValuesAttributes(...)</code>
+ *     so that it calls the <code>FieldType.blockReader()</code> method with the correct <code>FieldExtractPreference</code></li>
+ * </ul>
+ * The question has been raised why the spatial functions need to know if they are using doc-values or not. At first glance one might
+ * perceive ES|QL functions as being logical planning only constructs, reflecting only the intent of the user. This, however, is not true.
+ * The ES|QL functions all contain the runtime implementation of the functions behaviour, in the form of one or more static methods,
+ * as well as a <code>toEvaluator()</code> instance method that is used to generates Block traversal code to call these runtime
+ * implementations, based on some internal state of the instance of the function. In most cases this internal state contains information
+ * determined during the logical planning phase, such as the field name and type, and whether it is a literal and can be folded.
+ * In the case of spatial functions, the internal state also contains information about whether the function is using doc-values or not.
+ * This knowledge is determined in the class being described here, and is only determined during local physical planning on each data
+ * node. This is because the decision to use doc-values is based on the local data node's index configuration, and the local physical plan
+ * is the only place where this information is available. This also means that the knowledge of the usage of doc-values does not need
+ * to be serialized between nodes, and is only used locally.
+ */
 public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.OptimizerRule<AggregateExec> {
     @Override
     protected PhysicalPlan rule(AggregateExec aggregate) {
@@ -65,14 +102,7 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Optimizer
             if (exec instanceof EvalExec evalExec) {
                 List<Alias> fields = evalExec.fields();
                 List<Alias> changed = fields.stream()
-                    .map(
-                        f -> (Alias) f.transformDown(
-                            SpatialRelatesFunction.class,
-                            spatialRelatesFunction -> (spatialRelatesFunction.hasFieldAttribute(foundAttributes))
-                                ? spatialRelatesFunction.withDocValues(foundAttributes)
-                                : spatialRelatesFunction
-                        )
-                    )
+                    .map(f -> (Alias) f.transformDown(BinarySpatialFunction.class, s -> withDocValues(s, foundAttributes)))
                     .toList();
                 if (changed.equals(fields) == false) {
                     exec = new EvalExec(exec.source(), exec.child(), changed);
@@ -81,13 +111,7 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Optimizer
             if (exec instanceof FilterExec filterExec) {
                 // Note that ST_CENTROID does not support shapes, but SpatialRelatesFunction does, so when we extend the centroid
                 // to support shapes, we need to consider loading shape doc-values for both centroid and relates (ST_INTERSECTS)
-                var condition = filterExec.condition()
-                    .transformDown(
-                        SpatialRelatesFunction.class,
-                        spatialRelatesFunction -> (spatialRelatesFunction.hasFieldAttribute(foundAttributes))
-                            ? spatialRelatesFunction.withDocValues(foundAttributes)
-                            : spatialRelatesFunction
-                    );
+                var condition = filterExec.condition().transformDown(BinarySpatialFunction.class, s -> withDocValues(s, foundAttributes));
                 if (filterExec.condition().equals(condition) == false) {
                     exec = new FilterExec(filterExec.source(), filterExec.child(), condition);
                 }
@@ -110,6 +134,21 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Optimizer
         return plan;
     }
 
+    private BinarySpatialFunction withDocValues(BinarySpatialFunction spatial, Set<FieldAttribute> foundAttributes) {
+        // Only update the docValues flags if the field is found in the attributes
+        boolean foundLeft = foundField(spatial.left(), foundAttributes);
+        boolean foundRight = foundField(spatial.right(), foundAttributes);
+        return foundLeft || foundRight ? spatial.withDocValues(foundLeft, foundRight) : spatial;
+    }
+
+    private boolean hasFieldAttribute(BinarySpatialFunction spatial, Set<FieldAttribute> foundAttributes) {
+        return foundField(spatial.left(), foundAttributes) || foundField(spatial.right(), foundAttributes);
+    }
+
+    private boolean foundField(Expression expression, Set<FieldAttribute> foundAttributes) {
+        return expression instanceof FieldAttribute field && foundAttributes.contains(field);
+    }
+
     /**
      * This function disallows the use of more than one field for doc-values extraction in the same spatial relation function.
      * This is because comparing two doc-values fields is not supported in the current implementation.
@@ -123,7 +162,7 @@ public class SpatialDocValuesExtraction extends PhysicalOptimizerRules.Optimizer
         var spatialRelatesAttributes = new HashSet<FieldAttribute>();
         agg.forEachExpressionDown(SpatialRelatesFunction.class, relatesFunction -> {
             candidateDocValuesAttributes.forEach(candidate -> {
-                if (relatesFunction.hasFieldAttribute(Set.of(candidate))) {
+                if (hasFieldAttribute(relatesFunction, Set.of(candidate))) {
                     spatialRelatesAttributes.add(candidate);
                 }
             });

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.optimizer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Build;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -20,12 +21,15 @@ import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.RegexpQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.GeoDistanceSortBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
@@ -41,6 +45,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
@@ -151,14 +156,17 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.parser.ExpressionBuilder.MAX_EXPRESSION_DEPTH;
 import static org.elasticsearch.xpack.esql.parser.LogicalPlanBuilder.MAX_QUERY_DEPTH;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -529,11 +537,11 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(names(extract.attributesToExtract()), contains("salary", "emp_no", "last_name"));
         var source = source(extract.child());
         assertThat(source.limit(), is(topN.limit()));
-        assertThat(source.sorts(), is(sorts(topN.order())));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
 
         assertThat(source.limit(), is(l(10)));
         assertThat(source.sorts().size(), is(1));
-        FieldSort order = source.sorts().get(0);
+        EsQueryExec.Sort order = source.sorts().get(0);
         assertThat(order.direction(), is(Order.OrderDirection.ASC));
         assertThat(name(order.field()), is("last_name"));
         // last name is keyword, salary, emp_no, doc id, segment, forwards and backwards doc id maps are all ints
@@ -802,6 +810,19 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(query.query(), is(boolQuery().should(existsQuery("emp_no")).should(existsQuery("salary"))));
     }
 
+    /**
+     * This used to not allow pushing the sort down to the source, but now it does, since the eval is not used for the sort
+     * <code>
+     * TopNExec[[Order[emp_no{f}#6,ASC,LAST]],1[INTEGER],0]
+     * \_ExchangeExec[[_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, gender{f}#8, job{f}#13, job.raw{f}#14, ..],false]
+     *   \_ProjectExec[[_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, gender{f}#8, job{f}#13, job.raw{f}#14, ..]]
+     *     \_FieldExtractExec[_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..][]
+     *       \_EvalExec[[null[INTEGER] AS nullsum]]
+     *         \_EsQueryExec[test], indexMode[standard], query[][_doc{f}#27], limit[1], sort[[
+     *           FieldSort[field=emp_no{f}#6, direction=ASC, nulls=LAST]
+     *         ]] estimatedRowSize[340]
+     * </code>
+     */
     public void testQueryWithNull() {
         var plan = physicalPlan("""
             from test
@@ -818,15 +839,10 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var exchange = asRemoteExchange(topN.child());
         var project = as(exchange.child(), ProjectExec.class);
         var extract = as(project.child(), FieldExtractExec.class);
-        var topNLocal = as(extract.child(), TopNExec.class);
-        // All fields except emp_no are loaded after this topn. We load an extra int for the doc and segment mapping.
-        assertThat(topNLocal.estimatedRowSize(), equalTo(allFieldRowSize + Integer.BYTES));
-
-        var extractForEval = as(topNLocal.child(), FieldExtractExec.class);
-        var eval = as(extractForEval.child(), EvalExec.class);
+        var eval = as(extract.child(), EvalExec.class);
         var source = source(eval.child());
-        // emp_no and nullsum are longs, doc id is an int
-        assertThat(source.estimatedRowSize(), equalTo(Integer.BYTES * 2 + Integer.BYTES));
+        // All fields loaded
+        assertThat(source.estimatedRowSize(), equalTo(allFieldRowSize + 3 * Integer.BYTES + Long.BYTES));
     }
 
     public void testPushAndInequalitiesFilter() {
@@ -1065,7 +1081,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var extract = as(project.child(), FieldExtractExec.class);
         var source = source(extract.child());
         assertThat(source.limit(), is(topN.limit()));
-        assertThat(source.sorts(), is(sorts(topN.order())));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
         // an int for doc id, an int for segment id, two ints for doc id map, and int for emp_no.
         assertThat(source.estimatedRowSize(), equalTo(Integer.BYTES * 5 + KEYWORD_EST));
     }
@@ -1221,11 +1237,11 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(names(extract.attributesToExtract()), contains("languages", "salary"));
         var source = source(extract.child());
         assertThat(source.limit(), is(topN.limit()));
-        assertThat(source.sorts(), is(sorts(topN.order())));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
 
         assertThat(source.limit(), is(l(1)));
         assertThat(source.sorts().size(), is(1));
-        FieldSort order = source.sorts().get(0);
+        EsQueryExec.Sort order = source.sorts().get(0);
         assertThat(order.direction(), is(Order.OrderDirection.ASC));
         assertThat(name(order.field()), is("salary"));
         // ints for doc id, segment id, forwards and backwards mapping, languages, and salary
@@ -1752,6 +1768,124 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var regexpQuery = (RegexpQueryBuilder) mustNot.get(0);
         assertThat(regexpQuery.fieldName(), is("first_name"));
         assertThat(regexpQuery.value(), is(".*foo.*"));
+    }
+
+    /**
+     * <code>
+     * TopNExec[[Order[name{r}#4,ASC,LAST]],1000[INTEGER],0]
+     * \_ExchangeExec[[_meta_field{f}#20, emp_no{f}#14, gender{f}#16, job{f}#21, job.raw{f}#22, languages{f}#17,
+     *     long_noidx{f}#23, salary{f}#19, name{r}#4, first_name{r}#7, last_name{r}#10
+     *   ],false]
+     *   \_ProjectExec[[_meta_field{f}#20, emp_no{f}#14, gender{f}#16, job{f}#21, job.raw{f}#22, languages{f}#17,
+     *       long_noidx{f}#23, salary{f}#19, name{r}#4, first_name{r}#7, last_name{r}#10
+     *     ]]
+     *     \_FieldExtractExec[_meta_field{f}#20, emp_no{f}#14, gender{f}#16, job{..][]
+     *       \_EvalExec[[first_name{f}#15 AS name, last_name{f}#18 AS first_name, name{r}#4 AS last_name]]
+     *         \_FieldExtractExec[first_name{f}#15, last_name{f}#18][]
+     *           \_EsQueryExec[test], indexMode[standard], query[{
+     *             "bool":{"must":[
+     *               {"esql_single_value":{"field":"last_name","next":{"term":{"last_name":{"value":"foo"}}},"source":...}},
+     *               {"esql_single_value":{"field":"first_name","next":{"term":{"first_name":{"value":"bar"}}},"source":...}}
+     *             ],"boost":1.0}}][_doc{f}#37], limit[1000], sort[[
+     *               FieldSort[field=first_name{f}#15, direction=ASC, nulls=LAST]
+     *             ]] estimatedRowSize[486]
+     * </code>
+     */
+    public void testPushDownEvalFilter() {
+        var plan = physicalPlan("""
+            FROM test
+            | EVAL name = first_name, first_name = last_name, last_name = name
+            | WHERE first_name == "foo" AND last_name == "bar"
+            | SORT name
+            """);
+        var optimized = optimizedPlan(plan);
+
+        var topN = as(optimized, TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(extract.attributesToExtract().size(), greaterThan(5));
+        var eval = as(extract.child(), EvalExec.class);
+        extract = as(eval.child(), FieldExtractExec.class);
+        assertThat(
+            extract.attributesToExtract().stream().map(Attribute::name).collect(Collectors.toList()),
+            contains("first_name", "last_name")
+        );
+
+        // Now verify the correct Lucene push-down of both the filter and the sort
+        var source = source(extract.child());
+        QueryBuilder query = source.query();
+        assertNotNull(query);
+        assertThat(query, instanceOf(BoolQueryBuilder.class));
+        var boolQuery = (BoolQueryBuilder) query;
+        var must = boolQuery.must();
+        assertThat(must.size(), is(2));
+        var range1 = (TermQueryBuilder) ((SingleValueQuery.Builder) must.get(0)).next();
+        assertThat(range1.fieldName(), is("last_name"));
+        var range2 = (TermQueryBuilder) ((SingleValueQuery.Builder) must.get(1)).next();
+        assertThat(range2.fieldName(), is("first_name"));
+        var sort = source.sorts();
+        assertThat(sort.size(), is(1));
+        assertThat(sort.get(0).field().fieldName(), is("first_name"));
+    }
+
+    /**
+     * <code>
+     * ProjectExec[[last_name{f}#21 AS name, first_name{f}#18 AS last_name, last_name{f}#21 AS first_name]]
+     * \_TopNExec[[Order[last_name{f}#21,ASC,LAST]],10[INTEGER],0]
+     *   \_ExchangeExec[[last_name{f}#21, first_name{f}#18],false]
+     *     \_ProjectExec[[last_name{f}#21, first_name{f}#18]]
+     *       \_FieldExtractExec[last_name{f}#21, first_name{f}#18][]
+     *         \_EsQueryExec[test], indexMode[standard], query[{
+     *           "bool":{"must":[
+     *             {"esql_single_value":{
+     *               "field":"last_name",
+     *               "next":{"range":{"last_name":{"gt":"B","boost":1.0}}},
+     *               "source":"first_name &gt; \"B\"@3:9"
+     *             }},
+     *             {"exists":{"field":"first_name","boost":1.0}}
+     *           ],"boost":1.0}}][_doc{f}#40], limit[10], sort[[
+     *             FieldSort[field=last_name{f}#21, direction=ASC, nulls=LAST]
+     *           ]] estimatedRowSize[116]
+     * </code>
+     */
+    public void testPushDownEvalSwapFilter() {
+        var plan = physicalPlan("""
+            FROM test
+            | EVAL name = last_name, last_name = first_name, first_name = name
+            | WHERE first_name > "B" AND last_name IS NOT NULL
+            | SORT name
+            | LIMIT 10
+            | KEEP name, last_name, first_name
+            """);
+        var optimized = optimizedPlan(plan);
+
+        var topProject = as(optimized, ProjectExec.class);
+        var topN = as(topProject.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(
+            extract.attributesToExtract().stream().map(Attribute::name).collect(Collectors.toList()),
+            contains("last_name", "first_name")
+        );
+
+        // Now verify the correct Lucene push-down of both the filter and the sort
+        var source = source(extract.child());
+        QueryBuilder query = source.query();
+        assertNotNull(query);
+        assertThat(query, instanceOf(BoolQueryBuilder.class));
+        var boolQuery = (BoolQueryBuilder) query;
+        var must = boolQuery.must();
+        assertThat(must.size(), is(2));
+        var svq = (SingleValueQuery.Builder) must.get(0);
+        var range = (RangeQueryBuilder) svq.next();
+        assertThat(range.fieldName(), is("last_name"));
+        var exists = (ExistsQueryBuilder) must.get(1);
+        assertThat(exists.fieldName(), is("first_name"));
+        var sort = source.sorts();
+        assertThat(sort.size(), is(1));
+        assertThat(sort.get(0).field().fieldName(), is("last_name"));
     }
 
     /**
@@ -3074,6 +3208,107 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         }
     }
 
+    /**
+     * Plan:
+     * <code>
+     * LimitExec[1000[INTEGER]]
+     * \_ExchangeExec[[],false]
+     *   \_FragmentExec[filter=null, estimatedRowSize=0, reducer=[], fragment=[
+     * Limit[1000[INTEGER]]
+     * \_Filter[rank{r}#4 lt 4[INTEGER]]
+     *   \_Eval[[scalerank{f}#8 AS rank]]
+     *     \_EsRelation[airports][abbrev{f}#6, city{f}#12, city_location{f}#13, count..]]]
+     * </code>
+     * Optimized:
+     * <code>
+     * LimitExec[1000[INTEGER]]
+     * \_ExchangeExec[[abbrev{f}#6, city{f}#12, city_location{f}#13, country{f}#11, location{f}#10, name{f}#7, scalerank{f}#8,
+     *     type{f}#9, rank{r}#4],false]
+     *   \_ProjectExec[[abbrev{f}#6, city{f}#12, city_location{f}#13, country{f}#11, location{f}#10, name{f}#7, scalerank{f}#8,
+     *       type{f}#9, rank{r}#4]]
+     *     \_FieldExtractExec[abbrev{f}#6, city{f}#12, city_location{f}#13, count..][]
+     *       \_LimitExec[1000[INTEGER]]
+     *         \_EvalExec[[scalerank{f}#8 AS rank]]
+     *           \_FieldExtractExec[scalerank{f}#8][]
+     *             \_EsQueryExec[airports], indexMode[standard], query[{"
+     *               esql_single_value":{"field":"scalerank","next":{"range":{"scalerank":{"lt":4,"boost":1.0}}},"source":"rank &lt; 4@3:9"}
+     *             }][_doc{f}#23], limit[], sort[] estimatedRowSize[304]
+     * </code>
+     */
+    public void testPushWhereEvalToSource() {
+        String query = """
+            FROM airports
+            | EVAL rank = scalerank
+            | WHERE rank < 4
+            """;
+
+        var plan = this.physicalPlan(query, airports);
+        var limit = as(plan, LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var fragment = as(exchange.child(), FragmentExec.class);
+        var limit2 = as(fragment.fragment(), Limit.class);
+        var filter = as(limit2.child(), Filter.class);
+        assertThat("filter contains LessThan", filter.condition(), instanceOf(LessThan.class));
+
+        var optimized = optimizedPlan(plan);
+        var topLimit = as(optimized, LimitExec.class);
+        exchange = as(topLimit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var fieldExtract = as(project.child(), FieldExtractExec.class);
+        assertThat(fieldExtract.attributesToExtract().size(), greaterThan(5));
+        limit = as(fieldExtract.child(), LimitExec.class);
+        var eval = as(limit.child(), EvalExec.class);
+        fieldExtract = as(eval.child(), FieldExtractExec.class);
+        assertThat(fieldExtract.attributesToExtract().stream().map(Attribute::name).collect(Collectors.toList()), contains("scalerank"));
+        var source = source(fieldExtract.child());
+        var condition = as(source.query(), SingleValueQuery.Builder.class);
+        assertThat("Expected predicate to be passed to Lucene query", condition.source().text(), equalTo("rank < 4"));
+        assertThat("Expected field to be passed to Lucene query", condition.field(), equalTo("scalerank"));
+        var range = as(condition.next(), RangeQueryBuilder.class);
+        assertThat("Expected range have no lower bound", range.from(), nullValue());
+        assertThat("Expected range to be less than 4", range.to(), equalTo(4));
+    }
+
+    public void testPushSpatialIntersectsEvalToSource() {
+        for (String query : new String[] { """
+            FROM airports
+            | EVAL point = location
+            | WHERE ST_INTERSECTS(point, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))"))
+            """, """
+            FROM airports
+            | EVAL point = location
+            | WHERE ST_INTERSECTS(TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))"), point)
+            """ }) {
+
+            var plan = this.physicalPlan(query, airports);
+            var limit = as(plan, LimitExec.class);
+            var exchange = as(limit.child(), ExchangeExec.class);
+            var fragment = as(exchange.child(), FragmentExec.class);
+            var limit2 = as(fragment.fragment(), Limit.class);
+            var filter = as(limit2.child(), Filter.class);
+            assertThat("filter contains ST_INTERSECTS", filter.condition(), instanceOf(SpatialIntersects.class));
+
+            var optimized = optimizedPlan(plan);
+            var topLimit = as(optimized, LimitExec.class);
+            exchange = as(topLimit.child(), ExchangeExec.class);
+            var project = as(exchange.child(), ProjectExec.class);
+            var fieldExtract = as(project.child(), FieldExtractExec.class);
+            assertThat(fieldExtract.attributesToExtract().size(), greaterThan(5));
+            limit = as(fieldExtract.child(), LimitExec.class);
+            var eval = as(limit.child(), EvalExec.class);
+            fieldExtract = as(eval.child(), FieldExtractExec.class);
+            assertThat(fieldExtract.attributesToExtract().stream().map(Attribute::name).collect(Collectors.toList()), contains("location"));
+            var source = source(fieldExtract.child());
+            var condition = as(source.query(), SpatialRelatesQuery.ShapeQueryBuilder.class);
+            assertThat("Geometry field name", condition.fieldName(), equalTo("location"));
+            assertThat("Spatial relationship", condition.relation(), equalTo(ShapeRelation.INTERSECTS));
+            assertThat("Geometry is Polygon", condition.shape().type(), equalTo(ShapeType.POLYGON));
+            var polygon = as(condition.shape(), Polygon.class);
+            assertThat("Polygon shell length", polygon.getPolygon().length(), equalTo(5));
+            assertThat("Polygon holes", polygon.getNumberOfHoles(), equalTo(0));
+        }
+    }
+
     private record TestSpatialRelation(ShapeRelation relation, TestDataSource index, boolean literalRight, boolean canPushToSource) {
         String function() {
             return switch (relation) {
@@ -3257,30 +3492,22 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * </code>
      * Optimized:
      * <code>
-     * LimitExec[500[INTEGER]]
-     * \_AggregateExec[[],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,58]
+     * LimitExec[1000[INTEGER]]
+     * \_AggregateExec[[],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,[...],29]
      *   \_ExchangeExec[[xVal{r}#16, xDel{r}#17, yVal{r}#18, yDel{r}#19, count{r}#20, count{r}#21, seen{r}#22],true]
-     *     \_AggregateExec[[],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count],PARTIAL,58]
+     *     \_AggregateExec[[],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count],INITIAL,[...],29]
      *       \_FieldExtractExec[location{f}#12][location{f}#12]
-     *         \_EsQueryExec[airports], query[{
-     *           "esql_single_value":{
-     *             "field":"location",
-     *             "next":{
-     *               "geo_shape":{
-     *                 "location":{
-     *                   "shape":{
-     *                     "type":"Polygon",
-     *                     "coordinates":[[[42.0,14.0],[43.0,14.0],[43.0,15.0],[42.0,15.0],[42.0,14.0]]]
-     *                   },
-     *                   "relation":"intersects"
-     *                 },
-     *                 "ignore_unmapped":false,
-     *                 "boost":1.0
+     *         \_EsQueryExec[airports], indexMode[standard], query[{
+     *           "geo_shape":{
+     *             "location":{
+     *               "relation":"INTERSECTS",
+     *               "shape":{
+     *                 "type":"Polygon",
+     *                 "coordinates":[[[42.0,14.0],[43.0,14.0],[43.0,15.0],[42.0,15.0],[42.0,14.0]]]
      *               }
-     *             },
-     *             "source":"ST_INTERSECTS(location, \"POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))\")@2:9"
+     *             }
      *           }
-     *         }][_doc{f}#140, limit[], sort[] estimatedRowSize[54]
+     *         }][_doc{f}#47], limit[], sort[] estimatedRowSize[25]
      * </code>
      */
     public void testPushSpatialIntersectsStringToSourceAndUseDocValuesForCentroid() {
@@ -3732,6 +3959,167 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertShapeQueryRange(shapeQueryBuilders, 400000.0, 600000.0);
     }
 
+    /**
+     * Plan:
+     * <code>
+     * LimitExec[1000[INTEGER]]
+     * \_ExchangeExec[[],false]
+     *   \_FragmentExec[filter=null, estimatedRowSize=0, reducer=[], fragment=[
+     *     Limit[1000[INTEGER]]
+     *     \_Filter[distance{r}#4 le 600000[INTEGER] AND distance{r}#4 ge 400000[INTEGER]]
+     *        \_Eval[[STDISTANCE(location{f}#11,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *          AS distance]]
+     *          \_EsRelation[airports][abbrev{f}#7, city{f}#13, city_location{f}#14, count..]]]
+     * </code>
+     * Optimized:
+     * <code>
+     * LimitExec[1000[INTEGER]]
+     * \_ExchangeExec[[abbrev{f}#7, city{f}#13, city_location{f}#14, country{f}#12, location{f}#11, name{f}#8, scalerank{f}#9, type{
+     * f}#10, distance{r}#4],false]
+     *   \_ProjectExec[[abbrev{f}#7, city{f}#13, city_location{f}#14, country{f}#12, location{f}#11, name{f}#8, scalerank{f}#9, type{
+     * f}#10, distance{r}#4]]
+     *     \_FieldExtractExec[abbrev{f}#7, city{f}#13, city_location{f}#14, count..][]
+     *       \_LimitExec[1000[INTEGER]]
+     *         \_EvalExec[[STDISTANCE(location{f}#11,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *           AS distance]]
+     *           \_FieldExtractExec[location{f}#11][]
+     *             \_EsQueryExec[airports], indexMode[standard], query[{
+     *               "bool":{
+     *                 "must":[
+     *                   {
+     *                     "geo_shape":{
+     *                       "location":{
+     *                         "relation":"INTERSECTS",
+     *                         "shape":{
+     *                           "type":"Circle",
+     *                           "radius":"600000.0m",
+     *                           "coordinates":[12.565,55.673]
+     *                         }
+     *                       }
+     *                     }
+     *                   },
+     *                   {
+     *                     "geo_shape":{
+     *                       "location":{
+     *                         "relation":"DISJOINT",
+     *                         "shape":{
+     *                           "type":"Circle",
+     *                           "radius":"400000.0m",
+     *                           "coordinates":[12.565,55.673]
+     *                         }
+     *                       }
+     *                     }
+     *                   }
+     *                 ],
+     *                 "boost":1.0
+     *               }}][_doc{f}#24], limit[], sort[] estimatedRowSize[308]
+     * </code>
+     */
+    public void testPushSpatialDistanceEvalToSource() {
+        var query = """
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | WHERE distance <= 600000
+                AND distance >= 400000
+            """;
+        var plan = this.physicalPlan(query, airports);
+        var limit = as(plan, LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var fragment = as(exchange.child(), FragmentExec.class);
+        var limit2 = as(fragment.fragment(), Limit.class);
+        var filter = as(limit2.child(), Filter.class);
+
+        // Validate the EVAL expression
+        var eval = as(filter.child(), Eval.class);
+        var alias = as(eval.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        var stDistance = as(alias.child(), StDistance.class);
+        var location = as(stDistance.left(), FieldAttribute.class);
+        assertThat(location.fieldName(), is("location"));
+
+        // Validate the filter condition
+        var and = as(filter.condition(), And.class);
+        for (Expression expression : and.arguments()) {
+            var comp = as(expression, EsqlBinaryComparison.class);
+            var expectedComp = comp.equals(and.left()) ? LessThanOrEqual.class : GreaterThanOrEqual.class;
+            assertThat("filter contains expected binary comparison", comp, instanceOf(expectedComp));
+            var distance = as(comp.left(), ReferenceAttribute.class);
+            assertThat(distance.name(), is("distance"));
+        }
+
+        var optimized = optimizedPlan(plan);
+        var topLimit = as(optimized, LimitExec.class);
+        exchange = as(topLimit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var fieldExtract = as(project.child(), FieldExtractExec.class);
+        var limit3 = as(fieldExtract.child(), LimitExec.class);
+        var evalExec = as(limit3.child(), EvalExec.class);
+        var fieldExtract2 = as(evalExec.child(), FieldExtractExec.class);
+        var source = source(fieldExtract2.child());
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected zero range query builder", rangeQueryBuilders.size(), equalTo(0));
+        var shapeQueryBuilders = bool.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 400000.0, 600000.0);
+    }
+
+    public void testPushSpatialDistanceMultiEvalToSource() {
+        var query = """
+            FROM airports
+            | EVAL poi = TO_GEOPOINT("POINT(12.565 55.673)")
+            | EVAL distance = ST_DISTANCE(location, poi)
+            | WHERE distance <= 600000
+                AND distance >= 400000
+            """;
+        var plan = this.physicalPlan(query, airports);
+        var limit = as(plan, LimitExec.class);
+        var exchange = as(limit.child(), ExchangeExec.class);
+        var fragment = as(exchange.child(), FragmentExec.class);
+        var limit2 = as(fragment.fragment(), Limit.class);
+        var filter = as(limit2.child(), Filter.class);
+
+        // Validate the EVAL expression
+        var eval = as(filter.child(), Eval.class);
+        assertThat(eval.fields().size(), is(2));
+        var alias1 = as(eval.fields().get(0), Alias.class);
+        assertThat(alias1.name(), is("poi"));
+        var poi = as(alias1.child(), Literal.class);
+        assertThat(poi.fold(), instanceOf(BytesRef.class));
+        var alias2 = as(eval.fields().get(1), Alias.class);
+        assertThat(alias2.name(), is("distance"));
+        var stDistance = as(alias2.child(), StDistance.class);
+        var location = as(stDistance.left(), FieldAttribute.class);
+        assertThat(location.fieldName(), is("location"));
+        var poiRef = as(stDistance.right(), Literal.class);
+        assertThat(poiRef.fold(), instanceOf(BytesRef.class));
+        assertThat(poiRef.fold().toString(), is(poi.fold().toString()));
+
+        // Validate the filter condition
+        var and = as(filter.condition(), And.class);
+        for (Expression expression : and.arguments()) {
+            var comp = as(expression, EsqlBinaryComparison.class);
+            var expectedComp = comp.equals(and.left()) ? LessThanOrEqual.class : GreaterThanOrEqual.class;
+            assertThat("filter contains expected binary comparison", comp, instanceOf(expectedComp));
+            var distance = as(comp.left(), ReferenceAttribute.class);
+            assertThat(distance.name(), is("distance"));
+        }
+
+        var optimized = optimizedPlan(plan);
+        var topLimit = as(optimized, LimitExec.class);
+        exchange = as(topLimit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var fieldExtract = as(project.child(), FieldExtractExec.class);
+        var limit3 = as(fieldExtract.child(), LimitExec.class);
+        var evalExec = as(limit3.child(), EvalExec.class);
+        var fieldExtract2 = as(evalExec.child(), FieldExtractExec.class);
+        var source = source(fieldExtract2.child());
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected zero range query builder", rangeQueryBuilders.size(), equalTo(0));
+        var shapeQueryBuilders = bool.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 400000.0, 600000.0);
+    }
+
     public void testPushSpatialDistanceDisjointBandsToSource() {
         var query = """
             FROM airports
@@ -3826,6 +4214,1361 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         }
     }
 
+    /**
+     * <code>
+     * \_ExchangeExec[[abbrev{f}#22, city{f}#28, city_location{f}#29, country{f}#27, location{f}#26, name{f}#23, scalerank{f}#24,
+     *     type{f}#25, poi_x{r}#3, distance_x{r}#7, poi{r}#10, distance{r}#13],false]
+     *   \_ProjectExec[[abbrev{f}#22, city{f}#28, city_location{f}#29, country{f}#27, location{f}#26, name{f}#23, scalerank{f}#24,
+     *       type{f}#25, poi_x{r}#3, distance_x{r}#7, poi{r}#10, distance{r}#13]]
+     *     \_FieldExtractExec[abbrev{f}#22, city{f}#28, city_location{f}#29, coun..][]
+     *       \_LimitExec[1000[INTEGER]]
+     *         \_EvalExec[[
+     *             [1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT] AS poi_x,
+     *             DISTANCE(location{f}#26,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance_x,
+     *             [1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT] AS poi,
+     *             distance_x{r}#7 AS distance
+     *           ]]
+     *           \_FieldExtractExec[location{f}#26][]
+     *             \_EsQueryExec[airports], indexMode[standard], query[{
+     *               "bool":{
+     *                 "must":[
+     *                   {"esql_single_value":{
+     *                     "field":"abbrev",
+     *                     "next":{"bool":{"must_not":[{"term":{"abbrev":{"value":"PLQ"}}}],"boost":1.0}},
+     *                     "source":"NOT abbrev == \"PLQ\"@10:9"
+     *                   }},
+     *                   {"esql_single_value":{
+     *                     "field":"scalerank",
+     *                     "next":{"range":{"scalerank":{"lt":6,"boost":1.0}}},
+     *                     "source":"scalerank lt 6@11:9"
+     *                   }}
+     *                 ],
+     *                 "filter":[
+     *                   {"bool":{
+     *                     "should":[
+     *                       {"bool":{"must":[
+     *                         {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                         {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}},
+     *                         {"bool":{"must_not":[
+     *                           {"bool":{"must":[
+     *                             {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                             {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *                           ],"boost":1.0}}
+     *                         ],"boost":1.0}}
+     *                       ],"boost":1.0}},
+     *                       {"bool":{"must":[
+     *                         {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                         {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *                       ],"boost":1.0}}
+     *                     ],"boost":1.0
+     *                   }}
+     *                 ],"boost":1.0}}][_doc{f}#34], limit[], sort[] estimatedRowSize[329]
+     * </code>
+     */
+    public void testPushSpatialDistanceComplexPredicateWithEvalToSource() {
+        var query = """
+            FROM airports
+            | EVAL poi_x = TO_GEOPOINT("POINT(12.565 55.673)")
+            | EVAL distance_x = ST_DISTANCE(location, poi_x)
+            | EVAL poi = poi_x
+            | EVAL distance = distance_x
+            | WHERE ((distance <= 600000
+                  AND distance >= 400000
+                  AND NOT (distance <= 500000
+                       AND distance >= 430000))
+                  OR (distance <= 300000
+                           AND distance >= 200000))
+                AND NOT abbrev == "PLQ"
+                AND scalerank < 6
+            """;
+        var plan = this.physicalPlan(query, airports);
+        var optimized = optimizedPlan(plan);
+        var topLimit = as(optimized, LimitExec.class);
+        var exchange = as(topLimit.child(), ExchangeExec.class);
+        var project = as(exchange.child(), ProjectExec.class);
+        var fieldExtract = as(project.child(), FieldExtractExec.class);
+        var limit2 = as(fieldExtract.child(), LimitExec.class);
+        var evalExec = as(limit2.child(), EvalExec.class);
+        var fieldExtract2 = as(evalExec.child(), FieldExtractExec.class);
+        var source = source(fieldExtract2.child());
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        assertThat("Expected boolean query of three MUST clauses", bool.must().size(), equalTo(2));
+        assertThat("Expected boolean query of one FILTER clause", bool.filter().size(), equalTo(1));
+        var boolDisjuntive = as(bool.filter().get(0), BoolQueryBuilder.class);
+        var disjuntiveQueryBuilders = boolDisjuntive.should().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        assertThat("Expected two disjunctive query builders", disjuntiveQueryBuilders.size(), equalTo(2));
+        for (int i = 0; i < disjuntiveQueryBuilders.size(); i++) {
+            var subRangeBool = as(disjuntiveQueryBuilders.get(i), BoolQueryBuilder.class);
+            var shapeQueryBuilders = subRangeBool.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+            assertShapeQueryRange(shapeQueryBuilders, i == 0 ? 400000.0 : 200000.0, i == 0 ? 600000.0 : 300000.0);
+        }
+    }
+
+    /**
+     * Plan:
+     * <code>
+     * LimitExec[1000[INTEGER]]
+     * \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS count],FINAL,[count{r}#17, seen{r}#18],null]
+     *   \_ExchangeExec[[count{r}#17, seen{r}#18],true]
+     *     \_FragmentExec[filter=null, estimatedRowSize=0, reducer=[], fragment=[
+     * Aggregate[STANDARD,[],[COUNT([2a][KEYWORD]) AS count]]
+     * \_Filter[distance{r}#4 lt 1000000[INTEGER] AND distance{r}#4 gt 10000[INTEGER]]
+     *   \_Eval[[
+     *       STDISTANCE(location{f}#13,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance
+     *     ]]
+     *     \_EsRelation[airports][abbrev{f}#9, city{f}#15, city_location{f}#16, count..]]]
+     * </code>
+     * Optimized:
+     * <code>
+     * LimitExec[1000[INTEGER]]
+     * \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS count],FINAL,[count{r}#17, seen{r}#18],8]
+     *   \_ExchangeExec[[count{r}#17, seen{r}#18],true]
+     *     \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS count],INITIAL,[count{r}#31, seen{r}#32],8]
+     *       \_EvalExec[[
+     *           STDISTANCE(location{f}#13,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance
+     *         ]]
+     *         \_FieldExtractExec[location{f}#13][]
+     *           \_EsQueryExec[airports], indexMode[standard], query[{
+     *             "bool":{
+     *               "must":[
+     *                 {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                 {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *               ],"boost":1.0}}][_doc{f}#33], limit[], sort[] estimatedRowSize[33]
+     * </code>
+     */
+    public void testPushSpatialDistanceEvalWithSimpleStatsToSource() {
+        var query = """
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | WHERE distance < 1000000 AND distance > 10000
+            | STATS count=COUNT(*)
+            """;
+        var plan = this.physicalPlan(query, airports);
+        var limit = as(plan, LimitExec.class);
+        var agg = as(limit.child(), AggregateExec.class);
+        var exchange = as(agg.child(), ExchangeExec.class);
+        var fragment = as(exchange.child(), FragmentExec.class);
+        var agg2 = as(fragment.fragment(), Aggregate.class);
+        var filter = as(agg2.child(), Filter.class);
+
+        // Validate the filter condition (two distance filters)
+        var and = as(filter.condition(), And.class);
+        for (Expression expression : and.arguments()) {
+            var comp = as(expression, EsqlBinaryComparison.class);
+            var expectedComp = comp.equals(and.left()) ? LessThan.class : GreaterThan.class;
+            assertThat("filter contains expected binary comparison", comp, instanceOf(expectedComp));
+            var distance = as(comp.left(), ReferenceAttribute.class);
+            assertThat(distance.name(), is("distance"));
+        }
+
+        // Validate the eval (calculating distance)
+        var eval = as(filter.child(), Eval.class);
+        var alias = as(eval.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        as(eval.child(), EsRelation.class);
+
+        // Now optimize the plan
+        var optimized = optimizedPlan(plan);
+        var topLimit = as(optimized, LimitExec.class);
+        var aggExec = as(topLimit.child(), AggregateExec.class);
+        var exchangeExec = as(aggExec.child(), ExchangeExec.class);
+        var aggExec2 = as(exchangeExec.child(), AggregateExec.class);
+        // TODO: Remove the eval entirely, since the distance is no longer required after filter pushdown
+        // Right now we don't mark the distance field as doc-values, introducing a performance hit
+        // However, fixing this to doc-values is not as good as removing the EVAL entirely, which is a more sensible optimization
+        var evalExec = as(aggExec2.child(), EvalExec.class);
+        var stDistance = as(evalExec.fields().get(0).child(), StDistance.class);
+        assertThat("Expect distance function to expect doc-values", stDistance.leftDocValues(), is(false));
+        var source = assertChildIsGeoPointExtract(evalExec, false);
+
+        // No sort is pushed down
+        assertThat(source.limit(), nullValue());
+        assertThat(source.sorts(), nullValue());
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var shapeQueryBuilders = bool.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 1000000.0);
+    }
+
+    /**
+     * Plan:
+     * <code>
+     * TopNExec[[Order[count{r}#10,DESC,FIRST], Order[country{f}#21,ASC,LAST]],1000[INTEGER],null]
+     * \_AggregateExec[[country{f}#21],[COUNT([2a][KEYWORD]) AS count, SPATIALCENTROID(location{f}#20) AS centroid, country{f}#21],FINA
+     * L,[country{f}#21, count{r}#24, seen{r}#25, xVal{r}#26, xDel{r}#27, yVal{r}#28, yDel{r}#29, count{r}#30],null]
+     *   \_ExchangeExec[[country{f}#21, count{r}#24, seen{r}#25, xVal{r}#26, xDel{r}#27, yVal{r}#28, yDel{r}#29, count{r}#30],true]
+     *     \_FragmentExec[filter=null, estimatedRowSize=0, reducer=[], fragment=[
+     * Aggregate[STANDARD,[country{f}#21],[COUNT([2a][KEYWORD]) AS count, SPATIALCENTROID(location{f}#20) AS centroid, country{f}
+     * #21]]
+     * \_Filter[distance{r}#4 lt 1000000[INTEGER] AND distance{r}#4 gt 10000[INTEGER]]
+     *   \_Eval[[STDISTANCE(location{f}#20,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *     AS distance]]
+     *     \_Filter[scalerank{f}#18 lt 6[INTEGER]]
+     *       \_EsRelation[airports][abbrev{f}#16, city{f}#22, city_location{f}#23, coun..]]]
+     * </code>
+     * Optimized:
+     * <code>
+     * TopNExec[[Order[count{r}#10,DESC,FIRST], Order[country{f}#21,ASC,LAST]],1000[INTEGER],0]
+     * \_AggregateExec[[country{f}#21],[COUNT([2a][KEYWORD]) AS count, SPATIALCENTROID(location{f}#20) AS centroid, country{f}#21],FINA
+     * L,[country{f}#21, count{r}#24, seen{r}#25, xVal{r}#26, xDel{r}#27, yVal{r}#28, yDel{r}#29, count{r}#30],79]
+     *   \_ExchangeExec[[country{f}#21, count{r}#24, seen{r}#25, xVal{r}#26, xDel{r}#27, yVal{r}#28, yDel{r}#29, count{r}#30],true]
+     *     \_AggregateExec[[country{f}#21],[COUNT([2a][KEYWORD]) AS count, SPATIALCENTROID(location{f}#20) AS centroid, country{f}#21],INIT
+     * IAL,[country{f}#21, count{r}#49, seen{r}#50, xVal{r}#51, xDel{r}#52, yVal{r}#53, yDel{r}#54, count{r}#55],79]
+     *       \_EvalExec[[STDISTANCE(location{f}#20,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *         AS distance]]
+     *         \_FieldExtractExec[location{f}#20][location{f}#20]
+     *           \_EsQueryExec[airports], indexMode[standard], query[{
+     *               "bool":{
+     *                 "filter":[
+     *                   {
+     *                     "esql_single_value":{
+     *                       "field":"scalerank",
+     *                       "next":{"range":{"scalerank":{"lt":6,"boost":1.0}}},
+     *                       "source":"scalerank lt 6@3:31"
+     *                     }
+     *                   },
+     *                   {
+     *                     "bool":{
+     *                       "must":[
+     *                         {"geo_shape":{
+     *                           "location":{
+     *                             "relation":"INTERSECTS",
+     *                             "shape":{"type":"Circle","radius":"1000000m","coordinates":[12.565,55.673]}
+     *                           }
+     *                         }},
+     *                         {"geo_shape":{
+     *                           "location":{
+     *                             "relation":"DISJOINT",
+     *                             "shape":{"type":"Circle","radius":"10000m","coordinates":[12.565,55.673]}
+     *                           }
+     *                         }}
+     *                       ],
+     *                       "boost":1.0
+     *                     }
+     *                   }
+     *                 ],
+     *                 "boost":1.0
+     *             }}][_doc{f}#56], limit[], sort[] estimatedRowSize[33]
+     * </code>
+     */
+    public void testPushSpatialDistanceEvalWithStatsToSource() {
+        var query = """
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | WHERE distance < 1000000 AND scalerank < 6 AND distance > 10000
+            | STATS count=COUNT(*), centroid=ST_CENTROID_AGG(location) BY country
+            | SORT count DESC, country ASC
+            """;
+        var plan = this.physicalPlan(query, airports);
+        var topN = as(plan, TopNExec.class);
+        var agg = as(topN.child(), AggregateExec.class);
+        var exchange = as(agg.child(), ExchangeExec.class);
+        var fragment = as(exchange.child(), FragmentExec.class);
+        var agg2 = as(fragment.fragment(), Aggregate.class);
+        var filter = as(agg2.child(), Filter.class);
+
+        // Validate the filter condition (two distance filters)
+        var and = as(filter.condition(), And.class);
+        for (Expression expression : and.arguments()) {
+            var comp = as(expression, EsqlBinaryComparison.class);
+            var expectedComp = comp.equals(and.left()) ? LessThan.class : GreaterThan.class;
+            assertThat("filter contains expected binary comparison", comp, instanceOf(expectedComp));
+            var distance = as(comp.left(), ReferenceAttribute.class);
+            assertThat(distance.name(), is("distance"));
+        }
+
+        // Validate the eval (calculating distance)
+        var eval = as(filter.child(), Eval.class);
+        var alias = as(eval.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        var filter2 = as(eval.child(), Filter.class);
+
+        // Now optimize the plan
+        var optimized = optimizedPlan(plan);
+        var topLimit = as(optimized, TopNExec.class);
+        var aggExec = as(topLimit.child(), AggregateExec.class);
+        var exchangeExec = as(aggExec.child(), ExchangeExec.class);
+        var aggExec2 = as(exchangeExec.child(), AggregateExec.class);
+        // TODO: Remove the eval entirely, since the distance is no longer required after filter pushdown
+        var evalExec = as(aggExec2.child(), EvalExec.class);
+        var stDistance = as(evalExec.fields().get(0).child(), StDistance.class);
+        assertThat("Expect distance function to expect doc-values", stDistance.leftDocValues(), is(true));
+        var source = assertChildIsGeoPointExtract(evalExec, true);
+
+        // No sort is pushed down
+        assertThat(source.limit(), nullValue());
+        assertThat(source.sorts(), nullValue());
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+        assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+        var filterBool = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        var fb = as(filterBool.get(0), BoolQueryBuilder.class);
+        var shapeQueryBuilders = fb.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 1000000.0);
+    }
+
+    /**
+     * ProjectExec[[languages{f}#8, salary{f}#10]]
+     * \_TopNExec[[Order[salary{f}#10,DESC,FIRST]],10[INTEGER],0]
+     *   \_ExchangeExec[[languages{f}#8, salary{f}#10],false]
+     *     \_ProjectExec[[languages{f}#8, salary{f}#10]]
+     *       \_FieldExtractExec[languages{f}#8, salary{f}#10][]
+     *         \_EsQueryExec[test],
+     *           indexMode[standard],
+     *           query[][_doc{f}#25],
+     *           limit[10],
+     *           sort[[FieldSort[field=salary{f}#10, direction=DESC, nulls=FIRST]]] estimatedRowSize[24]
+     */
+    public void testPushTopNToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM test
+            | SORT salary DESC
+            | LIMIT 10
+            | KEEP languages, salary
+            """));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("languages", "salary"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("languages", "salary"));
+        var source = source(extract.child());
+        assertThat(source.limit(), is(topN.limit()));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
+
+        assertThat(source.limit(), is(l(10)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.DESC));
+        assertThat(name(sort.field()), is("salary"));
+        assertThat(sort.sortBuilder(), isA(FieldSortBuilder.class));
+        assertNull(source.query());
+    }
+
+    /**
+     * ProjectExec[[languages{f}#9, salary{f}#11]]
+     * \_TopNExec[[Order[salary{f}#11,DESC,FIRST]],10[INTEGER],0]
+     *   \_ExchangeExec[[languages{f}#9, salary{f}#11],false]
+     *     \_ProjectExec[[languages{f}#9, salary{f}#11]]
+     *       \_FieldExtractExec[languages{f}#9, salary{f}#11][]
+     *         \_EsQueryExec[test],
+     *           indexMode[standard],
+     *           query[{"esql_single_value":{
+     *             "field":"salary",
+     *             "next":{"range":{"salary":{"gt":50000,"boost":1.0}}},
+     *             "source":"salary > 50000@2:9"
+     *           }}][_doc{f}#26],
+     *           limit[10],
+     *           sort[[FieldSort[field=salary{f}#11, direction=DESC, nulls=FIRST]]] estimatedRowSize[24]
+     */
+    public void testPushTopNWithFilterToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM test
+            | WHERE salary > 50000
+            | SORT salary DESC
+            | LIMIT 10
+            | KEEP languages, salary
+            """));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("languages", "salary"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("languages", "salary"));
+        var source = source(extract.child());
+        assertThat(source.limit(), is(topN.limit()));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
+
+        assertThat(source.limit(), is(l(10)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.DESC));
+        assertThat(name(sort.field()), is("salary"));
+        assertThat(sort.sortBuilder(), isA(FieldSortBuilder.class));
+        var rq = as(sv(source.query(), "salary"), RangeQueryBuilder.class);
+        assertThat(rq.fieldName(), equalTo("salary"));
+        assertThat(rq.from(), equalTo(50000));
+        assertThat(rq.includeLower(), equalTo(false));
+        assertThat(rq.to(), nullValue());
+    }
+
+    /**
+     * ProjectExec[[abbrev{f}#12321, name{f}#12322, location{f}#12325, country{f}#12326, city{f}#12327]]
+     * \_TopNExec[[Order[abbrev{f}#12321,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#12321, name{f}#12322, location{f}#12325, country{f}#12326, city{f}#12327],false]
+     *     \_ProjectExec[[abbrev{f}#12321, name{f}#12322, location{f}#12325, country{f}#12326, city{f}#12327]]
+     *       \_FieldExtractExec[abbrev{f}#12321, name{f}#12322, location{f}#12325, ..][]
+     *         \_EsQueryExec[airports],
+     *           indexMode[standard],
+     *           query[][_doc{f}#12337],
+     *           limit[5],
+     *           sort[[FieldSort[field=abbrev{f}#12321, direction=ASC, nulls=LAST]]] estimatedRowSize[237]
+     */
+    public void testPushTopNKeywordToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | SORT abbrev
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "location", "country", "city"));
+        var source = source(extract.child());
+        assertThat(source.limit(), is(topN.limit()));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
+
+        assertThat(source.limit(), is(l(5)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(sort.field()), is("abbrev"));
+        assertThat(sort.sortBuilder(), isA(FieldSortBuilder.class));
+        assertNull(source.query());
+    }
+
+    /**
+     * <code>
+     * ProjectExec[[abbrev{f}#12, name{f}#13, location{f}#16, country{f}#17, city{f}#18, abbrev{f}#12 AS code]]
+     * \_TopNExec[[Order[abbrev{f}#12,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#12, name{f}#13, location{f}#16, country{f}#17, city{f}#18],false]
+     *     \_ProjectExec[[abbrev{f}#12, name{f}#13, location{f}#16, country{f}#17, city{f}#18]]
+     *       \_FieldExtractExec[abbrev{f}#12, name{f}#13, location{f}#16, country{f..][]
+     *         \_EsQueryExec[airports], indexMode[standard], query[][_doc{f}#29], limit[5],
+     *             sort[[FieldSort[field=abbrev{f}#12, direction=ASC, nulls=LAST]]] estimatedRowSize[237]
+     * </code>
+     */
+    public void testPushTopNAliasedKeywordToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL code = abbrev
+            | SORT code
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city, code
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "code"));
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "location", "country", "city"));
+        var source = source(extract.child());
+        assertThat(source.limit(), is(topN.limit()));
+        assertThat(source.sorts(), is(fieldSorts(topN.order())));
+
+        assertThat(source.limit(), is(l(5)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(sort.field()), is("abbrev"));
+        assertThat(sort.sortBuilder(), isA(FieldSortBuilder.class));
+        assertNull(source.query());
+    }
+
+    /**
+     * ProjectExec[[abbrev{f}#11, name{f}#12, location{f}#15, country{f}#16, city{f}#17]]
+     * \_TopNExec[[Order[distance{r}#4,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#11, name{f}#12, location{f}#15, country{f}#16, city{f}#17, distance{r}#4],false]
+     *     \_ProjectExec[[abbrev{f}#11, name{f}#12, location{f}#15, country{f}#16, city{f}#17, distance{r}#4]]
+     *       \_FieldExtractExec[abbrev{f}#11, name{f}#12, country{f}#16, city{f}#17][]
+     *         \_EvalExec[[STDISTANCE(location{f}#15,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *             AS distance]]
+     *           \_FieldExtractExec[location{f}#15][]
+     *             \_EsQueryExec[airports],
+     *               indexMode[standard],
+     *               query[][_doc{f}#28],
+     *               limit[5],
+     *               sort[[GeoDistanceSort[field=location{f}#15, direction=ASC, lat=55.673, lon=12.565]]] estimatedRowSize[245]
+     */
+    public void testPushTopNDistanceToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | SORT distance ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var evalExec = as(extract.child(), EvalExec.class);
+        var alias = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        var stDistance = as(alias.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(5)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(sort.field()), is("location"));
+        assertThat(sort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+        assertNull(source.query());
+    }
+
+    /**
+     * ProjectExec[[abbrev{f}#8, name{f}#9, location{f}#12, country{f}#13, city{f}#14]]
+     * \_TopNExec[[Order[$$order_by$0$0{r}#16,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#8, name{f}#9, location{f}#12, country{f}#13, city{f}#14, $$order_by$0$0{r}#16],false]
+     *     \_ProjectExec[[abbrev{f}#8, name{f}#9, location{f}#12, country{f}#13, city{f}#14, $$order_by$0$0{r}#16]]
+     *       \_FieldExtractExec[abbrev{f}#8, name{f}#9, country{f}#13, city{f}#14][]
+     *         \_EvalExec[[
+     *             STDISTANCE(location{f}#12,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS $$order_by$0$0
+     *           ]]
+     *           \_FieldExtractExec[location{f}#12][]
+     *             \_EsQueryExec[airports],
+     *               indexMode[standard],
+     *               query[][_doc{f}#26],
+     *               limit[5],
+     *               sort[[GeoDistanceSort[field=location{f}#12, direction=ASC, lat=55.673, lon=12.565]]] estimatedRowSize[245]
+     */
+    public void testPushTopNInlineDistanceToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | SORT ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")) ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "$$order_by$0$0"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var evalExec = as(extract.child(), EvalExec.class);
+        var alias = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("$$order_by$0$0"));
+        var stDistance = as(alias.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "$$order_by$0$0"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(5)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(sort.field()), is("location"));
+        assertThat(sort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+        assertNull(source.query());
+    }
+
+    /**
+     * <code>
+     * ProjectExec[[abbrev{f}#12, name{f}#13, location{f}#16, country{f}#17, city{f}#18]]
+     * \_TopNExec[[Order[distance{r}#4,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#12, name{f}#13, location{f}#16, country{f}#17, city{f}#18, distance{r}#4],false]
+     *     \_ProjectExec[[abbrev{f}#12, name{f}#13, location{f}#16, country{f}#17, city{f}#18, distance{r}#4]]
+     *       \_FieldExtractExec[abbrev{f}#12, name{f}#13, country{f}#17, city{f}#18][]
+     *         \_EvalExec[[STDISTANCE(location{f}#16,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance
+     * ]]
+     *           \_FieldExtractExec[location{f}#16][]
+     *             \_EsQueryExec[airports], indexMode[standard], query[
+     * {
+     *   "geo_shape":{
+     *     "location":{
+     *       "relation":"DISJOINT",
+     *       "shape":{
+     *         "type":"Circle",
+     *         "radius":"50000.00000000001m",
+     *         "coordinates":[12.565,55.673]
+     *       }
+     *     }
+     *   }
+     * }][_doc{f}#29], limit[5], sort[[GeoDistanceSort[field=location{f}#16, direction=ASC, lat=55.673, lon=12.565]]] estimatedRowSize[245]
+     * </code>
+     */
+    public void testPushTopNDistanceWithFilterToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | WHERE distance > 50000
+            | SORT distance ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var evalExec = as(extract.child(), EvalExec.class);
+        var alias = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        var stDistance = as(alias.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(5)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(sort.field()), is("location"));
+        assertThat(sort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+
+        var condition = as(source.query(), SpatialRelatesQuery.ShapeQueryBuilder.class);
+        assertThat("Geometry field name", condition.fieldName(), equalTo("location"));
+        assertThat("Spatial relationship", condition.relation(), equalTo(ShapeRelation.DISJOINT));
+        assertThat("Geometry is Circle", condition.shape().type(), equalTo(ShapeType.CIRCLE));
+        var circle = as(condition.shape(), Circle.class);
+        assertThat("Circle center-x", circle.getX(), equalTo(12.565));
+        assertThat("Circle center-y", circle.getY(), equalTo(55.673));
+        assertThat("Circle radius for predicate", circle.getRadiusMeters(), closeTo(50000.0, 1e-9));
+    }
+
+    /**
+     * <code>
+     * ProjectExec[[abbrev{f}#14, name{f}#15, location{f}#18, country{f}#19, city{f}#20]]
+     * \_TopNExec[[Order[distance{r}#4,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#14, name{f}#15, location{f}#18, country{f}#19, city{f}#20, distance{r}#4],false]
+     *     \_ProjectExec[[abbrev{f}#14, name{f}#15, location{f}#18, country{f}#19, city{f}#20, distance{r}#4]]
+     *       \_FieldExtractExec[abbrev{f}#14, name{f}#15, country{f}#19, city{f}#20][]
+     *         \_EvalExec[[STDISTANCE(location{f}#18,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *           AS distance]]
+     *           \_FieldExtractExec[location{f}#18][]
+     *             \_EsQueryExec[airports], indexMode[standard], query[{
+     *               "bool":{
+     *                 "filter":[
+     *                   {
+     *                     "esql_single_value":{
+     *                       "field":"scalerank",
+     *                       "next":{"range":{"scalerank":{"lt":6,"boost":1.0}}},
+     *                       "source":"scalerank lt 6@3:31"
+     *                     }
+     *                   },
+     *                   {
+     *                     "bool":{
+     *                       "must":[
+     *                         {"geo_shape":{
+     *                           "location":{
+     *                             "relation":"INTERSECTS",
+     *                             "shape":{"type":"Circle","radius":"499999.99999999994m","coordinates":[12.565,55.673]}
+     *                           }
+     *                         }},
+     *                         {"geo_shape":{
+     *                           "location":{
+     *                             "relation":"DISJOINT",
+     *                             "shape":{"type":"Circle","radius":"10000.000000000002m","coordinates":[12.565,55.673]}
+     *                           }
+     *                         }}
+     *                       ],
+     *                       "boost":1.0
+     *                     }
+     *                   }
+     *                 ],
+     *                 "boost":1.0
+     *               }}][_doc{f}#31], limit[5], sort[[
+     *                 GeoDistanceSort[field=location{f}#18, direction=ASC, lat=55.673, lon=12.565]
+     *               ]] estimatedRowSize[245]
+     * </code>
+     */
+    public void testPushTopNDistanceWithCompoundFilterToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | WHERE distance < 500000 AND scalerank < 6 AND distance > 10000
+            | SORT distance ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var evalExec = as(extract.child(), EvalExec.class);
+        var alias = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        var stDistance = as(alias.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(5)));
+        assertThat(source.sorts().size(), is(1));
+        EsQueryExec.Sort sort = source.sorts().get(0);
+        assertThat(sort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(sort.field()), is("location"));
+        assertThat(sort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+        assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+        var filterBool = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        var fb = as(filterBool.get(0), BoolQueryBuilder.class);
+        var shapeQueryBuilders = fb.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 500000.0);
+    }
+
+    /**
+     * This test shows that with an additional EVAL used in the filter, we can no longer push down the SORT distance.
+     * TODO: This could be optimized in future work. Consider moving much of EnableSpatialDistancePushdown into logical planning.
+     * <code>
+     * ProjectExec[[abbrev{f}#23, name{f}#24, location{f}#27, country{f}#28, city{f}#29, scalerank{f}#25 AS scale]]
+     * \_TopNExec[[Order[distance{r}#4,ASC,LAST], Order[scalerank{f}#25,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#23, name{f}#24, location{f}#27, country{f}#28, city{f}#29, scalerank{f}#25, distance{r}#4],false]
+     *     \_ProjectExec[[abbrev{f}#23, name{f}#24, location{f}#27, country{f}#28, city{f}#29, scalerank{f}#25, distance{r}#4]]
+     *       \_FieldExtractExec[abbrev{f}#23, name{f}#24, country{f}#28, city{f}#29][]
+     *         \_TopNExec[[Order[distance{r}#4,ASC,LAST], Order[scalerank{f}#25,ASC,LAST]],5[INTEGER],208]
+     *           \_FieldExtractExec[scalerank{f}#25][]
+     *             \_FilterExec[SUBSTRING(position{r}#7,1[INTEGER],5[INTEGER]) == [50 4f 49 4e 54][KEYWORD]]
+     *               \_EvalExec[[
+     *                   STDISTANCE(location{f}#27,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance,
+     *                   TOSTRING(location{f}#27) AS position
+     *                 ]]
+     *                 \_FieldExtractExec[location{f}#27][]
+     *                   \_EsQueryExec[airports], indexMode[standard], query[{
+     *                     "bool":{"filter":[
+     *                       {"esql_single_value":{"field":"scalerank","next":{"range":{"scalerank":{"lt":6,"boost":1.0}}},"source":...}},
+     *                       {"bool":{"must":[
+     *                         {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                         {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *                       ],"boost":1.0}}],"boost":1.0}}][_doc{f}#42], limit[], sort[] estimatedRowSize[87]
+     * </code>
+     */
+    public void testPushTopNDistanceAndNonPushableEvalWithCompoundFilterToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")), position = location::keyword, scale = scalerank
+            | WHERE distance < 500000 AND SUBSTRING(position, 1, 5) == "POINT" AND distance > 10000 AND scale < 6
+            | SORT distance ASC, scale ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city, scale
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "scalerank", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var topNChild = as(extract.child(), TopNExec.class);
+        extract = as(topNChild.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("scalerank"));
+        var filter = as(extract.child(), FilterExec.class);
+        var evalExec = as(filter.child(), EvalExec.class);
+        assertThat(evalExec.fields().size(), is(2));
+        var aliasDistance = as(evalExec.fields().get(0), Alias.class);
+        assertThat(aliasDistance.name(), is("distance"));
+        var stDistance = as(aliasDistance.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        var aliasPosition = as(evalExec.fields().get(1), Alias.class);
+        assertThat(aliasPosition.name(), is("position"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // In this example TopN is not pushed down (we can optimize that in later work)
+        assertThat(source.limit(), nullValue());
+        assertThat(source.sorts(), nullValue());
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+        assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+        var filterBool = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        var fb = as(filterBool.get(0), BoolQueryBuilder.class);
+        var shapeQueryBuilders = fb.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 500000.0);
+    }
+
+    /**
+     * This test further shows that with a non-aliasing function, with the same name, less gets pushed down.
+     * <code>
+     * ProjectExec[[abbrev{f}#23, name{f}#24, location{f}#27, country{f}#28, city{f}#29, scale{r}#10]]
+     * \_TopNExec[[Order[distance{r}#4,ASC,LAST], Order[scale{r}#10,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#23, name{f}#24, location{f}#27, country{f}#28, city{f}#29, scale{r}#10, distance{r}#4],false]
+     *     \_ProjectExec[[abbrev{f}#23, name{f}#24, location{f}#27, country{f}#28, city{f}#29, scale{r}#10, distance{r}#4]]
+     *       \_FieldExtractExec[abbrev{f}#23, name{f}#24, country{f}#28, city{f}#29][]
+     *         \_TopNExec[[Order[distance{r}#4,ASC,LAST], Order[scale{r}#10,ASC,LAST]],5[INTEGER],208]
+     *           \_FilterExec[
+     *               SUBSTRING(position{r}#7,1[INTEGER],5[INTEGER]) == [50 4f 49 4e 54][KEYWORD]
+     *               AND scale{r}#10 &gt; 3[INTEGER]
+     *             ]
+     *             \_EvalExec[[
+     *                 STDISTANCE(location{f}#27,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance,
+     *                 TOSTRING(location{f}#27) AS position,
+     *                 10[INTEGER] - scalerank{f}#25 AS scale
+     *               ]]
+     *               \_FieldExtractExec[location{f}#27, scalerank{f}#25][]
+     *                 \_EsQueryExec[airports], indexMode[standard], query[{
+     *                   "bool":{"must":[
+     *                     {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                     {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *                   ],"boost":1.0}}][_doc{f}#42], limit[], sort[] estimatedRowSize[91]
+     * </code>
+     */
+    public void testPushTopNDistanceAndNonPushableEvalsWithCompoundFilterToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")),
+                   position = location::keyword, scalerank = 10 - scalerank
+            | WHERE distance < 500000 AND SUBSTRING(position, 1, 5) == "POINT" AND distance > 10000 AND scalerank > 3
+            | SORT distance ASC, scalerank ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city, scalerank
+            """, airports));
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "scalerank", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var topNChild = as(extract.child(), TopNExec.class);
+        var filter = as(topNChild.child(), FilterExec.class);
+        assertThat(filter.condition(), isA(And.class));
+        var and = (And) filter.condition();
+        assertThat(and.left(), isA(Equals.class));
+        assertThat(and.right(), isA(GreaterThan.class));
+        var evalExec = as(filter.child(), EvalExec.class);
+        assertThat(evalExec.fields().size(), is(3));
+        var aliasDistance = as(evalExec.fields().get(0), Alias.class);
+        assertThat(aliasDistance.name(), is("distance"));
+        var stDistance = as(aliasDistance.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        var aliasPosition = as(evalExec.fields().get(1), Alias.class);
+        assertThat(aliasPosition.name(), is("position"));
+        var aliasScale = as(evalExec.fields().get(2), Alias.class);
+        assertThat(aliasScale.name(), is("scalerank"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location", "scalerank"));
+        var source = source(extract.child());
+
+        // In this example TopN is not pushed down (we can optimize that in later work)
+        assertThat(source.limit(), nullValue());
+        assertThat(source.sorts(), nullValue());
+
+        // Fine-grained checks on the pushed down query, only the spatial distance gets pushed down, not the scale filter
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var shapeQueryBuilders = bool.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 500000.0);
+    }
+
+    /**
+     * This test shows that with if the top level AND'd predicate contains a non-pushable component, we should not push anything.
+     * <code>
+     * ProjectExec[[abbrev{f}#8612, name{f}#8613, location{f}#8616, country{f}#8617, city{f}#8618, scalerank{f}#8614 AS scale]]
+     * \_TopNExec[[Order[distance{r}#8596,ASC,LAST], Order[scalerank{f}#8614,ASC,LAST]],5[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#8612, name{f}#8613, location{f}#8616, country{f}#8617, city{f}#8618,
+     *       scalerank{f}#8614, distance{r}#8596
+     *     ],false]
+     *     \_ProjectExec[[abbrev{f}#8612, name{f}#8613, location{f}#8616, country{f}#8617, city{f}#8618,
+     *         scalerank{f}#8614, distance{r}#8596
+     *       ]]
+     *       \_FieldExtractExec[abbrev{f}#8612, name{f}#8613, country{f}#8617, city..][]
+     *         \_TopNExec[[Order[distance{r}#8596,ASC,LAST], Order[scalerank{f}#8614,ASC,LAST]],5[INTEGER],208]
+     *           \_FilterExec[
+     *               distance{r}#8596 &lt; 500000[INTEGER]
+     *               AND distance{r}#8596 &gt; 10000[INTEGER]
+     *               AND scalerank{f}#8614 &lt; 6[INTEGER]
+     *               OR SUBSTRING(TOSTRING(location{f}#8616),1[INTEGER],5[INTEGER]) == [50 4f 49 4e 54][KEYWORD]
+     *             ]
+     *             \_FieldExtractExec[scalerank{f}#8614][]
+     *               \_EvalExec[[
+     *                   STDISTANCE(location{f}#8616,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance
+     *                 ]]
+     *                 \_FieldExtractExec[location{f}#8616][]
+     *                   \_EsQueryExec[airports], indexMode[standard], query[][_doc{f}#8630], limit[], sort[] estimatedRowSize[37]
+     * </code>
+     */
+    public void testPushTopNDistanceWithCompoundFilterToSourceAndDisjunctiveNonPushableEval() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")), scale = scalerank
+            | WHERE distance < 500000 AND distance > 10000 AND scale < 6 OR SUBSTRING(location::keyword, 1, 5) == "POINT"
+            | SORT distance ASC, scale ASC
+            | LIMIT 5
+            | KEEP abbrev, name, location, country, city, scale
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "scalerank", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city"));
+        var topNChild = as(extract.child(), TopNExec.class);
+        var filter = as(topNChild.child(), FilterExec.class);
+        assertThat(filter.condition(), isA(Or.class));
+        var filterOr = (Or) filter.condition();
+        assertThat(filterOr.left(), isA(And.class));
+        assertThat(filterOr.right(), isA(Equals.class));
+        extract = as(filter.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("scalerank"));
+        var evalExec = as(extract.child(), EvalExec.class);
+        assertThat(evalExec.fields().size(), is(1));
+        var aliasDistance = as(evalExec.fields().get(0), Alias.class);
+        assertThat(aliasDistance.name(), is("distance"));
+        var stDistance = as(aliasDistance.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // In this example neither TopN not filter is pushed down
+        assertThat(source.limit(), nullValue());
+        assertThat(source.sorts(), nullValue());
+        assertThat(source.query(), nullValue());
+    }
+
+    /**
+     * <code>
+     * ProjectExec[[abbrev{f}#15, name{f}#16, location{f}#19, country{f}#20, city{f}#21]]
+     * \_TopNExec[[Order[scalerank{f}#17,ASC,LAST], Order[distance{r}#4,ASC,LAST]],15[INTEGER],0]
+     *   \_ExchangeExec[[abbrev{f}#15, name{f}#16, location{f}#19, country{f}#20, city{f}#21, scalerank{f}#17, distance{r}#4],false]
+     *     \_ProjectExec[[abbrev{f}#15, name{f}#16, location{f}#19, country{f}#20, city{f}#21, scalerank{f}#17, distance{r}#4]]
+     *       \_FieldExtractExec[abbrev{f}#15, name{f}#16, country{f}#20, city{f}#21, ..][]
+     *         \_EvalExec[[STDISTANCE(location{f}#19,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT])
+     *           AS distance]]
+     *           \_FieldExtractExec[location{f}#19][]
+     *             \_EsQueryExec[airports], indexMode[standard], query[{
+     *               "bool":{
+     *                 "filter":[
+     *                   {"esql_single_value":{"field":"scalerank",...,"source":"scalerank lt 6@3:31"}},
+     *                   {"bool":{"must":[
+     *                     {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                     {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *                   ],"boost":1.0}}
+     *                 ],"boost":1.0
+     *               }
+     *             }][_doc{f}#32], limit[], sort[[
+     *               FieldSort[field=scalerank{f}#17, direction=ASC, nulls=LAST],
+     *               GeoDistanceSort[field=location{f}#19, direction=ASC, lat=55.673, lon=12.565]
+     *             ]] estimatedRowSize[37]
+     * </code>
+     */
+    public void testPushCompoundTopNDistanceWithCompoundFilterToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL distance = ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))
+            | WHERE distance < 500000 AND scalerank < 6 AND distance > 10000
+            | SORT scalerank, distance
+            | LIMIT 15
+            | KEEP abbrev, name, location, country, city
+            """, airports));
+
+        var project = as(optimized, ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city"));
+        var topN = as(project.child(), TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        project = as(exchange.child(), ProjectExec.class);
+        assertThat(names(project.projections()), contains("abbrev", "name", "location", "country", "city", "scalerank", "distance"));
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("abbrev", "name", "country", "city", "scalerank"));
+        var evalExec = as(extract.child(), EvalExec.class);
+        var alias = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias.name(), is("distance"));
+        var stDistance = as(alias.child(), StDistance.class);
+        assertThat(stDistance.left().toString(), startsWith("location"));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(15)));
+        assertThat(source.sorts().size(), is(2));
+        EsQueryExec.Sort fieldSort = source.sorts().get(0);
+        assertThat(fieldSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(fieldSort.field()), is("scalerank"));
+        assertThat(fieldSort.sortBuilder(), isA(FieldSortBuilder.class));
+        EsQueryExec.Sort distSort = source.sorts().get(1);
+        assertThat(distSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(distSort.field()), is("location"));
+        assertThat(distSort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+        assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+        var filterBool = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        var fb = as(filterBool.get(0), BoolQueryBuilder.class);
+        var shapeQueryBuilders = fb.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 500000.0);
+    }
+
+    /**
+     * <code>
+     * TopNExec[[Order[scalerank{f}#15,ASC,LAST], Order[distance{r}#7,ASC,LAST]],15[INTEGER],0]
+     * \_ExchangeExec[[abbrev{f}#13, city{f}#19, city_location{f}#20, country{f}#18, location{f}#17, name{f}#14, scalerank{f}#15,
+     *     type{f}#16, poi{r}#3, distance{r}#7],false]
+     *   \_ProjectExec[[abbrev{f}#13, city{f}#19, city_location{f}#20, country{f}#18, location{f}#17, name{f}#14, scalerank{f}#15,
+     *       type{f}#16, poi{r}#3, distance{r}#7]]
+     *     \_FieldExtractExec[abbrev{f}#13, city{f}#19, city_location{f}#20, coun..][]
+     *       \_EvalExec[[
+     *           [1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT] AS poi,
+     *           STDISTANCE(location{f}#17,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance
+     *         ]]
+     *         \_FieldExtractExec[location{f}#17][]
+     *           \_EsQueryExec[airports], indexMode[standard], query[{
+     *             "bool":{
+     *               "filter":[
+     *                 {"esql_single_value":{"field":"scalerank",...,"source":"scalerank lt 6@4:31"}},
+     *                 {"bool":{"must":[
+     *                   {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                   {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *                 ],"boost":1.0}}
+     *               ],"boost":1.0
+     *             }
+     *           }][_doc{f}#31], limit[15], sort[[
+     *             FieldSort[field=scalerank{f}#15, direction=ASC, nulls=LAST],
+     *             GeoDistanceSort[field=location{f}#17, direction=ASC, lat=55.673, lon=12.565]
+     *           ]] estimatedRowSize[341]
+     * </code>
+     */
+    public void testPushCompoundTopNDistanceWithCompoundFilterAndCompoundEvalToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL poi = TO_GEOPOINT("POINT(12.565 55.673)")
+            | EVAL distance = ST_DISTANCE(location, poi)
+            | WHERE distance < 500000 AND scalerank < 6 AND distance > 10000
+            | SORT scalerank, distance
+            | LIMIT 15
+            """, airports));
+
+        var topN = as(optimized, TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        var project = as(exchange.child(), ProjectExec.class);
+        assertThat(
+            names(project.projections()),
+            containsInAnyOrder("abbrev", "name", "type", "location", "country", "city", "city_location", "scalerank", "poi", "distance")
+        );
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(
+            names(extract.attributesToExtract()),
+            containsInAnyOrder("abbrev", "name", "type", "country", "city", "city_location", "scalerank")
+        );
+        var evalExec = as(extract.child(), EvalExec.class);
+        assertThat(evalExec.fields().size(), is(2));
+        var alias1 = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias1.name(), is("poi"));
+        var poi = as(alias1.child(), Literal.class);
+        assertThat(poi.fold(), instanceOf(BytesRef.class));
+        var alias2 = as(evalExec.fields().get(1), Alias.class);
+        assertThat(alias2.name(), is("distance"));
+        var stDistance = as(alias2.child(), StDistance.class);
+        var location = as(stDistance.left(), FieldAttribute.class);
+        assertThat(location.fieldName(), is("location"));
+        var poiRef = as(stDistance.right(), Literal.class);
+        assertThat(poiRef.fold(), instanceOf(BytesRef.class));
+        assertThat(poiRef.fold().toString(), is(poi.fold().toString()));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(15)));
+        assertThat(source.sorts().size(), is(2));
+        EsQueryExec.Sort fieldSort = source.sorts().get(0);
+        assertThat(fieldSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(fieldSort.field()), is("scalerank"));
+        assertThat(fieldSort.sortBuilder(), isA(FieldSortBuilder.class));
+        EsQueryExec.Sort distSort = source.sorts().get(1);
+        assertThat(distSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(distSort.field()), is("location"));
+        assertThat(distSort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+        assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+        var filterBool = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        var fb = as(filterBool.get(0), BoolQueryBuilder.class);
+        var shapeQueryBuilders = fb.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 500000.0);
+    }
+
+    public void testPushCompoundTopNDistanceWithDeeplyNestedCompoundEvalToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL poi = TO_GEOPOINT("POINT(12.565 55.673)")
+            | EVAL poi2 = poi, poi3 = poi2
+            | EVAL loc2 = location
+            | EVAL loc3 = loc2
+            | EVAL dist = ST_DISTANCE(loc3, poi3)
+            | EVAL distance = dist
+            | SORT scalerank, distance
+            | LIMIT 15
+            """, airports));
+
+        var topN = as(optimized, TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        var project = as(exchange.child(), ProjectExec.class);
+        assertThat(
+            names(project.projections()),
+            containsInAnyOrder(
+                "abbrev",
+                "name",
+                "type",
+                "location",
+                "country",
+                "city",
+                "city_location",
+                "scalerank",
+                "poi",
+                "poi2",
+                "poi3",
+                "loc2",
+                "loc3",
+                "dist",
+                "distance"
+            )
+        );
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(
+            names(extract.attributesToExtract()),
+            containsInAnyOrder("abbrev", "name", "type", "country", "city", "city_location", "scalerank")
+        );
+        var evalExec = as(extract.child(), EvalExec.class);
+        assertThat(evalExec.fields().size(), is(7));
+        var alias1 = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias1.name(), is("poi"));
+        var poi = as(alias1.child(), Literal.class);
+        assertThat(poi.fold(), instanceOf(BytesRef.class));
+        var alias4 = as(evalExec.fields().get(3), Alias.class);
+        assertThat(alias4.name(), is("loc2"));
+        as(alias4.child(), FieldAttribute.class);
+        var alias5 = as(evalExec.fields().get(4), Alias.class);
+        assertThat(alias5.name(), is("loc3"));
+        as(alias5.child(), ReferenceAttribute.class);
+        var alias6 = as(evalExec.fields().get(5), Alias.class);
+        assertThat(alias6.name(), is("dist"));
+        var stDistance = as(alias6.child(), StDistance.class);
+        var refLocation = as(stDistance.left(), ReferenceAttribute.class);
+        assertThat(refLocation.name(), is("loc3"));
+        var poiRef = as(stDistance.right(), Literal.class);
+        assertThat(poiRef.fold(), instanceOf(BytesRef.class));
+        assertThat(poiRef.fold().toString(), is(poi.fold().toString()));
+        var alias7 = as(evalExec.fields().get(6), Alias.class);
+        assertThat(alias7.name(), is("distance"));
+        as(alias7.child(), ReferenceAttribute.class);
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(15)));
+        assertThat(source.sorts().size(), is(2));
+        EsQueryExec.Sort fieldSort = source.sorts().get(0);
+        assertThat(fieldSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(fieldSort.field()), is("scalerank"));
+        assertThat(fieldSort.sortBuilder(), isA(FieldSortBuilder.class));
+        EsQueryExec.Sort distSort = source.sorts().get(1);
+        assertThat(distSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(distSort.field()), is("location"));
+        assertThat(distSort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+
+        // No filter is pushed down
+        assertThat(source.query(), nullValue());
+    }
+
+    /**
+     * TopNExec[[Order[scalerank{f}#15,ASC,LAST], Order[distance{r}#7,ASC,LAST]],15[INTEGER],0]
+     * \_ExchangeExec[[abbrev{f}#13, city{f}#19, city_location{f}#20, country{f}#18, location{f}#17, name{f}#14, scalerank{f}#15,
+     *     type{f}#16, poi{r}#3, distance{r}#7],false]
+     *   \_ProjectExec[[abbrev{f}#13, city{f}#19, city_location{f}#20, country{f}#18, location{f}#17, name{f}#14, scalerank{f}#15,
+     *       type{f}#16, poi{r}#3, distance{r}#7]]
+     *     \_FieldExtractExec[abbrev{f}#13, city{f}#19, city_location{f}#20, coun..][]
+     *       \_EvalExec[[
+     *           [1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT] AS poi,
+     *           STDISTANCE(location{f}#17,[1 1 0 0 0 e1 7a 14 ae 47 21 29 40 a0 1a 2f dd 24 d6 4b 40][GEO_POINT]) AS distance]
+     *         ]
+     *         \_FieldExtractExec[location{f}#17][]
+     *           \_EsQueryExec[airports], indexMode[standard], query[{"bool":{
+     *             "filter":[
+     *               {"esql_single_value":{"field":"scalerank","next":{"range":{...}},"source":"scalerank lt 6@4:31"}},
+     *               {"bool":{"must":[
+     *                 {"geo_shape":{"location":{"relation":"INTERSECTS","shape":{...}}}},
+     *                 {"geo_shape":{"location":{"relation":"DISJOINT","shape":{...}}}}
+     *               ],"boost":1.0}}
+     *             ],"boost":1.0
+     *           }}][_doc{f}#31], limit[15], sort[[
+     *             FieldSort[field=scalerank{f}#15, direction=ASC, nulls=LAST],
+     *             GeoDistanceSort[field=location{f}#17, direction=ASC, lat=55.673, lon=12.565]
+     *           ]] estimatedRowSize[341]
+     */
+    public void testPushCompoundTopNDistanceWithCompoundFilterAndNestedCompoundEvalToSource() {
+        var optimized = optimizedPlan(physicalPlan("""
+            FROM airports
+            | EVAL poi = TO_GEOPOINT("POINT(12.565 55.673)")
+            | EVAL distance = ST_DISTANCE(location, poi)
+            | WHERE distance < 500000 AND scalerank < 6 AND distance > 10000
+            | SORT scalerank, distance
+            | LIMIT 15
+            """, airports));
+
+        var topN = as(optimized, TopNExec.class);
+        var exchange = asRemoteExchange(topN.child());
+
+        var project = as(exchange.child(), ProjectExec.class);
+        assertThat(
+            names(project.projections()),
+            containsInAnyOrder("abbrev", "name", "type", "location", "country", "city", "city_location", "scalerank", "poi", "distance")
+        );
+        var extract = as(project.child(), FieldExtractExec.class);
+        assertThat(
+            names(extract.attributesToExtract()),
+            containsInAnyOrder("abbrev", "name", "type", "country", "city", "city_location", "scalerank")
+        );
+        var evalExec = as(extract.child(), EvalExec.class);
+        assertThat(evalExec.fields().size(), is(2));
+        var alias1 = as(evalExec.fields().get(0), Alias.class);
+        assertThat(alias1.name(), is("poi"));
+        var poi = as(alias1.child(), Literal.class);
+        assertThat(poi.fold(), instanceOf(BytesRef.class));
+        var alias2 = as(evalExec.fields().get(1), Alias.class);
+        assertThat(alias2.name(), is("distance"));
+        var stDistance = as(alias2.child(), StDistance.class);
+        var location = as(stDistance.left(), FieldAttribute.class);
+        assertThat(location.fieldName(), is("location"));
+        var poiRef = as(stDistance.right(), Literal.class);
+        assertThat(poiRef.fold(), instanceOf(BytesRef.class));
+        assertThat(poiRef.fold().toString(), is(poi.fold().toString()));
+        extract = as(evalExec.child(), FieldExtractExec.class);
+        assertThat(names(extract.attributesToExtract()), contains("location"));
+        var source = source(extract.child());
+
+        // Assert that the TopN(distance) is pushed down as geo-sort(location)
+        assertThat(source.limit(), is(topN.limit()));
+        Set<String> orderSet = orderAsSet(topN.order());
+        Set<String> sortsSet = sortsAsSet(source.sorts(), Map.of("location", "distance"));
+        assertThat(orderSet, is(sortsSet));
+
+        // Fine-grained checks on the pushed down sort
+        assertThat(source.limit(), is(l(15)));
+        assertThat(source.sorts().size(), is(2));
+        EsQueryExec.Sort fieldSort = source.sorts().get(0);
+        assertThat(fieldSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(fieldSort.field()), is("scalerank"));
+        assertThat(fieldSort.sortBuilder(), isA(FieldSortBuilder.class));
+        EsQueryExec.Sort distSort = source.sorts().get(1);
+        assertThat(distSort.direction(), is(Order.OrderDirection.ASC));
+        assertThat(name(distSort.field()), is("location"));
+        assertThat(distSort.sortBuilder(), isA(GeoDistanceSortBuilder.class));
+
+        // Fine-grained checks on the pushed down query
+        var bool = as(source.query(), BoolQueryBuilder.class);
+        var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+        assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+        assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+        var filterBool = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+        var fb = as(filterBool.get(0), BoolQueryBuilder.class);
+        var shapeQueryBuilders = fb.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 10000.0, 500000.0);
+    }
+
+    private Set<String> orderAsSet(List<Order> sorts) {
+        return sorts.stream().map(o -> ((Attribute) o.child()).name() + "->" + o.direction()).collect(Collectors.toSet());
+    }
+
+    private Set<String> sortsAsSet(List<EsQueryExec.Sort> sorts, Map<String, String> fieldMap) {
+        return sorts.stream()
+            .map(s -> fieldMap.getOrDefault(s.field().name(), s.field().name()) + "->" + s.direction())
+            .collect(Collectors.toSet());
+    }
+
     private void assertShapeQueryRange(List<QueryBuilder> shapeQueryBuilders, double min, double max) {
         assertThat("Expected two shape query builders", shapeQueryBuilders.size(), equalTo(2));
         var relationStats = new HashMap<ShapeRelation, Integer>();
@@ -3838,7 +5581,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             var circle = as(condition.shape(), Circle.class);
             assertThat("Circle center-x", circle.getX(), equalTo(12.565));
             assertThat("Circle center-y", circle.getY(), equalTo(55.673));
-            assertThat("Circle radius for shape relation " + condition.relation(), circle.getRadiusMeters(), equalTo(expected));
+            assertThat("Circle radius for shape relation " + condition.relation(), circle.getRadiusMeters(), closeTo(expected, 1e-9));
         }
         assertThat("Expected one INTERSECTS and one DISJOINT", relationStats.size(), equalTo(2));
         assertThat("Expected one INTERSECTS", relationStats.get(ShapeRelation.INTERSECTS), equalTo(1));
@@ -4796,7 +6539,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         return physical;
     }
 
-    private List<FieldSort> sorts(List<Order> orders) {
+    private List<FieldSort> fieldSorts(List<Order> orders) {
         return orders.stream().map(o -> new FieldSort((FieldAttribute) o.child(), o.direction(), o.nullsPosition())).toList();
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNToSourceTests.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDistance;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.stats.DisabledSearchStats;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushTopNToSourceTests.TestPhysicalPlanBuilder.from;
+import static org.elasticsearch.xpack.esql.plan.physical.AbstractPhysicalPlanSerializationTests.randomEstimatedRowSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class PushTopNToSourceTests extends ESTestCase {
+
+    public void testSimpleSortField() {
+        // FROM index | SORT field | LIMIT 10
+        var query = from("index").sort("field").limit(10);
+        assertPushdownSort(query);
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortMultipleFields() {
+        // FROM index | SORT field, integer, double | LIMIT 10
+        var query = from("index").sort("field").sort("integer").sort("double").limit(10);
+        assertPushdownSort(query);
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortFieldAndEvalLiteral() {
+        // FROM index | EVAL x = 1 | SORT field | LIMIT 10
+        var query = from("index").eval("x", e -> e.i(1)).sort("field").limit(10);
+        assertPushdownSort(query, List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortFieldWithAlias() {
+        // FROM index | EVAL x = field | SORT field | LIMIT 10
+        var query = from("index").eval("x", b -> b.field("field")).sort("field").limit(10);
+        assertPushdownSort(query, List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortMultipleFieldsWithAliases() {
+        // FROM index | EVAL x = field, y = integer, z = double | SORT field, integer, double | LIMIT 10
+        var query = from("index").eval("x", b -> b.field("field"))
+            .eval("y", b -> b.field("integer"))
+            .eval("z", b -> b.field("double"))
+            .sort("field")
+            .sort("integer")
+            .sort("double")
+            .limit(10);
+        assertPushdownSort(query, List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortFieldAsAlias() {
+        // FROM index | EVAL x = field | SORT x | LIMIT 10
+        var query = from("index").eval("x", b -> b.field("field")).sort("x").limit(10);
+        assertPushdownSort(query, Map.of("x", "field"), List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortFieldAndEvalSumLiterals() {
+        // FROM index | EVAL sum = 1 + 2 | SORT field | LIMIT 10
+        var query = from("index").eval("sum", b -> b.add(b.i(1), b.i(2))).sort("field").limit(10);
+        assertPushdownSort(query, List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortFieldAndEvalSumLiteralAndField() {
+        // FROM index | EVAL sum = 1 + integer | SORT integer | LIMIT 10
+        var query = from("index").eval("sum", b -> b.add(b.i(1), b.field("integer"))).sort("integer").limit(10);
+        assertPushdownSort(query, List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSimpleSortEvalSumLiteralAndField() {
+        // FROM index | EVAL sum = 1 + integer | SORT sum | LIMIT 10
+        var query = from("index").eval("sum", b -> b.add(b.i(1), b.field("integer"))).sort("sum").limit(10);
+        // TODO: Consider supporting this if we can determine that the eval function maintains the same order
+        assertNoPushdownSort(query, "when sorting on a derived field");
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/114515")
+    public void testPartiallyPushableSort() {
+        // FROM index | EVAL sum = 1 + integer | SORT integer, sum, field | LIMIT 10
+        var query = from("index").eval("sum", b -> b.add(b.i(1), b.field("integer"))).sort("integer").sort("sum").sort("field").limit(10);
+        // Both integer and field can be pushed down, but we can only push down the leading sortable fields, so the 'sum' blocks 'field'
+        assertPushdownSort(query, List.of(query.orders.get(0)), null, List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoPointField() {
+        // FROM index | SORT location | LIMIT 10
+        var query = from("index").sort("location", Order.OrderDirection.ASC).limit(10);
+        // NOTE: while geo_point is not sortable, this is checked during logical planning and the physical planner does not know or care
+        assertPushdownSort(query);
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoDistanceFunction() {
+        // FROM index | EVAL distance = ST_DISTANCE(location, POINT(1 2)) | SORT distance | LIMIT 10
+        var query = from("index").eval("distance", b -> b.distance("location", "POINT(1 2)"))
+            .sort("distance", Order.OrderDirection.ASC)
+            .limit(10);
+        // The pushed-down sort will use the underlying field 'location', not the sorted reference field 'distance'
+        assertPushdownSort(query, Map.of("distance", "location"), List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoDistanceFunctionInverted() {
+        // FROM index | EVAL distance = ST_DISTANCE(POINT(1 2), location) | SORT distance | LIMIT 10
+        var query = from("index").eval("distance", b -> b.distance("POINT(1 2)", "location"))
+            .sort("distance", Order.OrderDirection.ASC)
+            .limit(10);
+        // The pushed-down sort will use the underlying field 'location', not the sorted reference field 'distance'
+        assertPushdownSort(query, Map.of("distance", "location"), List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoDistanceFunctionLiterals() {
+        // FROM index | EVAL distance = ST_DISTANCE(POINT(2 1), POINT(1 2)) | SORT distance | LIMIT 10
+        var query = from("index").eval("distance", b -> b.distance("POINT(2 1)", "POINT(1 2)"))
+            .sort("distance", Order.OrderDirection.ASC)
+            .limit(10);
+        // The pushed-down sort will use the underlying field 'location', not the sorted reference field 'distance'
+        assertNoPushdownSort(query, "sort on foldable distance function");
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoDistanceFunctionAndFieldsWithAliases() {
+        // FROM index | EVAL distance = ST_DISTANCE(location, POINT(1 2)), x = field | SORT distance, field, integer | LIMIT 10
+        var query = from("index").eval("distance", b -> b.distance("location", "POINT(1 2)"))
+            .eval("x", b -> b.field("field"))
+            .sort("distance", Order.OrderDirection.ASC)
+            .sort("field", Order.OrderDirection.DESC)
+            .sort("integer", Order.OrderDirection.DESC)
+            .limit(10);
+        // The pushed-down sort will use the underlying field 'location', not the sorted reference field 'distance'
+        assertPushdownSort(query, query.orders, Map.of("distance", "location"), List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoDistanceFunctionAndFieldsAndAliases() {
+        // FROM index | EVAL distance = ST_DISTANCE(location, POINT(1 2)), x = field | SORT distance, x, integer | LIMIT 10
+        var query = from("index").eval("distance", b -> b.distance("location", "POINT(1 2)"))
+            .eval("x", b -> b.field("field"))
+            .sort("distance", Order.OrderDirection.ASC)
+            .sort("x", Order.OrderDirection.DESC)
+            .sort("integer", Order.OrderDirection.DESC)
+            .limit(10);
+        // The pushed-down sort will use the underlying field 'location', not the sorted reference field 'distance'
+        assertPushdownSort(query, query.orders, Map.of("distance", "location", "x", "field"), List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    public void testSortGeoDistanceFunctionAndFieldsAndManyAliases() {
+        // FROM index
+        // | EVAL loc = location, loc2 = loc, loc3 = loc2, distance = ST_DISTANCE(loc3, POINT(1 2)), x = field
+        // | SORT distance, x, integer
+        // | LIMIT 10
+        var query = from("index").eval("loc", b -> b.field("location"))
+            .eval("loc2", b -> b.ref("loc"))
+            .eval("loc3", b -> b.ref("loc2"))
+            .eval("distance", b -> b.distance("loc3", "POINT(1 2)"))
+            .eval("x", b -> b.field("field"))
+            .sort("distance", Order.OrderDirection.ASC)
+            .sort("x", Order.OrderDirection.DESC)
+            .sort("integer", Order.OrderDirection.DESC)
+            .limit(10);
+        // The pushed-down sort will use the underlying field 'location', not the sorted reference field 'distance'
+        assertPushdownSort(query, Map.of("distance", "location", "x", "field"), List.of(EvalExec.class, EsQueryExec.class));
+        assertNoPushdownSort(query.asTimeSeries(), "for time series index mode");
+    }
+
+    private static void assertPushdownSort(TestPhysicalPlanBuilder builder) {
+        assertPushdownSort(builder, null, List.of(EsQueryExec.class));
+    }
+
+    private static void assertPushdownSort(TestPhysicalPlanBuilder builder, List<Class<? extends PhysicalPlan>> topClass) {
+        assertPushdownSort(builder, null, topClass);
+    }
+
+    private static void assertPushdownSort(
+        TestPhysicalPlanBuilder builder,
+        Map<String, String> fieldMap,
+        List<Class<? extends PhysicalPlan>> topClass
+    ) {
+        var topNExec = builder.build();
+        var result = pushTopNToSource(topNExec);
+        assertPushdownSort(result, builder.orders, fieldMap, topClass);
+    }
+
+    private static void assertPushdownSort(
+        TestPhysicalPlanBuilder builder,
+        List<Order> expectedSorts,
+        Map<String, String> fieldMap,
+        List<Class<? extends PhysicalPlan>> topClass
+    ) {
+        var topNExec = builder.build();
+        var result = pushTopNToSource(topNExec);
+        assertPushdownSort(result, expectedSorts, fieldMap, topClass);
+    }
+
+    private static void assertNoPushdownSort(TestPhysicalPlanBuilder builder, String message) {
+        var topNExec = builder.build();
+        var result = pushTopNToSource(topNExec);
+        assertNoPushdownSort(result, message);
+    }
+
+    private static PhysicalPlan pushTopNToSource(TopNExec topNExec) {
+        var configuration = EsqlTestUtils.configuration("from test");
+        var searchStats = new DisabledSearchStats();
+        var ctx = new LocalPhysicalOptimizerContext(configuration, searchStats);
+        var pushTopNToSource = new PushTopNToSource();
+        return pushTopNToSource.rule(topNExec, ctx);
+    }
+
+    private static void assertNoPushdownSort(PhysicalPlan plan, String message) {
+        var esQueryExec = findEsQueryExec(plan);
+        var sorts = esQueryExec.sorts();
+        assertThat("Expect no sorts " + message, sorts.size(), is(0));
+    }
+
+    private static void assertPushdownSort(
+        PhysicalPlan plan,
+        List<Order> expectedSorts,
+        Map<String, String> fieldMap,
+        List<Class<? extends PhysicalPlan>> topClass
+    ) {
+        if (topClass != null && topClass.size() > 0) {
+            PhysicalPlan current = plan;
+            for (var clazz : topClass) {
+                assertThat("Expect non-null physical plan class to match " + clazz.getSimpleName(), current, notNullValue());
+                assertThat("Expect top physical plan class to match", current.getClass(), is(clazz));
+                current = current.children().size() > 0 ? current.children().get(0) : null;
+            }
+            if (current != null) {
+                fail("No more child classes expected in plan, but found: " + current.getClass().getSimpleName());
+            }
+        }
+        var esQueryExec = findEsQueryExec(plan);
+        var sorts = esQueryExec.sorts();
+        assertThat("Expect sorts count to match", sorts.size(), is(expectedSorts.size()));
+        for (int i = 0; i < expectedSorts.size(); i++) {
+            String name = ((Attribute) expectedSorts.get(i).child()).name();
+            String fieldName = sorts.get(i).field().fieldName();
+            assertThat("Expect sort[" + i + "] name to match", fieldName, is(sortName(name, fieldMap)));
+            assertThat("Expect sort[" + i + "] direction to match", sorts.get(i).direction(), is(expectedSorts.get(i).direction()));
+        }
+    }
+
+    private static String sortName(String name, Map<String, String> fieldMap) {
+        return fieldMap != null ? fieldMap.getOrDefault(name, name) : name;
+    }
+
+    private static EsQueryExec findEsQueryExec(PhysicalPlan plan) {
+        if (plan instanceof EsQueryExec esQueryExec) {
+            return esQueryExec;
+        }
+        // We assume no physical plans with multiple children would be generated
+        return findEsQueryExec(plan.children().get(0));
+    }
+
+    /**
+     * This builder allows for easy creation of physical plans using a syntax like `from("index").sort("field").limit(10)`.
+     * The idea is to create tests that are clearly related to real queries, but also easy to make assertions on.
+     * It only supports a very small subset of possible plans, with FROM, EVAL and SORT+LIMIT, in that order, matching
+     * the physical plan rules that are being tested: TopNExec, EvalExec and EsQueryExec.
+     */
+    static class TestPhysicalPlanBuilder {
+        private final String index;
+        private final LinkedHashMap<String, FieldAttribute> fields;
+        private final LinkedHashMap<String, ReferenceAttribute> refs;
+        private IndexMode indexMode;
+        private final List<Alias> aliases = new ArrayList<>();
+        private final List<Order> orders = new ArrayList<>();
+        private int limit = Integer.MAX_VALUE;
+
+        private TestPhysicalPlanBuilder(String index, IndexMode indexMode) {
+            this.index = index;
+            this.indexMode = indexMode;
+            this.fields = new LinkedHashMap<>();
+            this.refs = new LinkedHashMap<>();
+            addSortableFieldAttributes(this.fields);
+        }
+
+        private static void addSortableFieldAttributes(Map<String, FieldAttribute> fields) {
+            addFieldAttribute(fields, "field", KEYWORD);
+            addFieldAttribute(fields, "integer", INTEGER);
+            addFieldAttribute(fields, "double", DOUBLE);
+            addFieldAttribute(fields, "keyword", KEYWORD);
+            addFieldAttribute(fields, "location", GEO_POINT);
+        }
+
+        private static void addFieldAttribute(Map<String, FieldAttribute> fields, String name, DataType type) {
+            fields.put(name, new FieldAttribute(Source.EMPTY, name, new EsField(name, type, new HashMap<>(), true)));
+        }
+
+        static TestPhysicalPlanBuilder from(String index) {
+            return new TestPhysicalPlanBuilder(index, IndexMode.STANDARD);
+        }
+
+        public TestPhysicalPlanBuilder eval(Alias... aliases) {
+            if (orders.isEmpty() == false) {
+                throw new IllegalArgumentException("Eval must be before sort");
+            }
+            if (aliases.length == 0) {
+                throw new IllegalArgumentException("At least one alias must be provided");
+            }
+            for (Alias alias : aliases) {
+                if (refs.containsKey(alias.name())) {
+                    throw new IllegalArgumentException("Reference already exists: " + alias.name());
+                }
+                refs.put(
+                    alias.name(),
+                    new ReferenceAttribute(Source.EMPTY, alias.name(), alias.dataType(), Nullability.FALSE, alias.id(), alias.synthetic())
+                );
+                this.aliases.add(alias);
+            }
+            return this;
+        }
+
+        public TestPhysicalPlanBuilder eval(String name, Function<TestExpressionBuilder, Expression> builder) {
+            var testExpressionBuilder = new TestExpressionBuilder();
+            Expression expression = builder.apply(testExpressionBuilder);
+            return eval(new Alias(Source.EMPTY, name, expression));
+        }
+
+        public TestPhysicalPlanBuilder sort(String field) {
+            return sort(field, Order.OrderDirection.ASC);
+        }
+
+        public TestPhysicalPlanBuilder sort(String field, Order.OrderDirection direction) {
+            Attribute attr = refs.get(field);
+            if (attr == null) {
+                attr = fields.get(field);
+            }
+            if (attr == null) {
+                throw new IllegalArgumentException("Field not found: " + field);
+            }
+            orders.add(new Order(Source.EMPTY, attr, direction, Order.NullsPosition.LAST));
+            return this;
+        }
+
+        public TestPhysicalPlanBuilder limit(int limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public TopNExec build() {
+            EsIndex esIndex = new EsIndex(this.index, Map.of());
+            List<Attribute> attributes = new ArrayList<>(fields.values());
+            PhysicalPlan child = new EsQueryExec(Source.EMPTY, esIndex, indexMode, attributes, null, null, List.of(), 0);
+            if (aliases.isEmpty() == false) {
+                child = new EvalExec(Source.EMPTY, child, aliases);
+            }
+            return new TopNExec(Source.EMPTY, child, orders, new Literal(Source.EMPTY, limit, INTEGER), randomEstimatedRowSize());
+        }
+
+        public TestPhysicalPlanBuilder asTimeSeries() {
+            this.indexMode = IndexMode.TIME_SERIES;
+            return this;
+        }
+
+        class TestExpressionBuilder {
+            Expression field(String name) {
+                return fields.get(name);
+            }
+
+            Expression ref(String name) {
+                return refs.get(name);
+            }
+
+            Expression literal(Object value, DataType dataType) {
+                return new Literal(Source.EMPTY, value, dataType);
+            }
+
+            Expression i(int value) {
+                return new Literal(Source.EMPTY, value, DataType.INTEGER);
+            }
+
+            Expression d(double value) {
+                return new Literal(Source.EMPTY, value, DOUBLE);
+            }
+
+            Expression k(String value) {
+                return new Literal(Source.EMPTY, value, KEYWORD);
+            }
+
+            public Expression add(Expression left, Expression right) {
+                return new Add(Source.EMPTY, left, right);
+            }
+
+            public Expression distance(String left, String right) {
+                return new StDistance(Source.EMPTY, geoExpr(left), geoExpr(right));
+            }
+
+            private Expression geoExpr(String text) {
+                if (text.startsWith("POINT")) {
+                    try {
+                        Geometry geometry = WellKnownText.fromWKT(GeometryValidator.NOOP, false, text);
+                        BytesRef bytes = new BytesRef(WellKnownBinary.toWKB(geometry, ByteOrder.LITTLE_ENDIAN));
+                        return new Literal(Source.EMPTY, bytes, GEO_POINT);
+                    } catch (IOException | ParseException e) {
+                        throw new IllegalArgumentException("Failed to parse WKT: " + text, e);
+                    }
+                }
+                if (fields.containsKey(text)) {
+                    return fields.get(text);
+                }
+                if (refs.containsKey(text)) {
+                    return refs.get(text);
+                }
+                throw new IllegalArgumentException("Unknown field: " + text);
+            }
+        }
+
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExecSerializationTests.java
@@ -13,19 +13,14 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.Order;
-import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.EsIndexSerializationTests;
 
 import java.io.IOException;
 import java.util.List;
-
-import static org.elasticsearch.xpack.esql.plan.logical.AbstractLogicalPlanSerializationTests.randomFieldAttributes;
 
 public class EsQueryExecSerializationTests extends AbstractPhysicalPlanSerializationTests<EsQueryExec> {
     public static EsQueryExec randomEsQueryExec() {
@@ -35,24 +30,12 @@ public class EsQueryExecSerializationTests extends AbstractPhysicalPlanSerializa
         List<Attribute> attrs = randomFieldAttributes(1, 10, false);
         QueryBuilder query = randomQuery();
         Expression limit = new Literal(randomSource(), between(0, Integer.MAX_VALUE), DataType.INTEGER);
-        List<EsQueryExec.FieldSort> sorts = randomFieldSorts();
         Integer estimatedRowSize = randomEstimatedRowSize();
-        return new EsQueryExec(source, index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+        return new EsQueryExec(source, index, indexMode, attrs, query, limit, EsQueryExec.NO_SORTS, estimatedRowSize);
     }
 
     public static QueryBuilder randomQuery() {
         return randomBoolean() ? new MatchAllQueryBuilder() : new TermQueryBuilder(randomAlphaOfLength(4), randomAlphaOfLength(4));
-    }
-
-    public static List<EsQueryExec.FieldSort> randomFieldSorts() {
-        return randomList(0, 4, EsQueryExecSerializationTests::randomFieldSort);
-    }
-
-    public static EsQueryExec.FieldSort randomFieldSort() {
-        FieldAttribute field = FieldAttributeTests.createFieldAttribute(0, false);
-        Order.OrderDirection direction = randomFrom(Order.OrderDirection.values());
-        Order.NullsPosition nulls = randomFrom(Order.NullsPosition.values());
-        return new EsQueryExec.FieldSort(field, direction, nulls);
     }
 
     @Override
@@ -67,9 +50,8 @@ public class EsQueryExecSerializationTests extends AbstractPhysicalPlanSerializa
         List<Attribute> attrs = instance.attrs();
         QueryBuilder query = instance.query();
         Expression limit = instance.limit();
-        List<EsQueryExec.FieldSort> sorts = instance.sorts();
         Integer estimatedRowSize = instance.estimatedRowSize();
-        switch (between(0, 6)) {
+        switch (between(0, 5)) {
             case 0 -> index = randomValueOtherThan(index, EsIndexSerializationTests::randomEsIndex);
             case 1 -> indexMode = randomValueOtherThan(indexMode, () -> randomFrom(IndexMode.values()));
             case 2 -> attrs = randomValueOtherThan(attrs, () -> randomFieldAttributes(1, 10, false));
@@ -78,13 +60,12 @@ public class EsQueryExecSerializationTests extends AbstractPhysicalPlanSerializa
                 limit,
                 () -> new Literal(randomSource(), between(0, Integer.MAX_VALUE), DataType.INTEGER)
             );
-            case 5 -> sorts = randomValueOtherThan(sorts, EsQueryExecSerializationTests::randomFieldSorts);
-            case 6 -> estimatedRowSize = randomValueOtherThan(
+            case 5 -> estimatedRowSize = randomValueOtherThan(
                 estimatedRowSize,
                 AbstractPhysicalPlanSerializationTests::randomEstimatedRowSize
             );
         }
-        return new EsQueryExec(instance.source(), index, indexMode, attrs, query, limit, sorts, estimatedRowSize);
+        return new EsQueryExec(instance.source(), index, indexMode, attrs, query, limit, EsQueryExec.NO_SORTS, estimatedRowSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -107,6 +107,21 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         assertThat(factory.limit(), equalTo(10));
     }
 
+    public void testLuceneTopNSourceOperatorDistanceSort() throws IOException {
+        int estimatedRowSize = randomEstimatedRowSize(estimatedRowSizeIsHuge);
+        FieldAttribute sortField = new FieldAttribute(Source.EMPTY, "point", new EsField("point", DataType.GEO_POINT, Map.of(), true));
+        EsQueryExec.GeoDistanceSort sort = new EsQueryExec.GeoDistanceSort(sortField, Order.OrderDirection.ASC, 1, -1);
+        Literal limit = new Literal(Source.EMPTY, 10, DataType.INTEGER);
+        LocalExecutionPlanner.LocalExecutionPlan plan = planner().plan(
+            new EsQueryExec(Source.EMPTY, index(), IndexMode.STANDARD, List.of(), null, limit, List.of(sort), estimatedRowSize)
+        );
+        assertThat(plan.driverFactories.size(), lessThanOrEqualTo(pragmas.taskConcurrency()));
+        LocalExecutionPlanner.DriverSupplier supplier = plan.driverFactories.get(0).driverSupplier();
+        var factory = (LuceneTopNSourceOperator.Factory) supplier.physicalOperation().sourceOperatorFactory;
+        assertThat(factory.maxPageSize(), maxPageSizeMatcher(estimatedRowSizeIsHuge, estimatedRowSize));
+        assertThat(factory.limit(), equalTo(10));
+    }
+
     private int randomEstimatedRowSize(boolean huge) {
         int hugeBoundary = SourceOperator.MIN_TARGET_PAGE_SIZE * 10;
         return huge ? between(hugeBoundary, Integer.MAX_VALUE) : between(1, hugeBoundary);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -87,6 +87,7 @@ import java.util.jar.JarInputStream;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.ConfigurationTestUtils.randomConfiguration;
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -421,7 +422,11 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             // Grok.Parser is a record / final, cannot be mocked
             return Grok.pattern(Source.EMPTY, randomGrokPattern());
         } else if (argClass == EsQueryExec.FieldSort.class) {
+            // TODO: It appears neither FieldSort nor GeoDistanceSort are ever actually tested
             return randomFieldSort();
+        } else if (argClass == EsQueryExec.GeoDistanceSort.class) {
+            // TODO: It appears neither FieldSort nor GeoDistanceSort are ever actually tested
+            return randomGeoDistanceSort();
         } else if (toBuildClass == Pow.class && Expression.class.isAssignableFrom(argClass)) {
             return randomResolvedExpression(randomBoolean() ? FieldAttribute.class : Literal.class);
         } else if (isPlanNodeClass(toBuildClass) && Expression.class.isAssignableFrom(argClass)) {
@@ -676,6 +681,15 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             field(randomAlphaOfLength(16), randomFrom(DATA_TYPES)),
             randomFrom(EnumSet.allOf(Order.OrderDirection.class)),
             randomFrom(EnumSet.allOf(Order.NullsPosition.class))
+        );
+    }
+
+    static EsQueryExec.GeoDistanceSort randomGeoDistanceSort() {
+        return new EsQueryExec.GeoDistanceSort(
+            field(randomAlphaOfLength(16), GEO_POINT),
+            randomFrom(EnumSet.allOf(Order.OrderDirection.class)),
+            randomDoubleBetween(-90, 90, false),
+            randomDoubleBetween(-180, 180, false)
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Enable pushing Sort/Filter by ReferenceAttribute down to Lucene, and thereby optimize Sort by ST_DISTANCE (#112938)