### PR TITLE
[8.x] [DOCS] Updates adaptive allocations reference docs. (#114986)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -3,7 +3,6 @@ Adaptive allocations configuration object.
 If enabled, the number of allocations of the model is set based on the current load the process gets.
 When the load is high, a new model allocation is automatically created (respecting the value of `max_number_of_allocations` if it's set).
 When the load is low, a model allocation is automatically removed (respecting the value of `min_number_of_allocations` if it's set).
-The number of model allocations cannot be scaled down to less than `1` this way.
 If `adaptive_allocations` is enabled, do not set the number of allocations manually.
 end::adaptive-allocation[]
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [DOCS] Updates adaptive allocations reference docs. (#114986)