### PR TITLE
Reducing error-level stack trace logging for normal events in GeoIpDownloader

### DIFF
--- a/docs/changelog/114924.yaml
+++ b/docs/changelog/114924.yaml
@@ -1,0 +1,5 @@
+pr: 114924
+summary: Reducing error-level stack trace logging for normal events in `GeoIpDownloader`
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
We currently log an exception stack trace whenever the geoip downloader runs when the `.geoip_databases` index has unallocated shards or a write block. These are normal situations, and the downloader recovers whenever they are corrected. For example, every time I start up a cluster I'm seeing a stack trace from the downloader because it attempts to run before all shards are not allocated yet. Having "normal" error-level stack traces in the logs at startup will cause users to start ignoring real error messages. This PR changes them to debug-level log messages, but the behavior remains unchanged -- the downloader just tries again later.
Here's an example stack traces from the logs:
```
[2024-10-15T16:24:39,981][ERROR][o.e.i.g.GeoIpDownloader  ] [keiths-mbp.lan] exception during geoip databases updateorg.elasticsearch.ElasticsearchException: not all primary shards of [.geoip_databases] index are active
	at org.elasticsearch.ingest.geoip@9.0.0-SNAPSHOT/org.elasticsearch.ingest.geoip.GeoIpDownloader.updateDatabases(GeoIpDownloader.java:142)
	at org.elasticsearch.ingest.geoip@9.0.0-SNAPSHOT/org.elasticsearch.ingest.geoip.GeoIpDownloader.runDownloader(GeoIpDownloader.java:294)
	at org.elasticsearch.ingest.geoip@9.0.0-SNAPSHOT/org.elasticsearch.ingest.geoip.GeoIpDownloaderTaskExecutor.nodeOperation(GeoIpDownloaderTaskExecutor.java:165)
	at org.elasticsearch.ingest.geoip@9.0.0-SNAPSHOT/org.elasticsearch.ingest.geoip.GeoIpDownloaderTaskExecutor.nodeOperation(GeoIpDownloaderTaskExecutor.java:64)
	at org.elasticsearch.server@9.0.0-SNAPSHOT/org.elasticsearch.persistent.NodePersistentTasksExecutor$1.doRun(NodePersistentTasksExecutor.java:35)
```
This exception logging was originally added in #86842.