### PR TITLE
(Doc+) Cross-link max shards

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -571,6 +571,8 @@ PUT _cluster/settings
 }
 ----
 
+For more information, see <troubleshooting-shards-capacity-issues>>.
+
 [discrete]
 [[troubleshooting-max-docs-limit]]
 ==== Number of documents in the shard cannot exceed [2147483519]

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -571,7 +571,7 @@ PUT _cluster/settings
 }
 ----
 
-For more information, see <troubleshooting-shards-capacity-issues>>.
+For more information, see <<troubleshooting-shards-capacity-issues,Troubleshooting shards capacity>>.
 
 [discrete]
 [[troubleshooting-max-docs-limit]]


### PR DESCRIPTION
👋 It appears we have two docs of similar content about max open shards. [This one](https://www.elastic.co/guide/en/elasticsearch/reference/master/size-your-shards.html#troubleshooting-max-shards-open) contains the error users search (so is what we linked the error to in https://github.com/elastic/elasticsearch/pull/110993) but [the other](https://www.elastic.co/guide/en/elasticsearch/reference/current/troubleshooting-shards-capacity-issues.html) I believe is a placeholder doc for the health api code. Should maybe consolidate some day but in the mean time at least cross-link for discoverability. 