### PR TITLE
[8.x] ESQL: adapt to new range in ToDatetimeTests (#114605)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
@@ -134,9 +134,9 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
             "ToDatetimeFromStringEvaluator[field=" + read + "]",
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
-                    "<date string before 0001-01-01T00:00:00.000Z>",
-                    // millis before "0001-01-01T00:00:00.000Z"
-                    () -> new BytesRef(randomDateString(Long.MIN_VALUE, -62135596800001L)),
+                    "<date string before -9999-12-31T23:59:59.999Z>",
+                    // millis before "-9999-12-31T23:59:59.999Z"
+                    () -> new BytesRef(randomDateString(Long.MIN_VALUE, -377736739200000L)),
                     DataType.KEYWORD
                 )
             ),
@@ -154,8 +154,8 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
             "ToDatetimeFromStringEvaluator[field=" + read + "]",
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
-                    "<date string before 0001-01-01T00:00:00.000Z>",
-                    // millis before "0001-01-01T00:00:00.000Z"
+                    "<date string after 9999-12-31T23:59:59.999Z>",
+                    // millis after "9999-12-31T23:59:59.999Z"
                     () -> new BytesRef(randomDateString(253402300800000L, Long.MAX_VALUE)),
                     DataType.KEYWORD
                 )


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: adapt to new range in ToDatetimeTests (#114605)