### PR TITLE
[ML] Fix issues in dynamically reading the number of allocations

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -24,6 +24,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasSize;
@@ -325,5 +326,10 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         } finally {
             deleteModel(modelId);
         }
+    }
+
+    public void testGetZeroModels() throws IOException {
+        var models = getModels("_all", TaskType.RERANK);
+        assertThat(models, empty());
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -126,6 +126,11 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
     }
 
     private void parseModels(List<UnparsedModel> unparsedModels, ActionListener<GetInferenceModelAction.Response> listener) {
+        if (unparsedModels.isEmpty()) {
+            listener.onResponse(new GetInferenceModelAction.Response(List.of()));
+            return;
+        }
+
         var parsedModelsByService = new HashMap<String, List<Model>>();
         try {
             for (var unparsedModel : unparsedModels) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
@@ -92,12 +92,7 @@ public abstract class ElasticsearchInternalModel extends Model {
     }
 
     public void updateNumAllocation(Integer numAllocations) {
-        this.internalServiceSettings = new ElasticsearchInternalServiceSettings(
-            numAllocations,
-            this.internalServiceSettings.getNumThreads(),
-            this.internalServiceSettings.modelId(),
-            this.internalServiceSettings.getAdaptiveAllocationsSettings()
-        );
+        this.internalServiceSettings.setNumAllocations(numAllocations);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -781,7 +781,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         var modelsByDeploymentIds = new HashMap<String, ElasticsearchInternalModel>();
         for (var model : models) {
             if (model instanceof ElasticsearchInternalModel esModel) {
-                modelsByDeploymentIds.put(esModel.internalServiceSettings.deloymentId(), esModel);
+                modelsByDeploymentIds.put(esModel.mlNodeDeploymentId(), esModel);
             } else {
                 listener.onFailure(
                     new ElasticsearchStatusException(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -39,7 +39,7 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
     public static final String DEPLOYMENT_ID = "deployment_id";
     public static final String ADAPTIVE_ALLOCATIONS = "adaptive_allocations";
 
-    private final Integer numAllocations;
+    private Integer numAllocations;
     private final int numThreads;
     private final String modelId;
     private final AdaptiveAllocationsSettings adaptiveAllocationsSettings;
@@ -170,6 +170,10 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         this.deploymentId = in.getTransportVersion().onOrAfter(TransportVersions.ML_INFERENCE_ATTACH_TO_EXISTSING_DEPLOYMENT)
             ? in.readOptionalString()
             : null;
+    }
+
+    public void setNumAllocations(Integer numAllocations) {
+        this.numAllocations = numAllocations;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
@@ -22,9 +22,9 @@ public class ElserInternalModelTests extends ESTestCase {
         );
 
         model.updateNumAllocation(1);
-        assertEquals(1, model.internalServiceSettings.getNumAllocations().intValue());
+        assertEquals(1, model.getServiceSettings().getNumAllocations().intValue());
 
         model.updateNumAllocation(null);
-        assertNull(model.internalServiceSettings.getNumAllocations());
+        assertNull(model.getServiceSettings().getNumAllocations());
     }
 }


### PR DESCRIPTION
Relates to problems in the GET inference API which should dynamically update the num_allocations field with the actual number from the deployed model. This is required for adaptive allocations where the field will change dynamically. 

The `num_allocations` field in `service_settings` is updated with the current value.

```
GET _inference/elser_on_ml

{
  "endpoints": [
    {
      "inference_id": "elser_on_ml",
      "task_type": "sparse_embedding",
      "service": "elasticsearch",
      "service_settings": {
        "num_allocations": 3,            <-- this field is dynamic
        "num_threads": 1,
        "model_id": ".elser_model_2",
        "deployment_id": ".elser_model_2_for_me"
      },
      "chunking_settings": {
        "strategy": "sentence",
        "max_chunk_size": 250,
        "sentence_overlap": 1
      }
    }
  ]
}
```

The first issue is that GroupedActionListener throws if called with size == 0. This is now protected against by skipping the model update if the list is empty.

The second issue is that the wrong field was being updated so the update was not seen in the API response. Tests are added to cover both cases.

Non issue as the code is not live