### PR TITLE
Avoid throw exception in SyntheticSourceIndexSettingsProvider

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -122,7 +122,7 @@ preview:[]
 
     The number of shards a custom <<mapping-routing-field,routing>> value can go to.
     Defaults to 1 and can only be set at index creation time. This value must be less
-    than the `index.number_of_shards` unless the `index.number_of_shards` value is also 1.
+    than the `index.number_of_routing_shards` unless the `index.number_of_routing_shards` value is also 1.
     See <<routing-index-partition>> for more details about how this setting is used.
 
 [[ccr-index-soft-deletes]]

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -881,7 +881,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         );
         assertThat(
             eBadSettings.getMessage(),
-            containsString("partition size [6] should be a positive number less than the number of shards [5]")
+            containsString("partition size [6] should be a positive number less than the number of routing shards [5]")
         );
 
         // provide an invalid mapping for a partitioned index
@@ -913,7 +913,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
 
         assertThat(
             eBadIndex.getMessage(),
-            containsString("partition size [6] should be a positive number less than the number of shards [5]")
+            containsString("partition size [6] should be a positive number less than the number of routing shards [5]")
         );
 
         // finally, create a valid index

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2268,7 +2268,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                     "routing partition size ["
                         + routingPartitionSize
                         + "] should be a positive number"
-                        + " less than the number of shards ["
+                        + " less than the number of routing shards ["
                         + getRoutingNumShards()
                         + "] for ["
                         + index

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProvider.java
@@ -79,15 +79,17 @@ final class SyntheticSourceIndexSettingsProvider implements IndexSettingProvider
             return false;
         }
 
-        var tmpIndexMetadata = buildIndexMetadataForMapperService(indexName, isTimeSeries, indexTemplateAndCreateRequestSettings);
-        try (var mapperService = mapperServiceFactory.apply(tmpIndexMetadata)) {
-            // combinedTemplateMappings can be null when creating system indices
-            // combinedTemplateMappings can be empty when creating a normal index that doesn't match any template and without mapping.
-            if (combinedTemplateMappings == null || combinedTemplateMappings.isEmpty()) {
-                combinedTemplateMappings = List.of(new CompressedXContent("{}"));
+        try {
+            var tmpIndexMetadata = buildIndexMetadataForMapperService(indexName, isTimeSeries, indexTemplateAndCreateRequestSettings);
+            try (var mapperService = mapperServiceFactory.apply(tmpIndexMetadata)) {
+                // combinedTemplateMappings can be null when creating system indices
+                // combinedTemplateMappings can be empty when creating a normal index that doesn't match any template and without mapping.
+                if (combinedTemplateMappings == null || combinedTemplateMappings.isEmpty()) {
+                    combinedTemplateMappings = List.of(new CompressedXContent("{}"));
+                }
+                mapperService.merge(MapperService.SINGLE_MAPPING_NAME, combinedTemplateMappings, MapperService.MergeReason.INDEX_TEMPLATE);
+                return mapperService.documentMapper().sourceMapper().isSynthetic();
             }
-            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, combinedTemplateMappings, MapperService.MergeReason.INDEX_TEMPLATE);
-            return mapperService.documentMapper().sourceMapper().isSynthetic();
         } catch (AssertionError | Exception e) {
             // In case invalid mappings or setting are provided, then mapper service creation can fail.
             // In that case it is ok to return false here. The index creation will fail anyway later, so need to fallback to stored source.


### PR DESCRIPTION
Backport of #114479:

- Move buildIndexMetadata inside a try/catch block to prevent errors, as SyntheticSourceIndexSettingsProvider can use a incomplete settings to build an IndexMetadata.
- Update documentation for index_routing_shards.