### PR TITLE
[8.x] [ML] Ignore unrecognized openai sse fields (#114715)

### DIFF
--- a/docs/changelog/114715.yaml
+++ b/docs/changelog/114715.yaml
@@ -1,0 +1,5 @@
+pr: 114715
+summary: Ignore unrecognized openai sse fields
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Ignore unrecognized openai sse fields (#114715)