### PR TITLE
Add refresh .security index call between security migrations

### DIFF
--- a/docs/changelog/114879.yaml
+++ b/docs/changelog/114879.yaml
@@ -1,0 +1,5 @@
+pr: 114879
+summary: Add refresh `.security` index call between security migrations
+area: Security
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutor.java
@@ -68,7 +68,15 @@ public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityM
             return;
         }
 
-        applyOutstandingMigrations(task, params.getMigrationVersion(), listener);
+        refreshSecurityIndex(
+            new ThreadedActionListener<>(
+                this.getExecutor(),
+                ActionListener.wrap(
+                    refreshResponse -> applyOutstandingMigrations(task, params.getMigrationVersion(), listener),
+                    listener::onFailure
+                )
+            )
+        );
     }
 
     private void applyOutstandingMigrations(AllocatedPersistentTask task, int currentMigrationVersion, ActionListener<Void> listener) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutor.java
@@ -72,7 +72,7 @@ public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityM
         refreshSecurityIndex(
             new ThreadedActionListener<>(
                 this.getExecutor(),
-                listener.delegateFailureAndWrap((l, response) -> applyOutstandingMigrations(task, params.getMigrationVersion(), l))
+                listener.delegateFailureIgnoreResponseAndWrap(l -> applyOutstandingMigrations(task, params.getMigrationVersion(), l))
             )
         );
     }
@@ -94,18 +94,18 @@ public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityM
                 .migrate(
                     securityIndexManager,
                     client,
-                    migrationsListener.delegateFailureAndWrap(
-                        (updateVersionListener, response) -> updateMigrationVersion(
+                    migrationsListener.delegateFailureIgnoreResponseAndWrap(
+                        updateVersionListener -> updateMigrationVersion(
                             migrationEntry.getKey(),
                             securityIndexManager.getConcreteIndexName(),
                             new ThreadedActionListener<>(
                                 this.getExecutor(),
-                                updateVersionListener.delegateFailureAndWrap((refreshListener, updateResponse) -> {
+                                updateVersionListener.delegateFailureIgnoreResponseAndWrap(refreshListener -> {
                                     refreshSecurityIndex(
                                         new ThreadedActionListener<>(
                                             this.getExecutor(),
-                                            refreshListener.delegateFailureAndWrap(
-                                                (l, refreshResponse) -> applyOutstandingMigrations(task, migrationEntry.getKey(), l)
+                                            refreshListener.delegateFailureIgnoreResponseAndWrap(
+                                                l -> applyOutstandingMigrations(task, migrationEntry.getKey(), l)
                                             )
                                         )
                                     );
@@ -143,7 +143,7 @@ public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityM
         client.execute(
             UpdateIndexMigrationVersionAction.INSTANCE,
             new UpdateIndexMigrationVersionAction.Request(TimeValue.MAX_VALUE, migrationVersion, indexName),
-            listener.delegateFailureAndWrap((l, response) -> l.onResponse(null))
+            listener.delegateFailureIgnoreResponseAndWrap(l -> l.onResponse(null))
         );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutor.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.security.support;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.core.TimeValue;
@@ -23,6 +25,9 @@ import org.elasticsearch.xpack.core.security.support.SecurityMigrationTaskParams
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
+
+import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityMigrationTaskParams> {
 
@@ -83,13 +88,17 @@ public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityM
                         response -> updateMigrationVersion(
                             migrationEntry.getKey(),
                             securityIndexManager.getConcreteIndexName(),
-                            new ThreadedActionListener<>(
-                                this.getExecutor(),
-                                ActionListener.wrap(
-                                    updateResponse -> applyOutstandingMigrations(task, migrationEntry.getKey(), listener),
-                                    listener::onFailure
-                                )
-                            )
+                            new ThreadedActionListener<>(this.getExecutor(), ActionListener.wrap(updateResponse -> {
+                                refreshSecurityIndex(
+                                    new ThreadedActionListener<>(
+                                        this.getExecutor(),
+                                        ActionListener.wrap(
+                                            refreshResponse -> applyOutstandingMigrations(task, migrationEntry.getKey(), listener),
+                                            listener::onFailure
+                                        )
+                                    )
+                                );
+                            }, listener::onFailure))
                         ),
                         listener::onFailure
                     )
@@ -98,6 +107,21 @@ public class SecurityMigrationExecutor extends PersistentTasksExecutor<SecurityM
             logger.info("Security migrations applied until version: [" + currentMigrationVersion + "]");
             listener.onResponse(null);
         }
+    }
+
+    /**
+     * Refresh security index to make sure that docs that were migrated are visible to the next migration and to prevent version conflicts
+     * or unexpected behaviour by APIs relying on migrated docs.
+     */
+    private void refreshSecurityIndex(ActionListener<Void> listener) {
+        RefreshRequest refreshRequest = new RefreshRequest(securityIndexManager.getConcreteIndexName());
+        executeAsyncWithOrigin(
+            client,
+            SECURITY_ORIGIN,
+            RefreshAction.INSTANCE,
+            refreshRequest,
+            ActionListener.wrap(response -> listener.onResponse(null), listener::onFailure)
+        );
     }
 
     private void updateMigrationVersion(int migrationVersion, String indexName, ActionListener<Void> listener) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityMigrationExecutorTests.java
@@ -98,7 +98,7 @@ public class SecurityMigrationExecutorTests extends ESTestCase {
         verify(mockTask, times(1)).markAsCompleted();
         verify(mockTask, times(0)).markAsFailed(any());
         assertEquals(2, updateIndexMigrationVersionActionInvocations);
-        assertEquals(2, refreshActionInvocations);
+        assertEquals(3, refreshActionInvocations);
         assertEquals(2, migrateInvocations[0]);
     }
 
@@ -125,7 +125,7 @@ public class SecurityMigrationExecutorTests extends ESTestCase {
         verify(mockTask, times(1)).markAsCompleted();
         verify(mockTask, times(0)).markAsFailed(any());
         assertEquals(0, updateIndexMigrationVersionActionInvocations);
-        assertEquals(0, refreshActionInvocations);
+        assertEquals(1, refreshActionInvocations);
         assertEquals(0, migrateInvocationsCounter[0]);
     }
 
@@ -155,7 +155,7 @@ public class SecurityMigrationExecutorTests extends ESTestCase {
         securityMigrationExecutor.nodeOperation(mockTask, new SecurityMigrationTaskParams(0, true), mock(PersistentTaskState.class));
         verify(mockTask, times(1)).markAsCompleted();
         verify(mockTask, times(0)).markAsFailed(any());
-        assertEquals(2, refreshActionInvocations);
+        assertEquals(3, refreshActionInvocations);
         assertEquals(2, updateIndexMigrationVersionActionInvocations);
         assertEquals(2, migrateInvocations[0]);
     }
@@ -174,7 +174,7 @@ public class SecurityMigrationExecutorTests extends ESTestCase {
         verify(mockTask, times(1)).markAsCompleted();
         verify(mockTask, times(0)).markAsFailed(any());
         assertEquals(0, updateIndexMigrationVersionActionInvocations);
-        assertEquals(0, refreshActionInvocations);
+        assertEquals(1, refreshActionInvocations);
         assertEquals(0, migrateInvocations[0]);
     }
 
@@ -203,14 +203,13 @@ public class SecurityMigrationExecutorTests extends ESTestCase {
             }))
         );
 
-        assertThrows(
-            IllegalStateException.class,
-            () -> securityMigrationExecutor.nodeOperation(
+        securityMigrationExecutor.nodeOperation(
                 mockTask,
                 new SecurityMigrationTaskParams(0, true),
                 mock(PersistentTaskState.class)
-            )
-        );
+            );
+        verify(mockTask, times(1)).markAsFailed(any());
+        verify(mockTask, times(0)).markAsCompleted();
     }
 
     public void testUpdateMigrationVersionThrowsException() {


### PR DESCRIPTION
This PR addresses this issue: https://github.com/elastic/elasticsearch/issues/110562

We're now adding more security migrations so we need to make sure that the framework handles migrations that depend on each other properly. 

As part of that work we need to make sure that any subsequent migrations following a migration doesn't experience docs version conflicts, outdated docs or that APIs relying on migrated docs temporarily return the wrong results. 

The security index currently relies on the `index.refresh_interval` (defaults to 1s in stateful and 5s in stateless). See this PR: https://github.com/elastic/elasticsearch/pull/97815

This adds an explicit refresh before any migrations run and between migrations to make sure the index is refreshed when a migration starts. 