### PR TITLE
Re-enable incremental bulk tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -259,12 +259,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.AvgTests
   method: "testFold {TestCase=<double> #7}"
   issue: https://github.com/elastic/elasticsearch/issues/114175
-- class: org.elasticsearch.action.bulk.IncrementalBulkIT
-  method: testMultipleBulkPartsWithBackoff
-  issue: https://github.com/elastic/elasticsearch/issues/114181
-- class: org.elasticsearch.action.bulk.IncrementalBulkIT
-  method: testIncrementalBulkLowWatermarkBackOff
-  issue: https://github.com/elastic/elasticsearch/issues/114182
 - class: org.elasticsearch.xpack.ilm.ExplainLifecycleIT
   method: testStepInfoPreservedOnAutoRetry
   issue: https://github.com/elastic/elasticsearch/issues/114220


### PR DESCRIPTION
These tests should be fixed and can be unmuted. The associated github
issues have already been closed.

Related:
#114182
#114181
#114073