### PR TITLE
Test StDistance multivalue consistency and fixed two CartesianPoint bugs

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownCartesianPointIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownCartesianPointIT.java
@@ -31,4 +31,10 @@ public class SpatialPushDownCartesianPointIT extends SpatialPushDownPointsTestCa
     protected String castingFunction() {
         return "TO_CARTESIANSHAPE";
     }
+
+    @Override
+    protected double searchDistance() {
+        // We search much larger distances for Cartesian, to ensure we actually get results from the much wider data range
+        return 1e12;
+    }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownGeoPointIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownGeoPointIT.java
@@ -36,4 +36,9 @@ public class SpatialPushDownGeoPointIT extends SpatialPushDownPointsTestCase {
     protected String castingFunction() {
         return "TO_GEOSHAPE";
     }
+
+    @Override
+    protected double searchDistance() {
+        return 10000000;
+    }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialPushDownTestCase.java
@@ -28,7 +28,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 /**
  * Base class to check that a query than can be pushed down gives the same result
  * if it is actually pushed down and when it is executed by the compute engine,
- *
+ * <p>
  * For doing that we create two indices, one fully indexed and another with index
  * and doc values disabled. Then we index the same data in both indices and we check
  * that the same ES|QL queries produce the same results in both.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isNull;
@@ -203,7 +205,7 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
     }
 
     private static final String[] GEO_TYPE_NAMES = new String[] { GEO_POINT.typeName(), GEO_SHAPE.typeName() };
-    private static final String[] CARTESIAN_TYPE_NAMES = new String[] { GEO_POINT.typeName(), GEO_SHAPE.typeName() };
+    private static final String[] CARTESIAN_TYPE_NAMES = new String[] { CARTESIAN_POINT.typeName(), CARTESIAN_SHAPE.typeName() };
 
     protected static boolean spatialCRSCompatible(DataType spatialDataType, DataType otherDataType) {
         return DataType.isSpatialGeo(spatialDataType) && DataType.isSpatialGeo(otherDataType)


### PR DESCRIPTION
This PR adds MultiValue tests to verify that StDistance works the same when pushed down to Lucene, versus not. This lead to the discovery that the current code already works, because physical plans involving a field and a literal will always get re-written to ST_INTERSECTS, which already supports multi-values.

However, these tests highlighted real bugs in the support for CartesianPoint in StDistance, in both the distance pushdown and in the compute engine, and these are both fixed.