### PR TITLE
Reword docs on snapshot repo backup

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -248,10 +248,11 @@ that you have an archive copy of its contents that you can use to recreate the
 repository in its current state at a later date.
 
 You must ensure that {es} does not write to the repository while you are taking
-the backup of its contents. You can do this by unregistering it, or registering
-it with `readonly: true`, on all your clusters. If {es} writes any data to the
-repository during the backup then the contents of the backup may not be
-consistent and it may not be possible to recover any data from it in future.
+the backup of its contents. If {es} writes any data to the repository during
+the backup then the contents of the backup may not be consistent and it may not
+be possible to recover any data from it in future. Prevent writes to the
+repository by unregistering the repository from the cluster which has write
+access to it.
 
 Alternatively, if your repository supports it, you may take an atomic snapshot
 of the underlying filesystem and then take a backup of this filesystem


### PR DESCRIPTION
Because of #93575 it's not sufficient to mark repositories with
`readonly: true` while taking a backup. The only safe way to avoid
writes is to completely unregister them.