### PR TITLE
[8.x] Reset array scope tracking for nested objects (#114891)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -351,48 +351,79 @@ tests:
 - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
   method: testPutE5WithTrainedModelAndInference
   issue: https://github.com/elastic/elasticsearch/issues/114023
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/40_synthetic_source/enrich documents over _bulk}
-  issue: https://github.com/elastic/elasticsearch/issues/114825
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/70_dense_vector_telemetry/Field mapping stats}
-  issue: https://github.com/elastic/elasticsearch/issues/114556
-- class: org.elasticsearch.threadpool.SimpleThreadPoolIT
-  method: testThreadPoolMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/108320
-- class: org.elasticsearch.xpack.eql.EqlRestValidationIT
-  method: testDefaultIndicesOptions
-  issue: https://github.com/elastic/elasticsearch/issues/114771
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/10_basic/Test enrich crud apis}
-  issue: https://github.com/elastic/elasticsearch/issues/114766
-- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
-  method: testPutE5Small_withPlatformAgnosticVariant
-  issue: https://github.com/elastic/elasticsearch/issues/113983
-- class: org.elasticsearch.xpack.eql.EqlRestIT
-  method: testIndexWildcardPatterns
-  issue: https://github.com/elastic/elasticsearch/issues/114749
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/20_standard_index/enrich stats REST response structure}
-  issue: https://github.com/elastic/elasticsearch/issues/114753
-- class: org.elasticsearch.ingest.geoip.DatabaseNodeServiceIT
-  method: testGzippedDatabase
-  issue: https://github.com/elastic/elasticsearch/issues/113752
+- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
+  method: test {yaml=reference/rest-api/usage/line_38}
+  issue: https://github.com/elastic/elasticsearch/issues/113694
 - class: org.elasticsearch.xpack.enrich.EnrichRestIT
   method: test {p0=enrich/10_basic/Test using the deprecated elasticsearch_version field results in a warning}
   issue: https://github.com/elastic/elasticsearch/issues/114748
+- class: org.elasticsearch.xpack.eql.EqlRestIT
+  method: testIndexWildcardPatterns
+  issue: https://github.com/elastic/elasticsearch/issues/114749
+- class: org.elasticsearch.xpack.eql.EqlRestIT
+  method: testBadRequests
+  issue: https://github.com/elastic/elasticsearch/issues/114752
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/20_standard_index/enrich stats REST response structure}
+  issue: https://github.com/elastic/elasticsearch/issues/114753
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/30_tsdb_index/enrich documents over _bulk}
+  issue: https://github.com/elastic/elasticsearch/issues/114761
 - class: org.elasticsearch.xpack.enrich.EnrichRestIT
   method: test {p0=enrich/20_standard_index/enrich documents over _bulk via an alias}
   issue: https://github.com/elastic/elasticsearch/issues/114763
-- class: org.elasticsearch.xpack.eql.EqlRestValidationIT
-  method: testAllowNoIndicesOption
-  issue: https://github.com/elastic/elasticsearch/issues/114789
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/10_basic/Test enrich crud apis}
+  issue: https://github.com/elastic/elasticsearch/issues/114766
 - class: org.elasticsearch.xpack.enrich.EnrichRestIT
   method: test {p0=enrich/20_standard_index/enrich documents over _bulk}
   issue: https://github.com/elastic/elasticsearch/issues/114768
-- class: org.elasticsearch.datastreams.LazyRolloverDuringDisruptionIT
-  method: testRolloverIsExecutedOnce
-  issue: https://github.com/elastic/elasticsearch/issues/112634
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/50_data_stream/enrich documents over _bulk via a data stream}
+  issue: https://github.com/elastic/elasticsearch/issues/114769
+- class: org.elasticsearch.xpack.eql.EqlRestValidationIT
+  method: testDefaultIndicesOptions
+  issue: https://github.com/elastic/elasticsearch/issues/114771
+- class: org.elasticsearch.xpack.enrich.EnrichIT
+  method: testEnrichSpecialTypes
+  issue: https://github.com/elastic/elasticsearch/issues/114773
+- class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
+  method: testEveryActionIsEitherOperatorOnlyOrNonOperator
+  issue: https://github.com/elastic/elasticsearch/issues/102992
+- class: org.elasticsearch.xpack.enrich.EnrichIT
+  method: testDeleteExistingPipeline
+  issue: https://github.com/elastic/elasticsearch/issues/114775
+- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
+  method: testNoStream
+  issue: https://github.com/elastic/elasticsearch/issues/114788
+- class: org.elasticsearch.xpack.eql.EqlRestValidationIT
+  method: testAllowNoIndicesOption
+  issue: https://github.com/elastic/elasticsearch/issues/114789
+- class: org.elasticsearch.xpack.eql.EqlStatsIT
+  method: testEqlRestUsage
+  issue: https://github.com/elastic/elasticsearch/issues/114790
+- class: org.elasticsearch.xpack.eql.EqlRestIT
+  method: testUnicodeChars
+  issue: https://github.com/elastic/elasticsearch/issues/114791
+- class: org.elasticsearch.ingest.geoip.HttpClientTests
+  issue: https://github.com/elastic/elasticsearch/issues/112618
+- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
+  method: testTracingCrossCluster
+  issue: https://github.com/elastic/elasticsearch/issues/112731
+- class: org.elasticsearch.xpack.enrich.EnrichIT
+  method: testImmutablePolicy
+  issue: https://github.com/elastic/elasticsearch/issues/114839
+- class: org.elasticsearch.license.LicensingTests
+  issue: https://github.com/elastic/elasticsearch/issues/114865
+- class: org.elasticsearch.xpack.enrich.EnrichIT
+  method: testDeleteIsCaseSensitive
+  issue: https://github.com/elastic/elasticsearch/issues/114840
+- class: org.elasticsearch.packaging.test.EnrollmentProcessTests
+  method: test20DockerAutoFormCluster
+  issue: https://github.com/elastic/elasticsearch/issues/114885
+- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+  method: test {yaml=cluster.stats/30_ccs_stats/cross-cluster search stats search}
+  issue: https://github.com/elastic/elasticsearch/issues/114902
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,6 +342,7 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testMinimumVersionShardDuringPhaseExecution
   issue: https://github.com/elastic/elasticsearch/issues/114611
+
 - class: org.elasticsearch.kibana.KibanaThreadPoolIT
   method: testBlockedThreadPoolsRejectUserRequests
   issue: https://github.com/elastic/elasticsearch/issues/113939
@@ -351,79 +352,48 @@ tests:
 - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
   method: testPutE5WithTrainedModelAndInference
   issue: https://github.com/elastic/elasticsearch/issues/114023
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/rest-api/usage/line_38}
-  issue: https://github.com/elastic/elasticsearch/issues/113694
 - class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/10_basic/Test using the deprecated elasticsearch_version field results in a warning}
-  issue: https://github.com/elastic/elasticsearch/issues/114748
-- class: org.elasticsearch.xpack.eql.EqlRestIT
-  method: testIndexWildcardPatterns
-  issue: https://github.com/elastic/elasticsearch/issues/114749
-- class: org.elasticsearch.xpack.eql.EqlRestIT
-  method: testBadRequests
-  issue: https://github.com/elastic/elasticsearch/issues/114752
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/20_standard_index/enrich stats REST response structure}
-  issue: https://github.com/elastic/elasticsearch/issues/114753
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/30_tsdb_index/enrich documents over _bulk}
-  issue: https://github.com/elastic/elasticsearch/issues/114761
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/20_standard_index/enrich documents over _bulk via an alias}
-  issue: https://github.com/elastic/elasticsearch/issues/114763
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/10_basic/Test enrich crud apis}
-  issue: https://github.com/elastic/elasticsearch/issues/114766
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/20_standard_index/enrich documents over _bulk}
-  issue: https://github.com/elastic/elasticsearch/issues/114768
-- class: org.elasticsearch.xpack.enrich.EnrichRestIT
-  method: test {p0=enrich/50_data_stream/enrich documents over _bulk via a data stream}
-  issue: https://github.com/elastic/elasticsearch/issues/114769
+  method: test {p0=enrich/40_synthetic_source/enrich documents over _bulk}
+  issue: https://github.com/elastic/elasticsearch/issues/114825
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search.vectors/70_dense_vector_telemetry/Field mapping stats}
+  issue: https://github.com/elastic/elasticsearch/issues/114556
+- class: org.elasticsearch.threadpool.SimpleThreadPoolIT
+  method: testThreadPoolMetrics
+  issue: https://github.com/elastic/elasticsearch/issues/108320
 - class: org.elasticsearch.xpack.eql.EqlRestValidationIT
   method: testDefaultIndicesOptions
   issue: https://github.com/elastic/elasticsearch/issues/114771
-- class: org.elasticsearch.xpack.enrich.EnrichIT
-  method: testEnrichSpecialTypes
-  issue: https://github.com/elastic/elasticsearch/issues/114773
-- class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
-  method: testEveryActionIsEitherOperatorOnlyOrNonOperator
-  issue: https://github.com/elastic/elasticsearch/issues/102992
-- class: org.elasticsearch.xpack.enrich.EnrichIT
-  method: testDeleteExistingPipeline
-  issue: https://github.com/elastic/elasticsearch/issues/114775
-- class: org.elasticsearch.xpack.inference.rest.ServerSentEventsRestActionListenerTests
-  method: testNoStream
-  issue: https://github.com/elastic/elasticsearch/issues/114788
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/10_basic/Test enrich crud apis}
+  issue: https://github.com/elastic/elasticsearch/issues/114766
+- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+  method: testPutE5Small_withPlatformAgnosticVariant
+  issue: https://github.com/elastic/elasticsearch/issues/113983
+- class: org.elasticsearch.xpack.eql.EqlRestIT
+  method: testIndexWildcardPatterns
+  issue: https://github.com/elastic/elasticsearch/issues/114749
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/20_standard_index/enrich stats REST response structure}
+  issue: https://github.com/elastic/elasticsearch/issues/114753
+- class: org.elasticsearch.ingest.geoip.DatabaseNodeServiceIT
+  method: testGzippedDatabase
+  issue: https://github.com/elastic/elasticsearch/issues/113752
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/10_basic/Test using the deprecated elasticsearch_version field results in a warning}
+  issue: https://github.com/elastic/elasticsearch/issues/114748
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/20_standard_index/enrich documents over _bulk via an alias}
+  issue: https://github.com/elastic/elasticsearch/issues/114763
 - class: org.elasticsearch.xpack.eql.EqlRestValidationIT
   method: testAllowNoIndicesOption
   issue: https://github.com/elastic/elasticsearch/issues/114789
-- class: org.elasticsearch.xpack.eql.EqlStatsIT
-  method: testEqlRestUsage
-  issue: https://github.com/elastic/elasticsearch/issues/114790
-- class: org.elasticsearch.xpack.eql.EqlRestIT
-  method: testUnicodeChars
-  issue: https://github.com/elastic/elasticsearch/issues/114791
-- class: org.elasticsearch.ingest.geoip.HttpClientTests
-  issue: https://github.com/elastic/elasticsearch/issues/112618
-- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-  method: testTracingCrossCluster
-  issue: https://github.com/elastic/elasticsearch/issues/112731
-- class: org.elasticsearch.xpack.enrich.EnrichIT
-  method: testImmutablePolicy
-  issue: https://github.com/elastic/elasticsearch/issues/114839
-- class: org.elasticsearch.license.LicensingTests
-  issue: https://github.com/elastic/elasticsearch/issues/114865
-- class: org.elasticsearch.xpack.enrich.EnrichIT
-  method: testDeleteIsCaseSensitive
-  issue: https://github.com/elastic/elasticsearch/issues/114840
-- class: org.elasticsearch.packaging.test.EnrollmentProcessTests
-  method: test20DockerAutoFormCluster
-  issue: https://github.com/elastic/elasticsearch/issues/114885
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=cluster.stats/30_ccs_stats/cross-cluster search stats search}
-  issue: https://github.com/elastic/elasticsearch/issues/114902
+- class: org.elasticsearch.xpack.enrich.EnrichRestIT
+  method: test {p0=enrich/20_standard_index/enrich documents over _bulk}
+  issue: https://github.com/elastic/elasticsearch/issues/114768
+- class: org.elasticsearch.datastreams.LazyRolloverDuringDisruptionIT
+  method: testRolloverIsExecutedOnce
+  issue: https://github.com/elastic/elasticsearch/issues/112634
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,7 +342,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testMinimumVersionShardDuringPhaseExecution
   issue: https://github.com/elastic/elasticsearch/issues/114611
-
 - class: org.elasticsearch.kibana.KibanaThreadPoolIT
   method: testBlockedThreadPoolsRejectUserRequests
   issue: https://github.com/elastic/elasticsearch/issues/113939

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -932,6 +932,36 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
             {"path":{"id":0.1,"to":{"id":[1,20,3,10]}}}""", syntheticSource);
     }
 
+    public void testArrayWithNestedObjects() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").startObject("properties");
+            {
+                b.startObject("to").field("type", "nested").startObject("properties");
+                {
+                    b.startObject("id").field("type", "integer").field("synthetic_source_keep", "arrays").endObject();
+                }
+                b.endObject().endObject();
+            }
+            b.endObject().endObject();
+        })).documentMapper();
+
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject().startArray("to");
+                {
+                    b.startObject().array("id", 1, 20, 3).endObject();
+                    b.startObject().field("id", 10).endObject();
+                }
+                b.endArray().endObject();
+                b.startObject().startObject("to").field("id", "0.1").endObject().endObject();
+            }
+            b.endArray();
+        });
+        assertEquals("""
+            {"path":{"to":[{"id":[1,20,3]},{"id":10},{"id":0}]}}""", syntheticSource);
+    }
+
     public void testArrayWithinArray() throws IOException {
         DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
             b.startObject("path");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Reset array scope tracking for nested objects (#114891)](https://github.com/elastic/elasticsearch/pull/114891)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)