### PR TITLE
[8.x] Simplify `XContent` output of epoch times (#114491)

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilderExtension.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilderExtension.java
@@ -68,4 +68,9 @@ public interface XContentBuilderExtension {
      * </pre>
      */
     Map<Class<?>, Function<Object, Object>> getDateTransformers();
+
+    /**
+     * Used to format a {@code long} representing the number of milliseconds since the Unix Epoch.
+     */
+    String formatUnixEpochMillis(long unixEpochMillis);
 }

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
@@ -65,17 +65,17 @@ public class DateDerivativeIT extends ESIntegTestCase {
     }
 
     private static IndexRequestBuilder indexDoc(String idx, ZonedDateTime date, int value) throws Exception {
-        return prepareIndex(idx).setSource(jsonBuilder().startObject().timeField("date", date).field("value", value).endObject());
+        return prepareIndex(idx).setSource(jsonBuilder().startObject().timestampField("date", date).field("value", value).endObject());
     }
 
     private IndexRequestBuilder indexDoc(int month, int day, int value) throws Exception {
         return prepareIndex("idx").setSource(
             jsonBuilder().startObject()
                 .field("value", value)
-                .timeField("date", date(month, day))
+                .timestampField("date", date(month, day))
                 .startArray("dates")
-                .timeValue(date(month, day))
-                .timeValue(date(month + 1, day + 1))
+                .timestampValue(date(month, day))
+                .timestampValue(date(month + 1, day + 1))
                 .endArray()
                 .endObject()
         );

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/DatabaseConfigurationMetadata.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/DatabaseConfigurationMetadata.java
@@ -66,7 +66,7 @@ public record DatabaseConfigurationMetadata(DatabaseConfiguration database, long
         // (we'll be a in a json map where the id is the key)
         builder.startObject();
         builder.field(VERSION.getPreferredName(), version);
-        builder.timeField(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), modifiedDate);
+        builder.timestampFieldsFromUnixEpochMillis(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), modifiedDate);
         builder.field(DATABASE.getPreferredName(), database);
         builder.endObject();
         return builder;

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/GetDatabaseConfigurationAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/direct/GetDatabaseConfigurationAction.java
@@ -110,7 +110,11 @@ public class GetDatabaseConfigurationAction extends ActionType<Response> {
                 builder.startObject();
                 builder.field("id", database.id()); // serialize including the id -- this is get response serialization
                 builder.field(VERSION.getPreferredName(), item.version());
-                builder.timeField(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), item.modifiedDate());
+                builder.timestampFieldsFromUnixEpochMillis(
+                    MODIFIED_DATE_MILLIS.getPreferredName(),
+                    MODIFIED_DATE.getPreferredName(),
+                    item.modifiedDate()
+                );
                 builder.field(DATABASE.getPreferredName(), database);
                 builder.endObject();
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -88,11 +88,11 @@ public class DateHistogramIT extends ESIntegTestCase {
     private IndexRequestBuilder indexDoc(String idx, ZonedDateTime date, int value) throws Exception {
         return prepareIndex(idx).setSource(
             jsonBuilder().startObject()
-                .timeField("date", date)
+                .timestampField("date", date)
                 .field("value", value)
                 .startArray("dates")
-                .timeValue(date)
-                .timeValue(date.plusMonths(1).plusDays(1))
+                .timestampValue(date)
+                .timestampValue(date.plusMonths(1).plusDays(1))
                 .endArray()
                 .endObject()
         );
@@ -103,10 +103,10 @@ public class DateHistogramIT extends ESIntegTestCase {
             jsonBuilder().startObject()
                 .field("value", value)
                 .field("constant", 1)
-                .timeField("date", date(month, day))
+                .timestampField("date", date(month, day))
                 .startArray("dates")
-                .timeValue(date(month, day))
-                .timeValue(date(month + 1, day + 1))
+                .timestampValue(date(month, day))
+                .timestampValue(date(month + 1, day + 1))
                 .endArray()
                 .endObject()
         );
@@ -162,53 +162,53 @@ public class DateHistogramIT extends ESIntegTestCase {
         for (int i = 1; i <= 3; i++) {
             builders.add(
                 prepareIndex("sort_idx").setSource(
-                    jsonBuilder().startObject().timeField("date", date(1, 1)).field("l", 1).field("d", i).endObject()
+                    jsonBuilder().startObject().timestampField("date", date(1, 1)).field("l", 1).field("d", i).endObject()
                 )
             );
             builders.add(
                 prepareIndex("sort_idx").setSource(
-                    jsonBuilder().startObject().timeField("date", date(1, 2)).field("l", 2).field("d", i).endObject()
+                    jsonBuilder().startObject().timestampField("date", date(1, 2)).field("l", 2).field("d", i).endObject()
                 )
             );
         }
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 3)).field("l", 3).field("d", 1).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 3)).field("l", 3).field("d", 1).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 3).plusHours(1)).field("l", 3).field("d", 2).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 3).plusHours(1)).field("l", 3).field("d", 2).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 4)).field("l", 3).field("d", 1).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 4)).field("l", 3).field("d", 1).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 4).plusHours(2)).field("l", 3).field("d", 3).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 4).plusHours(2)).field("l", 3).field("d", 3).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 5)).field("l", 5).field("d", 1).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 5)).field("l", 5).field("d", 1).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 5).plusHours(12)).field("l", 5).field("d", 2).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 5).plusHours(12)).field("l", 5).field("d", 2).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 6)).field("l", 5).field("d", 1).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 6)).field("l", 5).field("d", 1).endObject()
             )
         );
         builders.add(
             prepareIndex("sort_idx").setSource(
-                jsonBuilder().startObject().timeField("date", date(1, 7)).field("l", 5).field("d", 1).endObject()
+                jsonBuilder().startObject().timestampField("date", date(1, 7)).field("l", 5).field("d", 1).endObject()
             )
         );
     }
@@ -997,7 +997,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[5];
         ZonedDateTime date = date("2014-03-11T00:00:00+00:00");
         for (int i = 0; i < reqs.length; i++) {
-            reqs[i] = prepareIndex("idx2").setId("" + i).setSource(jsonBuilder().startObject().timeField("date", date).endObject());
+            reqs[i] = prepareIndex("idx2").setId("" + i).setSource(jsonBuilder().startObject().timestampField("date", date).endObject());
             date = date.plusHours(1);
         }
         indexRandom(true, reqs);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -63,7 +63,7 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
         IndexRequestBuilder[] reqs = new IndexRequestBuilder[numHours];
         for (int i = idxIdStart; i < idxIdStart + reqs.length; i++) {
             reqs[i - idxIdStart] = prepareIndex("idx2").setId("" + i)
-                .setSource(jsonBuilder().startObject().timeField("date", date).endObject());
+                .setSource(jsonBuilder().startObject().timestampField("date", date).endObject());
             date = date.plusHours(stepSizeHours);
         }
         indexRandom(true, reqs);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -58,10 +58,10 @@ public class DateRangeIT extends ESIntegTestCase {
         return prepareIndex("idx").setSource(
             jsonBuilder().startObject()
                 .field("value", value)
-                .timeField("date", date(month, day))
+                .timestampField("date", date(month, day))
                 .startArray("dates")
-                .timeValue(date(month, day))
-                .timeValue(date(month + 1, day + 1))
+                .timestampValue(date(month, day))
+                .timestampValue(date(month + 1, day + 1))
                 .endArray()
                 .endObject()
         );
@@ -620,8 +620,8 @@ public class DateRangeIT extends ESIntegTestCase {
         );
         indexRandom(
             true,
-            prepareIndex("cache_test_idx").setId("1").setSource(jsonBuilder().startObject().timeField("date", date(1, 1)).endObject()),
-            prepareIndex("cache_test_idx").setId("2").setSource(jsonBuilder().startObject().timeField("date", date(2, 1)).endObject())
+            prepareIndex("cache_test_idx").setId("1").setSource(jsonBuilder().startObject().timestampField("date", date(1, 1)).endObject()),
+            prepareIndex("cache_test_idx").setId("2").setSource(jsonBuilder().startObject().timestampField("date", date(2, 1)).endObject())
         );
 
         // Make sure we are starting with a clear cache

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/list/ListDanglingIndicesResponse.java
@@ -79,7 +79,7 @@ public class ListDanglingIndicesResponse extends BaseNodesResponse<NodeListDangl
 
             builder.field("index_name", info.indexName);
             builder.field("index_uuid", info.indexUUID);
-            builder.timeField("creation_date_millis", "creation_date", info.creationDateMillis);
+            builder.timestampFieldsFromUnixEpochMillis("creation_date_millis", "creation_date", info.creationDateMillis);
 
             builder.array("node_ids", info.nodeIds.toArray(new String[0]));
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageShardResponse.java
@@ -69,7 +69,7 @@ public class FieldUsageShardResponse implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(Fields.TRACKING_ID, trackingId);
-        builder.timeField(Fields.TRACKING_STARTED_AT_MILLIS, Fields.TRACKING_STARTED_AT, trackingStartTime);
+        builder.timestampFieldsFromUnixEpochMillis(Fields.TRACKING_STARTED_AT_MILLIS, Fields.TRACKING_STARTED_AT, trackingStartTime);
         builder.startObject(Fields.ROUTING)
             .field(Fields.STATE, shardRouting.state())
             .field(Fields.PRIMARY, shardRouting.primary())

--- a/server/src/main/java/org/elasticsearch/action/bulk/FailureStoreDocumentConverter.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/FailureStoreDocumentConverter.java
@@ -18,12 +18,14 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.xcontent.XContentElasticsearchExtension.DEFAULT_FORMATTER;
 import static org.elasticsearch.ingest.CompoundProcessor.PIPELINE_ORIGIN_EXCEPTION_HEADER;
 import static org.elasticsearch.ingest.CompoundProcessor.PROCESSOR_TAG_EXCEPTION_HEADER;
 import static org.elasticsearch.ingest.CompoundProcessor.PROCESSOR_TYPE_EXCEPTION_HEADER;
@@ -84,7 +86,7 @@ public class FailureStoreDocumentConverter {
         XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();
         {
-            builder.timeField("@timestamp", timeSupplier.get());
+            builder.field("@timestamp", DEFAULT_FORMATTER.format(Instant.ofEpochMilli(timeSupplier.get())));
             builder.startObject("document");
             {
                 if (source.id() != null) {

--- a/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/ExplainIndexDataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/ExplainIndexDataStreamLifecycle.java
@@ -123,7 +123,7 @@ public class ExplainIndexDataStreamLifecycle implements Writeable, ToXContentObj
         builder.field(MANAGED_BY_LIFECYCLE_FIELD.getPreferredName(), managedByLifecycle);
         if (managedByLifecycle) {
             if (indexCreationDate != null) {
-                builder.timeField(
+                builder.timestampFieldsFromUnixEpochMillis(
                     INDEX_CREATION_DATE_MILLIS_FIELD.getPreferredName(),
                     INDEX_CREATION_DATE_FIELD.getPreferredName(),
                     indexCreationDate
@@ -134,7 +134,11 @@ public class ExplainIndexDataStreamLifecycle implements Writeable, ToXContentObj
                 );
             }
             if (rolloverDate != null) {
-                builder.timeField(ROLLOVER_DATE_MILLIS_FIELD.getPreferredName(), ROLLOVER_DATE_FIELD.getPreferredName(), rolloverDate);
+                builder.timestampFieldsFromUnixEpochMillis(
+                    ROLLOVER_DATE_MILLIS_FIELD.getPreferredName(),
+                    ROLLOVER_DATE_FIELD.getPreferredName(),
+                    rolloverDate
+                );
                 builder.field(TIME_SINCE_ROLLOVER_FIELD.getPreferredName(), getTimeSinceRollover(nowSupplier).toHumanReadableString(2));
             }
             if (generationDateMillis != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterSnapshotStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterSnapshotStats.java
@@ -228,7 +228,7 @@ public record ClusterSnapshotStats(
             builder.endObject();
             builder.endObject();
 
-            builder.timeField("oldest_start_time_millis", "oldest_start_time", firstStartTimeMillis);
+            builder.timestampFieldsFromUnixEpochMillis("oldest_start_time_millis", "oldest_start_time", firstStartTimeMillis);
 
             return builder.endObject();
         }

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -180,7 +180,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
                         builder.value(snapshot.getName());
                     }
                     builder.endArray();
-                    builder.timeField("start_time_millis", "start_time", entry.startTime);
+                    builder.timestampFieldsFromUnixEpochMillis("start_time_millis", "start_time", entry.startTime);
                     builder.field("repository_state_id", entry.repositoryStateId);
                     builder.field("state", entry.state);
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -1404,7 +1404,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 }
             }
             builder.endArray();
-            builder.timeField("start_time_millis", "start_time", startTime);
+            builder.timestampFieldsFromUnixEpochMillis("start_time_millis", "start_time", startTime);
             builder.field("repository_state_id", repositoryStateId);
             builder.startArray("shards");
             {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -434,7 +434,7 @@ public final class IndexGraveyard implements Metadata.Custom {
             builder.startObject();
             builder.field(INDEX_KEY);
             index.toXContent(builder, params);
-            builder.timeField(DELETE_DATE_IN_MILLIS_KEY, DELETE_DATE_KEY, deleteDateInMillis);
+            builder.timestampFieldsFromUnixEpochMillis(DELETE_DATE_IN_MILLIS_KEY, DELETE_DATE_KEY, deleteDateInMillis);
             return builder.endObject();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
@@ -266,7 +266,11 @@ public class SingleNodeShutdownMetadata implements SimpleDiffable<SingleNodeShut
             builder.field(NODE_ID_FIELD.getPreferredName(), nodeId);
             builder.field(TYPE_FIELD.getPreferredName(), type);
             builder.field(REASON_FIELD.getPreferredName(), reason);
-            builder.timeField(STARTED_AT_MILLIS_FIELD.getPreferredName(), STARTED_AT_READABLE_FIELD, startedAtMillis);
+            builder.timestampFieldsFromUnixEpochMillis(
+                STARTED_AT_MILLIS_FIELD.getPreferredName(),
+                STARTED_AT_READABLE_FIELD,
+                startedAtMillis
+            );
             builder.field(NODE_SEEN_FIELD.getPreferredName(), nodeSeen);
             if (allocationDelay != null) {
                 builder.field(ALLOCATION_DELAY_FIELD.getPreferredName(), allocationDelay.getStringRep());

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
@@ -57,13 +57,13 @@ public class XContentElasticsearchExtension implements XContentBuilderExtension 
         // Fully-qualified here to reduce ambiguity around our (ES') Version class
         writers.put(org.apache.lucene.util.Version.class, (b, v) -> b.value(Objects.toString(v)));
         writers.put(TimeValue.class, (b, v) -> b.value(v.toString()));
-        writers.put(ZonedDateTime.class, XContentBuilder::timeValue);
-        writers.put(OffsetDateTime.class, XContentBuilder::timeValue);
-        writers.put(OffsetTime.class, XContentBuilder::timeValue);
-        writers.put(java.time.Instant.class, XContentBuilder::timeValue);
-        writers.put(LocalDateTime.class, XContentBuilder::timeValue);
-        writers.put(LocalDate.class, XContentBuilder::timeValue);
-        writers.put(LocalTime.class, XContentBuilder::timeValue);
+        writers.put(ZonedDateTime.class, XContentBuilder::timestampValue);
+        writers.put(OffsetDateTime.class, XContentBuilder::timestampValue);
+        writers.put(OffsetTime.class, XContentBuilder::timestampValue);
+        writers.put(java.time.Instant.class, XContentBuilder::timestampValue);
+        writers.put(LocalDateTime.class, XContentBuilder::timestampValue);
+        writers.put(LocalDate.class, XContentBuilder::timestampValue);
+        writers.put(LocalTime.class, XContentBuilder::timestampValue);
         writers.put(DayOfWeek.class, (b, v) -> b.value(v.toString()));
         writers.put(Month.class, (b, v) -> b.value(v.toString()));
         writers.put(MonthDay.class, (b, v) -> b.value(v.toString()));
@@ -103,10 +103,8 @@ public class XContentElasticsearchExtension implements XContentBuilderExtension 
     public Map<Class<?>, Function<Object, Object>> getDateTransformers() {
         Map<Class<?>, Function<Object, Object>> transformers = new HashMap<>();
         transformers.put(Date.class, d -> DEFAULT_FORMATTER.format(((Date) d).toInstant()));
-        transformers.put(Long.class, d -> DEFAULT_FORMATTER.format(Instant.ofEpochMilli((long) d)));
         transformers.put(Calendar.class, d -> DEFAULT_FORMATTER.format(((Calendar) d).toInstant()));
         transformers.put(GregorianCalendar.class, d -> DEFAULT_FORMATTER.format(((Calendar) d).toInstant()));
-        transformers.put(Instant.class, d -> DEFAULT_FORMATTER.format((Instant) d));
         transformers.put(ZonedDateTime.class, d -> DEFAULT_FORMATTER.format((ZonedDateTime) d));
         transformers.put(OffsetDateTime.class, d -> DEFAULT_FORMATTER.format((OffsetDateTime) d));
         transformers.put(OffsetTime.class, d -> OFFSET_TIME_FORMATTER.format((OffsetTime) d));
@@ -118,5 +116,10 @@ public class XContentElasticsearchExtension implements XContentBuilderExtension 
         transformers.put(LocalDate.class, d -> ((LocalDate) d).toString());
         transformers.put(LocalTime.class, d -> LOCAL_TIME_FORMATTER.format((LocalTime) d));
         return transformers;
+    }
+
+    @Override
+    public String formatUnixEpochMillis(long unixEpochMillis) {
+        return DEFAULT_FORMATTER.format(Instant.ofEpochMilli(unixEpochMillis));
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -293,9 +293,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         builder.field(Fields.TYPE, recoverySource.getType());
         builder.field(Fields.STAGE, stage.toString());
         builder.field(Fields.PRIMARY, primary);
-        builder.timeField(Fields.START_TIME_IN_MILLIS, Fields.START_TIME, timer.startTime);
+        builder.timestampFieldsFromUnixEpochMillis(Fields.START_TIME_IN_MILLIS, Fields.START_TIME, timer.startTime);
         if (timer.stopTime > 0) {
-            builder.timeField(Fields.STOP_TIME_IN_MILLIS, Fields.STOP_TIME, timer.stopTime);
+            builder.timestampFieldsFromUnixEpochMillis(Fields.STOP_TIME_IN_MILLIS, Fields.STOP_TIME, timer.stopTime);
         }
         builder.humanReadableField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, new TimeValue(timer.time()));
 

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -420,7 +420,7 @@ public class JvmInfo implements ReportingService.Info {
         builder.field(Fields.VM_VERSION, vmVersion);
         builder.field(Fields.VM_VENDOR, vmVendor);
         builder.field(Fields.USING_BUNDLED_JDK, usingBundledJdk);
-        builder.timeField(Fields.START_TIME_IN_MILLIS, Fields.START_TIME, startTime);
+        builder.timestampFieldsFromUnixEpochMillis(Fields.START_TIME_IN_MILLIS, Fields.START_TIME, startTime);
 
         builder.startObject(Fields.MEM);
         builder.humanReadableField(Fields.HEAP_INIT_IN_BYTES, Fields.HEAP_INIT, ByteSizeValue.ofBytes(mem.heapInit));

--- a/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -115,7 +115,7 @@ public record TaskInfo(
         if (description != null) {
             builder.field("description", description);
         }
-        builder.timeField("start_time_in_millis", "start_time", startTime);
+        builder.timestampFieldsFromUnixEpochMillis("start_time_in_millis", "start_time", startTime);
         if (builder.humanReadable()) {
             builder.field("running_time", new TimeValue(runningTimeNanos, TimeUnit.NANOSECONDS).toString());
         }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -390,28 +390,31 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testDate() throws Exception {
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (Date) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((Date) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (Date) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((Date) null).endObject());
 
         final Date d1 = Date.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timeField("d1", d1).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1").timeValue(d1).endObject());
+        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timestampField("d1", d1).endObject());
+        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1").timestampValue(d1).endObject());
 
         final Date d2 = Date.from(ZonedDateTime.of(2016, 12, 25, 7, 59, 42, 213000000, ZoneOffset.UTC).toInstant());
-        assertResult("{'d2':'2016-12-25T07:59:42.213Z'}", () -> builder().startObject().timeField("d2", d2).endObject());
-        assertResult("{'d2':'2016-12-25T07:59:42.213Z'}", () -> builder().startObject().field("d2").timeValue(d2).endObject());
+        assertResult("{'d2':'2016-12-25T07:59:42.213Z'}", () -> builder().startObject().timestampField("d2", d2).endObject());
+        assertResult("{'d2':'2016-12-25T07:59:42.213Z'}", () -> builder().startObject().field("d2").timestampValue(d2).endObject());
     }
 
-    public void testDateField() throws Exception {
+    public void testUnixEpochMillisField() throws Exception {
         final Date d = Date.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
 
         assertResult(
             "{'date_in_millis':1451606400000}",
-            () -> builder().startObject().timeField("date_in_millis", "date", d.getTime()).endObject()
+            () -> builder().startObject().timestampFieldsFromUnixEpochMillis("date_in_millis", "date", d.getTime()).endObject()
         );
         assertResult(
             "{'date':'2016-01-01T00:00:00.000Z','date_in_millis':1451606400000}",
-            () -> builder().humanReadable(true).startObject().timeField("date_in_millis", "date", d.getTime()).endObject()
+            () -> builder().humanReadable(true)
+                .startObject()
+                .timestampFieldsFromUnixEpochMillis("date_in_millis", "date", d.getTime())
+                .endObject()
         );
     }
 
@@ -419,7 +422,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         Calendar calendar = GregorianCalendar.from(ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
         assertResult(
             "{'calendar':'2016-01-01T00:00:00.000Z'}",
-            () -> builder().startObject().field("calendar").timeValue(calendar).endObject()
+            () -> builder().startObject().field("calendar").timestampValue(calendar).endObject()
         );
     }
 
@@ -427,83 +430,95 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         final ZonedDateTime d1 = ZonedDateTime.of(2016, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 
         // ZonedDateTime
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (ZonedDateTime) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((ZonedDateTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (ZonedDateTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((ZonedDateTime) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (ZonedDateTime) null).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timeField("d1", d1).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1").timeValue(d1).endObject());
+        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timestampField("d1", d1).endObject());
+        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1").timestampValue(d1).endObject());
         assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1", d1).endObject());
 
         // Instant
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (java.time.Instant) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((java.time.Instant) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (java.time.Instant) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((java.time.Instant) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (java.time.Instant) null).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timeField("d1", d1.toInstant()).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1").timeValue(d1.toInstant()).endObject());
+        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timestampField("d1", d1.toInstant()).endObject());
+        assertResult(
+            "{'d1':'2016-01-01T00:00:00.000Z'}",
+            () -> builder().startObject().field("d1").timestampValue(d1.toInstant()).endObject()
+        );
         assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1", d1.toInstant()).endObject());
 
         // LocalDateTime (no time zone)
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (LocalDateTime) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((LocalDateTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (LocalDateTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((LocalDateTime) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (LocalDateTime) null).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timeField("d1", d1.toLocalDateTime()).endObject());
         assertResult(
             "{'d1':'2016-01-01T00:00:00.000Z'}",
-            () -> builder().startObject().field("d1").timeValue(d1.toLocalDateTime()).endObject()
+            () -> builder().startObject().timestampField("d1", d1.toLocalDateTime()).endObject()
+        );
+        assertResult(
+            "{'d1':'2016-01-01T00:00:00.000Z'}",
+            () -> builder().startObject().field("d1").timestampValue(d1.toLocalDateTime()).endObject()
         );
         assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1", d1.toLocalDateTime()).endObject());
 
         // LocalDate (no time, no time zone)
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (LocalDate) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((LocalDate) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (LocalDate) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((LocalDate) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (LocalDate) null).endObject());
-        assertResult("{'d1':'2016-01-01'}", () -> builder().startObject().timeField("d1", d1.toLocalDate()).endObject());
-        assertResult("{'d1':'2016-01-01'}", () -> builder().startObject().field("d1").timeValue(d1.toLocalDate()).endObject());
+        assertResult("{'d1':'2016-01-01'}", () -> builder().startObject().timestampField("d1", d1.toLocalDate()).endObject());
+        assertResult("{'d1':'2016-01-01'}", () -> builder().startObject().field("d1").timestampValue(d1.toLocalDate()).endObject());
         assertResult("{'d1':'2016-01-01'}", () -> builder().startObject().field("d1", d1.toLocalDate()).endObject());
 
         // LocalTime (no date, no time zone)
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (LocalTime) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((LocalTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (LocalTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((LocalTime) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (LocalTime) null).endObject());
-        assertResult("{'d1':'00:00:00.000'}", () -> builder().startObject().timeField("d1", d1.toLocalTime()).endObject());
-        assertResult("{'d1':'00:00:00.000'}", () -> builder().startObject().field("d1").timeValue(d1.toLocalTime()).endObject());
+        assertResult("{'d1':'00:00:00.000'}", () -> builder().startObject().timestampField("d1", d1.toLocalTime()).endObject());
+        assertResult("{'d1':'00:00:00.000'}", () -> builder().startObject().field("d1").timestampValue(d1.toLocalTime()).endObject());
         assertResult("{'d1':'00:00:00.000'}", () -> builder().startObject().field("d1", d1.toLocalTime()).endObject());
         final ZonedDateTime d2 = ZonedDateTime.of(2016, 1, 1, 7, 59, 23, 123_000_000, ZoneOffset.UTC);
-        assertResult("{'d1':'07:59:23.123'}", () -> builder().startObject().timeField("d1", d2.toLocalTime()).endObject());
-        assertResult("{'d1':'07:59:23.123'}", () -> builder().startObject().field("d1").timeValue(d2.toLocalTime()).endObject());
+        assertResult("{'d1':'07:59:23.123'}", () -> builder().startObject().timestampField("d1", d2.toLocalTime()).endObject());
+        assertResult("{'d1':'07:59:23.123'}", () -> builder().startObject().field("d1").timestampValue(d2.toLocalTime()).endObject());
         assertResult("{'d1':'07:59:23.123'}", () -> builder().startObject().field("d1", d2.toLocalTime()).endObject());
 
         // OffsetDateTime
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (OffsetDateTime) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((OffsetDateTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (OffsetDateTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((OffsetDateTime) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (OffsetDateTime) null).endObject());
         assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().field("d1", d1.toOffsetDateTime()).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000Z'}", () -> builder().startObject().timeField("d1", d1.toOffsetDateTime()).endObject());
         assertResult(
             "{'d1':'2016-01-01T00:00:00.000Z'}",
-            () -> builder().startObject().field("d1").timeValue(d1.toOffsetDateTime()).endObject()
+            () -> builder().startObject().timestampField("d1", d1.toOffsetDateTime()).endObject()
+        );
+        assertResult(
+            "{'d1':'2016-01-01T00:00:00.000Z'}",
+            () -> builder().startObject().field("d1").timestampValue(d1.toOffsetDateTime()).endObject()
         );
         // also test with a date that has a real offset
         OffsetDateTime offsetDateTime = d1.withZoneSameLocal(ZoneOffset.ofHours(5)).toOffsetDateTime();
         assertResult("{'d1':'2016-01-01T00:00:00.000+05:00'}", () -> builder().startObject().field("d1", offsetDateTime).endObject());
-        assertResult("{'d1':'2016-01-01T00:00:00.000+05:00'}", () -> builder().startObject().timeField("d1", offsetDateTime).endObject());
         assertResult(
             "{'d1':'2016-01-01T00:00:00.000+05:00'}",
-            () -> builder().startObject().field("d1").timeValue(offsetDateTime).endObject()
+            () -> builder().startObject().timestampField("d1", offsetDateTime).endObject()
+        );
+        assertResult(
+            "{'d1':'2016-01-01T00:00:00.000+05:00'}",
+            () -> builder().startObject().field("d1").timestampValue(offsetDateTime).endObject()
         );
 
         // OffsetTime
-        assertResult("{'date':null}", () -> builder().startObject().timeField("date", (OffsetTime) null).endObject());
-        assertResult("{'date':null}", () -> builder().startObject().field("date").timeValue((OffsetTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().timestampField("date", (OffsetTime) null).endObject());
+        assertResult("{'date':null}", () -> builder().startObject().field("date").timestampValue((OffsetTime) null).endObject());
         assertResult("{'date':null}", () -> builder().startObject().field("date", (OffsetTime) null).endObject());
         final OffsetTime offsetTime = d2.toOffsetDateTime().toOffsetTime();
-        assertResult("{'o':'07:59:23.123Z'}", () -> builder().startObject().timeField("o", offsetTime).endObject());
-        assertResult("{'o':'07:59:23.123Z'}", () -> builder().startObject().field("o").timeValue(offsetTime).endObject());
+        assertResult("{'o':'07:59:23.123Z'}", () -> builder().startObject().timestampField("o", offsetTime).endObject());
+        assertResult("{'o':'07:59:23.123Z'}", () -> builder().startObject().field("o").timestampValue(offsetTime).endObject());
         assertResult("{'o':'07:59:23.123Z'}", () -> builder().startObject().field("o", offsetTime).endObject());
         // also test with a date that has a real offset
         final OffsetTime zonedOffsetTime = offsetTime.withOffsetSameLocal(ZoneOffset.ofHours(5));
-        assertResult("{'o':'07:59:23.123+05:00'}", () -> builder().startObject().timeField("o", zonedOffsetTime).endObject());
-        assertResult("{'o':'07:59:23.123+05:00'}", () -> builder().startObject().field("o").timeValue(zonedOffsetTime).endObject());
+        assertResult("{'o':'07:59:23.123+05:00'}", () -> builder().startObject().timestampField("o", zonedOffsetTime).endObject());
+        assertResult("{'o':'07:59:23.123+05:00'}", () -> builder().startObject().field("o").timestampValue(zonedOffsetTime).endObject());
         assertResult("{'o':'07:59:23.123+05:00'}", () -> builder().startObject().field("o", zonedOffsetTime).endObject());
 
         // DayOfWeek enum, not a real time value, but might be used in scripts

--- a/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/builder/XContentBuilderTests.java
@@ -189,7 +189,7 @@ public class XContentBuilderTests extends ESTestCase {
         Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"), Locale.ROOT);
         String expectedCalendar = XContentElasticsearchExtension.DEFAULT_FORMATTER.format(calendar.toInstant());
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
-        builder.startObject().timeField("date", date).endObject();
+        builder.startObject().timestampField("date", date).endObject();
         assertThat(Strings.toString(builder), equalTo("{\"date\":\"" + expectedDate + "\"}"));
 
         builder = XContentFactory.contentBuilder(XContentType.JSON);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/License.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/License.java
@@ -524,13 +524,13 @@ public class License implements ToXContentObject {
         if (licenseVersion == VERSION_START) {
             builder.field(Fields.SUBSCRIPTION_TYPE, subscriptionType);
         }
-        builder.timeField(Fields.ISSUE_DATE_IN_MILLIS, Fields.ISSUE_DATE, issueDate);
+        builder.timestampFieldsFromUnixEpochMillis(Fields.ISSUE_DATE_IN_MILLIS, Fields.ISSUE_DATE, issueDate);
         if (licenseVersion == VERSION_START) {
             builder.field(Fields.FEATURE, feature);
         }
 
         if (expiryDate != LicenseSettings.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS) {
-            builder.timeField(Fields.EXPIRY_DATE_IN_MILLIS, Fields.EXPIRY_DATE, expiryDate);
+            builder.timestampFieldsFromUnixEpochMillis(Fields.EXPIRY_DATE_IN_MILLIS, Fields.EXPIRY_DATE, expiryDate);
         }
 
         if (licenseVersion >= VERSION_ENTERPRISE) {
@@ -551,7 +551,7 @@ public class License implements ToXContentObject {
             builder.humanReadable(previouslyHumanReadable);
         }
         if (licenseVersion >= VERSION_START_DATE) {
-            builder.timeField(Fields.START_DATE_IN_MILLIS, Fields.START_DATE, startDate);
+            builder.timestampFieldsFromUnixEpochMillis(Fields.START_DATE_IN_MILLIS, Fields.START_DATE, startDate);
         }
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
@@ -226,7 +226,7 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
 
             builder.field("status", status.label());
             if (expiryDate != BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS) {
-                builder.timeField("expiry_date_in_millis", "expiry_date", expiryDate);
+                builder.timestampFieldsFromUnixEpochMillis("expiry_date_in_millis", "expiry_date", expiryDate);
             }
             return builder.endObject();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
@@ -489,7 +489,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
         if (managedByILM) {
             builder.field(POLICY_NAME_FIELD.getPreferredName(), policyName);
             if (indexCreationDate != null) {
-                builder.timeField(
+                builder.timestampFieldsFromUnixEpochMillis(
                     INDEX_CREATION_DATE_MILLIS_FIELD.getPreferredName(),
                     INDEX_CREATION_DATE_FIELD.getPreferredName(),
                     indexCreationDate
@@ -500,26 +500,42 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
                 );
             }
             if (lifecycleDate != null) {
-                builder.timeField(LIFECYCLE_DATE_MILLIS_FIELD.getPreferredName(), LIFECYCLE_DATE_FIELD.getPreferredName(), lifecycleDate);
+                builder.timestampFieldsFromUnixEpochMillis(
+                    LIFECYCLE_DATE_MILLIS_FIELD.getPreferredName(),
+                    LIFECYCLE_DATE_FIELD.getPreferredName(),
+                    lifecycleDate
+                );
                 builder.field(AGE_FIELD.getPreferredName(), getAge(nowSupplier).toHumanReadableString(2));
             }
             if (phase != null) {
                 builder.field(PHASE_FIELD.getPreferredName(), phase);
             }
             if (phaseTime != null) {
-                builder.timeField(PHASE_TIME_MILLIS_FIELD.getPreferredName(), PHASE_TIME_FIELD.getPreferredName(), phaseTime);
+                builder.timestampFieldsFromUnixEpochMillis(
+                    PHASE_TIME_MILLIS_FIELD.getPreferredName(),
+                    PHASE_TIME_FIELD.getPreferredName(),
+                    phaseTime
+                );
             }
             if (action != null) {
                 builder.field(ACTION_FIELD.getPreferredName(), action);
             }
             if (actionTime != null) {
-                builder.timeField(ACTION_TIME_MILLIS_FIELD.getPreferredName(), ACTION_TIME_FIELD.getPreferredName(), actionTime);
+                builder.timestampFieldsFromUnixEpochMillis(
+                    ACTION_TIME_MILLIS_FIELD.getPreferredName(),
+                    ACTION_TIME_FIELD.getPreferredName(),
+                    actionTime
+                );
             }
             if (step != null) {
                 builder.field(STEP_FIELD.getPreferredName(), step);
             }
             if (stepTime != null) {
-                builder.timeField(STEP_TIME_MILLIS_FIELD.getPreferredName(), STEP_TIME_FIELD.getPreferredName(), stepTime);
+                builder.timestampFieldsFromUnixEpochMillis(
+                    STEP_TIME_MILLIS_FIELD.getPreferredName(),
+                    STEP_TIME_FIELD.getPreferredName(),
+                    stepTime
+                );
             }
             if (Strings.hasLength(failedStep)) {
                 builder.field(FAILED_STEP_FIELD.getPreferredName(), failedStep);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseExecutionInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseExecutionInfo.java
@@ -130,7 +130,7 @@ public class PhaseExecutionInfo implements ToXContentObject, Writeable {
             builder.field(PHASE_DEFINITION_FIELD.getPreferredName(), phase);
         }
         builder.field(VERSION_FIELD.getPreferredName(), version);
-        builder.timeField(MODIFIED_DATE_IN_MILLIS_FIELD.getPreferredName(), "modified_date", modifiedDate);
+        builder.timestampFieldsFromUnixEpochMillis(MODIFIED_DATE_IN_MILLIS_FIELD.getPreferredName(), "modified_date", modifiedDate);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FlushJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/FlushJobAction.java
@@ -255,7 +255,7 @@ public class FlushJobAction extends ActionType<FlushJobAction.Response> {
             builder.startObject();
             builder.field("flushed", flushed);
             if (lastFinalizedBucketEnd != null) {
-                builder.timeField(
+                builder.timestampFieldsFromUnixEpochMillis(
                     FlushAcknowledgement.LAST_FINALIZED_BUCKET_END.getPreferredName(),
                     FlushAcknowledgement.LAST_FINALIZED_BUCKET_END.getPreferredName() + "_string",
                     lastFinalizedBucketEnd.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -332,17 +332,33 @@ public class Annotation implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(ANNOTATION.getPreferredName(), annotation);
-        builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            CREATE_TIME.getPreferredName(),
+            CREATE_TIME.getPreferredName() + "_string",
+            createTime.getTime()
+        );
         builder.field(CREATE_USERNAME.getPreferredName(), createUsername);
-        builder.timeField(TIMESTAMP.getPreferredName(), TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            TIMESTAMP.getPreferredName(),
+            TIMESTAMP.getPreferredName() + "_string",
+            timestamp.getTime()
+        );
         if (endTimestamp != null) {
-            builder.timeField(END_TIMESTAMP.getPreferredName(), END_TIMESTAMP.getPreferredName() + "_string", endTimestamp.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                END_TIMESTAMP.getPreferredName(),
+                END_TIMESTAMP.getPreferredName() + "_string",
+                endTimestamp.getTime()
+            );
         }
         if (jobId != null) {
             builder.field(Job.ID.getPreferredName(), jobId);
         }
         if (modifiedTime != null) {
-            builder.timeField(MODIFIED_TIME.getPreferredName(), MODIFIED_TIME.getPreferredName() + "_string", modifiedTime.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                MODIFIED_TIME.getPreferredName(),
+                MODIFIED_TIME.getPreferredName() + "_string",
+                modifiedTime.getTime()
+            );
         }
         if (modifiedUsername != null) {
             builder.field(MODIFIED_USERNAME.getPreferredName(), modifiedUsername);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEvent.java
@@ -217,8 +217,16 @@ public class ScheduledEvent implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(DESCRIPTION.getPreferredName(), description);
-        builder.timeField(START_TIME.getPreferredName(), START_TIME.getPreferredName() + "_string", startTime.toEpochMilli());
-        builder.timeField(END_TIME.getPreferredName(), END_TIME.getPreferredName() + "_string", endTime.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis(
+            START_TIME.getPreferredName(),
+            START_TIME.getPreferredName() + "_string",
+            startTime.toEpochMilli()
+        );
+        builder.timestampFieldsFromUnixEpochMillis(
+            END_TIME.getPreferredName(),
+            END_TIME.getPreferredName() + "_string",
+            endTime.toEpochMilli()
+        );
         builder.field(SKIP_RESULT.getPreferredName(), skipResult);
         builder.field(SKIP_MODEL_UPDATE.getPreferredName(), skipModelUpdate);
         if (forceTimeShift != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/SearchInterval.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/SearchInterval.java
@@ -30,8 +30,8 @@ public record SearchInterval(long startMs, long endMs) implements ToXContentObje
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.timeField(START_MS.getPreferredName(), START.getPreferredName(), startMs);
-        builder.timeField(END_MS.getPreferredName(), END.getPreferredName(), endMs);
+        builder.timestampFieldsFromUnixEpochMillis(START_MS.getPreferredName(), START.getPreferredName(), startMs);
+        builder.timestampFieldsFromUnixEpochMillis(END_MS.getPreferredName(), END.getPreferredName(), endMs);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -258,7 +258,11 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         builder.field(ID.getPreferredName(), id);
         if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             if (createTime != null) {
-                builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
+                builder.timestampFieldsFromUnixEpochMillis(
+                    CREATE_TIME.getPreferredName(),
+                    CREATE_TIME.getPreferredName() + "_string",
+                    createTime.toEpochMilli()
+                );
             }
             if (version != null) {
                 builder.field(VERSION.getPreferredName(), version);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
@@ -143,7 +143,7 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState, MlTaskS
             builder.field(REASON.getPreferredName(), reason);
         }
         if (lastStateChangeTime != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LAST_STATE_CHANGE_TIME.getPreferredName(),
                 LAST_STATE_CHANGE_TIME.getPreferredName() + "_string",
                 lastStateChangeTime.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ClassificationStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/classification/ClassificationStats.java
@@ -131,7 +131,11 @@ public class ClassificationStats implements AnalysisStats {
             builder.field(Fields.TYPE.getPreferredName(), TYPE_VALUE);
             builder.field(Fields.JOB_ID.getPreferredName(), jobId);
         }
-        builder.timeField(Fields.TIMESTAMP.getPreferredName(), Fields.TIMESTAMP.getPreferredName() + "_string", timestamp.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Fields.TIMESTAMP.getPreferredName(),
+            Fields.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.toEpochMilli()
+        );
         builder.field(ITERATION.getPreferredName(), iteration);
         builder.field(HYPERPARAMETERS.getPreferredName(), hyperparameters);
         builder.field(TIMING_STATS.getPreferredName(), timingStats);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/common/MemoryUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/common/MemoryUsage.java
@@ -126,7 +126,7 @@ public class MemoryUsage implements Writeable, ToXContentObject {
             builder.field(Fields.JOB_ID.getPreferredName(), jobId);
         }
         if (timestamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 Fields.TIMESTAMP.getPreferredName(),
                 Fields.TIMESTAMP.getPreferredName() + "_string",
                 timestamp.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
@@ -101,7 +101,11 @@ public class OutlierDetectionStats implements AnalysisStats {
             builder.field(Fields.TYPE.getPreferredName(), TYPE_VALUE);
             builder.field(Fields.JOB_ID.getPreferredName(), jobId);
         }
-        builder.timeField(Fields.TIMESTAMP.getPreferredName(), Fields.TIMESTAMP.getPreferredName() + "_string", timestamp.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Fields.TIMESTAMP.getPreferredName(),
+            Fields.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.toEpochMilli()
+        );
         builder.field(PARAMETERS.getPreferredName(), parameters);
         builder.field(TIMING_STATS.getPreferredName(), timingStats);
         builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/RegressionStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/regression/RegressionStats.java
@@ -131,7 +131,11 @@ public class RegressionStats implements AnalysisStats {
             builder.field(Fields.TYPE.getPreferredName(), TYPE_VALUE);
             builder.field(Fields.JOB_ID.getPreferredName(), jobId);
         }
-        builder.timeField(Fields.TIMESTAMP.getPreferredName(), Fields.TIMESTAMP.getPreferredName() + "_string", timestamp.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Fields.TIMESTAMP.getPreferredName(),
+            Fields.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.toEpochMilli()
+        );
         builder.field(ITERATION.getPreferredName(), iteration);
         builder.field(HYPERPARAMETERS.getPreferredName(), hyperparameters);
         builder.field(TIMING_STATS.getPreferredName(), timingStats);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -509,7 +509,11 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         if (params.paramAsBoolean(EXCLUDE_GENERATED, false) == false) {
             builder.field(CREATED_BY.getPreferredName(), createdBy);
             builder.field(VERSION.getPreferredName(), version.toString());
-            builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
+            builder.timestampFieldsFromUnixEpochMillis(
+                CREATE_TIME.getPreferredName(),
+                CREATE_TIME.getPreferredName() + "_string",
+                createTime.toEpochMilli()
+            );
             // If we are NOT storing the model, we should return the deprecated field name
             if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false) == false
                 && builder.getRestApiVersion().matches(RestApiVersion.equalTo(RestApiVersion.V_7))) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -297,7 +297,7 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 builder.field("inference_cache_hit_count", cacheHitCount);
             }
             if (lastAccess != null) {
-                builder.timeField("last_access", "last_access_string", lastAccess.toEpochMilli());
+                builder.timestampFieldsFromUnixEpochMillis("last_access", "last_access_string", lastAccess.toEpochMilli());
             }
             if (pendingCount != null) {
                 builder.field("number_of_pending_requests", pendingCount);
@@ -312,7 +312,7 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 builder.field("timeout_count", timeoutCount);
             }
             if (startTime != null) {
-                builder.timeField("start_time", "start_time_string", startTime.toEpochMilli());
+                builder.timestampFieldsFromUnixEpochMillis("start_time", "start_time_string", startTime.toEpochMilli());
             }
             if (threadsPerAllocation != null) {
                 builder.field("threads_per_allocation", threadsPerAllocation);
@@ -608,7 +608,7 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             builder.field("cache_size", cacheSize);
         }
         builder.field("priority", priority);
-        builder.timeField("start_time", "start_time_string", startTime.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis("start_time", "start_time_string", startTime.toEpochMilli());
 
         int totalErrorCount = nodeStats.stream().mapToInt(NodeStats::getErrorCount).sum();
         int totalRejectedExecutionCount = nodeStats.stream().mapToInt(NodeStats::getRejectedExecutionCount).sum();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -368,7 +368,7 @@ public final class TrainedModelAssignment implements SimpleDiffable<TrainedModel
         if (reason != null) {
             builder.field(REASON.getPreferredName(), reason);
         }
-        builder.timeField(START_TIME.getPreferredName(), startTime);
+        builder.timestampField(START_TIME.getPreferredName(), startTime);
         builder.field(MAX_ASSIGNED_ALLOCATIONS.getPreferredName(), maxAssignedAllocations);
         builder.field(ADAPTIVE_ALLOCATIONS.getPreferredName(), adaptiveAllocationsSettings);
         builder.endObject();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceStats.java
@@ -162,7 +162,11 @@ public class InferenceStats implements ToXContentObject, Writeable {
         builder.field(INFERENCE_COUNT.getPreferredName(), inferenceCount);
         builder.field(CACHE_MISS_COUNT.getPreferredName(), cacheMissCount);
         builder.field(MISSING_ALL_FIELDS_COUNT.getPreferredName(), missingAllFieldsCount);
-        builder.timeField(TIMESTAMP.getPreferredName(), TIMESTAMP.getPreferredName() + "_string", timeStamp.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis(
+            TIMESTAMP.getPreferredName(),
+            TIMESTAMP.getPreferredName() + "_string",
+            timeStamp.toEpochMilli()
+        );
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
@@ -260,7 +260,11 @@ public class ModelPackageConfig implements ToXContentObject, Writeable {
             builder.field(MINIMUM_VERSION.getPreferredName(), minimumVersion);
         }
         if (createTime != null) {
-            builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + "_string", createTime.toEpochMilli());
+            builder.timestampFieldsFromUnixEpochMillis(
+                CREATE_TIME.getPreferredName(),
+                CREATE_TIME.getPreferredName() + "_string",
+                createTime.toEpochMilli()
+            );
         }
         if (size > 0) {
             builder.field(SIZE.getPreferredName(), size);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -613,9 +613,13 @@ public class Job implements SimpleDiffable<Job>, Writeable, ToXContentObject {
             if (jobVersion != null) {
                 builder.field(JOB_VERSION.getPreferredName(), jobVersion);
             }
-            builder.timeField(CREATE_TIME.getPreferredName(), CREATE_TIME.getPreferredName() + humanReadableSuffix, createTime.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                CREATE_TIME.getPreferredName(),
+                CREATE_TIME.getPreferredName() + humanReadableSuffix,
+                createTime.getTime()
+            );
             if (finishedTime != null) {
-                builder.timeField(
+                builder.timestampFieldsFromUnixEpochMillis(
                     FINISHED_TIME.getPreferredName(),
                     FINISHED_TIME.getPreferredName() + humanReadableSuffix,
                     finishedTime.getTime()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
@@ -150,7 +150,7 @@ public class JobTaskState implements PersistentTaskState, MlTaskState {
             builder.field(REASON.getPreferredName(), reason);
         }
         if (lastStateChangeTime != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LAST_STATE_CHANGE_TIME.getPreferredName(),
                 LAST_STATE_CHANGE_TIME.getPreferredName() + "_string",
                 lastStateChangeTime.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/output/FlushAcknowledgement.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/output/FlushAcknowledgement.java
@@ -99,7 +99,7 @@ public class FlushAcknowledgement implements ToXContentObject, Writeable {
         builder.startObject();
         builder.field(ID.getPreferredName(), id);
         if (lastFinalizedBucketEnd != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LAST_FINALIZED_BUCKET_END.getPreferredName(),
                 LAST_FINALIZED_BUCKET_END.getPreferredName() + "_string",
                 lastFinalizedBucketEnd.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/CategorizerStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/CategorizerStats.java
@@ -195,8 +195,16 @@ public class CategorizerStats implements ToXContentObject, Writeable {
         builder.field(DEAD_CATEGORY_COUNT_FIELD.getPreferredName(), deadCategoryCount);
         builder.field(FAILED_CATEGORY_COUNT_FIELD.getPreferredName(), failedCategoryCount);
         builder.field(CATEGORIZATION_STATUS_FIELD.getPreferredName(), categorizationStatus);
-        builder.timeField(LOG_TIME_FIELD.getPreferredName(), LOG_TIME_FIELD.getPreferredName() + "_string", logTime.toEpochMilli());
-        builder.timeField(TIMESTAMP_FIELD.getPreferredName(), TIMESTAMP_FIELD.getPreferredName() + "_string", timestamp.toEpochMilli());
+        builder.timestampFieldsFromUnixEpochMillis(
+            LOG_TIME_FIELD.getPreferredName(),
+            LOG_TIME_FIELD.getPreferredName() + "_string",
+            logTime.toEpochMilli()
+        );
+        builder.timestampFieldsFromUnixEpochMillis(
+            TIMESTAMP_FIELD.getPreferredName(),
+            TIMESTAMP_FIELD.getPreferredName() + "_string",
+            timestamp.toEpochMilli()
+        );
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
@@ -583,35 +583,35 @@ public final class DataCounts implements ToXContentObject, Writeable {
         builder.field(SPARSE_BUCKET_COUNT.getPreferredName(), sparseBucketCount);
         builder.field(BUCKET_COUNT.getPreferredName(), bucketCount);
         if (earliestRecordTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 EARLIEST_RECORD_TIME.getPreferredName(),
                 EARLIEST_RECORD_TIME.getPreferredName() + "_string",
                 earliestRecordTimeStamp.getTime()
             );
         }
         if (latestRecordTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LATEST_RECORD_TIME.getPreferredName(),
                 LATEST_RECORD_TIME.getPreferredName() + "_string",
                 latestRecordTimeStamp.getTime()
             );
         }
         if (lastDataTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LAST_DATA_TIME.getPreferredName(),
                 LAST_DATA_TIME.getPreferredName() + "_string",
                 lastDataTimeStamp.getTime()
             );
         }
         if (latestEmptyBucketTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LATEST_EMPTY_BUCKET_TIME.getPreferredName(),
                 LATEST_EMPTY_BUCKET_TIME.getPreferredName() + "_string",
                 latestEmptyBucketTimeStamp.getTime()
             );
         }
         if (latestSparseBucketTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LATEST_SPARSE_BUCKET_TIME.getPreferredName(),
                 LATEST_SPARSE_BUCKET_TIME.getPreferredName() + "_string",
                 latestSparseBucketTimeStamp.getTime()
@@ -619,7 +619,11 @@ public final class DataCounts implements ToXContentObject, Writeable {
         }
         builder.field(INPUT_RECORD_COUNT.getPreferredName(), getInputRecordCount());
         if (logTime != null) {
-            builder.timeField(LOG_TIME.getPreferredName(), LOG_TIME.getPreferredName() + "_string", logTime.toEpochMilli());
+            builder.timestampFieldsFromUnixEpochMillis(
+                LOG_TIME.getPreferredName(),
+                LOG_TIME.getPreferredName() + "_string",
+                logTime.toEpochMilli()
+            );
         }
 
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
@@ -363,9 +363,17 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
         builder.field(DEAD_CATEGORY_COUNT_FIELD.getPreferredName(), deadCategoryCount);
         builder.field(FAILED_CATEGORY_COUNT_FIELD.getPreferredName(), failedCategoryCount);
         builder.field(CATEGORIZATION_STATUS_FIELD.getPreferredName(), categorizationStatus);
-        builder.timeField(LOG_TIME_FIELD.getPreferredName(), LOG_TIME_FIELD.getPreferredName() + "_string", logTime.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            LOG_TIME_FIELD.getPreferredName(),
+            LOG_TIME_FIELD.getPreferredName() + "_string",
+            logTime.getTime()
+        );
         if (timestamp != null) {
-            builder.timeField(TIMESTAMP_FIELD.getPreferredName(), TIMESTAMP_FIELD.getPreferredName() + "_string", timestamp.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                TIMESTAMP_FIELD.getPreferredName(),
+                TIMESTAMP_FIELD.getPreferredName() + "_string",
+                timestamp.getTime()
+            );
         }
 
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshot.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshot.java
@@ -194,7 +194,11 @@ public class ModelSnapshot implements ToXContentObject, Writeable {
         builder.field(Job.ID.getPreferredName(), jobId);
         builder.field(MIN_VERSION.getPreferredName(), minVersion);
         if (timestamp != null) {
-            builder.timeField(TIMESTAMP.getPreferredName(), TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                TIMESTAMP.getPreferredName(),
+                TIMESTAMP.getPreferredName() + "_string",
+                timestamp.getTime()
+            );
         }
         if (description != null) {
             builder.field(DESCRIPTION.getPreferredName(), description);
@@ -207,14 +211,14 @@ public class ModelSnapshot implements ToXContentObject, Writeable {
             builder.field(ModelSizeStats.RESULT_TYPE_FIELD.getPreferredName(), modelSizeStats);
         }
         if (latestRecordTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LATEST_RECORD_TIME.getPreferredName(),
                 LATEST_RECORD_TIME.getPreferredName() + "_string",
                 latestRecordTimeStamp.getTime()
             );
         }
         if (latestResultTimeStamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LATEST_RESULT_TIME.getPreferredName(),
                 LATEST_RESULT_TIME.getPreferredName() + "_string",
                 latestResultTimeStamp.getTime()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/AnomalyRecord.java
@@ -283,7 +283,11 @@ public class AnomalyRecord implements ToXContentObject, Writeable {
         builder.field(BUCKET_SPAN.getPreferredName(), bucketSpan);
         builder.field(Detector.DETECTOR_INDEX.getPreferredName(), detectorIndex);
         builder.field(Result.IS_INTERIM.getPreferredName(), isInterim);
-        builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Result.TIMESTAMP.getPreferredName(),
+            Result.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.getTime()
+        );
         if (byFieldName != null) {
             builder.field(BY_FIELD_NAME.getPreferredName(), byFieldName);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java
@@ -173,7 +173,11 @@ public class Bucket implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(JOB_ID.getPreferredName(), jobId);
-        builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Result.TIMESTAMP.getPreferredName(),
+            Result.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.getTime()
+        );
         builder.field(ANOMALY_SCORE.getPreferredName(), anomalyScore);
         builder.field(BUCKET_SPAN.getPreferredName(), bucketSpan);
         builder.field(INITIAL_ANOMALY_SCORE.getPreferredName(), initialAnomalyScore);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/BucketInfluencer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/BucketInfluencer.java
@@ -132,7 +132,11 @@ public class BucketInfluencer implements ToXContentObject, Writeable {
         builder.field(ANOMALY_SCORE.getPreferredName(), anomalyScore);
         builder.field(RAW_ANOMALY_SCORE.getPreferredName(), rawAnomalyScore);
         builder.field(PROBABILITY.getPreferredName(), probability);
-        builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Result.TIMESTAMP.getPreferredName(),
+            Result.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.getTime()
+        );
         builder.field(BUCKET_SPAN.getPreferredName(), bucketSpan);
         builder.field(Result.IS_INTERIM.getPreferredName(), isInterim);
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Forecast.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Forecast.java
@@ -140,7 +140,11 @@ public class Forecast implements ToXContentObject, Writeable {
         builder.field(BUCKET_SPAN.getPreferredName(), bucketSpan);
         builder.field(DETECTOR_INDEX.getPreferredName(), detectorIndex);
         if (timestamp != null) {
-            builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                Result.TIMESTAMP.getPreferredName(),
+                Result.TIMESTAMP.getPreferredName() + "_string",
+                timestamp.getTime()
+            );
         }
         if (partitionFieldName != null) {
             builder.field(PARTITION_FIELD_NAME.getPreferredName(), partitionFieldName);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Influencer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Influencer.java
@@ -132,7 +132,11 @@ public class Influencer implements ToXContentObject, Writeable {
         builder.field(PROBABILITY.getPreferredName(), probability);
         builder.field(BUCKET_SPAN.getPreferredName(), bucketSpan);
         builder.field(Result.IS_INTERIM.getPreferredName(), isInterim);
-        builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Result.TIMESTAMP.getPreferredName(),
+            Result.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.getTime()
+        );
         return builder;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ModelPlot.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ModelPlot.java
@@ -153,7 +153,11 @@ public class ModelPlot implements ToXContentObject, Writeable {
         builder.field(DETECTOR_INDEX.getPreferredName(), detectorIndex);
 
         if (timestamp != null) {
-            builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+            builder.timestampFieldsFromUnixEpochMillis(
+                Result.TIMESTAMP.getPreferredName(),
+                Result.TIMESTAMP.getPreferredName() + "_string",
+                timestamp.getTime()
+            );
         }
         if (partitionFieldName != null) {
             builder.field(PARTITION_FIELD_NAME.getPreferredName(), partitionFieldName);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/OverallBucket.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/OverallBucket.java
@@ -71,7 +71,11 @@ public class OverallBucket implements ToXContentObject, Writeable {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.timeField(Result.TIMESTAMP.getPreferredName(), Result.TIMESTAMP.getPreferredName() + "_string", timestamp.getTime());
+        builder.timestampFieldsFromUnixEpochMillis(
+            Result.TIMESTAMP.getPreferredName(),
+            Result.TIMESTAMP.getPreferredName() + "_string",
+            timestamp.getTime()
+        );
         builder.field(BUCKET_SPAN.getPreferredName(), bucketSpan);
         builder.field(OVERALL_SCORE.getPreferredName(), overallScore);
         builder.field(JOBS.getPreferredName(), jobs);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExponentialAverageCalculationContext.java
@@ -178,7 +178,7 @@ public class ExponentialAverageCalculationContext implements Writeable, ToXConte
         builder.startObject();
         builder.field(INCREMENTAL_METRIC_VALUE_MS.getPreferredName(), incrementalMetricValueMs);
         if (latestTimestamp != null) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 LATEST_TIMESTAMP.getPreferredName(),
                 LATEST_TIMESTAMP.getPreferredName() + "_string",
                 latestTimestamp.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -238,12 +238,16 @@ public class AsyncSearchResponse extends ActionResponse implements ChunkedToXCon
             }
             builder.field("is_partial", isPartial);
             builder.field("is_running", isRunning);
-            builder.timeField("start_time_in_millis", "start_time", startTimeMillis);
-            builder.timeField("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
+            builder.timestampFieldsFromUnixEpochMillis("start_time_in_millis", "start_time", startTimeMillis);
+            builder.timestampFieldsFromUnixEpochMillis("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
             if (searchResponse != null) {
                 if (isRunning == false) {
                     TimeValue took = searchResponse.getTook();
-                    builder.timeField("completion_time_in_millis", "completion_time", startTimeMillis + took.millis());
+                    builder.timestampFieldsFromUnixEpochMillis(
+                        "completion_time_in_millis",
+                        "completion_time",
+                        startTimeMillis + took.millis()
+                    );
                 }
                 builder.field("response");
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
@@ -175,10 +175,10 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
         builder.field("id", id);
         builder.field("is_running", isRunning);
         builder.field("is_partial", isPartial);
-        builder.timeField("start_time_in_millis", "start_time", startTimeMillis);
-        builder.timeField("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
+        builder.timestampFieldsFromUnixEpochMillis("start_time_in_millis", "start_time", startTimeMillis);
+        builder.timestampFieldsFromUnixEpochMillis("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
         if (completionTimeMillis != null) {
-            builder.timeField("completion_time_in_millis", "completion_time", completionTimeMillis);
+            builder.timestampFieldsFromUnixEpochMillis("completion_time_in_millis", "completion_time", completionTimeMillis);
         }
         RestActions.buildBroadcastShardsHeader(builder, params, totalShards, successfulShards, skippedShards, failedShards, null);
         if (clusters != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecord.java
@@ -106,9 +106,9 @@ public class SnapshotInvocationRecord implements SimpleDiffable<SnapshotInvocati
         {
             builder.field(SNAPSHOT_NAME.getPreferredName(), snapshotName);
             if (snapshotStartTimestamp != null) {
-                builder.timeField(START_TIMESTAMP.getPreferredName(), "start_time_string", snapshotStartTimestamp);
+                builder.timestampFieldsFromUnixEpochMillis(START_TIMESTAMP.getPreferredName(), "start_time_string", snapshotStartTimestamp);
             }
-            builder.timeField(TIMESTAMP.getPreferredName(), "time_string", snapshotFinishTimestamp);
+            builder.timestampFieldsFromUnixEpochMillis(TIMESTAMP.getPreferredName(), "time_string", snapshotFinishTimestamp);
             if (Objects.nonNull(details)) {
                 builder.field(DETAILS.getPreferredName(), details);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyItem.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyItem.java
@@ -157,7 +157,7 @@ public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeabl
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(policy.getId());
         builder.field(SnapshotLifecyclePolicyMetadata.VERSION.getPreferredName(), version);
-        builder.timeField(
+        builder.timestampFieldsFromUnixEpochMillis(
             SnapshotLifecyclePolicyMetadata.MODIFIED_DATE_MILLIS.getPreferredName(),
             SnapshotLifecyclePolicyMetadata.MODIFIED_DATE.getPreferredName(),
             modifiedDate
@@ -169,7 +169,7 @@ public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeabl
         if (lastFailure != null) {
             builder.field(SnapshotLifecyclePolicyMetadata.LAST_FAILURE.getPreferredName(), lastFailure);
         }
-        builder.timeField(
+        builder.timestampFieldsFromUnixEpochMillis(
             SnapshotLifecyclePolicyMetadata.NEXT_EXECUTION_MILLIS.getPreferredName(),
             SnapshotLifecyclePolicyMetadata.NEXT_EXECUTION.getPreferredName(),
             policy.calculateNextExecution(modifiedDate, Clock.systemUTC())
@@ -249,7 +249,7 @@ public class SnapshotLifecyclePolicyItem implements ToXContentFragment, Writeabl
             builder.field(NAME.getPreferredName(), snapshotId.getName());
             builder.field(UUID.getPreferredName(), snapshotId.getUUID());
             builder.field(STATE.getPreferredName(), state);
-            builder.timeField(START_TIME.getPreferredName(), "start_time", startTime);
+            builder.timestampFieldsFromUnixEpochMillis(START_TIME.getPreferredName(), "start_time", startTime);
             if (failure != null) {
                 builder.field(FAILURE.getPreferredName(), failure);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
@@ -192,7 +192,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         builder.field(POLICY.getPreferredName(), policy);
         builder.field(HEADERS.getPreferredName(), headers);
         builder.field(VERSION.getPreferredName(), version);
-        builder.timeField(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), modifiedDate);
+        builder.timestampFieldsFromUnixEpochMillis(MODIFIED_DATE_MILLIS.getPreferredName(), MODIFIED_DATE.getPreferredName(), modifiedDate);
         if (Objects.nonNull(lastSuccess)) {
             builder.field(LAST_SUCCESS.getPreferredName(), lastSuccess);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/cert/CertificateInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/cert/CertificateInfo.java
@@ -134,7 +134,7 @@ public class CertificateInfo implements ToXContentObject, Writeable, Comparable<
             .field("subject_dn", subjectDn)
             .field("serial_number", serialNumber)
             .field("has_private_key", hasPrivateKey)
-            .timeField("expiry", expiry);
+            .timestampField("expiry", expiry);
         if (Strings.hasLength(issuer)) {
             builder.field("issuer", issuer);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointStats.java
@@ -93,14 +93,14 @@ public class TransformCheckpointStats implements Writeable, ToXContentObject {
             builder.field(TransformField.CHECKPOINT_PROGRESS.getPreferredName(), checkpointProgress);
         }
         if (timestampMillis > 0) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 TransformField.TIMESTAMP_MILLIS.getPreferredName(),
                 TransformField.TIMESTAMP.getPreferredName(),
                 timestampMillis
             );
         }
         if (timeUpperBoundMillis > 0) {
-            builder.timeField(
+            builder.timestampFieldsFromUnixEpochMillis(
                 TransformField.TIME_UPPER_BOUND_MILLIS.getPreferredName(),
                 TransformField.TIME_UPPER_BOUND.getPreferredName(),
                 timeUpperBoundMillis

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpointingInfo.java
@@ -217,10 +217,14 @@ public class TransformCheckpointingInfo implements Writeable, ToXContentObject {
             builder.field(OPERATIONS_BEHIND, operationsBehind);
         }
         if (changesLastDetectedAt != null) {
-            builder.timeField(CHANGES_LAST_DETECTED_AT, CHANGES_LAST_DETECTED_AT_HUMAN, changesLastDetectedAt.toEpochMilli());
+            builder.timestampFieldsFromUnixEpochMillis(
+                CHANGES_LAST_DETECTED_AT,
+                CHANGES_LAST_DETECTED_AT_HUMAN,
+                changesLastDetectedAt.toEpochMilli()
+            );
         }
         if (lastSearchTime != null) {
-            builder.timeField(LAST_SEARCH_TIME, LAST_SEARCH_TIME_HUMAN, lastSearchTime.toEpochMilli());
+            builder.timestampFieldsFromUnixEpochMillis(LAST_SEARCH_TIME, LAST_SEARCH_TIME_HUMAN, lastSearchTime.toEpochMilli());
         }
         builder.endObject();
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -450,7 +450,7 @@ public final class TransformConfig implements SimpleDiffable<TransformConfig>, W
                 builder.field(TransformField.VERSION.getPreferredName(), transformVersion);
             }
             if (createTime != null) {
-                builder.timeField(
+                builder.timestampFieldsFromUnixEpochMillis(
                     TransformField.CREATE_TIME.getPreferredName(),
                     TransformField.CREATE_TIME.getPreferredName() + "_string",
                     createTime.toEpochMilli()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealthIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealthIssue.java
@@ -90,7 +90,7 @@ public class TransformHealthIssue implements Writeable, ToXContentObject {
         }
         builder.field(COUNT, count);
         if (firstOccurrence != null) {
-            builder.timeField(FIRST_OCCURRENCE, FIRST_OCCURRENCE_HUMAN_READABLE, firstOccurrence.toEpochMilli());
+            builder.timestampFieldsFromUnixEpochMillis(FIRST_OCCURRENCE, FIRST_OCCURRENCE_HUMAN_READABLE, firstOccurrence.toEpochMilli());
         }
         return builder.endObject();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/QueuedWatch.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/QueuedWatch.java
@@ -71,8 +71,8 @@ public class QueuedWatch implements Writeable, ToXContentObject {
         builder.startObject();
         builder.field("watch_id", watchId);
         builder.field("watch_record_id", watchRecordId);
-        builder.timeField("triggered_time", triggeredTime);
-        builder.timeField("execution_time", executionTime);
+        builder.timestampField("triggered_time", triggeredTime);
+        builder.timestampField("execution_time", executionTime);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionSnapshot.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/execution/WatchExecutionSnapshot.java
@@ -108,8 +108,8 @@ public class WatchExecutionSnapshot implements Writeable, ToXContentObject {
         builder.startObject();
         builder.field("watch_id", watchId);
         builder.field("watch_record_id", watchRecordId);
-        builder.timeField("triggered_time", triggeredTime);
-        builder.timeField("execution_time", executionTime);
+        builder.timestampField("triggered_time", triggeredTime);
+        builder.timestampField("execution_time", executionTime);
         builder.field("execution_phase", phase);
         if (executedActions != null) {
             builder.array("executed_actions", executedActions);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
@@ -169,8 +169,8 @@ public class DriverProfile implements Writeable, ChunkedToXContentObject {
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(ChunkedToXContentHelper.startObject(), Iterators.single((b, p) -> {
-            b.timeField("start_millis", "start", startMillis);
-            b.timeField("stop_millis", "stop", stopMillis);
+            b.timestampFieldsFromUnixEpochMillis("start_millis", "start", startMillis);
+            b.timestampFieldsFromUnixEpochMillis("stop_millis", "stop", stopMillis);
             b.field("took_nanos", tookNanos);
             if (b.humanReadable()) {
                 b.field("took_time", TimeValue.timeValueNanos(tookNanos));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverSleeps.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverSleeps.java
@@ -62,9 +62,9 @@ public record DriverSleeps(Map<String, Long> counts, List<Sleep> first, List<Sle
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field("reason", reason);
-            builder.timeField("sleep_millis", "sleep", sleep);
+            builder.timestampFieldsFromUnixEpochMillis("sleep_millis", "sleep", sleep);
             if (wake > 0) {
-                builder.timeField("wake_millis", "wake", wake);
+                builder.timestampFieldsFromUnixEpochMillis("wake_millis", "wake", wake);
             }
             return builder.endObject();
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/QlStatusResponse.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/QlStatusResponse.java
@@ -121,9 +121,9 @@ public class QlStatusResponse extends ActionResponse implements SearchStatusResp
             builder.field("is_running", isRunning);
             builder.field("is_partial", isPartial);
             if (startTimeMillis != null) { // start time is available only for a running eql search
-                builder.timeField("start_time_in_millis", "start_time", startTimeMillis);
+                builder.timestampFieldsFromUnixEpochMillis("start_time_in_millis", "start_time", startTimeMillis);
             }
-            builder.timeField("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
+            builder.timestampFieldsFromUnixEpochMillis("expiration_time_in_millis", "expiration_time", expirationTimeMillis);
             if (isRunning == false) { // completion status is available only for a completed eql search
                 builder.field("completion_status", completionStatus.getStatus());
             }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/SingleNodeShutdownStatus.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/SingleNodeShutdownStatus.java
@@ -122,7 +122,7 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
                         metadata.getAllocationDelay().getStringRep()
                     );
                 }
-                builder.timeField(
+                builder.timestampFieldsFromUnixEpochMillis(
                     SingleNodeShutdownMetadata.STARTED_AT_MILLIS_FIELD.getPreferredName(),
                     SingleNodeShutdownMetadata.STARTED_AT_READABLE_FIELD,
                     metadata.getStartedAtMillis()
@@ -138,7 +138,7 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
                     builder.field(TARGET_NODE_NAME_FIELD.getPreferredName(), metadata.getTargetNodeName());
                 }
                 if (metadata.getGracePeriod() != null) {
-                    builder.timeField(
+                    builder.timestampField(
                         SingleNodeShutdownMetadata.GRACE_PERIOD_FIELD.getPreferredName(),
                         metadata.getGracePeriod().getStringRep()
                     );

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryItem.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryItem.java
@@ -220,7 +220,7 @@ public class SnapshotHistoryItem implements Writeable, ToXContentObject {
     public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         {
-            builder.timeField(TIMESTAMP.getPreferredName(), "timestamp_string", timestamp);
+            builder.timestampFieldsFromUnixEpochMillis(TIMESTAMP.getPreferredName(), "timestamp_string", timestamp);
             builder.field(POLICY_ID.getPreferredName(), policyId);
             builder.field(REPOSITORY.getPreferredName(), repository);
             builder.field(SNAPSHOT_NAME.getPreferredName(), snapshotName);

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityResponseChunk.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/integrity/RepositoryVerifyIntegrityResponseChunk.java
@@ -158,7 +158,7 @@ public record RepositoryVerifyIntegrityResponseChunk(
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.timeField("timestamp_in_millis", "timestamp", timestampMillis);
+        builder.timestampFieldsFromUnixEpochMillis("timestamp_in_millis", "timestamp", timestampMillis);
 
         if (anomaly() != null) {
             builder.field("anomaly", anomaly());

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/ResultSetTestCase.java
@@ -1350,8 +1350,8 @@ public abstract class ResultSetTestCase extends JdbcIntegrationTestCase {
 
         indexSimpleDocumentWithBooleanValues("1", true, randomLongDate, randomLongDateNanos);
         index("test", "2", builder -> {
-            builder.timeField("test_date", null);
-            builder.timeField("test_date_nanos", null);
+            builder.timestampField("test_date", null);
+            builder.timestampField("test_date_nanos", null);
         });
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/Email.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/Email.java
@@ -141,7 +141,7 @@ public class Email implements ToXContentObject {
         if (priority != null) {
             builder.field(Field.PRIORITY.getPreferredName(), priority.value());
         }
-        builder.timeField(Field.SENT_DATE.getPreferredName(), sentDate);
+        builder.timestampField(Field.SENT_DATE.getPreferredName(), sentDate);
         if (to != null) {
             builder.field(Field.TO.getPreferredName(), to, params);
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Simplify `XContent` output of epoch times (#114491)