### PR TITLE
Clarify the null check for retention leases

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -485,6 +486,7 @@ public abstract class MetadataStateFormat<T> {
      * @param dataLocations the data-locations to try.
      * @return the latest state or <code>null</code> if no state was found.
      */
+    @Nullable
     public T loadLatestState(Logger logger, NamedXContentRegistry namedXContentRegistry, Path... dataLocations) throws IOException {
         return loadLatestStateWithGeneration(logger, namedXContentRegistry, dataLocations).v1();
     }

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.gateway.WriteStateException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -471,9 +471,9 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         return emptyIfNull(retentionLeases);
     }
 
-    @UpdateForV9(owner = UpdateForV9.Owner.DISTRIBUTED_INDEXING)
     private static RetentionLeases emptyIfNull(RetentionLeases retentionLeases) {
-        // we expect never to see a null in 8.x, so adjust this to throw an exception from v9 onwards.
+        // `MetadataStateFormat.FORMAT.loadLatestState` can actually return null when the state directory
+        // on a node hasn't been initialized yet
         return retentionLeases == null ? RetentionLeases.EMPTY : retentionLeases;
     }
 


### PR DESCRIPTION
`MetadataStateFormat.FORMAT.loadLatestState` can actually return null when the state directory hasn't been
initialized yet, so we have to keep the null check when loading retention leases during the initialization of the engine.

See https://github.com/elastic/elasticsearch/pull/39359
