### PR TITLE
[8.x] Reducing error-level stack trace logging for normal events in GeoIpDownloader (#114924)

### DIFF
--- a/docs/changelog/114924.yaml
+++ b/docs/changelog/114924.yaml
@@ -1,0 +1,5 @@
+pr: 114924
+summary: Reducing error-level stack trace logging for normal events in `GeoIpDownloader`
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Reducing error-level stack trace logging for normal events in GeoIpDownloader (#114924)