### PR TITLE
[8.16] [DOCS] Update local data extraction version info (#115001)

### DIFF
--- a/docs/reference/connector/docs/connectors-content-extraction.asciidoc
+++ b/docs/reference/connector/docs/connectors-content-extraction.asciidoc
@@ -90,7 +90,7 @@ include::_connectors-list-local-content-extraction.asciidoc[]
 Self-hosted content extraction is handled by a *separate* extraction service.
 
 The versions for the extraction service do not align with the Elastic stack.
-For version `8.11.x`, you should use extraction service version `0.3.x`.
+For versions after `8.11.x` (including {version}), you should use extraction service version `0.3.x`.
 
 You can run the service with the following command:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[DOCS] Update local data extraction version info (#115001)](https://github.com/elastic/elasticsearch/pull/115001)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)