### PR TITLE
Remove unused `ChunkedToXContent#toXContentChunkedV7`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -92,17 +92,12 @@ public class ClusterRerouteResponse extends ActionResponse implements IsAcknowle
         if (emitState(outerParams)) {
             deprecationLogger.critical(DeprecationCategory.API, "reroute_cluster_state", STATE_FIELD_DEPRECATION_MESSAGE);
         }
-        return toXContentChunkedV7(outerParams);
-    }
-
-    @Override
-    public Iterator<? extends ToXContent> toXContentChunkedV7(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).object(b -> {
+        return ChunkedToXContent.builder(outerParams).object(b -> {
             b.field(ACKNOWLEDGED_KEY, isAcknowledged());
-            if (emitState(params)) {
+            if (emitState(outerParams)) {
                 b.xContentObject("state", state);
             }
-            if (params.paramAsBoolean("explain", false)) {
+            if (outerParams.paramAsBoolean("explain", false)) {
                 b.append(explanations);
             }
         });

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -35,6 +35,27 @@ public interface ChunkedToXContent {
     }
 
     /**
+     * Create an iterator of {@link ToXContent} chunks for a REST response for the given {@link RestApiVersion}. Each chunk is serialized
+     * with the same {@link XContentBuilder} and {@link ToXContent.Params}, which is also the same as the {@link ToXContent.Params} passed
+     * as the {@code params} argument. For best results, all chunks should be {@code O(1)} size. The last chunk in the iterator must always
+     * yield at least one byte of output. See also {@link ChunkedToXContentHelper} for some handy utilities.
+     * <p>
+     * Note that chunked response bodies cannot send deprecation warning headers once transmission has started, so implementations must
+     * check for deprecated feature use before returning.
+     * <p>
+     * By default, delegates to {@link #toXContentChunked} or {#toXContentChunkedV8}.
+     *
+     * @return iterator over chunks of {@link ToXContent}
+     */
+    default Iterator<? extends ToXContent> toXContentChunked(RestApiVersion restApiVersion, ToXContent.Params params) {
+        return switch (restApiVersion) {
+            case V_7 -> throw new AssertionError("v7 API not supported");
+            case V_8 -> toXContentChunkedV8(params);
+            case V_9 -> toXContentChunked(params);
+        };
+    }
+
+    /**
      * Create an iterator of {@link ToXContent} chunks for a REST response. Each chunk is serialized with the same {@link XContentBuilder}
      * and {@link ToXContent.Params}, which is also the same as the {@link ToXContent.Params} passed as the {@code params} argument. For
      * best results, all chunks should be {@code O(1)} size. The last chunk in the iterator must always yield at least one byte of output.
@@ -48,12 +69,12 @@ public interface ChunkedToXContent {
     Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params);
 
     /**
-     * Create an iterator of {@link ToXContent} chunks for a response to the {@link RestApiVersion#V_7} API. Each chunk is serialized with
+     * Create an iterator of {@link ToXContent} chunks for a response to the {@link RestApiVersion#V_8} API. Each chunk is serialized with
      * the same {@link XContentBuilder} and {@link ToXContent.Params}, which is also the same as the {@link ToXContent.Params} passed as the
      * {@code params} argument. For best results, all chunks should be {@code O(1)} size. The last chunk in the iterator must always yield
      * at least one byte of output. See also {@link ChunkedToXContentHelper} for some handy utilities.
      * <p>
-     * Similar to {@link #toXContentChunked} but for the {@link RestApiVersion#V_7} API. By default this method delegates to {@link
+     * Similar to {@link #toXContentChunked} but for the {@link RestApiVersion#V_8} API. By default this method delegates to {@link
      * #toXContentChunked}.
      * <p>
      * Note that chunked response bodies cannot send deprecation warning headers once transmission has started, so implementations must
@@ -61,7 +82,7 @@ public interface ChunkedToXContent {
      *
      * @return iterator over chunks of {@link ToXContent}
      */
-    default Iterator<? extends ToXContent> toXContentChunkedV7(ToXContent.Params params) {
+    default Iterator<? extends ToXContent> toXContentChunkedV8(ToXContent.Params params) {
         return toXContentChunked(params);
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBodyPart.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBodyPart.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Streams;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -129,9 +128,10 @@ public interface ChunkedRestResponseBodyPart {
                 Streams.noCloseStream(out)
             );
 
-            private final Iterator<? extends ToXContent> serialization = builder.getRestApiVersion() == RestApiVersion.V_7
-                ? chunkedToXContent.toXContentChunkedV7(params)
-                : chunkedToXContent.toXContentChunked(params);
+            private final Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked(
+                builder.getRestApiVersion(),
+                params
+            );
 
             private BytesStream target;
 

--- a/server/src/main/java/org/elasticsearch/rest/StreamingXContentResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/StreamingXContentResponse.java
@@ -25,7 +25,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Streams;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xcontent.ToXContent;
@@ -125,9 +124,7 @@ public final class StreamingXContentResponse implements Releasable {
     }
 
     private Iterator<? extends ToXContent> getChunksIterator(StreamingFragment fragment) {
-        return xContentBuilder.getRestApiVersion() == RestApiVersion.V_7
-            ? fragment.fragment().toXContentChunkedV7(params)
-            : fragment.fragment().toXContentChunked(params);
+        return fragment.fragment().toXContentChunked(xContentBuilder.getRestApiVersion(), params);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -323,21 +322,6 @@ public class ClusterRerouteResponseTests extends ESTestCase {
 
         AbstractChunkedSerializingTestCase.assertChunkCount(response, params, o -> expectedChunks[0]);
         assertCriticalWarnings(criticalDeprecationWarnings);
-
-        // check the v7 API too
-        AbstractChunkedSerializingTestCase.assertChunkCount(new ChunkedToXContent() {
-            @Override
-            public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
-                return response.toXContentChunkedV7(outerParams);
-            }
-
-            @Override
-            public boolean isFragment() {
-                return response.isFragment();
-            }
-        }, params, o -> expectedChunks[0]++);
-        // the v7 API should not emit any deprecation warnings
-        assertCriticalWarnings();
     }
 
     private static ClusterRerouteResponse createClusterRerouteResponse(ClusterState clusterState) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/ServerSentEventsRestActionListener.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/ServerSentEventsRestActionListener.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Streams;
 import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestChannel;
@@ -299,9 +298,7 @@ public class ServerSentEventsRestActionListener implements ActionListener<Infere
             this.xContentBuilder = new LazyInitializable<>(
                 () -> channel.newBuilder(channel.request().getXContentType(), null, true, Streams.noCloseStream(out))
             );
-            this.serialization = channel.request().getRestApiVersion() == RestApiVersion.V_7
-                ? item.toXContentChunkedV7(params)
-                : item.toXContentChunked(params);
+            this.serialization = item.toXContentChunked(channel.request().getRestApiVersion(), params);
         }
 
         @Override


### PR DESCRIPTION
We don't support the v7 REST API in v9, so this commit removes the
now-unused `ChunkedToXContent#toXContentChunkedV7` method. It also
introduces a similar `ChunkedToXContent#toXContentChunkedV8` method for
implementations to use for v8 REST API compatibility.