### PR TITLE
Remove v7 compat from `{PUT,DELETE} /_snapshot/${REPO}` APIs

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -937,8 +937,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
     private static RepositoryConflictException newRepositoryConflictException(String repository, String reason) {
         return new RepositoryConflictException(
             repository,
-            "trying to modify or unregister repository that is currently used (" + reason + ')',
-            "trying to modify or unregister repository [" + repository + "] that is currently used (" + reason + ')'
+            "trying to modify or unregister repository that is currently used (" + reason + ')'
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryConflictException.java
@@ -11,6 +11,7 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
@@ -19,11 +20,8 @@ import java.io.IOException;
  * Repository conflict exception
  */
 public class RepositoryConflictException extends RepositoryException {
-    private final String backwardCompatibleMessage;
-
-    public RepositoryConflictException(String repository, String message, String backwardCompatibleMessage) {
+    public RepositoryConflictException(String repository, String message) {
         super(repository, message);
-        this.backwardCompatibleMessage = backwardCompatibleMessage;
     }
 
     @Override
@@ -31,18 +29,16 @@ public class RepositoryConflictException extends RepositoryException {
         return RestStatus.CONFLICT;
     }
 
-    public String getBackwardCompatibleMessage() {
-        return backwardCompatibleMessage;
-    }
-
+    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     public RepositoryConflictException(StreamInput in) throws IOException {
         super(in);
-        this.backwardCompatibleMessage = in.readString();
+        in.readString();
     }
 
     @Override
+    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_COORDINATION) // drop unneeded string from wire format
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
-        out.writeString(backwardCompatibleMessage);
+        out.writeString("");
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutRepositoryAction.java
@@ -44,8 +44,11 @@ public class RestPutRepositoryAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        String name = request.param("repository");
-        final var putRepositoryRequest = new PutRepositoryRequest(getMasterNodeTimeout(request), getAckTimeout(request), name);
+        final var putRepositoryRequest = new PutRepositoryRequest(
+            getMasterNodeTimeout(request),
+            getAckTimeout(request),
+            request.param("repository")
+        );
         try (XContentParser parser = request.contentParser()) {
             putRepositoryRequest.source(parser.mapOrdered());
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutRepositoryAction.java
@@ -10,10 +10,7 @@
 package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.repositories.RepositoryConflictException;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -53,17 +50,6 @@ public class RestPutRepositoryAction extends BaseRestHandler {
             putRepositoryRequest.source(parser.mapOrdered());
         }
         putRepositoryRequest.verify(request.paramAsBoolean("verify", true));
-        return channel -> client.admin()
-            .cluster()
-            .putRepository(
-                putRepositoryRequest,
-                new RestToXContentListener<AcknowledgedResponse>(channel).delegateResponse((delegate, err) -> {
-                    if (request.getRestApiVersion().equals(RestApiVersion.V_7) && err instanceof RepositoryConflictException) {
-                        delegate.onFailure(new IllegalStateException(((RepositoryConflictException) err).getBackwardCompatibleMessage()));
-                    } else {
-                        delegate.onFailure(err);
-                    }
-                })
-            );
+        return channel -> client.admin().cluster().putRepository(putRepositoryRequest, new RestToXContentListener<>(channel));
     }
 }


### PR DESCRIPTION
This exception mangling only existed for v7 API compatibility and is no
longer needed.