### PR TITLE
ESQL: Skip spatial.AirportsSortCityName before 8.13

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -1203,7 +1203,7 @@ count:long | country:k
 1          | Poland
 ;
 
-airportsSortCityName
+airportsSortCityName#[skip:-8.13.3, reason:fixed in 8.13]
 FROM airports
 | SORT abbrev
 | LIMIT 5


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/114767.

TopN didn't work in this scenario on old versions.