### PR TITLE
[8.16][ML] Temporarily ignore inference index (#114928)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1149,6 +1149,8 @@ public abstract class ESRestTestCase extends ESTestCase {
             if (preserveSecurityIndices) {
                 indexPatterns.add("-.security-*");
             }
+            // always preserve inference index see https://github.com/elastic/elasticsearch/issues/114748
+            indexPatterns.add("-.inference");
             final Request deleteRequest = new Request("DELETE", Strings.collectionToCommaDelimitedString(indexPatterns));
             deleteRequest.addParameter("expand_wildcards", "open,closed" + (includeHidden ? ",hidden" : ""));
             final Response response = adminClient().performRequest(deleteRequest);


### PR DESCRIPTION
Manual backport of #114928

Until we can figure out where in the tests the index is being created, temporarily ignore deleting it along with the other system indices.

Relates #114748

