### PR TITLE
Remove type assertion for new function merged back to 8.x already

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -402,11 +402,7 @@ setup:
           query: 'FROM test | SORT name | EVAL job_reversed = REVERSE(job), tag_reversed = REVERSE(tag) | KEEP job_reversed, tag_reversed'
 
   - match: { columns.0.name: "job_reversed" }
-  - match: { columns.0.type: "text" }
-
   - match: { columns.1.name: "tag_reversed" }
-  - match: { columns.1.type: "text" }
-
   - length: { values: 2 }
   - match: { values.0: [ "rotceriD TI", "rab oof" ] }
   - match: { values.1: [ "tsilaicepS lloryaP", "zab" ] }


### PR DESCRIPTION
Recent work in https://github.com/elastic/elasticsearch/pull/114334 changes the return type for many functions from TEXT too KEYWORD. However, using EsqlCapabilities is not sufficient to protect against YML tests recently merged back to 8.x, because we pull this test from 8.x and run it on current builds in yamlRestCompatTest, so we need to disable this check here (and in 8.x)

This PR will simply remove the assertions on return type for these fields, so no matter which direction the backwards compatibility is run, the test will pass.

Then the work in https://github.com/elastic/elasticsearch/pull/114334 can continue, and can also bring back the use of EsqlCapabilities for this test.