### PR TITLE
Fixing randomization issue in random rank retriever yaml tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -80,9 +80,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
   method: testSnapshotRestore {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111799
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/80_random_rerank_retriever/Random rerank retriever predictably shuffles results}
-  issue: https://github.com/elastic/elasticsearch/issues/111999
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/112147
 - class: org.elasticsearch.smoketest.WatcherYamlRestIT

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/80_random_rerank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/80_random_rerank_retriever.yml
@@ -8,6 +8,8 @@ setup:
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               text:


### PR DESCRIPTION
It seems that the expected scores specified in the yaml test match when we have only 1 shard. If due to randomization we may end up with  more than one shards (e.g. when using ` -Dtests.seed=1449F1BCAD7A1D83`) then the scores differ and the test fails.  So, in this PR we just ensure that we have only 1 shard in all cases. 

Closes https://github.com/elastic/elasticsearch/issues/111999