### PR TITLE
[8.x] Add missing preventDeletionLock.remove in corner case (#115010)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistry.java
@@ -397,6 +397,7 @@ public class ModelRegistry {
                 logger.error(
                     format("Failed to update inference endpoint [%s] due to [%s]", inferenceEntityId, configResponse.buildFailureMessage())
                 );
+                preventDeletionLock.remove(inferenceEntityId);
                 // Since none of our updates succeeded at this point, we can simply return.
                 finalListener.onFailure(
                     new ElasticsearchStatusException(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add missing preventDeletionLock.remove in corner case (#115010)](https://github.com/elastic/elasticsearch/pull/115010)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)