### PR TITLE
[TEST] Fix ccs-unavailable-clusters QA tests build configuration

### DIFF
--- a/qa/ccs-unavailable-clusters/build.gradle
+++ b/qa/ccs-unavailable-clusters/build.gradle
@@ -12,6 +12,6 @@ import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 apply plugin: 'elasticsearch.internal-java-rest-test'
 
 
-tasks.withType(StandaloneRestIntegTestTask) {
+tasks.withType(StandaloneRestIntegTestTask).configureEach  {
   usesDefaultDistribution()
 }


### PR DESCRIPTION
Properly use `configureEach` on the task configuration to postpone the tasks creation and configuration in the build process
