### PR TITLE
[8.x] [ML] Switch default chunking strategy to sentence (#114453)

### DIFF
--- a/docs/changelog/114453.yaml
+++ b/docs/changelog/114453.yaml
@@ -1,0 +1,5 @@
+pr: 114453
+summary: Switch default chunking strategy to sentence
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/chunking/ChunkingSettingsBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/chunking/ChunkingSettingsBuilder.java
@@ -13,7 +13,7 @@ import org.elasticsearch.inference.ChunkingStrategy;
 import java.util.Map;
 
 public class ChunkingSettingsBuilder {
-    public static final WordBoundaryChunkingSettings DEFAULT_SETTINGS = new WordBoundaryChunkingSettings(250, 100);
+    public static final SentenceBoundaryChunkingSettings DEFAULT_SETTINGS = new SentenceBoundaryChunkingSettings(250, 1);
 
     public static ChunkingSettings fromMap(Map<String, Object> settings) {
         if (settings.isEmpty()) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/chunking/ChunkingSettingsBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/chunking/ChunkingSettingsBuilderTests.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 public class ChunkingSettingsBuilderTests extends ESTestCase {
 
-    public static final WordBoundaryChunkingSettings DEFAULT_SETTINGS = new WordBoundaryChunkingSettings(250, 100);
+    public static final SentenceBoundaryChunkingSettings DEFAULT_SETTINGS = new SentenceBoundaryChunkingSettings(250, 1);
 
     public void testEmptyChunkingSettingsMap() {
         ChunkingSettings chunkingSettings = ChunkingSettingsBuilder.fromMap(Collections.emptyMap());


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Switch default chunking strategy to sentence (#114453)