### PR TITLE
[8.x] [ML] Send mid-stream errors to users (#114549)

### DIFF
--- a/docs/changelog/114549.yaml
+++ b/docs/changelog/114549.yaml
@@ -1,0 +1,5 @@
+pr: 114549
+summary: Send mid-stream errors to users
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Send mid-stream errors to users (#114549)