### PR TITLE
[8.x] Add timeout and cancellation check to rescore phase (#115048)

### DIFF
--- a/docs/changelog/115048.yaml
+++ b/docs/changelog/115048.yaml
@@ -1,0 +1,5 @@
+pr: 115048
+summary: Add timeout and cancellation check to rescore phase
+area: Ranking
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -9,19 +9,30 @@
 
 package org.elasticsearch.search.functionscore;
 
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.tests.util.English;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
+import org.elasticsearch.common.lucene.search.function.LeafScoreFunction;
+import org.elasticsearch.common.lucene.search.function.ScoreFunction;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.collapse.CollapseBuilder;
@@ -29,11 +40,14 @@ import org.elasticsearch.search.rescore.QueryRescoreMode;
 import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
@@ -979,9 +993,119 @@ public class QueryRescorerIT extends ESIntegTestCase {
         });
     }
 
+    public void testRescoreWithTimeout() throws Exception {
+        // no dummy docs since merges can change scores while we run queries.
+        int numDocs = indexRandomNumbers("whitespace", -1, false);
+
+        String intToEnglish = English.intToEnglish(between(0, numDocs - 1));
+        String query = intToEnglish.split(" ")[0];
+        assertResponse(
+            prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
+                .setSize(10)
+                .addRescorer(new QueryRescorerBuilder(functionScoreQuery(new TestTimedScoreFunctionBuilder())).windowSize(100))
+                .setTimeout(TimeValue.timeValueMillis(10)),
+            r -> assertTrue(r.isTimedOut())
+        );
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestTimedQueryPlugin.class);
+    }
+
     private QueryBuilder fieldValueScoreQuery(String scoreField) {
         return functionScoreQuery(termQuery("shouldFilter", false), ScoreFunctionBuilders.fieldValueFactorFunction(scoreField)).boostMode(
             CombineFunction.REPLACE
         );
+    }
+
+    public static class TestTimedQueryPlugin extends Plugin implements SearchPlugin {
+        @Override
+        public List<ScoreFunctionSpec<?>> getScoreFunctions() {
+            return List.of(
+                new ScoreFunctionSpec<>(
+                    new ParseField("timed"),
+                    TestTimedScoreFunctionBuilder::new,
+                    p -> new TestTimedScoreFunctionBuilder()
+                )
+            );
+        }
+    }
+
+    static class TestTimedScoreFunctionBuilder extends ScoreFunctionBuilder<TestTimedScoreFunctionBuilder> {
+        private final long time = 500;
+
+        TestTimedScoreFunctionBuilder() {}
+
+        TestTimedScoreFunctionBuilder(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        protected void doWriteTo(StreamOutput out) {}
+
+        @Override
+        public String getName() {
+            return "timed";
+        }
+
+        @Override
+        protected void doXContent(XContentBuilder builder, Params params) {}
+
+        @Override
+        protected boolean doEquals(TestTimedScoreFunctionBuilder functionBuilder) {
+            return false;
+        }
+
+        @Override
+        protected int doHashCode() {
+            return 0;
+        }
+
+        @Override
+        protected ScoreFunction doToFunction(SearchExecutionContext context) throws IOException {
+            return new ScoreFunction(REPLACE) {
+                @Override
+                public LeafScoreFunction getLeafScoreFunction(LeafReaderContext ctx) throws IOException {
+                    return new LeafScoreFunction() {
+                        @Override
+                        public double score(int docId, float subQueryScore) {
+                            try {
+                                Thread.sleep(time);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            return time;
+                        }
+
+                        @Override
+                        public Explanation explainScore(int docId, Explanation subQueryScore) {
+                            return null;
+                        }
+                    };
+                }
+
+                @Override
+                public boolean needsScores() {
+                    return true;
+                }
+
+                @Override
+                protected boolean doEquals(ScoreFunction other) {
+                    return false;
+                }
+
+                @Override
+                protected int doHashCode() {
+                    return 0;
+                }
+            };
+        }
+
+        @Override
+        public TransportVersion getMinimalSupportedVersion() {
+            return TransportVersion.current();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -407,7 +407,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         }
     }
 
-    private static class TimeExceededException extends RuntimeException {
+    public static class TimeExceededException extends RuntimeException {
         // This exception should never be re-thrown, but we fill in the stacktrace to be able to trace where it does not get properly caught
     }
 

--- a/server/src/main/java/org/elasticsearch/search/rescore/RescoreContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/RescoreContext.java
@@ -24,6 +24,7 @@ public class RescoreContext {
     private final int windowSize;
     private final Rescorer rescorer;
     private Set<Integer> rescoredDocs; // doc Ids for which rescoring was applied
+    private Runnable isCancelled;
 
     /**
      * Build the context.
@@ -32,6 +33,16 @@ public class RescoreContext {
     public RescoreContext(int windowSize, Rescorer rescorer) {
         this.windowSize = windowSize;
         this.rescorer = rescorer;
+    }
+
+    public void setCancellationChecker(Runnable isCancelled) {
+        this.isCancelled = isCancelled;
+    }
+
+    public void checkCancellation() {
+        if (isCancelled != null) {
+            isCancelled.run();
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/rescore/RescorePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/RescorePhaseTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.rescore;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.action.search.SearchShardTask;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
+import org.elasticsearch.search.internal.ContextIndexSearcher;
+import org.elasticsearch.search.internal.FilteredSearchContext;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.tasks.TaskCancelHelper;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.TestSearchContext;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class RescorePhaseTests extends IndexShardTestCase {
+
+    public void testRescorePhaseCancellation() throws IOException {
+        IndexWriterConfig iwc = newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc)) {
+                final int numDocs = scaledRandomIntBetween(100, 200);
+                for (int i = 0; i < numDocs; ++i) {
+                    Document doc = new Document();
+                    w.addDocument(doc);
+                }
+            }
+            try (IndexReader reader = DirectoryReader.open(dir)) {
+                ContextIndexSearcher s = new ContextIndexSearcher(
+                    reader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    new QueryCachingPolicy() {
+                        @Override
+                        public void onUse(Query query) {}
+
+                        @Override
+                        public boolean shouldCache(Query query) {
+                            return false;
+                        }
+                    },
+                    true
+                );
+                IndexShard shard = newShard(true);
+                try (TestSearchContext context = new TestSearchContext(null, shard, s)) {
+                    context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+                    SearchShardTask task = new SearchShardTask(123L, "", "", "", null, Collections.emptyMap());
+                    context.setTask(task);
+                    SearchContext wrapped = new FilteredSearchContext(context) {
+                        @Override
+                        public boolean lowLevelCancellation() {
+                            return true;
+                        }
+
+                        @Override
+                        public FetchDocValuesContext docValuesContext() {
+                            return context.docValuesContext();
+                        }
+
+                        @Override
+                        public SearchContext docValuesContext(FetchDocValuesContext docValuesContext) {
+                            return context.docValuesContext(docValuesContext);
+                        }
+
+                        @Override
+                        public FetchFieldsContext fetchFieldsContext() {
+                            return context.fetchFieldsContext();
+                        }
+
+                        @Override
+                        public SearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext) {
+                            return context.fetchFieldsContext(fetchFieldsContext);
+                        }
+                    };
+                    try (wrapped) {
+                        Runnable cancellationChecks = RescorePhase.getCancellationChecks(wrapped);
+                        assertNotNull(cancellationChecks);
+                        TaskCancelHelper.cancel(task, "test cancellation");
+                        assertTrue(wrapped.isCancelled());
+                        expectThrows(TaskCancelledException.class, cancellationChecks::run);
+                        QueryRescorer.QueryRescoreContext rescoreContext = new QueryRescorer.QueryRescoreContext(10);
+                        rescoreContext.setQuery(new ParsedQuery(new MatchAllDocsQuery()));
+                        rescoreContext.setCancellationChecker(cancellationChecks);
+                        expectThrows(
+                            TaskCancelledException.class,
+                            () -> new QueryRescorer().rescore(
+                                new TopDocs(
+                                    new TotalHits(10, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO),
+                                    new ScoreDoc[] { new ScoreDoc(0, 1.0f) }
+                                ),
+                                context.searcher(),
+                                rescoreContext
+                            )
+                        );
+                    }
+                }
+                closeShards(shard);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add timeout and cancellation check to rescore phase (#115048)