### PR TITLE
only return deprecation warning for elser service (#114507)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -151,6 +151,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                                 config,
                                 arch,
                                 serviceSettingsMap,
+                                true,
                                 chunkingSettings,
                                 modelListener
                             )
@@ -182,6 +183,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                             config,
                             arch,
                             serviceSettingsMap,
+                            OLD_ELSER_SERVICE_NAME.equals(serviceName),
                             chunkingSettings,
                             modelListener
                         )
@@ -341,6 +343,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         Map<String, Object> config,
         Set<String> platformArchitectures,
         Map<String, Object> serviceSettingsMap,
+        boolean isElserService,
         ChunkingSettings chunkingSettings,
         ActionListener<Model> modelListener
     ) {
@@ -371,15 +374,17 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             }
         }
 
-        DEPRECATION_LOGGER.warn(
-            DeprecationCategory.API,
-            "inference_api_elser_service",
-            "The [{}] service is deprecated and will be removed in a future release. Use the [{}] service instead, with"
-                + " [model_id] set to [{}] in the [service_settings]",
-            OLD_ELSER_SERVICE_NAME,
-            ElasticsearchInternalService.NAME,
-            defaultModelId
-        );
+        if (isElserService) {
+            DEPRECATION_LOGGER.warn(
+                DeprecationCategory.API,
+                "inference_api_elser_service",
+                "The [{}] service is deprecated and will be removed in a future release. Use the [{}] service instead, with"
+                    + " [model_id] set to [{}] in the [service_settings]",
+                OLD_ELSER_SERVICE_NAME,
+                ElasticsearchInternalService.NAME,
+                defaultModelId
+            );
+        }
 
         if (modelVariantDoesNotMatchArchitecturesAndIsNotPlatformAgnostic(platformArchitectures, esServiceSettingsBuilder.getModelId())) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
Backports the following commits to 8.x:

- only return deprecation warning for elser service (https://github.com/elastic/elasticsearch/pull/114507)