### PR TITLE
Fixed hyperlink in search.asciidoc

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -38,7 +38,7 @@ must have the `read` index privilege for the alias's data streams or indices.
 
 Allows you to execute a search query and get back search hits that match the
 query. You can provide search queries using the <<search-api-query-params-q,`q`
-query string parameter>> or <<search-search,request body>>.
+query string parameter>> or <<search-search-api-request-body,request body>>.
 
 [[search-search-api-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
In the documentation's description section, there is a link or reference to the "request body" within a paragraph. However, when users click on this link, it fails to redirect them to the intended "request body" section of the document.

I was just reading the search API and I found this issue, it should be a quick fix.