### PR TITLE
[8.x] Modify verifyVersions to care about 8.x rather than main for backport config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,11 +204,11 @@ tasks.register("verifyVersions") {
         throw new GradleException("No branch choice exists for development branch ${unreleasedVersion.branch} in .backportrc.json.")
       }
     }
-    String versionMapping = backportConfig.get("branchLabelMapping").fields().find { it.value.textValue() == 'main' }.key
+    String versionMapping = backportConfig.get("branchLabelMapping").fields().find { it.value.textValue() == '8.x' }.key
     String expectedMapping = "^v${versions.elasticsearch.replaceAll('-SNAPSHOT', '')}\$"
     if (versionMapping != expectedMapping) {
       throw new GradleException(
-        "Backport label mapping for branch 'main' is '${versionMapping}' but should be " +
+        "Backport label mapping for branch '8.x' is '${versionMapping}' but should be " +
           "'${expectedMapping}'. Update .backportrc.json."
       )
     }


### PR DESCRIPTION
Otherwise, it wants `main` to be the latest `8.x` version.

```
Execution failed for task ':verifyVersions'.
> Backport label mapping for branch 'main' is '^v9.0.0$' but should be '^v8.17.0$'. Update .backportrc.json.
```