### PR TITLE
[8.16] Introduce `index.mapping.source.mode` setting to override `_source.mode` (#114433)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -163,7 +163,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING,
         MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING,
         MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING,
-        MapperService.INDEX_MAPPER_DYNAMIC_SETTING,
         BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING,
         IndexModule.INDEX_STORE_TYPE_SETTING,
         IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
@@ -188,7 +187,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         FieldMapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING,
         IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_WRITE_SETTING,
         IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_READ_SETTING,
-        IndexSettings.SYNTHETIC_SOURCE_SECOND_DOC_PARSING_PASS_SETTING,
         SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING,
 
         // validate that built-in similarities don't get redefined

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING;
@@ -520,19 +519,17 @@ public final class IndexSettings {
         Property.IndexScope
     );
 
-    public static final Setting<String> DEFAULT_PIPELINE = new Setting<>(
+    public static final Setting<String> DEFAULT_PIPELINE = Setting.simpleString(
         "index.default_pipeline",
         IngestService.NOOP_PIPELINE_NAME,
-        Function.identity(),
         Property.Dynamic,
         Property.IndexScope,
         Property.ServerlessPublic
     );
 
-    public static final Setting<String> FINAL_PIPELINE = new Setting<>(
+    public static final Setting<String> FINAL_PIPELINE = Setting.simpleString(
         "index.final_pipeline",
         IngestService.NOOP_PIPELINE_NAME,
-        Function.identity(),
         Property.Dynamic,
         Property.IndexScope,
         Property.ServerlessPublic
@@ -655,13 +652,6 @@ public final class IndexSettings {
         Property.Final
     );
 
-    public static final Setting<Boolean> SYNTHETIC_SOURCE_SECOND_DOC_PARSING_PASS_SETTING = Setting.boolSetting(
-        "index.synthetic_source.enable_second_doc_parsing_pass",
-        true,
-        Property.IndexScope,
-        Property.Dynamic
-    );
-
     /**
      * Returns <code>true</code> if TSDB encoding is enabled. The default is <code>true</code>
      */
@@ -712,7 +702,7 @@ public final class IndexSettings {
     /**
      * The `index.mapping.ignore_above` setting defines the maximum length for the content of a field that will be indexed
      * or stored. If the length of the field’s content exceeds this limit, the field value will be ignored during indexing.
-     * This setting is  useful for `keyword`, `flattened`, and `wildcard` fields where very large values are undesirable.
+     * This setting is useful for `keyword`, `flattened`, and `wildcard` fields where very large values are undesirable.
      * It allows users to manage the size of indexed data by skipping fields with excessively long content. As an index-level
      * setting, it applies to all `keyword` and `wildcard` fields, as well as to keyword values within `flattened` fields.
      * When it comes to arrays, the `ignore_above` setting applies individually to each element of the array. If any element's
@@ -724,14 +714,30 @@ public final class IndexSettings {
      * <pre>
      * "index.mapping.ignore_above": 256
      * </pre>
+     * <p>
+     * NOTE: The value for `ignore_above` is the _character count_, but Lucene counts
+     * bytes. Here we set the limit to `32766 / 4 = 8191` since UTF-8 characters may
+     * occupy at most 4 bytes.
      */
+
     public static final Setting<Integer> IGNORE_ABOVE_SETTING = Setting.intSetting(
         "index.mapping.ignore_above",
-        Integer.MAX_VALUE,
+        IndexSettings::getIgnoreAboveDefaultValue,
         0,
+        Integer.MAX_VALUE,
         Property.IndexScope,
         Property.ServerlessPublic
     );
+
+    private static String getIgnoreAboveDefaultValue(final Settings settings) {
+        if (IndexSettings.MODE.get(settings) == IndexMode.LOGSDB
+            && IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings).onOrAfter(IndexVersions.ENABLE_IGNORE_ABOVE_LOGSDB)) {
+            return "8191";
+        } else {
+            return String.valueOf(Integer.MAX_VALUE);
+        }
+    }
+
     public static final NodeFeature IGNORE_ABOVE_INDEX_LEVEL_SETTING = new NodeFeature("mapper.ignore_above_index_level_setting");
 
     private final Index index;
@@ -815,7 +821,6 @@ public final class IndexSettings {
     private volatile long mappingDimensionFieldsLimit;
     private volatile boolean skipIgnoredSourceWrite;
     private volatile boolean skipIgnoredSourceRead;
-    private volatile boolean syntheticSourceSecondDocParsingPassEnabled;
     private final SourceFieldMapper.Mode indexMappingSourceMode;
 
     /**
@@ -977,7 +982,6 @@ public final class IndexSettings {
         es87TSDBCodecEnabled = scopedSettings.get(TIME_SERIES_ES87TSDB_CODEC_ENABLED_SETTING);
         skipIgnoredSourceWrite = scopedSettings.get(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_WRITE_SETTING);
         skipIgnoredSourceRead = scopedSettings.get(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_READ_SETTING);
-        syntheticSourceSecondDocParsingPassEnabled = scopedSettings.get(SYNTHETIC_SOURCE_SECOND_DOC_PARSING_PASS_SETTING);
         indexMappingSourceMode = scopedSettings.get(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING);
 
         scopedSettings.addSettingsUpdateConsumer(
@@ -1066,10 +1070,6 @@ public final class IndexSettings {
             this::setSkipIgnoredSourceWrite
         );
         scopedSettings.addSettingsUpdateConsumer(IgnoredSourceFieldMapper.SKIP_IGNORED_SOURCE_READ_SETTING, this::setSkipIgnoredSourceRead);
-        scopedSettings.addSettingsUpdateConsumer(
-            SYNTHETIC_SOURCE_SECOND_DOC_PARSING_PASS_SETTING,
-            this::setSyntheticSourceSecondDocParsingPassEnabled
-        );
     }
 
     private void setSearchIdleAfter(TimeValue searchIdleAfter) {
@@ -1660,14 +1660,6 @@ public final class IndexSettings {
 
     private void setSkipIgnoredSourceRead(boolean value) {
         this.skipIgnoredSourceRead = value;
-    }
-
-    private void setSyntheticSourceSecondDocParsingPassEnabled(boolean syntheticSourceSecondDocParsingPassEnabled) {
-        this.syntheticSourceSecondDocParsingPassEnabled = syntheticSourceSecondDocParsingPassEnabled;
-    }
-
-    public boolean isSyntheticSourceSecondDocParsingPassEnabled() {
-        return syntheticSourceSecondDocParsingPassEnabled;
     }
 
     public SourceFieldMapper.Mode getIndexMappingSourceMode() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -66,14 +66,10 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public static final Setting<Mode> INDEX_MAPPER_SOURCE_MODE_SETTING = Setting.enumSetting(SourceFieldMapper.Mode.class, settings -> {
         final IndexMode indexMode = IndexSettings.MODE.get(settings);
-
-        switch (indexMode) {
-            case LOGSDB:
-            case TIME_SERIES:
-                return Mode.SYNTHETIC.name();
-            default:
-                return Mode.STORED.name();
-        }
+        return switch (indexMode) {
+            case IndexMode.LOGSDB, IndexMode.TIME_SERIES -> Mode.SYNTHETIC.name();
+            default -> Mode.STORED.name();
+        };
     }, "index.mapping.source.mode", value -> {}, Setting.Property.Final, Setting.Property.IndexScope);
 
     /** The source mode */
@@ -90,42 +86,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         Strings.EMPTY_ARRAY,
         null,
         true
-    );
-
-    private static final SourceFieldMapper DEFAULT_DISABLED = new SourceFieldMapper(
-        Mode.DISABLED,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null,
-        true
-    );
-
-    private static final SourceFieldMapper DEFAULT_DISABLED_NO_RECOVERY_SOURCE = new SourceFieldMapper(
-        Mode.DISABLED,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null,
-        false
-    );
-
-    private static final SourceFieldMapper DEFAULT_SYNTHETIC = new SourceFieldMapper(
-        Mode.SYNTHETIC,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null,
-        true
-    );
-
-    private static final SourceFieldMapper DEFAULT_SYNTHETIC_NO_RECOVERY_SOURCE = new SourceFieldMapper(
-        Mode.SYNTHETIC,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null,
-        false
     );
 
     private static final SourceFieldMapper DEFAULT_NO_RECOVERY_SOURCE = new SourceFieldMapper(
@@ -337,7 +297,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                 ? INDEX_MAPPER_SOURCE_MODE_SETTING.get(settings)
                 : mode.get();
             if (isDefault(sourceMode)) {
-                return resolveSourceMode(indexMode, sourceMode == null ? Mode.STORED : sourceMode, enableRecoverySource);
+                return resolveSourceMode(indexMode, sourceMode, enableRecoverySource);
 
             }
             if (supportsNonDefaultParameterValues == false) {
@@ -380,39 +340,25 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     }
 
     private static SourceFieldMapper resolveSourceMode(final IndexMode indexMode, final Mode sourceMode, boolean enableRecoverySource) {
-        switch (indexMode) {
-            case STANDARD:
-                switch (sourceMode) {
-                    case SYNTHETIC:
-                        return enableRecoverySource ? DEFAULT_SYNTHETIC : DEFAULT_SYNTHETIC_NO_RECOVERY_SOURCE;
-                    case STORED:
-                        return enableRecoverySource ? DEFAULT : DEFAULT_NO_RECOVERY_SOURCE;
-                    case DISABLED:
-                        return enableRecoverySource ? DEFAULT_DISABLED : DEFAULT_DISABLED_NO_RECOVERY_SOURCE;
-                    default:
-                        throw new IllegalArgumentException("Unsupported source mode: " + sourceMode);
-                }
-            case TIME_SERIES:
-            case LOGSDB:
-                switch (sourceMode) {
-                    case SYNTHETIC:
-                        return enableRecoverySource
-                            ? (indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT : LOGSDB_DEFAULT)
-                            : (indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT_NO_RECOVERY_SOURCE : LOGSDB_DEFAULT_NO_RECOVERY_SOURCE);
-                    case STORED:
-                        return enableRecoverySource
-                            ? (indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT_STORED : LOGSDB_DEFAULT_STORED)
-                            : (indexMode == IndexMode.TIME_SERIES
-                                ? TSDB_DEFAULT_NO_RECOVERY_SOURCE_STORED
-                                : LOGSDB_DEFAULT_NO_RECOVERY_SOURCE_STORED);
-                    case DISABLED:
-                        throw new IllegalArgumentException("_source can not be disabled in index using [" + indexMode + "] index mode");
-                    default:
-                        throw new IllegalArgumentException("Unsupported source mode: " + sourceMode);
-                }
-            default:
-                throw new IllegalArgumentException("Unsupported index mode: " + indexMode);
+        if (indexMode == IndexMode.STANDARD) {
+            return enableRecoverySource ? DEFAULT : DEFAULT_NO_RECOVERY_SOURCE;
         }
+        final SourceFieldMapper syntheticWithoutRecoverySource = indexMode == IndexMode.TIME_SERIES
+            ? TSDB_DEFAULT_NO_RECOVERY_SOURCE
+            : LOGSDB_DEFAULT_NO_RECOVERY_SOURCE;
+        final SourceFieldMapper syntheticWithRecoverySource = indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT : LOGSDB_DEFAULT;
+        final SourceFieldMapper storedWithoutRecoverySource = indexMode == IndexMode.TIME_SERIES
+            ? TSDB_DEFAULT_NO_RECOVERY_SOURCE_STORED
+            : LOGSDB_DEFAULT_NO_RECOVERY_SOURCE_STORED;
+        final SourceFieldMapper storedWithRecoverySource = indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT_STORED : LOGSDB_DEFAULT_STORED;
+
+        return switch (sourceMode) {
+            case SYNTHETIC -> enableRecoverySource ? syntheticWithRecoverySource : syntheticWithoutRecoverySource;
+            case STORED -> enableRecoverySource ? storedWithRecoverySource : storedWithoutRecoverySource;
+            case DISABLED -> throw new IllegalArgumentException(
+                "_source can not be disabled in index using [" + indexMode + "] index mode"
+            );
+        };
     }
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(c -> {
@@ -425,7 +371,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                 return enableRecoverySource ? TSDB_LEGACY_DEFAULT : TSDB_LEGACY_DEFAULT_NO_RECOVERY_SOURCE;
             }
         }
-        return resolveSourceMode(indexMode, settingSourceMode == null ? Mode.STORED : settingSourceMode, enableRecoverySource);
+        return resolveSourceMode(indexMode, settingSourceMode, enableRecoverySource);
     },
         c -> new Builder(
             c.getIndexSettings().getMode(),
@@ -594,13 +540,5 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public boolean isSynthetic() {
         return mode == Mode.SYNTHETIC;
-    }
-
-    public boolean isDisabled() {
-        return mode == Mode.DISABLED;
-    }
-
-    public boolean isStored() {
-        return mode == null || mode == Mode.STORED;
     }
 }

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/40_source_mode_setting.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/40_source_mode_setting.yml
@@ -86,6 +86,11 @@ create an index with stored source mode and logsdb index mode without setting:
               mode: stored
 
   - do:
+      indices.get_settings:
+        index: "test_stored_logsdb"
+  - match: { test_stored_logsdb.settings.index.mode: logsdb }
+
+  - do:
       indices.get_mapping:
         index: test_stored_logsdb
 
@@ -157,10 +162,16 @@ create an index with stored source mode and time series index mode without setti
                 time_series_dimension: true
 
   - do:
+      indices.get_settings:
+        index: "test_stored_time_series"
+  - match: { test_stored_time_series.settings.index.mode: time_series }
+
+  - do:
       indices.get_mapping:
         index: test_stored_time_series
 
   - match: { test_stored_time_series.mappings._source.mode: stored }
+
 
 ---
 create an index with synthetic source mode and time series index mode without setting:
@@ -512,7 +523,7 @@ create an index with time_series index mode and stored source:
   - do:
       indices.get_settings:
         index: "test_time_series_index_mode_undefined"
-  - match: { test_time_series_index_mode_undefined.settings.index.mapping.source.mode: stored }
+  - match: { test_time_series_index_mode_undefined.settings.index.mode: time_series }
 
   - do:
       indices.get_mapping:
@@ -530,6 +541,11 @@ create an index with logsdb index mode and stored source:
             index:
               mode: logsdb
               mapping.source.mode: stored
+
+  - do:
+      indices.get_settings:
+        index: "test_logsdb_index_mode_undefined"
+  - match: { test_logsdb_index_mode_undefined.settings.index.mode: logsdb }
 
   - do:
       indices.get_mapping:


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.16` of:
 - #114433

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)