### PR TITLE
Mute tests expected to fail due to PR clash

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,6 +342,12 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testMinimumVersionShardDuringPhaseExecution
   issue: https://github.com/elastic/elasticsearch/issues/114611
+- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
+  method: testPushSpatialIntersectsEvalToSource {default}
+  issue: https://github.com/elastic/elasticsearch/issues/114627
+- class: org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizerTests
+  method: testPushWhereEvalToSource {default}
+  issue: https://github.com/elastic/elasticsearch/issues/114628
 
 # Examples:
 #


### PR DESCRIPTION
As discussed in https://github.com/elastic/elasticsearch/pull/114625, two PR's merged to main clashes causing two tests to fail. Only one of the two backported to 8.x, so the failure was not see on 8.x. Today the second one finally made it back, but before the real fix in https://github.com/elastic/elasticsearch/pull/114625 was merged. So for a (hopefully short) time we'll have the same failures. Rather than wait for CI to auto-mute these, I've made a PR for that purpose here.

If https://github.com/elastic/elasticsearch/pull/114625 gets merged and backported soon, this PR can be closed. Otherwise we merge this PR first.