### PR TITLE
Document _cat/indices behavior when encountering source only indices

### DIFF
--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -6,8 +6,8 @@
 
 [IMPORTANT]
 ====
-cat APIs are only intended for human consumption using the command line or {kib} 
-console. They are _not_ intended for use by applications. For application 
+cat APIs are only intended for human consumption using the command line or {kib}
+console. They are _not_ intended for use by applications. For application
 consumption, use the <<indices-get-index,get index API>>.
 ====
 
@@ -49,6 +49,10 @@ indexing and search. As a result, all document counts include hidden
 
 To get an accurate count of {es} documents, use the <<cat-count,cat count>> or
 <<search-count,count>> APIs.
+
+Note that information such as document count, deleted document count and store size are not shown for
+indices restored from <<snapshots-source-only-repository,source-only snapshots>> since these indices
+do not contain the relevant data structures to retrieve this information from.
 
 
 [[cat-indices-api-path-params]]

--- a/docs/reference/snapshot-restore/repository-source-only.asciidoc
+++ b/docs/reference/snapshot-restore/repository-source-only.asciidoc
@@ -27,6 +27,9 @@ As a result, indices adopting synthetic source cannot be restored. When you rest
  * The mapping of the restored index is empty, but the original mapping is available from the types top
    level `meta` element.
 
+ * Information such as document count, deleted document count and store size are not available for such indices
+   since these indices do not contain the relevant data structures to retrieve this information from. Therefore,
+   this information is not shown for such indices in APIs such as the <<cat-indices,cat indices API>>.
 ==================================================
 
 Before registering a source-only repository, use {kib} or the


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/114884