### PR TITLE
[8.x] Set min number of allocations for ElasticSearchInternalService to 0 (#114829)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
@@ -64,7 +64,7 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         assertThat(
             modelConfig.toString(),
             adaptiveAllocations,
-            Matchers.is(Map.of("enabled", true, "min_number_of_allocations", 1, "max_number_of_allocations", 8))
+            Matchers.is(Map.of("enabled", true, "min_number_of_allocations", 0, "max_number_of_allocations", 8))
         );
     }
 
@@ -99,7 +99,7 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         assertThat(
             modelConfig.toString(),
             adaptiveAllocations,
-            Matchers.is(Map.of("enabled", true, "min_number_of_allocations", 1, "max_number_of_allocations", 8))
+            Matchers.is(Map.of("enabled", true, "min_number_of_allocations", 0, "max_number_of_allocations", 8))
         );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -842,7 +842,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 null,
                 1,
                 useLinuxOptimizedModel ? ELSER_V2_MODEL_LINUX_X86 : ELSER_V2_MODEL,
-                new AdaptiveAllocationsSettings(Boolean.TRUE, 1, 8)
+                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 8)
             ),
             ElserMlNodeTaskSettings.DEFAULT,
             null // default chunking settings
@@ -855,7 +855,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 null,
                 1,
                 useLinuxOptimizedModel ? MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86 : MULTILINGUAL_E5_SMALL_MODEL_ID,
-                new AdaptiveAllocationsSettings(Boolean.TRUE, 1, 8)
+                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 8)
             ),
             null // default chunking settings
         );


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Set min number of allocations for ElasticSearchInternalService to 0 (#114829)