### PR TITLE
Fix Max Score Propagation in RankDocsQuery

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/retriever/rankdoc/RankDocsQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/rankdoc/RankDocsQuery.java
@@ -107,11 +107,10 @@ public class RankDocsQuery extends Query {
 
                 @Override
                 public Scorer scorer(LeafReaderContext context) {
-                    // Segment starts indicate how many docs are in the segment,
-                    // upper equalling lower indicates no documents for this segment
-                    if (segmentStarts[context.ord] == segmentStarts[context.ord + 1]) {
-                        return null;
-                    }
+                    /**
+                     * We return a scorer even if there are no ranked documents within the segment.
+                     * This ensures the correct propagation of the maximum score.
+                     */
                     return new Scorer(this) {
                         final int lower = segmentStarts[context.ord];
                         final int upper = segmentStarts[context.ord + 1];

--- a/server/src/test/java/org/elasticsearch/search/retriever/rankdoc/RankDocsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/rankdoc/RankDocsQueryBuilderTests.java
@@ -199,20 +199,17 @@ public class RankDocsQueryBuilderTests extends AbstractQueryTestCase<RankDocsQue
                 {
                     // A single rank doc in the last segment
                     RankDoc[] singleRankDoc = new RankDoc[1];
-                    singleRankDoc[0] = rankDocs[rankDocs.length-1];
+                    singleRankDoc[0] = rankDocs[rankDocs.length - 1];
                     RankDocsQuery q = new RankDocsQuery(
-                            reader,
-                            singleRankDoc,
-                            new Query[] { NumericDocValuesField.newSlowExactQuery("active", 1) },
-                            new String[1],
-                            false
+                        reader,
+                        singleRankDoc,
+                        new Query[] { NumericDocValuesField.newSlowExactQuery("active", 1) },
+                        new String[1],
+                        false
                     );
                     var topDocsManager = new TopScoreDocCollectorManager(1, null, 0);
                     var col = searcher.search(q, topDocsManager);
-                    assertThat(
-                            col.totalHits.value,
-                            lessThanOrEqualTo((long) (2 + rankDocs.length))
-                    );
+                    assertThat(col.totalHits.value, lessThanOrEqualTo((long) (2 + rankDocs.length)));
                     assertEqualTopDocs(col.scoreDocs, singleRankDoc);
                 }
             }

--- a/server/src/test/java/org/elasticsearch/search/retriever/rankdoc/RankDocsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/rankdoc/RankDocsQueryBuilderTests.java
@@ -195,6 +195,26 @@ public class RankDocsQueryBuilderTests extends AbstractQueryTestCase<RankDocsQue
                     assertThat(col.totalHits.value, equalTo((long) topSize));
                     assertEqualTopDocs(col.scoreDocs, rankDocs);
                 }
+
+                {
+                    // A single rank doc in the last segment
+                    RankDoc[] singleRankDoc = new RankDoc[1];
+                    singleRankDoc[0] = rankDocs[rankDocs.length-1];
+                    RankDocsQuery q = new RankDocsQuery(
+                            reader,
+                            singleRankDoc,
+                            new Query[] { NumericDocValuesField.newSlowExactQuery("active", 1) },
+                            new String[1],
+                            false
+                    );
+                    var topDocsManager = new TopScoreDocCollectorManager(1, null, 0);
+                    var col = searcher.search(q, topDocsManager);
+                    assertThat(
+                            col.totalHits.value,
+                            lessThanOrEqualTo((long) (2 + rankDocs.length))
+                    );
+                    assertEqualTopDocs(col.scoreDocs, singleRankDoc);
+                }
             }
         }
     }


### PR DESCRIPTION
This change resolves the issue of the maximum score not being correctly propagated when some segments contain no ranked documents.
This PR is tagged as a non-issue since the bug has not been released in any version.

Relates #114097 (not closing the issue since we still need to unmute the test in the lucene_snapshot_branch).
