### PR TITLE
Split out FailedToCommitClusterStateException from watched file error reporting for file-based settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ testfixtures_shared/
 # Generated
 checkstyle_ide.xml
 x-pack/plugin/esql/src/main/generated-src/generated/
+x-pack/plugin/esql/gen

--- a/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java
@@ -297,9 +297,9 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
                 listener.watchedFileChanged();
             }
         } catch (NoChangeOccurredException e) {
-            logger.info("Unable to process watched file: {}", watchedFile(), e);
+            logger.info(() -> "Unable to process watched file: " + watchedFile(), e);
         } catch (IOException | ExecutionException e) {
-            logger.error("Error processing watched file: {}", watchedFile(), e);
+            logger.error(() -> "Error processing watched file: " + watchedFile(), e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java
@@ -296,8 +296,10 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
             for (var listener : eventListeners) {
                 listener.watchedFileChanged();
             }
+        } catch (NoChangeOccurredException e) {
+            logger.info("Unable to process watched file: {}", watchedFile(), e);
         } catch (IOException | ExecutionException e) {
-            logger.error(() -> "Error processing watched file: " + watchedFile(), e);
+            logger.error("Error processing watched file: {}", watchedFile(), e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/file/NoChangeOccurredException.java
+++ b/server/src/main/java/org/elasticsearch/common/file/NoChangeOccurredException.java
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 package org.elasticsearch.common.file;

--- a/server/src/main/java/org/elasticsearch/common/file/NoChangeOccurredException.java
+++ b/server/src/main/java/org/elasticsearch/common/file/NoChangeOccurredException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.file;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Indicates that {@link AbstractFileWatchingService#processFileChanges()} had no effect,
+ * and listeners should not be notified because there's nothing for them to do.
+ */
+public class NoChangeOccurredException extends ExecutionException {
+    public NoChangeOccurredException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
`processSettingsAndNotifyListeners` is something of a blunt instrument when it comes to error handling: `processFileChanges` is [required to throw](https://github.com/elastic/elasticsearch/blob/f6a1e36d6be56a5d480765ad2d5f72f4adcaef5b/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java#L73) `ExecutionException` "_if there is an issue while applying the changes from the file_", and in response, `processSettingsAndNotifyListeners` [logs an "Error processing watched file"](https://github.com/elastic/elasticsearch/blob/f6a1e36d6be56a5d480765ad2d5f72f4adcaef5b/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java#L300) error and continues.

In ES-9360 we've found that this one catch-all error message is not specific enough to determine the appropriate alert severity, and so we'd like a way to opt out of the catch-all error message. @thecoop and I discussed some options, and this was the simplest, so I thought I'd start with that. It peels of a subclass of `ExecutionException` to represent the case that we want to opt out of the error reporting.

This PR is something of a "request for comments": it's a minimal change that achieves the opting out, but I find it hard to tell whether the resulting method contracts are coherent and understandable.