### PR TITLE
[8.x] Add alias event.dataset -> data_stream.dataset (#114642)

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/otel@mappings.yaml
@@ -17,6 +17,9 @@ template:
         type: constant_keyword
       data_stream.namespace:
         type: constant_keyword
+      event.dataset:
+        type: alias
+        path: data_stream.dataset
       attributes:
         type: passthrough
         dynamic: true

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
@@ -145,3 +145,21 @@ Structured log body:
         index: $datastream-backing-index
   - is_true: $datastream-backing-index
   - match: { .$datastream-backing-index.mappings.properties.body.properties.flattened.type: "flattened" }
+---
+"event.dataset alias must point to data_stream.dataset":
+  - do:
+      bulk:
+        index: logs-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:49:33.467654000Z","data_stream":{"dataset":"generic.otel","namespace":"default"}, "body_text":"error1"}'
+  - is_false: errors
+  - is_false: errors
+  - do:
+      search:
+        index: logs-generic.otel-default
+        body:
+          fields: ["event.dataset"]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.event\.dataset: ["generic.otel"] }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add alias event.dataset -&gt; data_stream.dataset (#114642)](https://github.com/elastic/elasticsearch/pull/114642)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)