### PR TITLE
[8.x] Skip spatial.AirportsSortCityName before 8.13 (#114795)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -1203,7 +1203,7 @@ count:long | country:k
 1          | Poland
 ;
 
-airportsSortCityName
+airportsSortCityName#[skip:-8.13.3, reason:fixed in 8.13]
 FROM airports
 | SORT abbrev
 | LIMIT 5


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Skip spatial.AirportsSortCityName before 8.13 (#114795)