### PR TITLE
Replace IntermittentLongGCDisruption with blocking cluster state updates

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/LazyRolloverDuringDisruptionIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/LazyRolloverDuringDisruptionIT.java
@@ -18,17 +18,19 @@ import org.elasticsearch.action.datastreams.CreateDataStreamAction;
 import org.elasticsearch.action.datastreams.GetDataStreamAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.disruption.IntermittentLongGCDisruption;
-import org.elasticsearch.test.disruption.SingleNodeDisruption;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +45,7 @@ public class LazyRolloverDuringDisruptionIT extends ESIntegTestCase {
     }
 
     public void testRolloverIsExecutedOnce() throws ExecutionException, InterruptedException {
-        String masterNode = internalCluster().startMasterOnlyNode();
+        internalCluster().startMasterOnlyNode();
         internalCluster().startDataOnlyNodes(3);
         ensureStableCluster(4);
 
@@ -59,9 +61,22 @@ public class LazyRolloverDuringDisruptionIT extends ESIntegTestCase {
         assertThat(dataStream.getBackingIndices().getIndices().size(), equalTo(1));
 
         // Introduce a disruption to the master node that should delay the rollover execution
-        SingleNodeDisruption masterNodeDisruption = new IntermittentLongGCDisruption(random(), masterNode, 100, 200, 30000, 60000);
-        internalCluster().setDisruptionScheme(masterNodeDisruption);
-        masterNodeDisruption.startDisrupting();
+        final var barrier = new CyclicBarrier(2);
+        internalCluster().getCurrentMasterNodeInstance(ClusterService.class)
+            .submitUnbatchedStateUpdateTask("block", new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    safeAwait(barrier);
+                    safeAwait(barrier);
+                    return currentState;
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail(e);
+                }
+            });
+        safeAwait(barrier);
 
         // Start indexing operations
         int docs = randomIntBetween(5, 10);
@@ -84,7 +99,7 @@ public class LazyRolloverDuringDisruptionIT extends ESIntegTestCase {
         }
 
         // End the disruption so that all pending tasks will complete
-        masterNodeDisruption.stopDisrupting();
+        safeAwait(barrier);
 
         // Wait for all the indexing requests to be processed successfully
         countDownLatch.await();


### PR DESCRIPTION
In JDK 23 `Thread.resume` has been removed this means that we cannot use `IntermittentLongGCDisruption` that depends on it. 

We simulate the master node disruption with a `CyclicBarrier` that blocks cluster state updates.

Closes: https://github.com/elastic/elasticsearch/issues/115045

The backport will close: https://github.com/elastic/elasticsearch/issues/112634
