### PR TITLE
Report JVM stats for all memory pools (97046)

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/GcNames.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/GcNames.java
@@ -15,8 +15,14 @@ public class GcNames {
     public static final String OLD = "old";
     public static final String SURVIVOR = "survivor";
 
+    private GcNames() {}
+
     /**
-     * Resolves the GC type by its memory pool name ({@link java.lang.management.MemoryPoolMXBean#getName()}.
+     * Resolves the memory area name by the memory pool name provided by {@link java.lang.management.MemoryPoolMXBean#getName()}
+     *
+     * @param poolName the name of the memory pool from {@link java.lang.management.MemoryPoolMXBean}
+     * @param defaultName the name to return if the pool name does not match any known memory area
+     * @return memory area name corresponding to the pool name or {@code defaultName} if no match is found
      */
     public static String getByMemoryPoolName(String poolName, String defaultName) {
         if ("Eden Space".equals(poolName)
@@ -40,6 +46,13 @@ public class GcNames {
         return defaultName;
     }
 
+    /**
+     * Resolves the GC type by the GC name provided by {@link java.lang.management.GarbageCollectorMXBean#getName()}
+     *
+     * @param gcName the name of the GC from {@link java.lang.management.GarbageCollectorMXBean}
+     * @param defaultName the name to return if the GC name does not match any known GC type
+     * @return GC type corresponding to the GC name or {@code defaultName} if no match is found
+     */
     public static String getByGcName(String gcName, String defaultName) {
         if ("Copy".equals(gcName) || "PS Scavenge".equals(gcName) || "ParNew".equals(gcName) || "G1 Young Generation".equals(gcName)) {
             return YOUNG;

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -64,10 +64,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
         List<MemoryPool> pools = new ArrayList<>();
         for (MemoryPoolMXBean memoryPoolMXBean : memoryPoolMXBeans) {
             try {
-                String name = GcNames.getByMemoryPoolName(memoryPoolMXBean.getName(), null);
-                if (name == null) { // if we can't resolve it, its not interesting.... (Per Gen, Code Cache)
-                    continue;
-                }
+                String name = GcNames.getByMemoryPoolName(memoryPoolMXBean.getName(), memoryPoolMXBean.getName());
                 MemoryUsage usage = memoryPoolMXBean.getUsage();
                 MemoryUsage peakUsage = memoryPoolMXBean.getPeakUsage();
                 pools.add(


### PR DESCRIPTION
This fix allows reporting of all JVM memory pools sizes in JVM stats
