### PR TITLE
[DOCS] Add DLS multi-match limitation

### DIFF
--- a/docs/reference/security/limitations.asciidoc
+++ b/docs/reference/security/limitations.asciidoc
@@ -81,12 +81,13 @@ including the following queries:
 * A search request cannot be profiled if document level security is enabled.
 * The <<search-terms-enum,terms enum API>> does not return terms if document
 level security is enabled.
+* The <<query-dsl-multi-match-query, `multi_match`>> query does not support specifying fields using wildcards.
 
 NOTE: While document-level security prevents users from viewing restricted documents,
 it's still possible to write search requests that return aggregate information about the
 entire index. A user whose access is restricted to specific documents in an index could
 still learn about field names and terms that only exist in inaccessible
-documents, and count how many inaccessible documents contain a given term. 
+documents, and count how many inaccessible documents contain a given term.
 
 [discrete]
 [[alias-limitations]]


### PR DESCRIPTION
After deciding against [this](https://github.com/elastic/elasticsearch/pull/112141) PR due to security concerns, we now document that specifying fields using wildcards in a DLS multi-match query is not supported. 