### PR TITLE
[8.x] SQL: Remove dependency on `org.elasticsearch.Version` (#112094)

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/EsDataSource.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/EsDataSource.java
@@ -25,7 +25,7 @@ import javax.sql.DataSource;
 public class EsDataSource implements DataSource, Wrapper {
 
     static {
-        // invoke Version to perform classpath/jar sanity checks
+        // invoke version to perform classpath/jar sanity checks
         ClientVersion.CURRENT.toString();
     }
 

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/EsDriver.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/EsDriver.java
@@ -23,7 +23,7 @@ public class EsDriver implements Driver {
     private static final EsDriver INSTANCE = new EsDriver();
 
     static {
-        // invoke Version to perform classpath/jar sanity checks
+        // invoke version to perform classpath/jar sanity checks
         ClientVersion.CURRENT.toString();
 
         try {

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/DriverManagerRegistrationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/DriverManagerRegistrationTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.jdbc;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.test.ESTestCase;
 
 import java.security.AccessController;
@@ -27,8 +26,8 @@ public class DriverManagerRegistrationTests extends ESTestCase {
             /* This test will only work properly in gradle because in gradle we run the tests
              * using the jar. */
 
-            assertNotEquals(String.valueOf(Version.CURRENT.major), d.getMajorVersion());
-            assertNotEquals(String.valueOf(Version.CURRENT.minor), d.getMinorVersion());
+            assertNotEquals(String.valueOf(VersionTests.current().major), d.getMajorVersion());
+            assertNotEquals(String.valueOf(VersionTests.current().minor), d.getMinorVersion());
         });
     }
 

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/VersionTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/VersionTests.java
@@ -6,15 +6,20 @@
  */
 package org.elasticsearch.xpack.sql.jdbc;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.ClientVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 public class VersionTests extends ESTestCase {
     public void testVersionIsCurrent() {
         /* This test will only work properly in gradle because in gradle we run the tests
          * using the jar. */
-        assertEquals(org.elasticsearch.Version.CURRENT.major, ClientVersion.CURRENT.major);
-        assertEquals(org.elasticsearch.Version.CURRENT.minor, ClientVersion.CURRENT.minor);
-        assertEquals(org.elasticsearch.Version.CURRENT.revision, ClientVersion.CURRENT.revision);
+        assertEquals(current(), ClientVersion.CURRENT);
+    }
+
+    /** Returns the current stack version. Can be unreleased. */
+    public static SqlVersion current() {
+        return SqlVersion.fromString(Build.current().version());
     }
 }

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/WebServerTestCase.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/WebServerTestCase.java
@@ -8,13 +8,13 @@
 package org.elasticsearch.xpack.sql.jdbc;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.rest.root.MainResponse;
 import org.elasticsearch.test.BuildUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.junit.After;
 import org.junit.Before;
 
@@ -42,10 +42,10 @@ public abstract class WebServerTestCase extends ESTestCase {
     }
 
     MainResponse createCurrentVersionMainResponse() {
-        return createMainResponse(Version.CURRENT);
+        return createMainResponse(VersionTests.current());
     }
 
-    MainResponse createMainResponse(Version version) {
+    MainResponse createMainResponse(SqlVersion version) {
         // the SQL client only cares about node version,
         // so ignore index & transport versions here (just set them to current)
         String clusterUuid = randomAlphaOfLength(10);

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ConnectionTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ConnectionTestCase.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.qa.jdbc;
 
-import org.elasticsearch.Version;
-
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -22,8 +20,8 @@ public abstract class ConnectionTestCase extends JdbcIntegrationTestCase {
             assertFalse(c.isClosed());
             assertTrue(c.isReadOnly());
             DatabaseMetaData md = c.getMetaData();
-            assertEquals(Version.CURRENT.major, md.getDatabaseMajorVersion());
-            assertEquals(Version.CURRENT.minor, md.getDatabaseMinorVersion());
+            assertEquals(JdbcTestUtils.CURRENT.major, md.getDatabaseMajorVersion());
+            assertEquals(JdbcTestUtils.CURRENT.minor, md.getDatabaseMinorVersion());
         }
     }
 

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcWarningsTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcWarningsTestCase.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.sql.qa.jdbc;
 
-import org.elasticsearch.Version;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -20,13 +19,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_WARNING_HANDLING;
 import static org.elasticsearch.xpack.sql.qa.jdbc.JdbcTestUtils.JDBC_DRIVER_VERSION;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 
 public abstract class JdbcWarningsTestCase extends JdbcIntegrationTestCase {
-
-    private static final Version WARNING_HANDLING_ADDED_VERSION = Version.V_8_2_0;
 
     @Before
     public void setupData() throws IOException {
@@ -89,7 +87,7 @@ public abstract class JdbcWarningsTestCase extends JdbcIntegrationTestCase {
     }
 
     private void assumeWarningHandlingDriverVersion() {
-        assumeTrue("Driver does not yet handle deprecation warnings", JDBC_DRIVER_VERSION.onOrAfter(WARNING_HANDLING_ADDED_VERSION));
+        assumeTrue("Driver does not yet handle deprecation warnings", JDBC_DRIVER_VERSION.onOrAfter(INTRODUCING_WARNING_HANDLING));
     }
 
 }

--- a/x-pack/plugin/sql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.sql.qa.mixed_node;
 
 import org.apache.http.HttpHost;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -19,6 +18,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.ql.TestNode;
 import org.elasticsearch.xpack.ql.TestNodes;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.junit.After;
 import org.junit.Before;
 
@@ -36,13 +36,14 @@ import java.util.stream.Collectors;
 import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.xpack.ql.TestUtils.buildNodeAndVersions;
 import static org.elasticsearch.xpack.ql.TestUtils.readResource;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_VERSION_FIELD_TYPE;
 
 public class SqlSearchIT extends ESRestTestCase {
 
     private static final String BWC_NODES_VERSION = System.getProperty("tests.bwc_nodes_version");
 
-    // TODO[lor]: replace this with feature-based checks when we have one
-    private static final boolean SUPPORTS_VERSION_FIELD_QL_INTRODUCTION = Version.fromString(BWC_NODES_VERSION).onOrAfter(Version.V_8_4_0);
+    private static final boolean SUPPORTS_VERSION_FIELD_QL_INTRODUCTION = SqlVersion.fromString(BWC_NODES_VERSION)
+        .onOrAfter(INTRODUCING_VERSION_FIELD_TYPE);
 
     private static final String index = "test_sql_mixed_versions";
     private static int numShards;

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -10,7 +10,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -23,12 +22,13 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.NotEqualMessageBuilder;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonStringEncoder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.sql.proto.CoreProtocol;
 import org.elasticsearch.xpack.sql.proto.Mode;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
 import org.elasticsearch.xpack.sql.proto.StringUtils;
 import org.elasticsearch.xpack.sql.qa.ErrorsTestCase;
 import org.hamcrest.Matcher;
@@ -60,7 +60,6 @@ import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.common.Strings.hasText;
 import static org.elasticsearch.xpack.ql.TestUtils.getNumberOfSearchContexts;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_UNSIGNED_LONG;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.COLUMNS_NAME;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.HEADER_NAME_ASYNC_ID;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.HEADER_NAME_ASYNC_PARTIAL;
@@ -76,6 +75,7 @@ import static org.elasticsearch.xpack.sql.proto.CoreProtocol.SQL_ASYNC_STATUS_RE
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.URL_PARAM_DELIMITER;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.URL_PARAM_FORMAT;
 import static org.elasticsearch.xpack.sql.proto.CoreProtocol.WAIT_FOR_COMPLETION_TIMEOUT_NAME;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_UNSIGNED_LONG;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -1159,7 +1159,8 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
 
     public void testPreventedUnsignedLongMaskedAccess() throws IOException {
         loadUnsignedLongTestData();
-        Version version = VersionUtils.randomVersionBetween(random(), null, VersionUtils.getPreviousVersion(INTRODUCING_UNSIGNED_LONG));
+        var preVersionCompat = SqlVersions.getAllVersions().stream().filter(v -> v.onOrAfter(INTRODUCING_UNSIGNED_LONG) == false).toList();
+        SqlVersion version = preVersionCompat.get(random().nextInt(preVersionCompat.size()));
         String query = query("SELECT unsigned_long::STRING FROM " + indexPattern("test")).version(version.toString()).toString();
         expectBadRequest(
             () -> runSql(new StringEntity(query, ContentType.APPLICATION_JSON), "", randomMode()),

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -6,9 +6,7 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.common.Strings;
@@ -30,7 +28,8 @@ import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.RequestInfo;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
-import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
+import org.elasticsearch.xpack.sql.proto.VersionCompatibility;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -288,15 +287,15 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
                         validationException
                     );
                 }
-            } else if (SqlVersion.isClientCompatible(SqlVersion.fromId(Version.CURRENT.id), requestInfo().version()) == false) {
+            } else if (VersionCompatibility.isClientCompatible(SqlVersions.SERVER_COMPAT_VERSION, requestInfo().version()) == false) {
                 validationException = addValidationError(
                     "The ["
                         + requestInfo().version()
                         + "] version of the ["
                         + mode.toString()
                         + "] "
-                        + "client is not compatible with Elasticsearch version ["
-                        + Build.current().version()
+                        + "client is not compatible with Elasticsearch server compatibility version ["
+                        + SqlVersions.SERVER_COMPAT_VERSION
                         + "]",
                     validationException
                 );

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryResponse.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryResponse.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.sql.action;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -21,6 +20,7 @@ import org.elasticsearch.xpack.ql.async.QlStatusResponse;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
 import org.elasticsearch.xpack.sql.proto.StringUtils;
 
 import java.io.IOException;
@@ -33,8 +33,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.xpack.sql.action.AbstractSqlQueryRequest.CURSOR;
 import static org.elasticsearch.xpack.sql.proto.Mode.CLI;
 import static org.elasticsearch.xpack.sql.proto.Mode.JDBC;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.fromId;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.isClientCompatible;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.isClientCompatible;
 
 /**
  * Response to perform an sql query
@@ -108,7 +107,7 @@ public class SqlQueryResponse extends ActionResponse implements ToXContentObject
     ) {
         this.cursor = cursor;
         this.mode = mode;
-        this.sqlVersion = sqlVersion != null ? sqlVersion : fromId(Version.CURRENT.id);
+        this.sqlVersion = sqlVersion != null ? sqlVersion : SqlVersions.SERVER_COMPAT_VERSION;
         this.columnar = columnar;
         this.columns = columns;
         this.rows = rows;
@@ -276,7 +275,7 @@ public class SqlQueryResponse extends ActionResponse implements ToXContentObject
     public static XContentBuilder value(XContentBuilder builder, Mode mode, SqlVersion sqlVersion, Object value) throws IOException {
         if (value instanceof ZonedDateTime zdt) {
             // use the ISO format
-            if (mode == JDBC && isClientCompatible(SqlVersion.fromId(Version.CURRENT.id), sqlVersion)) {
+            if (mode == JDBC && isClientCompatible(SqlVersions.SERVER_COMPAT_VERSION, sqlVersion)) {
                 builder.value(StringUtils.toString(zdt, sqlVersion));
             } else {
                 builder.value(StringUtils.toString(zdt));

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryResponseTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlQueryResponseTests.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.xpack.sql.action.AbstractSqlQueryRequest.CURSOR;
 import static org.elasticsearch.xpack.sql.action.Protocol.ID_NAME;
 import static org.elasticsearch.xpack.sql.action.Protocol.IS_PARTIAL_NAME;
 import static org.elasticsearch.xpack.sql.action.Protocol.IS_RUNNING_NAME;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.DATE_NANOS_SUPPORT_VERSION;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_DATE_NANOS;
 import static org.hamcrest.Matchers.hasSize;
 
 public class SqlQueryResponseTests extends AbstractXContentSerializingTestCase<SqlQueryResponse> {
@@ -118,7 +118,7 @@ public class SqlQueryResponseTests extends AbstractXContentSerializingTestCase<S
                 rows.add(row);
             }
         }
-        return new SqlQueryResponse(cursor, mode, DATE_NANOS_SUPPORT_VERSION, false, columns, rows, asyncExecutionId, isPartial, isRunning);
+        return new SqlQueryResponse(cursor, mode, INTRODUCING_DATE_NANOS, false, columns, rows, asyncExecutionId, isPartial, isRunning);
     }
 
     public void testToXContent() throws IOException {
@@ -177,7 +177,7 @@ public class SqlQueryResponseTests extends AbstractXContentSerializingTestCase<S
         return new SqlQueryResponse(
             protoResponse.cursor(),
             Mode.JDBC,
-            DATE_NANOS_SUPPORT_VERSION,
+            INTRODUCING_DATE_NANOS,
             false,
             protoResponse.columns(),
             protoResponse.rows(),

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlRequestParsersTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -18,6 +17,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.sql.proto.CoreProtocol;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.SqlTypedParamValue;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -154,7 +154,9 @@ public class SqlRequestParsersTests extends ESTestCase {
         String params;
         List<SqlTypedParamValue> list = new ArrayList<>(1);
 
-        final String clientVersion = Mode.isDedicatedClient(randomMode) ? "\"version\": \"" + Version.CURRENT.toString() + "\"," : "";
+        final String clientVersion = Mode.isDedicatedClient(randomMode)
+            ? "\"version\": \"" + SqlVersions.SERVER_COMPAT_VERSION + "\","
+            : "";
         if (Mode.isDriver(randomMode)) {
             params = "{\"value\":123, \"type\":\"whatever\"}";
             list.add(new SqlTypedParamValue("whatever", 123, true));
@@ -178,7 +180,7 @@ public class SqlRequestParsersTests extends ESTestCase {
         assertNull(request.clientId());
         assertEquals(randomMode, request.mode());
         if (Mode.isDedicatedClient(randomMode)) {
-            assertEquals(Version.CURRENT.toString(), request.version().toString());
+            assertEquals(SqlVersions.SERVER_COMPAT_VERSION.toString(), request.version().toString());
         }
         assertEquals("whatever", request.cursor());
         assertEquals("select", request.query());

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/CliSessionTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/CliSessionTests.java
@@ -6,19 +6,19 @@
  */
 package org.elasticsearch.xpack.sql.cli;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xpack.sql.cli.command.CliSession;
 import org.elasticsearch.xpack.sql.client.ClientException;
 import org.elasticsearch.xpack.sql.client.ClientVersion;
 import org.elasticsearch.xpack.sql.client.HttpClient;
 import org.elasticsearch.xpack.sql.proto.MainResponse;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
 
 import java.sql.SQLException;
 
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_VERSION_COMPATIBILITY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,8 +55,11 @@ public class CliSessionTests extends SqlCliTestCase {
 
     public void testWrongServerVersion() throws Exception {
         HttpClient httpClient = mock(HttpClient.class);
-        Version v = VersionUtils.randomVersionBetween(random(), null, VersionUtils.getPreviousVersion(Version.V_7_7_0));
-        SqlVersion version = new SqlVersion(v.major, v.minor, v.revision);
+        var preVersionCompat = SqlVersions.getAllVersions()
+            .stream()
+            .filter(v -> v.onOrAfter(INTRODUCING_VERSION_COMPATIBILITY) == false)
+            .toList();
+        SqlVersion version = preVersionCompat.get(random().nextInt(preVersionCompat.size()));
         when(httpClient.serverInfo()).thenReturn(
             new MainResponse(randomAlphaOfLength(5), version.toString(), ClusterName.DEFAULT.value(), UUIDs.randomBase64UUID())
         );
@@ -66,7 +69,7 @@ public class CliSessionTests extends SqlCliTestCase {
             "This version of the CLI is only compatible with Elasticsearch version "
                 + ClientVersion.CURRENT.majorMinorToString()
                 + " or newer; attempting to connect to a server version "
-                + version.toString(),
+                + version,
             throwable.getMessage()
         );
         verify(httpClient, times(1)).serverInfo();
@@ -75,8 +78,8 @@ public class CliSessionTests extends SqlCliTestCase {
 
     public void testHigherServerVersion() throws Exception {
         HttpClient httpClient = mock(HttpClient.class);
-        Version v = VersionUtils.randomVersionBetween(random(), Version.V_7_7_0, null);
-        SqlVersion version = new SqlVersion(v.major, v.minor, v.revision);
+        var postVersionCompat = SqlVersions.getAllVersions().stream().filter(v -> v.onOrAfter(INTRODUCING_VERSION_COMPATIBILITY)).toList();
+        SqlVersion version = postVersionCompat.get(random().nextInt(postVersionCompat.size()));
         when(httpClient.serverInfo()).thenReturn(
             new MainResponse(randomAlphaOfLength(5), version.toString(), ClusterName.DEFAULT.value(), UUIDs.randomBase64UUID())
         );

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/VersionTests.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/VersionTests.java
@@ -6,16 +6,15 @@
  */
 package org.elasticsearch.xpack.sql.cli;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.Build;
 import org.elasticsearch.xpack.sql.client.ClientVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 public class VersionTests extends SqlCliTestCase {
     public void testVersionIsCurrent() {
         /* This test will only work properly in gradle because in gradle we run the tests
          * using the jar. */
-        assertEquals(Version.CURRENT.major, ClientVersion.CURRENT.major);
-        assertEquals(Version.CURRENT.minor, ClientVersion.CURRENT.minor);
-        assertEquals(Version.CURRENT.revision, ClientVersion.CURRENT.revision);
+        assertEquals(SqlVersion.fromString(Build.current().version()), ClientVersion.CURRENT);
     }
 
 }

--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/ClientVersion.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/ClientVersion.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.client;
 
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.VersionCompatibility;
 
 import java.io.IOException;
 import java.net.JarURLConnection;
@@ -119,7 +120,7 @@ public class ClientVersion {
     // as well.
     public static boolean isServerCompatible(SqlVersion server) {
         // Starting with this version, the compatibility logic moved from the client to the server.
-        return SqlVersion.hasVersionCompatibility(server);
+        return VersionCompatibility.hasVersionCompatibility(server);
     }
 
     public static int jdbcMajorVersion() {

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersion.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersion.java
@@ -30,10 +30,6 @@ public class SqlVersion implements Comparable<SqlVersion> {
     public static final int MINOR_MULTIPLIER = REVISION_MULTIPLIER * REVISION_MULTIPLIER;
     public static final int MAJOR_MULTIPLIER = REVISION_MULTIPLIER * MINOR_MULTIPLIER;
 
-    public static final SqlVersion V_7_7_0 = new SqlVersion(7, 7, 0);
-    public static final SqlVersion V_7_12_0 = new SqlVersion(7, 12, 0);
-    public static final SqlVersion DATE_NANOS_SUPPORT_VERSION = V_7_12_0; // TODO: move to VersionCompatibilityChecks
-
     public SqlVersion(byte major, byte minor, byte revision) {
         this(toString(major, minor, revision), major, minor, revision);
     }
@@ -148,29 +144,7 @@ public class SqlVersion implements Comparable<SqlVersion> {
         return id - o.id;
     }
 
-    public static int majorMinorId(SqlVersion v) {
-        return v.major * MAJOR_MULTIPLIER + v.minor * MINOR_MULTIPLIER;
-    }
-
-    public int compareToMajorMinor(SqlVersion o) {
-        return majorMinorId(this) - majorMinorId(o);
-    }
-
-    public static boolean hasVersionCompatibility(SqlVersion version) {
-        return version.compareTo(V_7_7_0) >= 0;
-    }
-
-    // A client is version-compatible with the server if:
-    // - it supports version compatibility (past or on 7.7.0); and
-    // - it's not on a version newer than server's; and
-    // - it's major version is at most one unit behind server's.
-    public static boolean isClientCompatible(SqlVersion server, SqlVersion client) {
-        // ES's Version.CURRENT not available (core not a dependency), so it needs to be passed in as a parameter.
-        return hasVersionCompatibility(client) && server.compareTo(client) >= 0 && server.major - client.major <= 1;
-    }
-
-    // TODO: move to VersionCompatibilityChecks
-    public static boolean supportsDateNanos(SqlVersion version) {
-        return DATE_NANOS_SUPPORT_VERSION.compareTo(version) <= 0;
+    public boolean onOrAfter(SqlVersion other) {
+        return this.compareTo(other) >= 0;
     }
 }

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersions.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/SqlVersions.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.proto;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.xpack.sql.proto.SqlVersion.fromId;
+
+public final class SqlVersions {
+
+    public static final SqlVersion V_7_0_0 = fromId(7_00_00_99);
+    public static final SqlVersion V_7_0_1 = fromId(7_00_01_99);
+    public static final SqlVersion V_7_1_0 = fromId(7_01_00_99);
+    public static final SqlVersion V_7_1_1 = fromId(7_01_01_99);
+    public static final SqlVersion V_7_2_0 = fromId(7_02_00_99);
+    public static final SqlVersion V_7_2_1 = fromId(7_02_01_99);
+    public static final SqlVersion V_7_3_0 = fromId(7_03_00_99);
+    public static final SqlVersion V_7_3_1 = fromId(7_03_01_99);
+    public static final SqlVersion V_7_3_2 = fromId(7_03_02_99);
+    public static final SqlVersion V_7_4_0 = fromId(7_04_00_99);
+    public static final SqlVersion V_7_4_1 = fromId(7_04_01_99);
+    public static final SqlVersion V_7_4_2 = fromId(7_04_02_99);
+    public static final SqlVersion V_7_5_0 = fromId(7_05_00_99);
+    public static final SqlVersion V_7_5_1 = fromId(7_05_01_99);
+    public static final SqlVersion V_7_5_2 = fromId(7_05_02_99);
+    public static final SqlVersion V_7_6_0 = fromId(7_06_00_99);
+    public static final SqlVersion V_7_6_1 = fromId(7_06_01_99);
+    public static final SqlVersion V_7_6_2 = fromId(7_06_02_99);
+    public static final SqlVersion V_7_7_0 = fromId(7_07_00_99);
+    public static final SqlVersion V_7_7_1 = fromId(7_07_01_99);
+    public static final SqlVersion V_7_8_0 = fromId(7_08_00_99);
+    public static final SqlVersion V_7_8_1 = fromId(7_08_01_99);
+    public static final SqlVersion V_7_9_0 = fromId(7_09_00_99);
+    public static final SqlVersion V_7_9_1 = fromId(7_09_01_99);
+    public static final SqlVersion V_7_9_2 = fromId(7_09_02_99);
+    public static final SqlVersion V_7_9_3 = fromId(7_09_03_99);
+    public static final SqlVersion V_7_10_0 = fromId(7_10_00_99);
+    public static final SqlVersion V_7_10_1 = fromId(7_10_01_99);
+    public static final SqlVersion V_7_10_2 = fromId(7_10_02_99);
+    public static final SqlVersion V_7_11_0 = fromId(7_11_00_99);
+    public static final SqlVersion V_7_11_1 = fromId(7_11_01_99);
+    public static final SqlVersion V_7_11_2 = fromId(7_11_02_99);
+    public static final SqlVersion V_7_12_0 = fromId(7_12_00_99);
+    public static final SqlVersion V_7_12_1 = fromId(7_12_01_99);
+    public static final SqlVersion V_7_13_0 = fromId(7_13_00_99);
+    public static final SqlVersion V_7_13_1 = fromId(7_13_01_99);
+    public static final SqlVersion V_7_13_2 = fromId(7_13_02_99);
+    public static final SqlVersion V_7_13_3 = fromId(7_13_03_99);
+    public static final SqlVersion V_7_13_4 = fromId(7_13_04_99);
+    public static final SqlVersion V_7_14_0 = fromId(7_14_00_99);
+    public static final SqlVersion V_7_14_1 = fromId(7_14_01_99);
+    public static final SqlVersion V_7_14_2 = fromId(7_14_02_99);
+    public static final SqlVersion V_7_15_0 = fromId(7_15_00_99);
+    public static final SqlVersion V_7_15_1 = fromId(7_15_01_99);
+    public static final SqlVersion V_7_15_2 = fromId(7_15_02_99);
+    public static final SqlVersion V_7_16_0 = fromId(7_16_00_99);
+    public static final SqlVersion V_7_16_1 = fromId(7_16_01_99);
+    public static final SqlVersion V_7_16_2 = fromId(7_16_02_99);
+    public static final SqlVersion V_7_16_3 = fromId(7_16_03_99);
+    public static final SqlVersion V_7_17_0 = fromId(7_17_00_99);
+    public static final SqlVersion V_7_17_1 = fromId(7_17_01_99);
+    public static final SqlVersion V_7_17_2 = fromId(7_17_02_99);
+    public static final SqlVersion V_7_17_3 = fromId(7_17_03_99);
+    public static final SqlVersion V_7_17_4 = fromId(7_17_04_99);
+    public static final SqlVersion V_7_17_5 = fromId(7_17_05_99);
+    public static final SqlVersion V_7_17_6 = fromId(7_17_06_99);
+    public static final SqlVersion V_7_17_7 = fromId(7_17_07_99);
+    public static final SqlVersion V_7_17_8 = fromId(7_17_08_99);
+    public static final SqlVersion V_7_17_9 = fromId(7_17_09_99);
+    public static final SqlVersion V_7_17_10 = fromId(7_17_10_99);
+    public static final SqlVersion V_7_17_11 = fromId(7_17_11_99);
+    public static final SqlVersion V_7_17_12 = fromId(7_17_12_99);
+    public static final SqlVersion V_7_17_13 = fromId(7_17_13_99);
+    public static final SqlVersion V_7_17_14 = fromId(7_17_14_99);
+    public static final SqlVersion V_7_17_15 = fromId(7_17_15_99);
+    public static final SqlVersion V_7_17_16 = fromId(7_17_16_99);
+    public static final SqlVersion V_7_17_17 = fromId(7_17_17_99);
+    public static final SqlVersion V_7_17_18 = fromId(7_17_18_99);
+    public static final SqlVersion V_7_17_19 = fromId(7_17_19_99);
+    public static final SqlVersion V_7_17_20 = fromId(7_17_20_99);
+    public static final SqlVersion V_7_17_21 = fromId(7_17_21_99);
+    public static final SqlVersion V_7_17_22 = fromId(7_17_22_99);
+    public static final SqlVersion V_7_17_23 = fromId(7_17_23_99);
+    public static final SqlVersion V_7_17_24 = fromId(7_17_24_99);
+
+    public static final SqlVersion V_8_0_0 = fromId(8_00_00_99);
+    public static final SqlVersion V_8_0_1 = fromId(8_00_01_99);
+    public static final SqlVersion V_8_1_0 = fromId(8_01_00_99);
+    public static final SqlVersion V_8_1_1 = fromId(8_01_01_99);
+    public static final SqlVersion V_8_1_2 = fromId(8_01_02_99);
+    public static final SqlVersion V_8_1_3 = fromId(8_01_03_99);
+    public static final SqlVersion V_8_2_0 = fromId(8_02_00_99);
+    public static final SqlVersion V_8_2_1 = fromId(8_02_01_99);
+    public static final SqlVersion V_8_2_2 = fromId(8_02_02_99);
+    public static final SqlVersion V_8_2_3 = fromId(8_02_03_99);
+    public static final SqlVersion V_8_3_0 = fromId(8_03_00_99);
+    public static final SqlVersion V_8_3_1 = fromId(8_03_01_99);
+    public static final SqlVersion V_8_3_2 = fromId(8_03_02_99);
+    public static final SqlVersion V_8_3_3 = fromId(8_03_03_99);
+    public static final SqlVersion V_8_4_0 = fromId(8_04_00_99);
+    public static final SqlVersion V_8_4_1 = fromId(8_04_01_99);
+    public static final SqlVersion V_8_4_2 = fromId(8_04_02_99);
+    public static final SqlVersion V_8_4_3 = fromId(8_04_03_99);
+    public static final SqlVersion V_8_5_0 = fromId(8_05_00_99);
+    public static final SqlVersion V_8_5_1 = fromId(8_05_01_99);
+    public static final SqlVersion V_8_5_2 = fromId(8_05_02_99);
+    public static final SqlVersion V_8_5_3 = fromId(8_05_03_99);
+    public static final SqlVersion V_8_6_0 = fromId(8_06_00_99);
+    public static final SqlVersion V_8_6_1 = fromId(8_06_01_99);
+    public static final SqlVersion V_8_6_2 = fromId(8_06_02_99);
+    public static final SqlVersion V_8_7_0 = fromId(8_07_00_99);
+    public static final SqlVersion V_8_7_1 = fromId(8_07_01_99);
+    public static final SqlVersion V_8_8_0 = fromId(8_08_00_99);
+    public static final SqlVersion V_8_8_1 = fromId(8_08_01_99);
+    public static final SqlVersion V_8_8_2 = fromId(8_08_02_99);
+    public static final SqlVersion V_8_9_0 = fromId(8_09_00_99);
+    public static final SqlVersion V_8_9_1 = fromId(8_09_01_99);
+    public static final SqlVersion V_8_9_2 = fromId(8_09_02_99);
+    public static final SqlVersion V_8_10_0 = fromId(8_10_00_99);
+    public static final SqlVersion V_8_10_1 = fromId(8_10_01_99);
+    public static final SqlVersion V_8_10_2 = fromId(8_10_02_99);
+    public static final SqlVersion V_8_10_3 = fromId(8_10_03_99);
+    public static final SqlVersion V_8_10_4 = fromId(8_10_04_99);
+    public static final SqlVersion V_8_11_0 = fromId(8_11_00_99);
+    public static final SqlVersion V_8_11_1 = fromId(8_11_01_99);
+    public static final SqlVersion V_8_11_2 = fromId(8_11_02_99);
+    public static final SqlVersion V_8_11_3 = fromId(8_11_03_99);
+    public static final SqlVersion V_8_11_4 = fromId(8_11_04_99);
+    public static final SqlVersion V_8_12_0 = fromId(8_12_00_99);
+    public static final SqlVersion V_8_12_1 = fromId(8_12_01_99);
+    public static final SqlVersion V_8_12_2 = fromId(8_12_02_99);
+    public static final SqlVersion V_8_13_0 = fromId(8_13_00_99);
+    public static final SqlVersion V_8_13_1 = fromId(8_13_01_99);
+    public static final SqlVersion V_8_13_2 = fromId(8_13_02_99);
+    public static final SqlVersion V_8_13_3 = fromId(8_13_03_99);
+    public static final SqlVersion V_8_13_4 = fromId(8_13_04_99);
+    public static final SqlVersion V_8_14_0 = fromId(8_14_00_99);
+    public static final SqlVersion V_8_14_1 = fromId(8_14_01_99);
+    public static final SqlVersion V_8_14_2 = fromId(8_14_02_99);
+    public static final SqlVersion V_8_14_3 = fromId(8_14_03_99);
+    public static final SqlVersion V_8_15_0 = fromId(8_15_00_99);
+    public static final SqlVersion V_8_15_1 = fromId(8_15_01_99);
+    public static final SqlVersion V_8_16_0 = fromId(8_16_00_99);
+
+    static final List<SqlVersion> DECLARED_VERSIONS = getDeclaredVersions();
+
+    /**
+     * What's the version of the server that the clients should be compatible with?
+     */
+    public static final SqlVersion SERVER_COMPAT_VERSION = getLatestVersion();
+
+    public static SqlVersion getFirstVersion() {
+        return DECLARED_VERSIONS.get(0);
+    }
+
+    public static SqlVersion getLatestVersion() {
+        return DECLARED_VERSIONS.get(DECLARED_VERSIONS.size() - 1);
+    }
+
+    public static SqlVersion getPreviousVersion(SqlVersion version) {
+        int index = Collections.binarySearch(DECLARED_VERSIONS, version);
+        if (index < 1) {
+            throw new IllegalArgumentException("couldn't find any released versions before [" + version + "]");
+        }
+        return DECLARED_VERSIONS.get(index - 1);
+    }
+
+    public static SqlVersion getNextVersion(SqlVersion version) {
+        int index = Collections.binarySearch(DECLARED_VERSIONS, version);
+        if (index >= DECLARED_VERSIONS.size() - 1) {
+            throw new IllegalArgumentException("couldn't find any released versions before [" + version + "]");
+        }
+        return DECLARED_VERSIONS.get(index + 1);
+    }
+
+    public static List<SqlVersion> getAllVersions() {
+        return DECLARED_VERSIONS;
+    }
+
+    // lifted from org.elasticsearch.Version#getDeclaredVersions
+    private static List<SqlVersion> getDeclaredVersions() {
+        final Field[] fields = SqlVersions.class.getFields();
+        final List<SqlVersion> versions = new ArrayList<>(fields.length);
+        for (final Field field : fields) {
+            final int mod = field.getModifiers();
+            if (false == (Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod))) {
+                continue;
+            }
+            if (field.getType() != SqlVersion.class) {
+                continue;
+            }
+            switch (field.getName()) {
+                case "LATEST":
+                case "SERVER_COMPAT_VERSION":
+                    continue;
+            }
+            assert field.getName().matches("V(_\\d+){3}?") : field.getName();
+            try {
+                if (field.get(null) == null) {
+                    throw new IllegalStateException("field " + field.getName() + " is null");
+                }
+                versions.add(((SqlVersion) field.get(null)));
+            } catch (final IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        Collections.sort(versions);
+        return versions;
+    }
+}

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/StringUtils.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/StringUtils.java
@@ -24,7 +24,7 @@ import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.DATE_NANOS_SUPPORT_VERSION;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_DATE_NANOS;
 
 public final class StringUtils {
 
@@ -82,7 +82,7 @@ public final class StringUtils {
 
     // This method doesn't support compatibility with older JDBC drivers
     public static String toString(Object value) {
-        return toString(value, DATE_NANOS_SUPPORT_VERSION);
+        return toString(value, INTRODUCING_DATE_NANOS);
     }
 
     public static String toString(Object value, SqlVersion sqlVersion) {
@@ -91,14 +91,14 @@ public final class StringUtils {
         }
 
         if (value instanceof ZonedDateTime) {
-            if (SqlVersion.supportsDateNanos(sqlVersion)) {
+            if (VersionCompatibility.supportsDateNanos(sqlVersion)) {
                 return ((ZonedDateTime) value).format(ISO_DATETIME_WITH_NANOS);
             } else {
                 return ((ZonedDateTime) value).format(ISO_DATETIME_WITH_MILLIS);
             }
         }
         if (value instanceof OffsetTime) {
-            if (SqlVersion.supportsDateNanos(sqlVersion)) {
+            if (VersionCompatibility.supportsDateNanos(sqlVersion)) {
                 return ((OffsetTime) value).format(ISO_TIME_WITH_NANOS);
             } else {
                 return ((OffsetTime) value).format(ISO_TIME_WITH_MILLIS);

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/VersionCompatibility.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/VersionCompatibility.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.proto;
+
+public class VersionCompatibility {
+
+    public static final SqlVersion INTRODUCING_VERSION_COMPATIBILITY = SqlVersions.V_7_7_0;
+    public static final SqlVersion INTRODUCING_DATE_NANOS = SqlVersions.V_7_12_0;
+    public static final SqlVersion INTRODUCING_UNSIGNED_LONG = SqlVersions.V_8_2_0;
+    public static final SqlVersion INTRODUCING_WARNING_HANDLING = SqlVersions.V_8_2_0;
+    public static final SqlVersion INTRODUCING_VERSION_FIELD_TYPE = SqlVersions.V_8_4_0;
+    public static final SqlVersion INTRODUCING_VERSIONING_INDEPENDENT_FEATURES = SqlVersions.V_8_16_0;
+
+    public static boolean hasVersionCompatibility(SqlVersion version) {
+        return version.onOrAfter(INTRODUCING_VERSION_COMPATIBILITY);
+    }
+
+    /** Is the client on or past a version that is SQL-specific, independent of stack versioning? */
+    public static boolean hasVersioningIndependentFeatures(SqlVersion version) {
+        return version.onOrAfter(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES);
+    }
+
+    // A client is version-compatible with the server if:
+    // - it is on or past the version-independent feature gating version; OR
+    // - it supports version compatibility (past or on 7.7.0); AND
+    // - it's not on a version newer than server's; AND
+    // - it's major version is at most one unit behind server's.
+    public static boolean isClientCompatible(SqlVersion server, SqlVersion client) {
+        if (hasVersioningIndependentFeatures(client)) {
+            return true;
+        }
+        // ES's CURRENT not available (core not a dependency), so it needs to be passed in as a parameter.
+        return hasVersionCompatibility(client) && server.onOrAfter(client) && server.major - client.major <= 1;
+    }
+
+    // TODO: move to VersionCompatibilityChecks
+    public static boolean supportsDateNanos(SqlVersion version) {
+        return version.onOrAfter(INTRODUCING_DATE_NANOS);
+    }
+
+    /**
+     * Does the provided {@code version} support the unsigned_long type (PR#60050)?
+     */
+    public static boolean supportsUnsignedLong(SqlVersion version) {
+        return version.onOrAfter(INTRODUCING_UNSIGNED_LONG);
+    }
+
+    /**
+     * Does the provided {@code version} support the version type (PR#85502)?
+     */
+    public static boolean supportsVersionType(SqlVersion version) {
+        return version.onOrAfter(INTRODUCING_VERSION_FIELD_TYPE);
+    }
+}

--- a/x-pack/plugin/sql/sql-proto/src/test/java/org/elasticsearch/xpack/sql/proto/SqlVersionTests.java
+++ b/x-pack/plugin/sql/sql-proto/src/test/java/org/elasticsearch/xpack/sql/proto/SqlVersionTests.java
@@ -13,8 +13,9 @@ import static org.elasticsearch.Version.CURRENT;
 import static org.elasticsearch.xpack.sql.proto.SqlVersion.MAJOR_MULTIPLIER;
 import static org.elasticsearch.xpack.sql.proto.SqlVersion.MINOR_MULTIPLIER;
 import static org.elasticsearch.xpack.sql.proto.SqlVersion.REVISION_MULTIPLIER;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.V_7_7_0;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.isClientCompatible;
+import static org.elasticsearch.xpack.sql.proto.SqlVersions.V_7_7_0;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_VERSIONING_INDEPENDENT_FEATURES;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.isClientCompatible;
 
 public class SqlVersionTests extends ESTestCase {
     public void test123FromString() {
@@ -35,6 +36,17 @@ public class SqlVersionTests extends ESTestCase {
         assertEquals(REVISION_MULTIPLIER - 1, ver.build);
         assertEquals(1 * MAJOR_MULTIPLIER + 2 * MINOR_MULTIPLIER + 3 * REVISION_MULTIPLIER + REVISION_MULTIPLIER - 1, ver.id);
         assertEquals("1.2.3-Alpha", ver.version);
+    }
+
+    public void test123AlphaWithIdFromString() {
+        String version = "1.2.3-Alpha[" + randomIntBetween(0, 100_000_000) + "]";
+        SqlVersion ver = SqlVersion.fromString(version);
+        assertEquals(1, ver.major);
+        assertEquals(2, ver.minor);
+        assertEquals(3, ver.revision);
+        assertEquals(REVISION_MULTIPLIER - 1, ver.build);
+        assertEquals(1 * MAJOR_MULTIPLIER + 2 * MINOR_MULTIPLIER + 3 * REVISION_MULTIPLIER + REVISION_MULTIPLIER - 1, ver.id);
+        assertEquals(version, ver.version);
     }
 
     public void test123AlphaSnapshotFromString() {
@@ -84,16 +96,28 @@ public class SqlVersionTests extends ESTestCase {
     }
 
     public void testVersionCompatibilityClientNewer() {
-        int major = randomIntBetween(7, 99);
-        SqlVersion server = new SqlVersion(major, randomIntBetween(major > 7 ? 0 : 7, 99), randomIntBetween(0, 98));
+        SqlVersion server = randomReleasedVersion(false);
         SqlVersion client = new SqlVersion(server.major, server.minor, (byte) (server.revision + 1));
         assertFalse(isClientCompatible(server, client));
     }
 
+    public void testVersionCompatibilityClientVersionIndependentFeatures() {
+        SqlVersion server = new SqlVersion(
+            randomIntBetween(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES.major, 99),
+            randomIntBetween(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES.minor, 99),
+            randomIntBetween(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES.revision, 99)
+        );
+        SqlVersion client = new SqlVersion(
+            randomIntBetween(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES.major, 99),
+            randomIntBetween(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES.minor, 99),
+            randomIntBetween(INTRODUCING_VERSIONING_INDEPENDENT_FEATURES.revision, 99)
+        );
+        assertTrue(server + " vs. " + client, isClientCompatible(server, client));
+    }
+
     public void testVersionCompatibilityClientTooOld() {
-        int major = randomIntBetween(9, 99);
-        SqlVersion server = new SqlVersion(major, randomIntBetween(0, 99), randomIntBetween(0, 99));
-        SqlVersion client = new SqlVersion(major - 2, randomIntBetween(0, 99), randomIntBetween(0, 99));
+        SqlVersion server = randomReleasedVersion(false);
+        SqlVersion client = new SqlVersion(server.major - 2, randomIntBetween(0, 99), randomIntBetween(0, 99));
         assertFalse(isClientCompatible(server, client));
     }
 
@@ -108,5 +132,10 @@ public class SqlVersionTests extends ESTestCase {
         int serverRevision = randomIntBetween(client.major == serverMajor && client.minor == serverMinor ? client.revision : 0, 99);
         SqlVersion server = new SqlVersion(serverMajor, serverMinor, serverRevision);
         assertTrue(isClientCompatible(server, client));
+    }
+
+    private static SqlVersion randomReleasedVersion(boolean includeVersioningIndependent) {
+        var allVersions = SqlVersions.getAllVersions();
+        return allVersions.get(randomIntBetween(0, allVersions.size() - 1 - (includeVersioningIndependent ? 0 : 1)));
     }
 }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlActionIT.java
@@ -6,11 +6,11 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.xpack.sql.proto.ColumnInfo;
 import org.elasticsearch.xpack.sql.proto.Mode;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,7 +31,7 @@ public class SqlActionIT extends AbstractSqlIntegTestCase {
         String columns = dataBeforeCount ? "data, count" : "count, data";
         SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query("SELECT " + columns + " FROM test ORDER BY count")
             .mode(Mode.JDBC)
-            .version(Version.CURRENT.toString())
+            .version(SqlVersions.SERVER_COMPAT_VERSION.toString())
             .get();
         assertThat(response.size(), equalTo(2L));
         assertThat(response.columns(), hasSize(2));
@@ -50,7 +50,7 @@ public class SqlActionIT extends AbstractSqlIntegTestCase {
     public void testSqlActionCurrentVersion() {
         SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query("SELECT true")
             .mode(randomFrom(Mode.CLI, Mode.JDBC))
-            .version(Version.CURRENT.toString())
+            .version(SqlVersions.SERVER_COMPAT_VERSION.toString())
             .get();
         assertThat(response.size(), equalTo(1L));
         assertEquals(true, response.rows().get(0).get(0));

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.analysis.analyzer;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.ql.capabilities.Unresolvable;
 import org.elasticsearch.xpack.ql.common.Failure;
@@ -77,11 +76,11 @@ import java.util.function.Consumer;
 import static java.util.stream.Collectors.toMap;
 import static org.elasticsearch.xpack.ql.analyzer.VerifierChecks.checkFilterConditionType;
 import static org.elasticsearch.xpack.ql.common.Failure.fail;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.versionIntroducingType;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BINARY;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.versionIntroducingType;
 import static org.elasticsearch.xpack.sql.stats.FeatureMetric.COMMAND;
 import static org.elasticsearch.xpack.sql.stats.FeatureMetric.GROUPBY;
 import static org.elasticsearch.xpack.sql.stats.FeatureMetric.HAVING;
@@ -1000,9 +999,8 @@ public final class Verifier {
     }
 
     private static void checkClientSupportsDataTypes(LogicalPlan p, Set<Failure> localFailures, SqlVersion version) {
-        Version ver = Version.fromId(version.id);
         p.output().forEach(e -> {
-            if (e.resolved() && isTypeSupportedInVersion(e.dataType(), ver) == false) {
+            if (e.resolved() && isTypeSupportedInVersion(e.dataType(), version) == false) {
                 localFailures.add(
                     fail(
                         e,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DelegatingActionListener;
 import org.elasticsearch.action.search.ClosePointInTimeRequest;
@@ -100,7 +101,7 @@ import static java.util.Collections.singletonList;
 import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.execution.search.extractor.AbstractFieldHitExtractor.MultiValueSupport.LENIENT;
 import static org.elasticsearch.xpack.ql.execution.search.extractor.AbstractFieldHitExtractor.MultiValueSupport.NONE;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_UNSIGNED_LONG;
 
 // TODO: add retry/back-off
 public class Querier {
@@ -201,7 +202,7 @@ public class Querier {
     public static SearchRequest prepareRequest(SearchSourceBuilder source, SqlConfiguration cfg, boolean includeFrozen, String... indices) {
         source.timeout(cfg.requestTimeout());
 
-        SearchRequest searchRequest = new SearchRequest(INTRODUCING_UNSIGNED_LONG);
+        SearchRequest searchRequest = new SearchRequest(Version.fromId(INTRODUCING_UNSIGNED_LONG.id));
         if (source.pointInTimeBuilder() == null) {
             searchRequest.indices(indices);
             searchRequest.indicesOptions(

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractor.java
@@ -22,11 +22,11 @@ import java.time.ZoneId;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_UNSIGNED_LONG_TRANSPORT;
 import static org.elasticsearch.xpack.ql.type.DataTypeConverter.toUnsignedLong;
 import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
 import static org.elasticsearch.xpack.ql.type.DataTypes.NULL;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.INTRODUCING_UNSIGNED_LONG_TRANSPORT;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.isDateBased;
 
 public class CompositeKeyExtractor implements BucketExtractor {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/index/IndexCompatibility.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/index/IndexCompatibility.java
@@ -5,22 +5,24 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.ql.index;
+package org.elasticsearch.xpack.sql.index;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.xpack.ql.index.EsIndex;
+import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.UnsupportedEsField;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 import java.util.Map;
 
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.ql.type.DataTypes.isPrimitive;
 import static org.elasticsearch.xpack.ql.type.Types.propagateUnsupportedType;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 
 public final class IndexCompatibility {
 
-    public static Map<String, EsField> compatible(Map<String, EsField> mapping, Version version) {
+    public static Map<String, EsField> compatible(Map<String, EsField> mapping, SqlVersion version) {
         for (Map.Entry<String, EsField> entry : mapping.entrySet()) {
             EsField esField = entry.getValue();
             DataType dataType = esField.getDataType();
@@ -35,12 +37,12 @@ public final class IndexCompatibility {
         return mapping;
     }
 
-    public static EsIndex compatible(EsIndex esIndex, Version version) {
+    public static EsIndex compatible(EsIndex esIndex, SqlVersion version) {
         compatible(esIndex.mapping(), version);
         return esIndex;
     }
 
-    public static IndexResolution compatible(IndexResolution indexResolution, Version version) {
+    public static IndexResolution compatible(IndexResolution indexResolution, SqlVersion version) {
         if (indexResolution.isValid()) {
             compatible(indexResolution.get(), version);
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/index/VersionCompatibilityChecks.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/index/VersionCompatibilityChecks.java
@@ -5,28 +5,28 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.ql.index;
+package org.elasticsearch.xpack.sql.index;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.Version;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
-import static org.elasticsearch.Version.V_8_2_0;
-import static org.elasticsearch.Version.V_8_4_0;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_VERSION_FIELD_TYPE;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.supportsUnsignedLong;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.supportsVersionType;
 
 public final class VersionCompatibilityChecks {
 
-    public static final Version INTRODUCING_UNSIGNED_LONG = V_8_2_0;
     public static final TransportVersion INTRODUCING_UNSIGNED_LONG_TRANSPORT = TransportVersions.V_8_2_0;
-    public static final Version INTRODUCING_VERSION_FIELD_TYPE = V_8_4_0;
 
     private VersionCompatibilityChecks() {}
 
-    public static boolean isTypeSupportedInVersion(DataType dataType, Version version) {
+    public static boolean isTypeSupportedInVersion(DataType dataType, SqlVersion version) {
         if (dataType == UNSIGNED_LONG) {
             return supportsUnsignedLong(version);
         }
@@ -36,21 +36,7 @@ public final class VersionCompatibilityChecks {
         return true;
     }
 
-    /**
-     * Does the provided {@code version} support the unsigned_long type (PR#60050)?
-     */
-    public static boolean supportsUnsignedLong(Version version) {
-        return INTRODUCING_UNSIGNED_LONG.compareTo(version) <= 0;
-    }
-
-    /**
-     * Does the provided {@code version} support the version type (PR#85502)?
-     */
-    public static boolean supportsVersionType(Version version) {
-        return INTRODUCING_VERSION_FIELD_TYPE.compareTo(version) <= 0;
-    }
-
-    public static @Nullable Version versionIntroducingType(DataType dataType) {
+    public static @Nullable SqlVersion versionIntroducingType(DataType dataType) {
         if (dataType == UNSIGNED_LONG) {
             return INTRODUCING_UNSIGNED_LONG;
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumns.java
@@ -6,18 +6,17 @@
  */
 package org.elasticsearch.xpack.sql.plan.logical.command;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.LikePattern;
-import org.elasticsearch.xpack.ql.index.IndexCompatibility;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
+import org.elasticsearch.xpack.sql.index.IndexCompatibility;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
@@ -91,8 +90,11 @@ public class ShowColumns extends Command {
                     List<List<?>> rows = emptyList();
                     if (indexResult.isValid()) {
                         rows = new ArrayList<>();
-                        Version version = Version.fromId(session.configuration().version().id);
-                        fillInRows(IndexCompatibility.compatible(indexResult, version).get().mapping(), null, rows);
+                        fillInRows(
+                            IndexCompatibility.compatible(indexResult, session.configuration().version()).get().mapping(),
+                            null,
+                            rows
+                        );
                     }
                     l.onResponse(of(session, rows));
                 })

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
@@ -7,21 +7,21 @@
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
 import org.apache.lucene.util.Counter;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.LikePattern;
 import org.elasticsearch.xpack.ql.index.EsIndex;
-import org.elasticsearch.xpack.ql.index.IndexCompatibility;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.util.StringUtils;
+import org.elasticsearch.xpack.sql.index.IndexCompatibility;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
 import org.elasticsearch.xpack.sql.proto.Mode;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.elasticsearch.xpack.sql.session.Cursor.Page;
 import org.elasticsearch.xpack.sql.session.ListCursor;
 import org.elasticsearch.xpack.sql.session.Rows;
@@ -156,7 +156,7 @@ public class SysColumns extends Command {
             tableCat = cluster;
         }
 
-        Version version = Version.fromId(session.configuration().version().id);
+        SqlVersion version = session.configuration().version();
         // special case for '%' (translated to *)
         if ("*".equals(idx)) {
             session.indexResolver()

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypes.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypes.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -24,12 +23,12 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
 import static org.elasticsearch.xpack.ql.type.DataTypes.INTEGER;
 import static org.elasticsearch.xpack.ql.type.DataTypes.SHORT;
 import static org.elasticsearch.xpack.ql.type.DataTypes.isSigned;
 import static org.elasticsearch.xpack.ql.type.DataTypes.isString;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.metaSqlDataType;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.metaSqlDateTimeSub;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.metaSqlMaximumScale;
@@ -85,9 +84,7 @@ public class SysTypes extends Command {
 
     @Override
     public final void execute(SqlSession session, ActionListener<Page> listener) {
-        Stream<DataType> values = SqlDataTypes.types()
-            .stream()
-            .filter(t -> isTypeSupportedInVersion(t, Version.fromId(session.configuration().version().id)));
+        Stream<DataType> values = SqlDataTypes.types().stream().filter(t -> isTypeSupportedInVersion(t, session.configuration().version()));
         if (type.intValue() != 0) {
             values = values.filter(t -> type.equals(sqlType(t).getVendorTypeNumber()));
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.session;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -14,6 +13,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.sql.action.SqlQueryTask;
 import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
 
 import java.time.ZoneId;
 import java.util.Map;
@@ -73,7 +73,7 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         this.runtimeMappings = runtimeMappings;
         this.mode = mode == null ? Mode.PLAIN : mode;
         this.clientId = clientId;
-        this.version = version != null ? version : SqlVersion.fromId(Version.CURRENT.id);
+        this.version = version != null ? version : SqlVersions.SERVER_COMPAT_VERSION;
         this.multiValueFieldLeniency = multiValueFieldLeniency;
         this.includeFrozenIndices = includeFrozen;
         this.taskId = taskId;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlSession.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlSession.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.session;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
@@ -15,7 +14,6 @@ import org.elasticsearch.xpack.ql.analyzer.PreAnalyzer;
 import org.elasticsearch.xpack.ql.analyzer.PreAnalyzer.PreAnalysis;
 import org.elasticsearch.xpack.ql.analyzer.TableInfo;
 import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
-import org.elasticsearch.xpack.ql.index.IndexCompatibility;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.index.MappingException;
@@ -26,6 +24,7 @@ import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.analyzer.AnalyzerContext;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
 import org.elasticsearch.xpack.sql.execution.PlanExecutor;
+import org.elasticsearch.xpack.sql.index.IndexCompatibility;
 import org.elasticsearch.xpack.sql.optimizer.Optimizer;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.physical.PhysicalPlan;
@@ -119,7 +118,7 @@ public class SqlSession implements Session {
             AnalyzerContext context = new AnalyzerContext(
                 configuration,
                 functionRegistry,
-                IndexCompatibility.compatible(r, Version.fromId(configuration.version().id))
+                IndexCompatibility.compatible(r, configuration.version())
             );
             Analyzer analyzer = new Analyzer(context, verifier);
             return analyzer.analyze(parsed, verify);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/action/BasicFormatterTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/action/BasicFormatterTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.sql.proto.formatter.SimpleFormatter.FormatOption;
 
 import java.util.Arrays;
 
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.DATE_NANOS_SUPPORT_VERSION;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_DATE_NANOS;
 import static org.elasticsearch.xpack.sql.proto.formatter.SimpleFormatter.FormatOption.CLI;
 import static org.hamcrest.Matchers.arrayWithSize;
 
@@ -23,7 +23,7 @@ public class BasicFormatterTests extends ESTestCase {
     private final SqlQueryResponse firstResponse = new SqlQueryResponse(
         "",
         format == CLI ? Mode.CLI : Mode.PLAIN,
-        DATE_NANOS_SUPPORT_VERSION,
+        INTRODUCING_DATE_NANOS,
         false,
         Arrays.asList(
             new ColumnInfo("", "foo", "string", 0),

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.sql.analysis.analyzer;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -19,7 +18,6 @@ import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.ql.index.EsIndex;
-import org.elasticsearch.xpack.ql.index.IndexCompatibility;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
@@ -31,6 +29,7 @@ import org.elasticsearch.xpack.ql.type.Types;
 import org.elasticsearch.xpack.ql.type.TypesTests;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.expression.function.SqlFunctionRegistry;
+import org.elasticsearch.xpack.sql.index.IndexCompatibility;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
 import org.elasticsearch.xpack.sql.session.SqlConfiguration;
@@ -41,15 +40,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_UNSIGNED_LONG;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_VERSION_FIELD_TYPE;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
 import static org.elasticsearch.xpack.ql.type.DataTypes.KEYWORD;
 import static org.elasticsearch.xpack.ql.type.DataTypes.TEXT;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_VERSION_FIELD_TYPE;
 import static org.elasticsearch.xpack.sql.types.SqlTypesTests.loadMapping;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.POST_UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.POST_VERSION_FIELD;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.PRE_UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.PRE_VERSION_FIELD;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -318,23 +321,21 @@ public class FieldAttributeTests extends ESTestCase {
         String queryWithArithmetic = "SELECT unsigned_long + 1 AS unsigned_long FROM test";
         String queryWithCast = "SELECT long + 1::unsigned_long AS unsigned_long FROM test";
 
-        Version preUnsignedLong = Version.fromId(INTRODUCING_UNSIGNED_LONG.id - SqlVersion.MINOR_MULTIPLIER);
-        Version postUnsignedLong = Version.fromId(INTRODUCING_UNSIGNED_LONG.id + SqlVersion.MINOR_MULTIPLIER);
-        SqlConfiguration sqlConfig = SqlTestUtils.randomConfiguration(SqlVersion.fromId(preUnsignedLong.id));
+        SqlConfiguration sqlConfig = SqlTestUtils.randomConfiguration(PRE_UNSIGNED_LONG);
 
         for (String sql : List.of(query, queryWithLiteral, queryWithCastLiteral, queryWithAlias, queryWithArithmetic, queryWithCast)) {
             analyzer = analyzer(
                 sqlConfig,
                 functionRegistry,
-                loadCompatibleIndexResolution("mapping-numeric.json", preUnsignedLong),
+                loadCompatibleIndexResolution("mapping-numeric.json", PRE_UNSIGNED_LONG),
                 new Verifier(new Metrics())
             );
             VerificationException ex = expectThrows(VerificationException.class, () -> plan(sql));
             assertThat(ex.getMessage(), containsString("Found 1 problem\nline 1:8: Cannot use field [unsigned_long]"));
 
-            for (Version v : List.of(INTRODUCING_UNSIGNED_LONG, postUnsignedLong)) {
+            for (SqlVersion v : List.of(INTRODUCING_UNSIGNED_LONG, POST_UNSIGNED_LONG)) {
                 analyzer = analyzer(
-                    SqlTestUtils.randomConfiguration(SqlVersion.fromId(v.id)),
+                    SqlTestUtils.randomConfiguration(v),
                     functionRegistry,
                     loadCompatibleIndexResolution("mapping-numeric.json", v),
                     verifier
@@ -357,23 +358,21 @@ public class FieldAttributeTests extends ESTestCase {
         String queryWithAlias = "SELECT version_number AS version_number FROM test";
         String queryWithCast = "SELECT CONCAT(version_number::string, '-SNAPSHOT')::version AS version_number FROM test";
 
-        Version preVersion = Version.fromId(INTRODUCING_VERSION_FIELD_TYPE.id - SqlVersion.MINOR_MULTIPLIER);
-        Version postVersion = Version.fromId(INTRODUCING_VERSION_FIELD_TYPE.id + SqlVersion.MINOR_MULTIPLIER);
-        SqlConfiguration sqlConfig = SqlTestUtils.randomConfiguration(SqlVersion.fromId(preVersion.id));
+        SqlConfiguration sqlConfig = SqlTestUtils.randomConfiguration(PRE_VERSION_FIELD);
 
         for (String sql : List.of(query, queryWithCastLiteral, queryWithAlias, queryWithCast)) {
             analyzer = analyzer(
                 sqlConfig,
                 functionRegistry,
-                loadCompatibleIndexResolution("mapping-version.json", preVersion),
+                loadCompatibleIndexResolution("mapping-version.json", PRE_VERSION_FIELD),
                 new Verifier(new Metrics())
             );
             VerificationException ex = expectThrows(VerificationException.class, () -> plan(sql));
             assertThat(ex.getMessage(), containsString("Cannot use field [version_number]"));
 
-            for (Version v : List.of(INTRODUCING_VERSION_FIELD_TYPE, postVersion)) {
+            for (SqlVersion v : List.of(INTRODUCING_VERSION_FIELD_TYPE, POST_VERSION_FIELD)) {
                 analyzer = analyzer(
-                    SqlTestUtils.randomConfiguration(SqlVersion.fromId(v.id)),
+                    SqlTestUtils.randomConfiguration(v),
                     functionRegistry,
                     loadCompatibleIndexResolution("mapping-version.json", v),
                     verifier
@@ -391,12 +390,10 @@ public class FieldAttributeTests extends ESTestCase {
     }
 
     public void testNonProjectedUnsignedLongVersionCompatibility() {
-        Version preUnsignedLong = Version.fromId(INTRODUCING_UNSIGNED_LONG.id - SqlVersion.MINOR_MULTIPLIER);
-        SqlConfiguration sqlConfig = SqlTestUtils.randomConfiguration(SqlVersion.fromId(preUnsignedLong.id));
         analyzer = analyzer(
-            sqlConfig,
+            SqlTestUtils.randomConfiguration(PRE_UNSIGNED_LONG),
             functionRegistry,
-            loadCompatibleIndexResolution("mapping-numeric.json", preUnsignedLong),
+            loadCompatibleIndexResolution("mapping-numeric.json", PRE_UNSIGNED_LONG),
             new Verifier(new Metrics())
         );
 
@@ -426,24 +423,17 @@ public class FieldAttributeTests extends ESTestCase {
             """;
         String sql = "SELECT container.ul as unsigned_long FROM test";
 
-        Version preUnsignedLong = Version.fromId(INTRODUCING_UNSIGNED_LONG.id - SqlVersion.MINOR_MULTIPLIER);
         analyzer = analyzer(
-            SqlTestUtils.randomConfiguration(SqlVersion.fromId(preUnsignedLong.id)),
+            SqlTestUtils.randomConfiguration(PRE_UNSIGNED_LONG),
             functionRegistry,
-            compatibleIndexResolution(props, preUnsignedLong),
+            compatibleIndexResolution(props, PRE_UNSIGNED_LONG),
             new Verifier(new Metrics())
         );
         VerificationException ex = expectThrows(VerificationException.class, () -> plan(sql));
         assertThat(ex.getMessage(), containsString("Cannot use field [container.ul] with unsupported type [UNSIGNED_LONG]"));
 
-        Version postUnsignedLong = Version.fromId(INTRODUCING_UNSIGNED_LONG.id + SqlVersion.MINOR_MULTIPLIER);
-        for (Version v : List.of(INTRODUCING_UNSIGNED_LONG, postUnsignedLong)) {
-            analyzer = analyzer(
-                SqlTestUtils.randomConfiguration(SqlVersion.fromId(v.id)),
-                functionRegistry,
-                compatibleIndexResolution(props, v),
-                verifier
-            );
+        for (SqlVersion v : List.of(INTRODUCING_UNSIGNED_LONG, POST_UNSIGNED_LONG)) {
+            analyzer = analyzer(SqlTestUtils.randomConfiguration(v), functionRegistry, compatibleIndexResolution(props, v), verifier);
             LogicalPlan plan = plan(sql);
             assertThat(plan, instanceOf(Project.class));
             Project p = (Project) plan;
@@ -456,17 +446,15 @@ public class FieldAttributeTests extends ESTestCase {
     }
 
     public void testUnsignedLongStarExpandedVersionControlled() {
-        SqlVersion preUnsignedLong = SqlVersion.fromId(INTRODUCING_UNSIGNED_LONG.id - SqlVersion.MINOR_MULTIPLIER);
-        SqlVersion postUnsignedLong = SqlVersion.fromId(INTRODUCING_UNSIGNED_LONG.id + SqlVersion.MINOR_MULTIPLIER);
         String query = "SELECT * FROM test";
 
-        for (SqlVersion version : List.of(preUnsignedLong, SqlVersion.fromId(INTRODUCING_UNSIGNED_LONG.id), postUnsignedLong)) {
+        for (SqlVersion version : List.of(PRE_UNSIGNED_LONG, INTRODUCING_UNSIGNED_LONG, POST_UNSIGNED_LONG)) {
             SqlConfiguration config = SqlTestUtils.randomConfiguration(version);
             // the mapping is mutated when making it "compatible", so it needs to be reloaded inside the loop.
             analyzer = analyzer(
                 config,
                 functionRegistry,
-                loadCompatibleIndexResolution("mapping-numeric.json", Version.fromId(version.id)),
+                loadCompatibleIndexResolution("mapping-numeric.json", version),
                 new Verifier(new Metrics())
             );
 
@@ -475,7 +463,7 @@ public class FieldAttributeTests extends ESTestCase {
             Project p = (Project) plan;
 
             List<DataType> projectedDataTypes = p.projections().stream().map(Expression::dataType).toList();
-            assertEquals(isTypeSupportedInVersion(UNSIGNED_LONG, Version.fromId(version.id)), projectedDataTypes.contains(UNSIGNED_LONG));
+            assertEquals(isTypeSupportedInVersion(UNSIGNED_LONG, version), projectedDataTypes.contains(UNSIGNED_LONG));
         }
 
     }
@@ -517,11 +505,11 @@ public class FieldAttributeTests extends ESTestCase {
         return IndexResolution.valid(index);
     }
 
-    private static IndexResolution loadCompatibleIndexResolution(String mappingName, Version version) {
+    private static IndexResolution loadCompatibleIndexResolution(String mappingName, SqlVersion version) {
         return IndexCompatibility.compatible(loadIndexResolution(mappingName), version);
     }
 
-    private static IndexResolution compatibleIndexResolution(String properties, Version version) {
+    private static IndexResolution compatibleIndexResolution(String properties, SqlVersion version) {
         Map<String, EsField> mapping = Types.fromEs(
             DefaultDataTypeRegistry.INSTANCE,
             XContentHelper.convertToMap(JsonXContent.jsonXContent, properties, randomBoolean())

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -149,7 +149,7 @@ public class IndexResolverTests extends ESTestCase {
         addFieldCaps(fieldCaps, "text", "keyword", true, true);
 
         String wildcard = "*";
-        IndexResolution resolution = mergedMappings(wildcard, new String[] { "index" }, fieldCaps);
+        IndexResolution resolution = mergedMappings(wildcard, new String[] { "org/elasticsearch/xpack/sql/index" }, fieldCaps);
         assertTrue(resolution.isValid());
 
         EsIndex esIndex = resolution.get();
@@ -159,7 +159,7 @@ public class IndexResolverTests extends ESTestCase {
         assertNull(esIndex.mapping().get("_doc_count"));
         assertEquals(INTEGER, esIndex.mapping().get("_not_meta_field").getDataType());
         assertEquals(KEYWORD, esIndex.mapping().get("text").getDataType());
-        assertEquals(Set.of("index"), resolution.get().concreteIndices());
+        assertEquals(Set.of("org/elasticsearch/xpack/sql/index"), resolution.get().concreteIndices());
     }
 
     public void testFlattenedHiddenSubfield() throws Exception {
@@ -174,12 +174,12 @@ public class IndexResolverTests extends ESTestCase {
         addFieldCaps(fieldCaps, "text", "keyword", true, true);
 
         String wildcard = "*";
-        IndexResolution resolution = mergedMappings(wildcard, new String[] { "index" }, fieldCaps);
+        IndexResolution resolution = mergedMappings(wildcard, new String[] { "org/elasticsearch/xpack/sql/index" }, fieldCaps);
         assertTrue(resolution.isValid());
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
-        assertEquals(Set.of("index"), resolution.get().concreteIndices());
+        assertEquals(Set.of("org/elasticsearch/xpack/sql/index"), resolution.get().concreteIndices());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("some_field").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("some_field").getProperties().get("_keyed").getDataType());
         assertEquals(OBJECT, esIndex.mapping().get("nested_field").getDataType());
@@ -204,12 +204,12 @@ public class IndexResolverTests extends ESTestCase {
         addFieldCaps(fieldCaps, "a.b.c.e", "foo", true, true);
 
         String wildcard = "*";
-        IndexResolution resolution = mergedMappings(wildcard, new String[] { "index" }, fieldCaps);
+        IndexResolution resolution = mergedMappings(wildcard, new String[] { "org/elasticsearch/xpack/sql/index" }, fieldCaps);
         assertTrue(resolution.isValid());
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
-        assertEquals(Set.of("index"), resolution.get().concreteIndices());
+        assertEquals(Set.of("org/elasticsearch/xpack/sql/index"), resolution.get().concreteIndices());
         assertEquals(TEXT, esIndex.mapping().get("a").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("a").getProperties().get("b").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("a").getProperties().get("b").getProperties().get("c").getDataType());
@@ -240,12 +240,12 @@ public class IndexResolverTests extends ESTestCase {
         addFieldCaps(fieldCaps, "text", "keyword", true, true);
 
         String wildcard = "*";
-        IndexResolution resolution = mergedMappings(wildcard, new String[] { "index" }, fieldCaps);
+        IndexResolution resolution = mergedMappings(wildcard, new String[] { "org/elasticsearch/xpack/sql/index" }, fieldCaps);
         assertTrue(resolution.isValid());
 
         EsIndex esIndex = resolution.get();
         assertEquals(wildcard, esIndex.name());
-        assertEquals(Set.of("index"), resolution.get().concreteIndices());
+        assertEquals(Set.of("org/elasticsearch/xpack/sql/index"), resolution.get().concreteIndices());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("some_field").getDataType());
         assertEquals(OBJECT, esIndex.mapping().get("nested_field").getDataType());
         assertEquals(UNSUPPORTED, esIndex.mapping().get("nested_field").getProperties().get("sub_field1").getDataType());
@@ -362,7 +362,7 @@ public class IndexResolverTests extends ESTestCase {
             Map<String, EsField> mapping = Maps.newMapWithExpectedSize(1);
             String fieldName = "field" + (i + 1);
             mapping.put(fieldName, new KeywordEsField(fieldName));
-            expectedIndices[i] = new EsIndex("index" + (i + 1), mapping);
+            expectedIndices[i] = new EsIndex("org/elasticsearch/xpack/sql/index" + (i + 1), mapping);
         }
         Arrays.sort(expectedIndices, Comparator.comparing(EsIndex::name));
 
@@ -384,7 +384,7 @@ public class IndexResolverTests extends ESTestCase {
             Map<String, EsField> mapping = Maps.newMapWithExpectedSize(1);
             String fieldName = "field" + (i + 1);
             mapping.put(fieldName, new KeywordEsField(fieldName));
-            String indexName = "index" + (i + 1);
+            String indexName = "org/elasticsearch/xpack/sql/index" + (i + 1);
             expectedIndices[i] = new EsIndex(indexName, mapping, Set.of(indexName));
             indexNames.add(indexName);
         }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowColumnsTests.java
@@ -7,10 +7,9 @@
 
 package org.elasticsearch.xpack.sql.plan.logical.command;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.ql.index.IndexCompatibility;
 import org.elasticsearch.xpack.ql.type.EsField;
+import org.elasticsearch.xpack.sql.index.IndexCompatibility;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 import java.sql.JDBCType;
@@ -19,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.supportsUnsignedLong;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.supportsVersionType;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
 import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
 import static org.elasticsearch.xpack.ql.type.DataTypes.FLOAT;
@@ -32,11 +29,13 @@ import static org.elasticsearch.xpack.ql.type.DataTypes.TEXT;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSUPPORTED;
 import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
-import static org.elasticsearch.xpack.sql.plan.logical.command.sys.SysColumnsTests.UNSIGNED_LONG_TEST_VERSIONS;
-import static org.elasticsearch.xpack.sql.plan.logical.command.sys.SysColumnsTests.VERSION_FIELD_TEST_VERSIONS;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.supportsUnsignedLong;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.supportsVersionType;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.GEO_POINT;
 import static org.elasticsearch.xpack.sql.type.SqlDataTypes.GEO_SHAPE;
 import static org.elasticsearch.xpack.sql.types.SqlTypesTests.loadMapping;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.UNSIGNED_LONG_TEST_VERSIONS;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.VERSION_FIELD_TEST_VERSIONS;
 
 public class ShowColumnsTests extends ESTestCase {
 
@@ -94,8 +93,8 @@ public class ShowColumnsTests extends ESTestCase {
             List<List<?>> rows = new ArrayList<>();
             // mapping's mutated by IndexCompatibility.compatible, needs to stay in the loop
             Map<String, EsField> mapping = loadMapping("mapping-multi-field-variation.json", true);
-            ShowColumns.fillInRows(IndexCompatibility.compatible(mapping, Version.fromId(version.id)), null, rows);
-            assertTrue((supportsUnsignedLong(Version.fromId(version.id)) && rows.contains(rowSupported)) || rows.contains(rowUnsupported));
+            ShowColumns.fillInRows(IndexCompatibility.compatible(mapping, version), null, rows);
+            assertTrue((supportsUnsignedLong(version) && rows.contains(rowSupported)) || rows.contains(rowUnsupported));
         }
     }
 
@@ -106,8 +105,8 @@ public class ShowColumnsTests extends ESTestCase {
             List<List<?>> rows = new ArrayList<>();
             // mapping's mutated by IndexCompatibility.compatible, needs to stay in the loop
             Map<String, EsField> mapping = loadMapping("mapping-multi-field-variation.json", true);
-            ShowColumns.fillInRows(IndexCompatibility.compatible(mapping, Version.fromId(version.id)), null, rows);
-            assertTrue((supportsVersionType(Version.fromId(version.id)) && rows.contains(rowSupported)) || rows.contains(rowUnsupported));
+            ShowColumns.fillInRows(IndexCompatibility.compatible(mapping, version), null, rows);
+            assertTrue((supportsVersionType(version) && rows.contains(rowSupported)) || rows.contains(rowUnsupported));
         }
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionTestUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.index.EsIndex;
@@ -34,19 +34,20 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
 import static org.elasticsearch.xpack.sql.analysis.analyzer.AnalyzerTestUtils.analyzer;
-import static org.elasticsearch.xpack.sql.plan.logical.command.sys.SysColumnsTests.UNSIGNED_LONG_TEST_VERSIONS;
-import static org.elasticsearch.xpack.sql.plan.logical.command.sys.SysColumnsTests.VERSION_FIELD_TEST_VERSIONS;
+import static org.elasticsearch.xpack.sql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
+import static org.elasticsearch.xpack.sql.proto.SqlVersions.SERVER_COMPAT_VERSION;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.UNSIGNED_LONG_TEST_VERSIONS;
+import static org.elasticsearch.xpack.sql.util.SqlVersionUtils.VERSION_FIELD_TEST_VERSIONS;
 import static org.mockito.Mockito.mock;
 
 public class SysTypesTests extends ESTestCase {
 
     private final SqlParser parser = new SqlParser();
 
-    private Tuple<Command, SqlSession> sql(String sql, Mode mode, SqlVersion version) {
+    private Tuple<Command, SqlSession> sql(String sql, Mode mode, @Nullable SqlVersion version) {
         SqlConfiguration configuration = new SqlConfiguration(
             DateUtils.UTC,
             null,
@@ -76,7 +77,7 @@ public class SysTypesTests extends ESTestCase {
     }
 
     private Tuple<Command, SqlSession> sql(String sql) {
-        return sql(sql, randomFrom(Mode.values()), randomBoolean() ? null : SqlVersion.fromId(Version.CURRENT.id));
+        return sql(sql, randomFrom(Mode.values()), randomBoolean() ? null : SERVER_COMPAT_VERSION);
     }
 
     public void testSysTypes() {
@@ -154,7 +155,7 @@ public class SysTypesTests extends ESTestCase {
                     List<String> types = new ArrayList<>();
                     r.forEachRow(rv -> types.add((String) rv.column(0)));
                     assertEquals(
-                        isTypeSupportedInVersion(UNSIGNED_LONG, Version.fromId(cmd.v2().configuration().version().id)),
+                        isTypeSupportedInVersion(UNSIGNED_LONG, cmd.v2().configuration().version()),
                         types.contains(UNSIGNED_LONG.toString())
                     );
                 }));
@@ -173,10 +174,7 @@ public class SysTypesTests extends ESTestCase {
                     SchemaRowSet r = (SchemaRowSet) p.rowSet();
                     List<String> types = new ArrayList<>();
                     r.forEachRow(rv -> types.add((String) rv.column(0)));
-                    assertEquals(
-                        isTypeSupportedInVersion(VERSION, Version.fromId(cmd.v2().configuration().version().id)),
-                        types.contains(VERSION.toString())
-                    );
+                    assertEquals(isTypeSupportedInVersion(VERSION, cmd.v2().configuration().version()), types.contains(VERSION.toString()));
                 }));
             }
         }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/TextFormatTests.java
@@ -28,7 +28,7 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.xpack.sql.plugin.TextFormat.CSV;
 import static org.elasticsearch.xpack.sql.plugin.TextFormat.PLAIN_TEXT;
 import static org.elasticsearch.xpack.sql.plugin.TextFormat.TSV;
-import static org.elasticsearch.xpack.sql.proto.SqlVersion.DATE_NANOS_SUPPORT_VERSION;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_DATE_NANOS;
 import static org.elasticsearch.xpack.sql.proto.formatter.SimpleFormatter.FormatOption.TEXT;
 
 public class TextFormatTests extends ESTestCase {
@@ -179,7 +179,7 @@ public class TextFormatTests extends ESTestCase {
             PLAIN_TEXT.format(
                 req(),
                 new BasicFormatter(emptyList(), emptyList(), TEXT),
-                new SqlQueryResponse(StringUtils.EMPTY, Mode.JDBC, DATE_NANOS_SUPPORT_VERSION, false, null, emptyList())
+                new SqlQueryResponse(StringUtils.EMPTY, Mode.JDBC, INTRODUCING_DATE_NANOS, false, null, emptyList())
             ).v1()
         );
     }
@@ -188,9 +188,9 @@ public class TextFormatTests extends ESTestCase {
         return new SqlQueryResponse(
             StringUtils.EMPTY,
             Mode.JDBC,
-            DATE_NANOS_SUPPORT_VERSION,
+            INTRODUCING_DATE_NANOS,
             false,
-            singletonList(new ColumnInfo("index", "name", "keyword")),
+            singletonList(new ColumnInfo("org/elasticsearch/xpack/sql/index", "name", "keyword")),
             emptyList()
         );
     }
@@ -198,29 +198,29 @@ public class TextFormatTests extends ESTestCase {
     private static SqlQueryResponse regularData() {
         // headers
         List<ColumnInfo> headers = new ArrayList<>();
-        headers.add(new ColumnInfo("index", "string", "keyword"));
-        headers.add(new ColumnInfo("index", "number", "integer"));
+        headers.add(new ColumnInfo("org/elasticsearch/xpack/sql/index", "string", "keyword"));
+        headers.add(new ColumnInfo("org/elasticsearch/xpack/sql/index", "number", "integer"));
 
         // values
         List<List<Object>> values = new ArrayList<>();
         values.add(asList("Along The River Bank", 11 * 60 + 48));
         values.add(asList("Mind Train", 4 * 60 + 40));
 
-        return new SqlQueryResponse(null, Mode.JDBC, DATE_NANOS_SUPPORT_VERSION, false, headers, values);
+        return new SqlQueryResponse(null, Mode.JDBC, INTRODUCING_DATE_NANOS, false, headers, values);
     }
 
     private static SqlQueryResponse escapedData() {
         // headers
         List<ColumnInfo> headers = new ArrayList<>();
-        headers.add(new ColumnInfo("index", "first", "keyword"));
-        headers.add(new ColumnInfo("index", "\"special\"", "keyword"));
+        headers.add(new ColumnInfo("org/elasticsearch/xpack/sql/index", "first", "keyword"));
+        headers.add(new ColumnInfo("org/elasticsearch/xpack/sql/index", "\"special\"", "keyword"));
 
         // values
         List<List<Object>> values = new ArrayList<>();
         values.add(asList("normal", "\"quo\"ted\",\n"));
         values.add(asList("commas", "a,b,c,\n,d,e,\t\n"));
 
-        return new SqlQueryResponse(null, Mode.JDBC, DATE_NANOS_SUPPORT_VERSION, false, headers, values);
+        return new SqlQueryResponse(null, Mode.JDBC, INTRODUCING_DATE_NANOS, false, headers, values);
     }
 
     private static RestRequest req() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/util/SqlVersionUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/util/SqlVersionUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.util;
+
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersions;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.sql.proto.SqlVersions.SERVER_COMPAT_VERSION;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_UNSIGNED_LONG;
+import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.INTRODUCING_VERSION_FIELD_TYPE;
+
+public final class SqlVersionUtils {
+
+    public static final SqlVersion PRE_UNSIGNED_LONG = SqlVersions.getPreviousVersion(INTRODUCING_UNSIGNED_LONG);
+    public static final SqlVersion POST_UNSIGNED_LONG = SqlVersions.getNextVersion(INTRODUCING_UNSIGNED_LONG);
+    public static final SqlVersion PRE_VERSION_FIELD = SqlVersions.getPreviousVersion(INTRODUCING_VERSION_FIELD_TYPE);
+    public static final SqlVersion POST_VERSION_FIELD = SqlVersions.getNextVersion(INTRODUCING_VERSION_FIELD_TYPE);
+
+    public static List<SqlVersion> UNSIGNED_LONG_TEST_VERSIONS = List.of(
+        PRE_UNSIGNED_LONG,
+        INTRODUCING_UNSIGNED_LONG,
+        POST_UNSIGNED_LONG,
+        SERVER_COMPAT_VERSION
+    );
+
+    public static List<SqlVersion> VERSION_FIELD_TEST_VERSIONS = List.of(
+        PRE_VERSION_FIELD,
+        INTRODUCING_VERSION_FIELD_TYPE,
+        POST_VERSION_FIELD,
+        SERVER_COMPAT_VERSION
+    );
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - SQL: Remove dependency on `org.elasticsearch.Version` (#112094)