### PR TITLE
(Doc+) link video for resolving shards too large

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -208,6 +208,8 @@ index can be <<indices-delete-index,removed>>. You may then consider setting
 <<indices-add-alias,Create Alias>> against the destination index for the source 
 index's name to point to it for continuity. 
 
+See link:https://www.youtube.com/watch?v=sHyNYnwbYro[this video] for example
+troubleshooting walkthrough.
 
 [discrete]
 [[shard-count-recommendation]]

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -209,7 +209,6 @@ index can be <<indices-delete-index,removed>>. You may then consider setting
 index's name to point to it for continuity. 
 
 See this https://www.youtube.com/watch?v=sHyNYnwbYro[fixing shard sizes video] for an example troubleshooting walkthrough.
-troubleshooting walkthrough.
 
 [discrete]
 [[shard-count-recommendation]]

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -208,7 +208,7 @@ index can be <<indices-delete-index,removed>>. You may then consider setting
 <<indices-add-alias,Create Alias>> against the destination index for the source 
 index's name to point to it for continuity. 
 
-See link:https://www.youtube.com/watch?v=sHyNYnwbYro[this video] for example
+See this https://www.youtube.com/watch?v=sHyNYnwbYro[fixing shard sizes video] for an example troubleshooting walkthrough.
 troubleshooting walkthrough.
 
 [discrete]


### PR DESCRIPTION
👋 howdy, team (cc: @anniegale9538 )!  Playing forward https://github.com/elastic/elasticsearch/pull/111254, [this video](https://www.youtube.com/watch?v=sHyNYnwbYro) demonstrates an example resolving shards too large via reindex under [this section](https://www.elastic.co/guide/en/elasticsearch/reference/master/size-your-shards.html#shard-size-recommendation) as it's a top support ask.
