### PR TITLE
[8.x] Remove IndexMode#isSyntheticSourceEnabled (#114963)

### DIFF
--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.StringStoredFieldFieldLoader;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextParams;
@@ -91,15 +92,10 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
 
         private final IndexVersion indexCreatedVersion;
         private final TextParams.Analyzers analyzers;
-        private final boolean isSyntheticSourceEnabledViaIndexMode;
+        private final boolean isSyntheticSourceEnabled;
         private final Parameter<Boolean> store;
 
-        public Builder(
-            String name,
-            IndexVersion indexCreatedVersion,
-            IndexAnalyzers indexAnalyzers,
-            boolean isSyntheticSourceEnabledViaIndexMode
-        ) {
+        public Builder(String name, IndexVersion indexCreatedVersion, IndexAnalyzers indexAnalyzers, boolean isSyntheticSourceEnabled) {
             super(name);
             this.indexCreatedVersion = indexCreatedVersion;
             this.analyzers = new TextParams.Analyzers(
@@ -108,10 +104,10 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
                 m -> builder(m).analyzers.positionIncrementGap.getValue(),
                 indexCreatedVersion
             );
-            this.isSyntheticSourceEnabledViaIndexMode = isSyntheticSourceEnabledViaIndexMode;
+            this.isSyntheticSourceEnabled = isSyntheticSourceEnabled;
             this.store = Parameter.storeParam(
                 m -> builder(m).store.getValue(),
-                () -> isSyntheticSourceEnabledViaIndexMode && multiFieldsBuilder.hasSyntheticSourceCompatibleKeywordField() == false
+                () -> isSyntheticSourceEnabled && multiFieldsBuilder.hasSyntheticSourceCompatibleKeywordField() == false
             );
         }
 
@@ -172,7 +168,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     }
 
     public static TypeParser PARSER = new TypeParser(
-        (n, c) -> new Builder(n, c.indexVersionCreated(), c.getIndexAnalyzers(), c.getIndexSettings().getMode().isSyntheticSourceEnabled())
+        (n, c) -> new Builder(n, c.indexVersionCreated(), c.getIndexAnalyzers(), SourceFieldMapper.isSynthetic(c.getIndexSettings()))
     );
 
     /**
@@ -560,12 +556,8 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(
-            leafName(),
-            builder.indexCreatedVersion,
-            builder.analyzers.indexAnalyzers,
-            builder.isSyntheticSourceEnabledViaIndexMode
-        ).init(this);
+        return new Builder(leafName(), builder.indexCreatedVersion, builder.analyzers.indexAnalyzers, builder.isSyntheticSourceEnabled)
+            .init(this);
     }
 
     @Override

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_source_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_source_mapping.yml
@@ -1,4 +1,23 @@
 ---
+synthetic _source is default:
+  - requires:
+      cluster_features: ["mapper.source.remove_synthetic_source_only_validation"]
+      reason: requires new validation logic
+
+  - do:
+      indices.create:
+        index: test-default-source
+        body:
+          settings:
+            index:
+              mode: logsdb
+  - do:
+      indices.get:
+        index: test-default-source
+
+  - match: { test-default-source.mappings._source.mode: "synthetic" }
+
+---
 stored _source mode is supported:
   - requires:
       cluster_features: ["mapper.source.remove_synthetic_source_only_validation"]
@@ -57,3 +76,77 @@ disabled _source is not supported:
   - match: { error.type: "mapper_parsing_exception" }
   - match: { error.root_cause.0.type: "mapper_parsing_exception" }
   - match: { error.reason: "Failed to parse mapping: _source can not be disabled in index using [logsdb] index mode" }
+
+---
+include/exclude is not supported with synthetic _source:
+  - requires:
+      cluster_features: ["mapper.source.remove_synthetic_source_only_validation"]
+      reason: requires new validation logic
+
+  - do:
+      catch: '/filtering the stored _source is incompatible with synthetic source/'
+      indices.create:
+        index: test-includes
+        body:
+          settings:
+            index:
+              mode: logsdb
+          mappings:
+            _source:
+              includes: [a]
+
+  - do:
+      catch: '/filtering the stored _source is incompatible with synthetic source/'
+      indices.create:
+        index: test-excludes
+        body:
+          settings:
+            index:
+              mode: logsdb
+          mappings:
+            _source:
+              excludes: [b]
+
+---
+include/exclude is supported with stored _source:
+  - requires:
+      cluster_features: ["mapper.source.remove_synthetic_source_only_validation"]
+      reason: requires new validation logic
+
+  - do:
+      indices.create:
+        index: test-includes
+        body:
+          settings:
+            index:
+              mode: logsdb
+          mappings:
+            _source:
+              mode: stored
+              includes: [a]
+
+  - do:
+      indices.get:
+        index: test-includes
+
+  - match: { test-includes.mappings._source.mode: "stored" }
+  - match: { test-includes.mappings._source.includes: ["a"] }
+
+  - do:
+      indices.create:
+        index: test-excludes
+        body:
+          settings:
+            index:
+              mode: logsdb
+          mappings:
+            _source:
+              mode: stored
+              excludes: [b]
+
+  - do:
+      indices.get:
+        index: test-excludes
+
+  - match: { test-excludes.mappings._source.mode: "stored" }
+  - match: { test-excludes.mappings._source.excludes: ["b"] }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -528,6 +528,36 @@ disabled source is not supported:
   - match: { error.root_cause.0.type: "mapper_parsing_exception" }
   - match: { error.reason: "Failed to parse mapping: _source can not be disabled in index using [time_series] index mode" }
 
+  - do:
+      catch: bad_request
+      indices.create:
+        index: tsdb_index
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [k8s.pod.uid]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            _source:
+              enabled: false
+            properties:
+              "@timestamp":
+                type: date
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+
+  - match: { error.type: "mapper_parsing_exception" }
+  - match: { error.root_cause.0.type: "mapper_parsing_exception" }
+  - match: { error.reason: "Failed to parse mapping: _source can not be disabled in index using [time_series] index mode" }
+
 ---
 source include/exclude:
   - requires:

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -120,8 +120,8 @@ public enum IndexMode {
         public void validateSourceFieldMapper(SourceFieldMapper sourceFieldMapper) {}
 
         @Override
-        public boolean isSyntheticSourceEnabled() {
-            return false;
+        public SourceFieldMapper.Mode defaultSourceMode() {
+            return SourceFieldMapper.Mode.STORED;
         }
     },
     TIME_SERIES("time_series") {
@@ -223,8 +223,8 @@ public enum IndexMode {
         }
 
         @Override
-        public boolean isSyntheticSourceEnabled() {
-            return true;
+        public SourceFieldMapper.Mode defaultSourceMode() {
+            return SourceFieldMapper.Mode.SYNTHETIC;
         }
     },
     LOGSDB("logsdb") {
@@ -300,8 +300,8 @@ public enum IndexMode {
         }
 
         @Override
-        public boolean isSyntheticSourceEnabled() {
-            return true;
+        public SourceFieldMapper.Mode defaultSourceMode() {
+            return SourceFieldMapper.Mode.SYNTHETIC;
         }
 
         @Override
@@ -460,9 +460,9 @@ public enum IndexMode {
     public abstract void validateSourceFieldMapper(SourceFieldMapper sourceFieldMapper);
 
     /**
-     * @return whether synthetic source is the only allowed source mode.
+     * @return default source mode for this mode
      */
-    public abstract boolean isSyntheticSourceEnabled();
+    public abstract SourceFieldMapper.Mode defaultSourceMode();
 
     public String getDefaultCodec() {
         return CodecService.DEFAULT_CODEC;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -49,13 +49,13 @@ public class BinaryFieldMapper extends FieldMapper {
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
-        private final boolean isSyntheticSourceEnabledViaIndexMode;
+        private final boolean isSyntheticSourceEnabled;
         private final Parameter<Boolean> hasDocValues;
 
-        public Builder(String name, boolean isSyntheticSourceEnabledViaIndexMode) {
+        public Builder(String name, boolean isSyntheticSourceEnabled) {
             super(name);
-            this.isSyntheticSourceEnabledViaIndexMode = isSyntheticSourceEnabledViaIndexMode;
-            this.hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, isSyntheticSourceEnabledViaIndexMode);
+            this.isSyntheticSourceEnabled = isSyntheticSourceEnabled;
+            this.hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, isSyntheticSourceEnabled);
         }
 
         @Override
@@ -79,9 +79,7 @@ public class BinaryFieldMapper extends FieldMapper {
         }
     }
 
-    public static final TypeParser PARSER = new TypeParser(
-        (n, c) -> new Builder(n, c.getIndexSettings().getMode().isSyntheticSourceEnabled())
-    );
+    public static final TypeParser PARSER = new TypeParser((n, c) -> new Builder(n, SourceFieldMapper.isSynthetic(c.getIndexSettings())));
 
     public static final class BinaryFieldType extends MappedFieldType {
         private BinaryFieldType(String name, boolean isStored, boolean hasDocValues, Map<String, String> meta) {
@@ -140,13 +138,13 @@ public class BinaryFieldMapper extends FieldMapper {
 
     private final boolean stored;
     private final boolean hasDocValues;
-    private final boolean isSyntheticSourceEnabledViaIndexMode;
+    private final boolean isSyntheticSourceEnabled;
 
     protected BinaryFieldMapper(String simpleName, MappedFieldType mappedFieldType, BuilderParams builderParams, Builder builder) {
         super(simpleName, mappedFieldType, builderParams);
         this.stored = builder.stored.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();
-        this.isSyntheticSourceEnabledViaIndexMode = builder.isSyntheticSourceEnabledViaIndexMode;
+        this.isSyntheticSourceEnabled = builder.isSyntheticSourceEnabled;
     }
 
     @Override
@@ -186,7 +184,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new BinaryFieldMapper.Builder(leafName(), isSyntheticSourceEnabledViaIndexMode).init(this);
+        return new BinaryFieldMapper.Builder(leafName(), isSyntheticSourceEnabled).init(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -334,13 +334,10 @@ final class DynamicFieldsBuilder {
                 );
             } else {
                 return createDynamicField(
-                    new TextFieldMapper.Builder(
-                        name,
-                        context.indexAnalyzers(),
-                        context.indexSettings().getMode().isSyntheticSourceEnabled()
-                    ).addMultiField(
-                        new KeywordFieldMapper.Builder("keyword", context.indexSettings().getIndexVersionCreated()).ignoreAbove(256)
-                    ),
+                    new TextFieldMapper.Builder(name, context.indexAnalyzers(), SourceFieldMapper.isSynthetic(context.indexSettings()))
+                        .addMultiField(
+                            new KeywordFieldMapper.Builder("keyword", context.indexSettings().getIndexVersionCreated()).ignoreAbove(256)
+                        ),
                     context
                 );
             }
@@ -412,10 +409,7 @@ final class DynamicFieldsBuilder {
         }
 
         boolean newDynamicBinaryField(DocumentParserContext context, String name) throws IOException {
-            return createDynamicField(
-                new BinaryFieldMapper.Builder(name, context.indexSettings().getMode().isSyntheticSourceEnabled()),
-                context
-            );
+            return createDynamicField(new BinaryFieldMapper.Builder(name, SourceFieldMapper.isSynthetic(context.indexSettings())), context);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -124,7 +124,10 @@ public final class MappingParser {
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersSupplier.get();
         Map<String, Object> meta = null;
 
-        boolean isSourceSynthetic = mappingParserContext.getIndexSettings().getMode().isSyntheticSourceEnabled();
+        // TODO this should be the final value once `_source.mode` mapping parameter is not used anymore
+        // and it should not be reassigned below.
+        // For now it is still possible to set `_source.mode` so this is correct.
+        boolean isSourceSynthetic = SourceFieldMapper.isSynthetic(mappingParserContext.getIndexSettings());
         boolean isDataStream = false;
 
         Iterator<Map.Entry<String, Object>> iterator = mappingSource.entrySet().iterator();

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -64,14 +64,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public static final Setting<Mode> INDEX_MAPPER_SOURCE_MODE_SETTING = Setting.enumSetting(SourceFieldMapper.Mode.class, settings -> {
         final IndexMode indexMode = IndexSettings.MODE.get(settings);
-
-        switch (indexMode) {
-            case LOGSDB:
-            case TIME_SERIES:
-                return Mode.SYNTHETIC.name();
-            default:
-                return Mode.STORED.name();
-        }
+        return indexMode.defaultSourceMode().name();
     }, "index.mapping.source.mode", value -> {}, Setting.Property.Final, Setting.Property.IndexScope);
 
     /** The source mode */
@@ -85,68 +78,28 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         null,
         Explicit.IMPLICIT_TRUE,
         Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null
+        Strings.EMPTY_ARRAY
     );
 
-    private static final SourceFieldMapper DEFAULT_DISABLED = new SourceFieldMapper(
+    private static final SourceFieldMapper STORED = new SourceFieldMapper(
+        Mode.STORED,
+        Explicit.IMPLICIT_TRUE,
+        Strings.EMPTY_ARRAY,
+        Strings.EMPTY_ARRAY
+    );
+
+    private static final SourceFieldMapper SYNTHETIC = new SourceFieldMapper(
+        Mode.SYNTHETIC,
+        Explicit.IMPLICIT_TRUE,
+        Strings.EMPTY_ARRAY,
+        Strings.EMPTY_ARRAY
+    );
+
+    private static final SourceFieldMapper DISABLED = new SourceFieldMapper(
         Mode.DISABLED,
         Explicit.IMPLICIT_TRUE,
         Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null
-    );
-
-    private static final SourceFieldMapper DEFAULT_SYNTHETIC = new SourceFieldMapper(
-        Mode.SYNTHETIC,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        null
-    );
-
-    private static final SourceFieldMapper TSDB_DEFAULT = new SourceFieldMapper(
-        Mode.SYNTHETIC,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        IndexMode.TIME_SERIES
-    );
-
-    private static final SourceFieldMapper TSDB_DEFAULT_STORED = new SourceFieldMapper(
-        Mode.STORED,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        IndexMode.TIME_SERIES
-    );
-
-    private static final SourceFieldMapper LOGSDB_DEFAULT = new SourceFieldMapper(
-        Mode.SYNTHETIC,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        IndexMode.LOGSDB
-    );
-
-    private static final SourceFieldMapper LOGSDB_DEFAULT_STORED = new SourceFieldMapper(
-        Mode.STORED,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        IndexMode.LOGSDB
-    );
-
-    /*
-     * Synthetic source was added as the default for TSDB in v.8.7. The legacy field mapper below
-     * is used in bwc tests and mixed clusters containing time series indexes created in an earlier version.
-     */
-    private static final SourceFieldMapper TSDB_LEGACY_DEFAULT = new SourceFieldMapper(
-        null,
-        Explicit.IMPLICIT_TRUE,
-        Strings.EMPTY_ARRAY,
-        Strings.EMPTY_ARRAY,
-        IndexMode.TIME_SERIES
+        Strings.EMPTY_ARRAY
     );
 
     public static class Defaults {
@@ -225,12 +178,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
             return new Parameter<?>[] { enabled, mode, includes, excludes };
         }
 
-        private boolean isDefault(final Mode sourceMode) {
-            if (sourceMode != null
-                && (((indexMode != null && indexMode.isSyntheticSourceEnabled() && sourceMode == Mode.SYNTHETIC) == false)
-                    || sourceMode == Mode.DISABLED)) {
-                return false;
-            }
+        private boolean isDefault() {
             return enabled.get().value() && includes.getValue().isEmpty() && excludes.getValue().isEmpty();
         }
 
@@ -241,15 +189,9 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                     throw new MapperParsingException("Cannot set both [mode] and [enabled] parameters");
                 }
             }
-            // NOTE: if the `index.mapper.source.mode` exists it takes precedence to determine the source mode for `_source`
-            // otherwise the mode is determined according to `index.mode` and `_source.mode`.
-            final Mode sourceMode = INDEX_MAPPER_SOURCE_MODE_SETTING.exists(settings)
-                ? INDEX_MAPPER_SOURCE_MODE_SETTING.get(settings)
-                : mode.get();
-            if (isDefault(sourceMode)) {
-                return resolveSourceMode(indexMode, sourceMode == null ? Mode.STORED : sourceMode);
 
-            }
+            final Mode sourceMode = resolveSourceMode();
+
             if (supportsNonDefaultParameterValues == false) {
                 List<String> disallowed = new ArrayList<>();
                 if (enabled.get().value() == false) {
@@ -273,61 +215,75 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                 }
             }
 
-            SourceFieldMapper sourceFieldMapper = new SourceFieldMapper(
-                sourceMode,
-                enabled.get(),
-                includes.getValue().toArray(Strings.EMPTY_ARRAY),
-                excludes.getValue().toArray(Strings.EMPTY_ARRAY),
-                indexMode
-            );
+            if (sourceMode == Mode.SYNTHETIC && (includes.getValue().isEmpty() == false || excludes.getValue().isEmpty() == false)) {
+                throw new IllegalArgumentException("filtering the stored _source is incompatible with synthetic source");
+            }
+
+            SourceFieldMapper sourceFieldMapper;
+            if (isDefault()) {
+                // Needed for bwc so that "mode" is not serialized in case of a standard index with stored source.
+                if (sourceMode == null) {
+                    sourceFieldMapper = DEFAULT;
+                } else {
+                    sourceFieldMapper = resolveStaticInstance(sourceMode);
+                }
+            } else {
+                sourceFieldMapper = new SourceFieldMapper(
+                    sourceMode,
+                    enabled.get(),
+                    includes.getValue().toArray(Strings.EMPTY_ARRAY),
+                    excludes.getValue().toArray(Strings.EMPTY_ARRAY)
+                );
+            }
             if (indexMode != null) {
                 indexMode.validateSourceFieldMapper(sourceFieldMapper);
             }
             return sourceFieldMapper;
         }
 
+        private Mode resolveSourceMode() {
+            // If the `index.mapper.source.mode` exists it takes precedence to determine the source mode for `_source`
+            // otherwise the mode is determined according to `_source.mode`.
+            if (INDEX_MAPPER_SOURCE_MODE_SETTING.exists(settings)) {
+                return INDEX_MAPPER_SOURCE_MODE_SETTING.get(settings);
+            }
+
+            // If `_source.mode` is not set we need to apply a default according to index mode.
+            if (mode.get() == null) {
+                if (indexMode == null || indexMode == IndexMode.STANDARD) {
+                    // Special case to avoid serializing mode.
+                    return null;
+                }
+
+                return indexMode.defaultSourceMode();
+            }
+
+            return mode.get();
+        }
     }
 
-    private static SourceFieldMapper resolveSourceMode(final IndexMode indexMode, final Mode sourceMode) {
-        switch (indexMode) {
-            case STANDARD:
-                switch (sourceMode) {
-                    case SYNTHETIC:
-                        return DEFAULT_SYNTHETIC;
-                    case STORED:
-                        return DEFAULT;
-                    case DISABLED:
-                        return DEFAULT_DISABLED;
-                    default:
-                        throw new IllegalArgumentException("Unsupported source mode: " + sourceMode);
-                }
-            case TIME_SERIES:
-            case LOGSDB:
-                switch (sourceMode) {
-                    case SYNTHETIC:
-                        return indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT : LOGSDB_DEFAULT;
-                    case STORED:
-                        return indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT_STORED : LOGSDB_DEFAULT_STORED;
-                    case DISABLED:
-                        throw new IllegalArgumentException("_source can not be disabled in index using [" + indexMode + "] index mode");
-                    default:
-                        throw new IllegalArgumentException("Unsupported source mode: " + sourceMode);
-                }
-            default:
-                throw new IllegalArgumentException("Unsupported index mode: " + indexMode);
-        }
+    private static SourceFieldMapper resolveStaticInstance(final Mode sourceMode) {
+        return switch (sourceMode) {
+            case SYNTHETIC -> SYNTHETIC;
+            case STORED -> STORED;
+            case DISABLED -> DISABLED;
+        };
     }
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(c -> {
         final IndexMode indexMode = c.getIndexSettings().getMode();
-        final Mode settingSourceMode = INDEX_MAPPER_SOURCE_MODE_SETTING.get(c.getSettings());
 
-        if (indexMode.isSyntheticSourceEnabled()) {
-            if (indexMode == IndexMode.TIME_SERIES && c.getIndexSettings().getIndexVersionCreated().before(IndexVersions.V_8_7_0)) {
-                return TSDB_LEGACY_DEFAULT;
-            }
+        if (indexMode == IndexMode.TIME_SERIES && c.getIndexSettings().getIndexVersionCreated().before(IndexVersions.V_8_7_0)) {
+            return DEFAULT;
         }
-        return resolveSourceMode(indexMode, settingSourceMode == null ? Mode.STORED : settingSourceMode);
+
+        final Mode settingSourceMode = INDEX_MAPPER_SOURCE_MODE_SETTING.get(c.getSettings());
+        // Needed for bwc so that "mode" is not serialized in case of standard index with stored source.
+        if (indexMode == IndexMode.STANDARD && settingSourceMode == Mode.STORED) {
+            return DEFAULT;
+        }
+
+        return resolveStaticInstance(settingSourceMode);
     },
         c -> new Builder(
             c.getIndexSettings().getMode(),
@@ -384,21 +340,14 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     private final String[] excludes;
     private final SourceFilter sourceFilter;
 
-    private final IndexMode indexMode;
-
-    private SourceFieldMapper(Mode mode, Explicit<Boolean> enabled, String[] includes, String[] excludes, IndexMode indexMode) {
+    private SourceFieldMapper(Mode mode, Explicit<Boolean> enabled, String[] includes, String[] excludes) {
         super(new SourceFieldType((enabled.explicit() && enabled.value()) || (enabled.explicit() == false && mode != Mode.DISABLED)));
-        assert enabled.explicit() == false || mode == null;
         this.mode = mode;
         this.enabled = enabled;
         this.sourceFilter = buildSourceFilter(includes, excludes);
         this.includes = includes;
         this.excludes = excludes;
-        if (this.sourceFilter != null && (mode == Mode.SYNTHETIC || indexMode == IndexMode.TIME_SERIES)) {
-            throw new IllegalArgumentException("filtering the stored _source is incompatible with synthetic source");
-        }
         this.complete = stored() && sourceFilter == null;
-        this.indexMode = indexMode;
     }
 
     private static SourceFilter buildSourceFilter(String[] includes, String[] excludes) {
@@ -436,9 +385,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         final BytesReference adaptedSource = applyFilters(originalSource, contentType);
 
         if (adaptedSource != null) {
-            assert context.indexSettings().getIndexVersionCreated().before(IndexVersions.V_8_7_0)
-                || indexMode == null
-                || indexMode.isSyntheticSourceEnabled() == false;
             final BytesRef ref = adaptedSource.toBytesRef();
             context.doc().add(new StoredField(fieldType().name(), ref.bytes, ref.offset, ref.length));
         }
@@ -472,7 +418,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(indexMode, Settings.EMPTY, false).init(this);
+        return new Builder(null, Settings.EMPTY, false).init(this);
     }
 
     /**
@@ -487,6 +433,10 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     public boolean isSynthetic() {
         return mode == Mode.SYNTHETIC;
+    }
+
+    public static boolean isSynthetic(IndexSettings indexSettings) {
+        return INDEX_MAPPER_SOURCE_MODE_SETTING.get(indexSettings.getSettings()) == SourceFieldMapper.Mode.SYNTHETIC;
     }
 
     public boolean isDisabled() {

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -235,7 +236,7 @@ public class QueryRewriteContext {
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(
                 name,
                 getIndexAnalyzers(),
-                getIndexSettings() != null && getIndexSettings().getMode().isSyntheticSourceEnabled()
+                getIndexSettings() != null && SourceFieldMapper.isSynthetic(getIndexSettings())
             );
             return builder.build(MapperBuilderContext.root(false, false)).fieldType();
         } else {

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
@@ -94,7 +95,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
                 fieldType = new TextFieldMapper.Builder(
                     fieldName,
                     createDefaultIndexAnalyzers(),
-                    indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+                    SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
                 ).fielddata(true).build(context).fieldType();
             }
         } else if (type.equals("float")) {
@@ -162,10 +163,9 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
                 docValues
             ).build(context).fieldType();
         } else if (type.equals("binary")) {
-            fieldType = new BinaryFieldMapper.Builder(fieldName, indexService.getIndexSettings().getMode().isSyntheticSourceEnabled())
-                .docValues(docValues)
-                .build(context)
-                .fieldType();
+            fieldType = new BinaryFieldMapper.Builder(fieldName, SourceFieldMapper.isSynthetic(indexService.getIndexSettings())).docValues(
+                docValues
+            ).build(context).fieldType();
         } else {
             throw new UnsupportedOperationException(type);
         }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 
 import java.util.List;
@@ -56,7 +57,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
             MappedFieldType ft = new TextFieldMapper.Builder(
                 "high_freq",
                 createDefaultIndexAnalyzers(),
-                indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+                SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
             ).fielddata(true).fielddataFrequencyFilter(0, random.nextBoolean() ? 100 : 0.5d, 0).build(builderContext).fieldType();
             IndexOrdinalsFieldData fieldData = searchExecutionContext.getForField(ft, MappedFieldType.FielddataOperation.SEARCH);
             for (LeafReaderContext context : contexts) {
@@ -72,7 +73,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
             MappedFieldType ft = new TextFieldMapper.Builder(
                 "high_freq",
                 createDefaultIndexAnalyzers(),
-                indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+                SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
             ).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, 201, 100)
                 .build(builderContext)
@@ -91,7 +92,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
             MappedFieldType ft = new TextFieldMapper.Builder(
                 "med_freq",
                 createDefaultIndexAnalyzers(),
-                indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+                SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
             ).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, Integer.MAX_VALUE, 101)
                 .build(builderContext)
@@ -111,7 +112,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
             MappedFieldType ft = new TextFieldMapper.Builder(
                 "med_freq",
                 createDefaultIndexAnalyzers(),
-                indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+                SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
             ).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, Integer.MAX_VALUE, 101)
                 .build(builderContext)

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -163,12 +164,12 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final MappedFieldType mapper1 = new TextFieldMapper.Builder(
             "field_1",
             createDefaultIndexAnalyzers(),
-            indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+            SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
         ).fielddata(true).build(context).fieldType();
         final MappedFieldType mapper2 = new TextFieldMapper.Builder(
             "field_2",
             createDefaultIndexAnalyzers(),
-            indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+            SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
         ).fielddata(true).build(context).fieldType();
         final IndexWriter writer = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new KeywordAnalyzer()));
         Document doc = new Document();
@@ -234,7 +235,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
         final MappedFieldType mapper1 = new TextFieldMapper.Builder(
             "s",
             createDefaultIndexAnalyzers(),
-            indexService.getIndexSettings().getMode().isSyntheticSourceEnabled()
+            SourceFieldMapper.isSynthetic(indexService.getIndexSettings())
         ).fielddata(true).build(context).fieldType();
         final IndexWriter writer = new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new KeywordAnalyzer()));
         Document doc = new Document();

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
@@ -323,7 +324,7 @@ public class HighlightBuilderTests extends ESTestCase {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(
                     name,
                     createDefaultIndexAnalyzers(),
-                    idxSettings.getMode().isSyntheticSourceEnabled()
+                    SourceFieldMapper.isSynthetic(idxSettings)
                 );
                 return builder.build(MapperBuilderContext.root(false, false)).fieldType();
             }

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MappingLookup;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -166,7 +167,7 @@ public class QueryRescorerBuilderTests extends ESTestCase {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(
                     name,
                     createDefaultIndexAnalyzers(),
-                    idxSettings.getMode().isSyntheticSourceEnabled()
+                    SourceFieldMapper.isSynthetic(idxSettings)
                 );
                 return builder.build(MapperBuilderContext.root(false, false)).fieldType();
             }
@@ -233,7 +234,7 @@ public class QueryRescorerBuilderTests extends ESTestCase {
                 TextFieldMapper.Builder builder = new TextFieldMapper.Builder(
                     name,
                     createDefaultIndexAnalyzers(),
-                    idxSettings.getMode().isSyntheticSourceEnabled()
+                    SourceFieldMapper.isSynthetic(idxSettings)
                 );
                 return builder.build(MapperBuilderContext.root(false, false)).fieldType();
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Remove IndexMode#isSyntheticSourceEnabled (#114963)](https://github.com/elastic/elasticsearch/pull/114963)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)