### PR TITLE
[ML] Avoid NPE in maybeStartAllocation in AdaptiveAllocations

### DIFF
--- a/docs/changelog/114958.yaml
+++ b/docs/changelog/114958.yaml
@@ -1,0 +1,5 @@
+pr: 114958
+summary: Avoid NPE in `maybeStartAllocation` in `AdaptiveAllocations`
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/114958.yaml
+++ b/docs/changelog/114958.yaml
@@ -1,5 +1,0 @@
-pr: 114958
-summary: Avoid NPE in `maybeStartAllocation` in `AdaptiveAllocations`
-area: Machine Learning
-type: bug
-issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/adaptiveallocations/AdaptiveAllocationsScalerService.java
@@ -434,7 +434,7 @@ public class AdaptiveAllocationsScalerService implements ClusterStateListener {
         if (assignment.getAdaptiveAllocationsSettings() != null
             && assignment.getAdaptiveAllocationsSettings().getEnabled() == Boolean.TRUE
             && (assignment.getAdaptiveAllocationsSettings().getMinNumberOfAllocations() == null
-                || assignment.getAdaptiveAllocationsSettings().getMinNumberOfAllocations() == 0)) {
+                || Integer.valueOf(0).equals(assignment.getAdaptiveAllocationsSettings().getMinNumberOfAllocations()))) {
 
             // Prevent against a flurry of scale up requests.
             if (deploymentIdsWithInFlightScaleFromZeroRequests.contains(assignment.getDeploymentId()) == false) {


### PR DESCRIPTION
@wwang500 reported an NPE from this line, which seems to be due to auto-unboxing of the null value stored in getMinNumberOfAllocations. With this change, we will use the equals method of a cached Integer object which cannot be null. 

Non-issue as this was caught in QA