### PR TITLE
[8.x] Add IndicesMetrics instead of IndicesService to toClose (#114782)

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -561,7 +561,7 @@ public class Node implements Closeable {
         toClose.add(() -> stopWatch.stop().start("transport"));
         toClose.add(injector.getInstance(TransportService.class));
         toClose.add(injector.getInstance(NodeMetrics.class));
-        toClose.add(injector.getInstance(IndicesService.class));
+        toClose.add(injector.getInstance(IndicesMetrics.class));
         if (ReadinessService.enabled(environment)) {
             toClose.add(injector.getInstance(ReadinessService.class));
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add IndicesMetrics instead of IndicesService to toClose (#114782)