### PR TITLE
[8.x] Unmute test that does not exist anymore (#114655)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -71,9 +71,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/111448
 - class: org.elasticsearch.search.SearchServiceTests
   issue: https://github.com/elastic/elasticsearch/issues/111529
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=rollup/security_tests/Index-based access}
-  issue: https://github.com/elastic/elasticsearch/issues/111631
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testSnapshotRestore {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/111777


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Unmute test that does not exist anymore (#114655)