### PR TITLE
Add constants used for minCompatibleShardNode removal and revert

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -246,6 +246,8 @@ public class TransportVersions {
     public static final TransportVersion ESQL_PER_AGGREGATE_FILTER = def(8_770_00_0);
     public static final TransportVersion ML_INFERENCE_ATTACH_TO_EXISTSING_DEPLOYMENT = def(8_771_00_0);
     public static final TransportVersion CONVERT_FAILURE_STORE_OPTIONS_TO_SELECTOR_OPTIONS_INTERNALLY = def(8_772_00_0);
+    public static final TransportVersion REMOVE_MIN_COMPATIBLE_SHARD_NODE = def(8_773_00_0);
+    public static final TransportVersion REVERT_REMOVE_MIN_COMPATIBLE_SHARD_NODE = def(8_774_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
These constants are added by https://github.com/elastic/elasticsearch/pull/114713 and https://github.com/elastic/elasticsearch/pull/115009, to ensure the transport protocol is identical between main and 8.x (for the meantime)

This results in no modifications to the binary protocol, but ensures the id is the same.