### PR TITLE
[8.15] Cannot skip tests named "values" (#115096)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -540,7 +540,7 @@ setup:
   - match: { values.1.0: "Payroll Specialist" }
 
 ---
-values:
+"values function":
   - requires:
       cluster_features: esql.agg_values
       reason: "values is available in 8.14+"


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Cannot skip tests named "values" (#115096)