### PR TITLE
[8.x] ESQL: Add skips to tests that were added retroactively (#114727)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -367,7 +367,7 @@ date1:date               | dd_ms:integer
 2023-12-02T11:00:00.000Z | 1000
 ;
 
-evalDateDiffMonthAsWhole0Months
+evalDateDiffMonthAsWhole0Months#[skip:-8.14.1, reason:omitting millis/timezone not allowed before 8.14]
 
 ROW from=TO_DATETIME("2023-12-31T23:59:59.999Z"), to=TO_DATETIME("2024-01-01T00:00:00")
 | EVAL msecs=DATE_DIFF("milliseconds", from, to), months=DATE_DIFF("month", from, to)
@@ -378,7 +378,7 @@ ROW from=TO_DATETIME("2023-12-31T23:59:59.999Z"), to=TO_DATETIME("2024-01-01T00:
 
 ;
 
-evalDateDiffMonthAsWhole1Month
+evalDateDiffMonthAsWhole1Month#[skip:-8.14.1, reason:omitting millis/timezone not allowed before 8.14]
 
 ROW from=TO_DATETIME("2023-12-31T23:59:59.999Z"), to=TO_DATETIME("2024-02-01T00:00:00")
 | EVAL secs=DATE_DIFF("seconds", from, to), months=DATE_DIFF("month", from, to)

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -135,7 +135,7 @@ null              |Swan             |-8.46                       |-8.46         
 Sanjiv            |Zschoche         |[-7.67, -3.25]              |[-3.25, -7.67]               |[-3, -8]             |10053
 ;
 
-sortingOnSwappedFields
+sortingOnSwappedFields#[skip:-8.13.3, reason:fixed in 8.13]
 FROM employees
 | EVAL name = last_name, last_name = first_name, first_name = name
 | WHERE first_name > "B" AND last_name IS NOT NULL
@@ -157,7 +157,7 @@ Brattka      | Charlene          | Brattka
 Bridgland    | Patricio          | Bridgland
 ;
 
-sortingOnSwappedFieldsNoKeep
+sortingOnSwappedFieldsNoKeep#[skip:-8.13.3, reason:fixed in 8.13]
 // Note that this test requires all fields to be returned in order to test a specific code path in physical planning
 FROM employees
 | EVAL name = first_name, first_name = last_name, last_name = name


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Add skips to tests that were added retroactively (#114727)