### PR TITLE
Rename the "values" test to "values function", because the former causes parsing errors in Jackson

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -563,7 +563,7 @@ setup:
   - match: { values.1.0: "Payroll Specialist" }
 
 ---
-values:
+"values function":
   - requires:
       cluster_features: esql.agg_values
       reason: "values is available in 8.14+"


### PR DESCRIPTION
When trying to use a gradle `skipTest` rule on tests named "values", we get a class-caste exception in Jackson.

This PR needs to rename this function for all versions of Elasticsearch that the `yamlRestCompatTestTransform` task will run on, so that later PRs that add skipTests will be able to pass. Since this test was added in 8.14, we must backport all the way back to there.

```
class com.fasterxml.jackson.databind.node.IntNode cannot be cast to class com.fasterxml.jackson.databind.node.ArrayNode (com.fasterxml.jackson.databind.node.IntNode and com.fasterxml.jackson.databind.node.ArrayNode are in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @50337c96)
```
