### PR TITLE
Mark Data Stream Lifecycle APIs to stable (#114780)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
       "description":"Deletes the data stream lifecycle of the selected data streams."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams-explain-lifecycle.html",
       "description": "Retrieves information about the index's current data stream lifecycle, such as any potential encountered error, time since creation etc."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html",
       "description":"Returns the data stream lifecycle of the selected data streams."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
       "description":"Updates the data stream lifecycle of the selected data streams."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]


### PR DESCRIPTION
Data Stream Lifecycle has GA'ed in 8.14, so we can safely mark these as stable.

Manual backport of #114780