### PR TITLE
Add generated code changes for HypotEvaluator

### DIFF
--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/HypotEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/math/HypotEvaluator.java
@@ -13,16 +13,16 @@ import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.expression.function.Warnings;
 
 /**
  * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Hypot}.
  * This class is generated. Do not edit it.
  */
 public final class HypotEvaluator implements EvalOperator.ExpressionEvaluator {
-  private final Warnings warnings;
+  private final Source source;
 
   private final EvalOperator.ExpressionEvaluator n1;
 
@@ -30,12 +30,14 @@ public final class HypotEvaluator implements EvalOperator.ExpressionEvaluator {
 
   private final DriverContext driverContext;
 
+  private Warnings warnings;
+
   public HypotEvaluator(Source source, EvalOperator.ExpressionEvaluator n1,
       EvalOperator.ExpressionEvaluator n2, DriverContext driverContext) {
+    this.source = source;
     this.n1 = n1;
     this.n2 = n2;
     this.driverContext = driverContext;
-    this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
   }
 
   @Override
@@ -64,7 +66,7 @@ public final class HypotEvaluator implements EvalOperator.ExpressionEvaluator {
         }
         if (n1Block.getValueCount(p) != 1) {
           if (n1Block.getValueCount(p) > 1) {
-            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+            warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
           }
           result.appendNull();
           continue position;
@@ -75,7 +77,7 @@ public final class HypotEvaluator implements EvalOperator.ExpressionEvaluator {
         }
         if (n2Block.getValueCount(p) != 1) {
           if (n2Block.getValueCount(p) > 1) {
-            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+            warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
           }
           result.appendNull();
           continue position;
@@ -103,6 +105,18 @@ public final class HypotEvaluator implements EvalOperator.ExpressionEvaluator {
   @Override
   public void close() {
     Releasables.closeExpectNoException(n1, n2);
+  }
+
+  private Warnings warnings() {
+    if (warnings == null) {
+      this.warnings = Warnings.createWarnings(
+              driverContext.warningsMode(),
+              source.source().getLineNumber(),
+              source.source().getColumnNumber(),
+              source.text()
+          );
+    }
+    return warnings;
   }
 
   static class Factory implements EvalOperator.ExpressionEvaluator.Factory {


### PR DESCRIPTION
Noticed I have these generated changes for `HypotEvaluator` which was recently added in https://github.com/elastic/elasticsearch/pull/114382

These changes seem inline with the current version of [X-InEvaluator.java.st](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st) so maybe the initial `HypotEvaluator` was manually edited.

Requested a review from the author and reviewers of the initial PR.