### PR TITLE
Document ?_tstart and ?_tend in Kibana

### DIFF
--- a/docs/reference/esql/esql-kibana.asciidoc
+++ b/docs/reference/esql/esql-kibana.asciidoc
@@ -171,7 +171,8 @@ FROM kibana_sample_data_logs
 [[esql-kibana-time-filter]]
 === Time filtering
 
-To display data within a specified time range, use one of the following methods.
+To display data within a specified time range, you can use the standard time filter, 
+custom time parameters, or a WHERE command.
 
 [discrete]
 ==== Standard time filter
@@ -182,7 +183,7 @@ when the indices you're querying have a field named `@timestamp`.
 ==== Custom time parameters
 If your indices do not have a field named `@timestamp`, you can use
 the `?_tstart` and `?_tend` parameters to specify a time range. These parameters 
-work with any timestamp field and automatically sync with the time filter.
+work with any timestamp field and automatically sync with the {kibana-ref}/set-time-filter.html[time filter].
 
 [source,esql]
 ----
@@ -190,8 +191,20 @@ FROM my_index
 | WHERE custom_timestamp >= ?_tstart AND custom_timestamp < ?_tend
 ----
 
+You can also use the `?_tstart` and `?_tend` parameters with the <<esql-bucket>> function 
+to create auto-incrementing time buckets in {esql} <<esql-kibana-visualizations,visualizations>>. 
+For example:
+
+[source,esql]
+----
+FROM kibana_sample_data_logs
+| STATS average_bytes = AVG(bytes) BY BUCKET(@timestamp, 50, ?_tstart, ?_tend)
+----
+
+This example uses `50` buckets, which is the maximum number of buckets.
+
 [discrete]
-==== WHERE clause with NOW function
+==== WHERE command
 You can also limit the time range using the <<esql-where>> command and the <<esql-now>> function.
 For example, if the timestamp field is called `timestamp`, to query the last 15
 minutes of data:
@@ -201,19 +214,6 @@ minutes of data:
 FROM kibana_sample_data_logs
 | WHERE timestamp > NOW() - 15minutes
 ----
-
-[discrete]
-==== Auto-incrementing time buckets
-You can use the <<esql-bucket>> function with the `?_tstart` and `?_tend` parameters 
-to create auto-incrementing time buckets in {esql} visualizations. For example:
-
-[source,esql]
-----
-FROM kibana_sample_data_logs
-| STATS average_bytes = AVG(bytes) BY BUCKET(@timestamp, 50, ?_tstart, ?_tend)
-----
-
-This example uses `50` buckets, which is the maximum number of buckets.
 
 [discrete]
 [[esql-kibana-visualizations]]

--- a/docs/reference/esql/esql-kibana.asciidoc
+++ b/docs/reference/esql/esql-kibana.asciidoc
@@ -171,19 +171,49 @@ FROM kibana_sample_data_logs
 [[esql-kibana-time-filter]]
 === Time filtering
 
-To display data within a specified time range, use the
-{kibana-ref}/set-time-filter.html[time filter]. The time filter is only enabled
-when the indices you're querying have a field called `@timestamp`.
+To display data within a specified time range, use one of the following methods.
 
-If your indices do not have a timestamp field called `@timestamp`, you can limit
-the time range using the <<esql-where>> command and the <<esql-now>> function.
+[discrete]
+==== Standard time filter
+The standard {kibana-ref}/set-time-filter.html[time filter] is enabled
+when the indices you're querying have a field named `@timestamp`.
+
+[discrete]
+==== Custom time parameters
+If your indices do not have a field named `@timestamp`, you can use
+the `?_tstart` and `?_tend` parameters to specify a time range. These parameters 
+work with any timestamp field and automatically sync with the time filter.
+
+[source,esql]
+----
+FROM my_index
+| WHERE custom_timestamp >= ?_tstart AND custom_timestamp < ?_tend
+----
+
+[discrete]
+==== WHERE clause with NOW function
+You can also limit the time range using the <<esql-where>> command and the <<esql-now>> function.
 For example, if the timestamp field is called `timestamp`, to query the last 15
 minutes of data:
+
 [source,esql]
 ----
 FROM kibana_sample_data_logs
 | WHERE timestamp > NOW() - 15minutes
 ----
+
+[discrete]
+==== Auto-incrementing time buckets
+You can use the <<esql-bucket>> function with the `?_tstart` and `?_tend` parameters 
+to create auto-incrementing time buckets in {esql} visualizations. For example:
+
+[source,esql]
+----
+FROM kibana_sample_data_logs
+| STATS average_bytes = AVG(bytes) BY BUCKET(@timestamp, 50, ?_tstart, ?_tend)
+----
+
+This example uses `50` buckets, which is the maximum number of buckets.
 
 [discrete]
 [[esql-kibana-visualizations]]


### PR DESCRIPTION
[Preview](https://elasticsearch_bk_114965.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/esql-kibana.html#esql-kibana-time-filter)

Notes for reviewers:
* Not sold on the subheadings 🤔 
* Initially I had "auto-incrementing time buckets" as a last subsection (separated out instead of folded under the custom section); I can redo it that way if we want to highlight `BUCKET`s.

Fix for [this issue](https://github.com/elastic/search-docs-team/issues/153)