### PR TITLE
[8.16] Reprocess operator file settings on service start (#114295)

### DIFF
--- a/docs/changelog/114295.yaml
+++ b/docs/changelog/114295.yaml
@@ -1,0 +1,5 @@
+pr: 114295
+summary: "Reprocess operator file settings when settings service starts, due to node restart or master node change"
+area: Infra/Settings
+type: enhancement
+issues: [ ]

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.upgrades;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.XContentTestUtils;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class FileSettingsRoleMappingUpgradeIT extends ParameterizedRollingUpgradeTestCase {
+
+    private static final String settingsJSON = """
+        {
+             "metadata": {
+                 "version": "1",
+                 "compatibility": "8.4.0"
+             },
+             "state": {
+                 "role_mappings": {
+                       "everyone_kibana": {
+                          "enabled": true,
+                          "roles": [ "kibana_user" ],
+                          "rules": { "field": { "username": "*" } }
+                       }
+                 }
+             }
+        }""";
+
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .version(getOldClusterTestVersion())
+        .nodes(NODE_NUM)
+        .setting("path.repo", new Supplier<>() {
+            @Override
+            @SuppressForbidden(reason = "TemporaryFolder only has io.File methods, not nio.File")
+            public String get() {
+                return repoDirectory.getRoot().getPath();
+            }
+        })
+        .setting("xpack.security.enabled", "true")
+        // workaround to avoid having to set up clients and authorization headers
+        .setting("xpack.security.authc.anonymous.roles", "superuser")
+        .configFile("operator/settings.json", Resource.fromString(settingsJSON))
+        .build();
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
+
+    public FileSettingsRoleMappingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Override
+    protected ElasticsearchCluster getUpgradeCluster() {
+        return cluster;
+    }
+
+    @Before
+    public void checkVersions() {
+        assumeTrue(
+            "Only relevant when upgrading from a version before role mappings were stored in cluster state",
+            oldClusterHasFeature("gte_v8.4.0") && oldClusterHasFeature("gte_v8.15.0") == false
+        );
+    }
+
+    public void testRoleMappingsAppliedOnUpgrade() throws IOException {
+        if (isOldCluster()) {
+            Request clusterStateRequest = new Request("GET", "/_cluster/state/metadata");
+            List<Object> roleMappings = new XContentTestUtils.JsonMapView(entityAsMap(client().performRequest(clusterStateRequest))).get(
+                "metadata.role_mappings.role_mappings"
+            );
+            assertThat(roleMappings, is(nullValue()));
+        } else if (isUpgradedCluster()) {
+            // the nodes have all been upgraded. Check they re-processed the role mappings in the settings file on
+            // upgrade
+            Request clusterStateRequest = new Request("GET", "/_cluster/state/metadata");
+            List<Object> roleMappings = new XContentTestUtils.JsonMapView(entityAsMap(client().performRequest(clusterStateRequest))).get(
+                "metadata.role_mappings.role_mappings"
+            );
+            assertThat(roleMappings, is(not(nullValue())));
+            assertThat(roleMappings.size(), equalTo(1));
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.reservedstate.action.ReservedClusterSettingsAction;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -40,6 +41,7 @@ import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
 import static org.elasticsearch.test.NodeRoles.masterNode;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -50,7 +52,12 @@ import static org.hamcrest.Matchers.nullValue;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public class FileSettingsServiceIT extends ESIntegTestCase {
 
-    private static final AtomicLong versionCounter = new AtomicLong(1);
+    private final AtomicLong versionCounter = new AtomicLong(1);
+
+    @Before
+    public void resetVersionCounter() {
+        versionCounter.set(1);
+    }
 
     private static final String testJSON = """
         {
@@ -102,6 +109,19 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
              }
         }""";
 
+    private static final String testOtherErrorJSON = """
+        {
+             "metadata": {
+                 "version": "%s",
+                 "compatibility": "8.4.0"
+             },
+             "state": {
+                 "bad_cluster_settings": {
+                     "search.allow_expensive_queries": "false"
+                 }
+             }
+        }""";
+
     private void assertMasterNode(Client client, String node) {
         assertThat(
             client.admin().cluster().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode().getName(),
@@ -109,8 +129,9 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         );
     }
 
-    public static void writeJSONFile(String node, String json, AtomicLong versionCounter, Logger logger) throws Exception {
-        long version = versionCounter.incrementAndGet();
+    public static void writeJSONFile(String node, String json, AtomicLong versionCounter, Logger logger, boolean incrementVersion)
+        throws Exception {
+        long version = incrementVersion ? versionCounter.incrementAndGet() : versionCounter.get();
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
@@ -122,6 +143,15 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         logger.info("--> Before writing new settings file with version [{}]", version);
         Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
         logger.info("--> After writing new settings file: [{}]", settingsFileContent);
+    }
+
+    public static void writeJSONFile(String node, String json, AtomicLong versionCounter, Logger logger) throws Exception {
+        writeJSONFile(node, json, versionCounter, logger, true);
+    }
+
+    public static void writeJSONFileWithoutVersionIncrement(String node, String json, AtomicLong versionCounter, Logger logger)
+        throws Exception {
+        writeJSONFile(node, json, versionCounter, logger, false);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupCleanupClusterStateListener(String node) {
@@ -171,7 +201,10 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
     private void assertClusterStateSaveOK(CountDownLatch savedClusterState, AtomicLong metadataVersion, String expectedBytesPerSec)
         throws Exception {
         assertTrue(savedClusterState.await(20, TimeUnit.SECONDS));
+        assertExpectedRecoveryBytesSettingAndVersion(metadataVersion, expectedBytesPerSec);
+    }
 
+    private static void assertExpectedRecoveryBytesSettingAndVersion(AtomicLong metadataVersion, String expectedBytesPerSec) {
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
             new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
@@ -337,6 +370,77 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         assertClusterStateNotSaved(savedClusterState.v1(), savedClusterState.v2());
     }
 
+    public void testErrorCanRecoverOnRestart() throws Exception {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        logger.info("--> start data node / non master node");
+        String dataNode = internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
+        FileSettingsService dataFileSettingsService = internalCluster().getInstance(FileSettingsService.class, dataNode);
+
+        assertFalse(dataFileSettingsService.watching());
+
+        logger.info("--> start master node");
+        final String masterNode = internalCluster().startMasterOnlyNode(
+            Settings.builder().put(INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s").build()
+        );
+        assertMasterNode(internalCluster().nonMasterClient(), masterNode);
+        var savedClusterState = setupClusterStateListenerForError(masterNode);
+
+        FileSettingsService masterFileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
+
+        assertTrue(masterFileSettingsService.watching());
+        assertFalse(dataFileSettingsService.watching());
+
+        writeJSONFile(masterNode, testErrorJSON, versionCounter, logger);
+        AtomicLong metadataVersion = savedClusterState.v2();
+        assertClusterStateNotSaved(savedClusterState.v1(), metadataVersion);
+        assertHasErrors(metadataVersion, "not_cluster_settings");
+
+        // write valid json without version increment to simulate ES being able to process settings after a restart (usually, this would be
+        // due to a code change)
+        writeJSONFileWithoutVersionIncrement(masterNode, testJSON, versionCounter, logger);
+        internalCluster().restartNode(masterNode);
+        ensureGreen();
+
+        // we don't know the exact metadata version to wait for so rely on an assertBusy instead
+        assertBusy(() -> assertExpectedRecoveryBytesSettingAndVersion(metadataVersion, "50mb"));
+        assertBusy(() -> assertNoErrors(metadataVersion));
+    }
+
+    public void testNewErrorOnRestartReprocessing() throws Exception {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        logger.info("--> start data node / non master node");
+        String dataNode = internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
+        FileSettingsService dataFileSettingsService = internalCluster().getInstance(FileSettingsService.class, dataNode);
+
+        assertFalse(dataFileSettingsService.watching());
+
+        logger.info("--> start master node");
+        final String masterNode = internalCluster().startMasterOnlyNode(
+            Settings.builder().put(INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s").build()
+        );
+        assertMasterNode(internalCluster().nonMasterClient(), masterNode);
+        var savedClusterState = setupClusterStateListenerForError(masterNode);
+
+        FileSettingsService masterFileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
+
+        assertTrue(masterFileSettingsService.watching());
+        assertFalse(dataFileSettingsService.watching());
+
+        writeJSONFile(masterNode, testErrorJSON, versionCounter, logger);
+        AtomicLong metadataVersion = savedClusterState.v2();
+        assertClusterStateNotSaved(savedClusterState.v1(), metadataVersion);
+        assertHasErrors(metadataVersion, "not_cluster_settings");
+
+        // write json with new error without version increment to simulate ES failing to process settings after a restart for a new reason
+        // (usually, this would be due to a code change)
+        writeJSONFileWithoutVersionIncrement(masterNode, testOtherErrorJSON, versionCounter, logger);
+        assertHasErrors(metadataVersion, "not_cluster_settings");
+        internalCluster().restartNode(masterNode);
+        ensureGreen();
+
+        assertBusy(() -> assertHasErrors(metadataVersion, "bad_cluster_settings"));
+    }
+
     public void testSettingsAppliedOnMasterReElection() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start master node");
@@ -383,4 +487,21 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         assertClusterStateSaveOK(savedClusterState.v1(), savedClusterState.v2(), "43mb");
     }
 
+    private void assertHasErrors(AtomicLong waitForMetadataVersion, String expectedError) {
+        var errorMetadata = getErrorMetadata(waitForMetadataVersion);
+        assertThat(errorMetadata, is(notNullValue()));
+        assertThat(errorMetadata.errors(), containsInAnyOrder(containsString(expectedError)));
+    }
+
+    private void assertNoErrors(AtomicLong waitForMetadataVersion) {
+        var errorMetadata = getErrorMetadata(waitForMetadataVersion);
+        assertThat(errorMetadata, is(nullValue()));
+    }
+
+    private ReservedStateErrorMetadata getErrorMetadata(AtomicLong waitForMetadataVersion) {
+        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(waitForMetadataVersion.get())
+        ).actionGet();
+        return clusterStateResponse.getState().getMetadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE).errorMetadata();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/common/file/AbstractFileWatchingService.java
@@ -77,6 +77,15 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
 
     protected abstract void processInitialFileMissing() throws InterruptedException, ExecutionException, IOException;
 
+    /**
+     * Defaults to generic {@link #processFileChanges()} behavior.
+     * An implementation can override this to define different file handling when the file is processed during
+     * initial service start.
+     */
+    protected void processFileOnServiceStart() throws IOException, ExecutionException, InterruptedException {
+        processFileChanges();
+    }
+
     public final void addFileChangedListener(FileChangedListener listener) {
         eventListeners.add(listener);
     }
@@ -174,7 +183,7 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
 
             if (Files.exists(path)) {
                 logger.debug("found initial operator settings file [{}], applying...", path);
-                processSettingsAndNotifyListeners();
+                processSettingsOnServiceStartAndNotifyListeners();
             } else {
                 processInitialFileMissing();
                 // Notify everyone we don't have any initial file settings
@@ -288,6 +297,17 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
                 retryCount++;
             }
         } while (true);
+    }
+
+    void processSettingsOnServiceStartAndNotifyListeners() throws InterruptedException {
+        try {
+            processFileOnServiceStart();
+            for (var listener : eventListeners) {
+                listener.watchedFileChanged();
+            }
+        } catch (IOException | ExecutionException e) {
+            logger.error(() -> "Error processing watched file: " + watchedFile(), e);
+        }
     }
 
     void processSettingsAndNotifyListeners() throws InterruptedException {

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ErrorState.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ErrorState.java
@@ -15,9 +15,22 @@ import java.util.List;
 
 import static org.elasticsearch.ExceptionsHelper.stackTrace;
 
-record ErrorState(String namespace, Long version, List<String> errors, ReservedStateErrorMetadata.ErrorKind errorKind) {
-    ErrorState(String namespace, Long version, Exception e, ReservedStateErrorMetadata.ErrorKind errorKind) {
-        this(namespace, version, List.of(stackTrace(e)), errorKind);
+record ErrorState(
+    String namespace,
+    Long version,
+    ReservedStateVersionCheck versionCheck,
+    List<String> errors,
+    ReservedStateErrorMetadata.ErrorKind errorKind
+) {
+
+    ErrorState(
+        String namespace,
+        Long version,
+        ReservedStateVersionCheck versionCheck,
+        Exception e,
+        ReservedStateErrorMetadata.ErrorKind errorKind
+    ) {
+        this(namespace, version, versionCheck, List.of(stackTrace(e)), errorKind);
     }
 
     public String toString() {

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -110,7 +110,13 @@ public class ReservedClusterStateService {
         try {
             return stateChunkParser.apply(parser, null);
         } catch (Exception e) {
-            ErrorState errorState = new ErrorState(namespace, EMPTY_VERSION, e, ReservedStateErrorMetadata.ErrorKind.PARSING);
+            ErrorState errorState = new ErrorState(
+                namespace,
+                EMPTY_VERSION,
+                ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
+                e,
+                ReservedStateErrorMetadata.ErrorKind.PARSING
+            );
             updateErrorState(errorState);
             logger.debug("error processing state change request for [{}] with the following errors [{}]", namespace, errorState);
 
@@ -123,16 +129,22 @@ public class ReservedClusterStateService {
      *
      * @param namespace the namespace under which we'll store the reserved keys in the cluster state metadata
      * @param parser the XContentParser to process
+     * @param versionCheck determines if current and new versions of reserved state require processing or should be skipped
      * @param errorListener a consumer called with {@link IllegalStateException} if the content has errors and the
      *        cluster state cannot be correctly applied, null if successful or state couldn't be applied because of incompatible version.
      */
-    public void process(String namespace, XContentParser parser, Consumer<Exception> errorListener) {
+    public void process(
+        String namespace,
+        XContentParser parser,
+        ReservedStateVersionCheck versionCheck,
+        Consumer<Exception> errorListener
+    ) {
         ReservedStateChunk stateChunk;
 
         try {
             stateChunk = parse(namespace, parser);
         } catch (Exception e) {
-            ErrorState errorState = new ErrorState(namespace, EMPTY_VERSION, e, ReservedStateErrorMetadata.ErrorKind.PARSING);
+            ErrorState errorState = new ErrorState(namespace, EMPTY_VERSION, versionCheck, e, ReservedStateErrorMetadata.ErrorKind.PARSING);
             updateErrorState(errorState);
             logger.debug("error processing state change request for [{}] with the following errors [{}]", namespace, errorState);
 
@@ -142,7 +154,7 @@ public class ReservedClusterStateService {
             return;
         }
 
-        process(namespace, stateChunk, errorListener);
+        process(namespace, stateChunk, versionCheck, errorListener);
     }
 
     public void initEmpty(String namespace, ActionListener<ActionResponse.Empty> listener) {
@@ -153,6 +165,7 @@ public class ReservedClusterStateService {
             new ReservedStateUpdateTask(
                 namespace,
                 emptyState,
+                ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
                 Map.of(),
                 List.of(),
                 // error state should not be possible since there is no metadata being parsed or processed
@@ -172,9 +185,14 @@ public class ReservedClusterStateService {
      * @param errorListener a consumer called with {@link IllegalStateException} if the content has errors and the
      *        cluster state cannot be correctly applied, null if successful or the state failed to apply because of incompatible version.
      */
-    public void process(String namespace, ReservedStateChunk reservedStateChunk, Consumer<Exception> errorListener) {
+    public void process(
+        String namespace,
+        ReservedStateChunk reservedStateChunk,
+        ReservedStateVersionCheck versionCheck,
+        Consumer<Exception> errorListener
+    ) {
         Map<String, Object> reservedState = reservedStateChunk.state();
-        final ReservedStateVersion reservedStateVersion = reservedStateChunk.metadata();
+        ReservedStateVersion reservedStateVersion = reservedStateChunk.metadata();
 
         LinkedHashSet<String> orderedHandlers;
         try {
@@ -183,6 +201,7 @@ public class ReservedClusterStateService {
             ErrorState errorState = new ErrorState(
                 namespace,
                 reservedStateVersion.version(),
+                versionCheck,
                 e,
                 ReservedStateErrorMetadata.ErrorKind.PARSING
             );
@@ -201,7 +220,7 @@ public class ReservedClusterStateService {
 
         // We check if we should exit early on the state version from clusterService. The ReservedStateUpdateTask
         // will check again with the most current state version if this continues.
-        if (checkMetadataVersion(namespace, existingMetadata, reservedStateVersion) == false) {
+        if (checkMetadataVersion(namespace, existingMetadata, reservedStateVersion, versionCheck) == false) {
             errorListener.accept(null);
             return;
         }
@@ -209,7 +228,7 @@ public class ReservedClusterStateService {
         // We trial run all handler validations to ensure that we can process all of the cluster state error free.
         var trialRunErrors = trialRun(namespace, state, reservedStateChunk, orderedHandlers);
         // this is not using the modified trial state above, but that doesn't matter, we're just setting errors here
-        var error = checkAndReportError(namespace, trialRunErrors, reservedStateVersion);
+        var error = checkAndReportError(namespace, trialRunErrors, reservedStateVersion, versionCheck);
 
         if (error != null) {
             errorListener.accept(error);
@@ -220,6 +239,7 @@ public class ReservedClusterStateService {
             new ReservedStateUpdateTask(
                 namespace,
                 reservedStateChunk,
+                versionCheck,
                 handlers,
                 orderedHandlers,
                 ReservedClusterStateService.this::updateErrorState,
@@ -233,7 +253,7 @@ public class ReservedClusterStateService {
                     @Override
                     public void onFailure(Exception e) {
                         // Don't spam the logs on repeated errors
-                        if (isNewError(existingMetadata, reservedStateVersion.version())) {
+                        if (isNewError(existingMetadata, reservedStateVersion.version(), versionCheck)) {
                             logger.debug("Failed to apply reserved cluster state", e);
                             errorListener.accept(e);
                         } else {
@@ -247,7 +267,12 @@ public class ReservedClusterStateService {
     }
 
     // package private for testing
-    Exception checkAndReportError(String namespace, List<String> errors, ReservedStateVersion reservedStateVersion) {
+    Exception checkAndReportError(
+        String namespace,
+        List<String> errors,
+        ReservedStateVersion reservedStateVersion,
+        ReservedStateVersionCheck versionCheck
+    ) {
         // Any errors should be discovered through validation performed in the transform calls
         if (errors.isEmpty() == false) {
             logger.debug("Error processing state change request for [{}] with the following errors [{}]", namespace, errors);
@@ -255,6 +280,7 @@ public class ReservedClusterStateService {
             var errorState = new ErrorState(
                 namespace,
                 reservedStateVersion.version(),
+                versionCheck,
                 errors,
                 ReservedStateErrorMetadata.ErrorKind.VALIDATION
             );

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -205,8 +205,8 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
                 namespace,
                 newVersion,
                 switch (versionCheck) {
-                    case ReservedStateVersionCheck.HIGHER_OR_SAME_VERSION -> "less than";
-                    case ReservedStateVersionCheck.HIGHER_VERSION_ONLY -> "less than or equal to";
+                    case HIGHER_OR_SAME_VERSION -> "less than";
+                    case HIGHER_VERSION_ONLY -> "less than or equal to";
                 },
                 currentVersion
             )

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -47,6 +47,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
 
     private final String namespace;
     private final ReservedStateChunk stateChunk;
+    private final ReservedStateVersionCheck versionCheck;
     private final Map<String, ReservedClusterStateHandler<?>> handlers;
     private final Collection<String> orderedHandlers;
     private final Consumer<ErrorState> errorReporter;
@@ -55,6 +56,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
     public ReservedStateUpdateTask(
         String namespace,
         ReservedStateChunk stateChunk,
+        ReservedStateVersionCheck versionCheck,
         Map<String, ReservedClusterStateHandler<?>> handlers,
         Collection<String> orderedHandlers,
         Consumer<ErrorState> errorReporter,
@@ -62,6 +64,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
     ) {
         this.namespace = namespace;
         this.stateChunk = stateChunk;
+        this.versionCheck = versionCheck;
         this.handlers = handlers;
         this.orderedHandlers = orderedHandlers;
         this.errorReporter = errorReporter;
@@ -89,7 +92,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         Map<String, Object> reservedState = stateChunk.state();
         ReservedStateVersion reservedStateVersion = stateChunk.metadata();
 
-        if (checkMetadataVersion(namespace, existingMetadata, reservedStateVersion) == false) {
+        if (checkMetadataVersion(namespace, existingMetadata, reservedStateVersion, versionCheck) == false) {
             return currentState;
         }
 
@@ -110,7 +113,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
             }
         }
 
-        checkAndThrowOnError(errors, reservedStateVersion);
+        checkAndThrowOnError(errors, reservedStateVersion, versionCheck);
 
         // Remove the last error if we had previously encountered any in prior processing of reserved state
         reservedMetadataBuilder.errorMetadata(null);
@@ -121,14 +124,15 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         return stateBuilder.metadata(metadataBuilder).build();
     }
 
-    private void checkAndThrowOnError(List<String> errors, ReservedStateVersion reservedStateVersion) {
+    private void checkAndThrowOnError(List<String> errors, ReservedStateVersion version, ReservedStateVersionCheck versionCheck) {
         // Any errors should be discovered through validation performed in the transform calls
         if (errors.isEmpty() == false) {
             logger.debug("Error processing state change request for [{}] with the following errors [{}]", namespace, errors);
 
             var errorState = new ErrorState(
                 namespace,
-                reservedStateVersion.version(),
+                version.version(),
+                versionCheck,
                 errors,
                 ReservedStateErrorMetadata.ErrorKind.VALIDATION
             );
@@ -155,7 +159,8 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
     static boolean checkMetadataVersion(
         String namespace,
         ReservedStateMetadata existingMetadata,
-        ReservedStateVersion reservedStateVersion
+        ReservedStateVersion reservedStateVersion,
+        ReservedStateVersionCheck versionCheck
     ) {
         if (Version.CURRENT.before(reservedStateVersion.minCompatibleVersion())) {
             logger.warn(
@@ -168,35 +173,45 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
             return false;
         }
 
-        if (reservedStateVersion.version().equals(ReservedStateMetadata.EMPTY_VERSION)) {
+        Long newVersion = reservedStateVersion.version();
+        if (newVersion.equals(ReservedStateMetadata.EMPTY_VERSION)) {
             return true;
         }
 
         // require a regular positive version, reject any special version
-        if (reservedStateVersion.version() <= 0L) {
+        if (newVersion <= 0L) {
             logger.warn(
                 () -> format(
                     "Not updating reserved cluster state for namespace [%s], because version [%s] is less or equal to 0",
                     namespace,
-                    reservedStateVersion.version()
+                    newVersion
                 )
             );
             return false;
         }
 
-        if (existingMetadata != null && existingMetadata.version() >= reservedStateVersion.version()) {
-            logger.warn(
-                () -> format(
-                    "Not updating reserved cluster state for namespace [%s], because version [%s] is less or equal"
-                        + " to the current metadata version [%s]",
-                    namespace,
-                    reservedStateVersion.version(),
-                    existingMetadata.version()
-                )
-            );
-            return false;
+        if (existingMetadata == null) {
+            return true;
         }
 
-        return true;
+        Long currentVersion = existingMetadata.version();
+        if (versionCheck.test(currentVersion, newVersion)) {
+            return true;
+        }
+
+        logger.warn(
+            () -> format(
+                "Not updating reserved cluster state for namespace [%s], because version [%s] is %s the current metadata version [%s]",
+                namespace,
+                newVersion,
+                switch (versionCheck) {
+                    case ReservedStateVersionCheck.HIGHER_OR_SAME_VERSION -> "less than";
+                    case ReservedStateVersionCheck.HIGHER_VERSION_ONLY -> "less than or equal to";
+                },
+                currentVersion
+            )
+        );
+        return false;
     }
+
 }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateVersionCheck.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateVersionCheck.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reservedstate.service;
+
+import java.util.function.BiPredicate;
+
+/**
+ * Enum representing the logic for determining whether a reserved state should be processed
+ * based on the current and new versions.
+ */
+public enum ReservedStateVersionCheck implements BiPredicate<Long, Long> {
+    /**
+     * Returns {@code true} if the new version is higher than the current version.
+     * This is the default behavior when processing changes to file settings.
+     */
+    HIGHER_VERSION_ONLY {
+        @Override
+        public boolean test(Long currentVersion, Long newVersion) {
+            return currentVersion < newVersion;
+        }
+    },
+    /**
+     * Returns {@code true} if the new version is higher or equal to the current version.
+     * This allows re-processing of the same version.
+     * Used when processing file settings during service startup.
+     */
+    HIGHER_OR_SAME_VERSION {
+        @Override
+        public boolean test(Long currentVersion, Long newVersion) {
+            return currentVersion <= newVersion;
+        }
+    };
+}

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -54,6 +54,7 @@ import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -148,9 +149,9 @@ public class FileSettingsServiceTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void testInitialFileError() throws Exception {
         doAnswer((Answer<Void>) invocation -> {
-            ((Consumer<Exception>) invocation.getArgument(2)).accept(new IllegalStateException("Some exception"));
+            ((Consumer<Exception>) invocation.getArgument(3)).accept(new IllegalStateException("Some exception"));
             return null;
-        }).when(controller).process(any(), any(XContentParser.class), any());
+        }).when(controller).process(any(), any(XContentParser.class), eq(randomFrom(ReservedStateVersionCheck.values())), any());
 
         AtomicBoolean settingsChanged = new AtomicBoolean(false);
         CountDownLatch latch = new CountDownLatch(1);
@@ -163,7 +164,7 @@ public class FileSettingsServiceTests extends ESTestCase {
             } finally {
                 latch.countDown();
             }
-        }).when(fileSettingsService).processFileChanges();
+        }).when(fileSettingsService).processFileOnServiceStart();
 
         Files.createDirectories(fileSettingsService.watchedFileDir());
         // contents of the JSON don't matter, we just need a file to exist
@@ -175,7 +176,8 @@ public class FileSettingsServiceTests extends ESTestCase {
         // wait until the watcher thread has started, and it has discovered the file
         assertTrue(latch.await(20, TimeUnit.SECONDS));
 
-        verify(fileSettingsService, times(1)).processFileChanges();
+        verify(fileSettingsService, times(1)).processFileOnServiceStart();
+        verify(controller, times(1)).process(any(), any(XContentParser.class), eq(ReservedStateVersionCheck.HIGHER_OR_SAME_VERSION), any());
         // assert we never notified any listeners of successful application of file based settings
         assertFalse(settingsChanged.get());
     }
@@ -184,9 +186,9 @@ public class FileSettingsServiceTests extends ESTestCase {
     public void testInitialFileWorks() throws Exception {
         // Let's check that if we didn't throw an error that everything works
         doAnswer((Answer<Void>) invocation -> {
-            ((Consumer<Exception>) invocation.getArgument(2)).accept(null);
+            ((Consumer<Exception>) invocation.getArgument(3)).accept(null);
             return null;
-        }).when(controller).process(any(), any(XContentParser.class), any());
+        }).when(controller).process(any(), any(XContentParser.class), any(), any());
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -196,13 +198,67 @@ public class FileSettingsServiceTests extends ESTestCase {
         // contents of the JSON don't matter, we just need a file to exist
         writeTestFile(fileSettingsService.watchedFile(), "{}");
 
+        doAnswer((Answer<?>) invocation -> {
+            try {
+                return invocation.callRealMethod();
+            } finally {
+                latch.countDown();
+            }
+        }).when(fileSettingsService).processFileOnServiceStart();
+
         fileSettingsService.start();
         fileSettingsService.clusterChanged(new ClusterChangedEvent("test", clusterService.state(), ClusterState.EMPTY_STATE));
 
         // wait for listener to be called
         assertTrue(latch.await(20, TimeUnit.SECONDS));
 
+        verify(fileSettingsService, times(1)).processFileOnServiceStart();
+        verify(controller, times(1)).process(any(), any(XContentParser.class), eq(ReservedStateVersionCheck.HIGHER_OR_SAME_VERSION), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testProcessFileChanges() throws Exception {
+        doAnswer((Answer<Void>) invocation -> {
+            ((Consumer<Exception>) invocation.getArgument(3)).accept(null);
+            return null;
+        }).when(controller).process(any(), any(XContentParser.class), any(), any());
+
+        // we get three events: initial clusterChanged event, first write, second write
+        CountDownLatch latch = new CountDownLatch(3);
+
+        fileSettingsService.addFileChangedListener(latch::countDown);
+
+        Files.createDirectories(fileSettingsService.watchedFileDir());
+        // contents of the JSON don't matter, we just need a file to exist
+        writeTestFile(fileSettingsService.watchedFile(), "{}");
+
+        doAnswer((Answer<?>) invocation -> {
+            try {
+                return invocation.callRealMethod();
+            } finally {
+                latch.countDown();
+            }
+        }).when(fileSettingsService).processFileOnServiceStart();
+        doAnswer((Answer<?>) invocation -> {
+            try {
+                return invocation.callRealMethod();
+            } finally {
+                latch.countDown();
+            }
+        }).when(fileSettingsService).processFileChanges();
+
+        fileSettingsService.start();
+        fileSettingsService.clusterChanged(new ClusterChangedEvent("test", clusterService.state(), ClusterState.EMPTY_STATE));
+        // second file change; contents still don't matter
+        writeTestFile(fileSettingsService.watchedFile(), "{}");
+
+        // wait for listener to be called (once for initial processing, once for subsequent update)
+        assertTrue(latch.await(20, TimeUnit.SECONDS));
+
+        verify(fileSettingsService, times(1)).processFileOnServiceStart();
+        verify(controller, times(1)).process(any(), any(XContentParser.class), eq(ReservedStateVersionCheck.HIGHER_OR_SAME_VERSION), any());
         verify(fileSettingsService, times(1)).processFileChanges();
+        verify(controller, times(1)).process(any(), any(XContentParser.class), eq(ReservedStateVersionCheck.HIGHER_VERSION_ONLY), any());
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTaskTests.java
@@ -23,7 +23,15 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class ReservedStateUpdateTaskTests extends ESTestCase {
     public void testBlockedClusterState() {
-        var task = new ReservedStateUpdateTask("dummy", null, Map.of(), List.of(), e -> {}, ActionListener.noop());
+        var task = new ReservedStateUpdateTask(
+            "dummy",
+            null,
+            ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
+            Map.of(),
+            List.of(),
+            e -> {},
+            ActionListener.noop()
+        );
         ClusterState notRecoveredClusterState = ClusterState.builder(ClusterName.DEFAULT)
             .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK))
             .build();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleStateServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleStateServiceTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.reservedstate.service.ReservedStateChunk;
 import org.elasticsearch.reservedstate.service.ReservedStateUpdateTask;
 import org.elasticsearch.reservedstate.service.ReservedStateUpdateTaskExecutor;
 import org.elasticsearch.reservedstate.service.ReservedStateVersion;
+import org.elasticsearch.reservedstate.service.ReservedStateVersionCheck;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -362,7 +363,7 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
         AtomicReference<Exception> x = new AtomicReference<>();
 
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, testJSON)) {
-            controller.process("operator", parser, x::set);
+            controller.process("operator", parser, randomFrom(ReservedStateVersionCheck.values()), x::set);
 
             assertThat(x.get(), instanceOf(IllegalStateException.class));
             assertThat(x.get().getMessage(), containsString("Error processing state change request for operator"));
@@ -383,7 +384,7 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
         );
 
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, testJSON)) {
-            controller.process("operator", parser, Assert::assertNull);
+            controller.process("operator", parser, randomFrom(ReservedStateVersionCheck.values()), Assert::assertNull);
         }
     }
 
@@ -420,7 +421,7 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
             new ReservedStateVersion(123L, Version.CURRENT)
         );
 
-        controller.process("operator", pack, x::set);
+        controller.process("operator", pack, randomFrom(ReservedStateVersionCheck.values()), x::set);
 
         assertThat(x.get(), instanceOf(IllegalStateException.class));
         assertThat(x.get().getMessage(), containsString("Error processing state change request for operator"));
@@ -439,6 +440,6 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
             )
         );
 
-        controller.process("operator", pack, Assert::assertNull);
+        controller.process("operator", pack, randomFrom(ReservedStateVersionCheck.values()), Assert::assertNull);
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -154,7 +154,17 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
     }
 
     public static void writeJSONFile(String node, String json, Logger logger, AtomicLong versionCounter) throws Exception {
-        long version = versionCounter.incrementAndGet();
+        writeJSONFile(node, json, logger, versionCounter, true);
+    }
+
+    public static void writeJSONFileWithoutVersionIncrement(String node, String json, Logger logger, AtomicLong versionCounter)
+        throws Exception {
+        writeJSONFile(node, json, logger, versionCounter, false);
+    }
+
+    private static void writeJSONFile(String node, String json, Logger logger, AtomicLong versionCounter, boolean incrementVersion)
+        throws Exception {
+        long version = incrementVersion ? versionCounter.incrementAndGet() : versionCounter.get();
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
         assertTrue(fileSettingsService.watching());

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -16,25 +16,33 @@ import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRole
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression;
 import org.elasticsearch.xpack.core.security.authz.RoleMappingMetadata;
 import org.elasticsearch.xpack.security.action.rolemapping.ReservedRoleMappingAction;
+import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.integration.RoleMappingFileSettingsIT.setupClusterStateListener;
 import static org.elasticsearch.integration.RoleMappingFileSettingsIT.setupClusterStateListenerForCleanup;
 import static org.elasticsearch.integration.RoleMappingFileSettingsIT.writeJSONFile;
+import static org.elasticsearch.integration.RoleMappingFileSettingsIT.writeJSONFileWithoutVersionIncrement;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.emptyIterable;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
 
-    private static AtomicLong versionCounter = new AtomicLong(1);
+    private final AtomicLong versionCounter = new AtomicLong(1);
 
-    private static String testJSONOnlyRoleMappings = """
+    @Before
+    public void resetVersion() {
+        versionCounter.set(1);
+    }
+
+    private static final String testJSONOnlyRoleMappings = """
         {
              "metadata": {
                  "version": "%s",
@@ -64,7 +72,28 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
              }
         }""";
 
-    private static String emptyJSON = """
+    private static final String testJSONOnlyUpdatedRoleMappings = """
+        {
+             "metadata": {
+                 "version": "%s",
+                 "compatibility": "8.4.0"
+             },
+             "state": {
+                 "role_mappings": {
+                       "everyone_kibana_together": {
+                          "enabled": true,
+                          "roles": [ "kibana_user", "kibana_admin" ],
+                          "rules": { "field": { "username": "*" } },
+                          "metadata": {
+                             "uuid" : "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7",
+                             "_foo": "something"
+                          }
+                       }
+                 }
+             }
+        }""";
+
+    private static final String emptyJSON = """
         {
              "metadata": {
                  "version": "%s",
@@ -88,12 +117,34 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
-        var clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
-        assertRoleMappingReservedMetadata(clusterState, "everyone_kibana_alone", "everyone_fleet_alone");
-        List<ExpressionRoleMapping> roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
-        assertThat(
-            roleMappings,
-            containsInAnyOrder(
+        assertRoleMappingsInClusterState(
+            new ExpressionRoleMapping(
+                "everyone_kibana_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("kibana_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                true
+            ),
+            new ExpressionRoleMapping(
+                "everyone_fleet_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("fleet_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
+                false
+            )
+        );
+
+        logger.info("--> restart master");
+        internalCluster().restartNode(masterNode);
+        ensureGreen();
+        awaitFileSettingsWatcher();
+
+        // assert busy to give mappings time to update after restart; otherwise, the role mapping names might be dummy values
+        // `name_not_available_after_deserialization`
+        assertBusy(
+            () -> assertRoleMappingsInClusterState(
                 new ExpressionRoleMapping(
                     "everyone_kibana_alone",
                     new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
@@ -113,59 +164,118 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
             )
         );
 
-        logger.info("--> restart master");
-        internalCluster().restartNode(masterNode);
-        ensureGreen();
-
-        // assert role mappings are recovered from "disk"
-        clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
-        assertRoleMappingReservedMetadata(clusterState, "everyone_kibana_alone", "everyone_fleet_alone");
-        roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
-        assertThat(
-            roleMappings,
-            containsInAnyOrder(
-                new ExpressionRoleMapping(
-                    "name_not_available_after_deserialization",
-                    new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
-                    List.of("kibana_user"),
-                    List.of(),
-                    Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
-                    true
-                ),
-                new ExpressionRoleMapping(
-                    "name_not_available_after_deserialization",
-                    new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
-                    List.of("fleet_user"),
-                    List.of(),
-                    Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
-                    false
-                )
-            )
-        );
-
         // now remove the role mappings via the same settings file
-        savedClusterState = setupClusterStateListenerForCleanup(masterNode);
-        awaitFileSettingsWatcher();
-        logger.info("--> remove the role mappings with an empty settings file");
-        writeJSONFile(masterNode, emptyJSON, logger, versionCounter);
-        awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
-        assertTrue(awaitSuccessful);
+        cleanupClusterState(masterNode);
 
-        clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
-        assertRoleMappingReservedMetadata(clusterState);
-        roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
-        assertThat(roleMappings, emptyIterable());
+        // no role mappings
+        assertRoleMappingsInClusterState();
 
         // and restart the master to confirm the role mappings are all gone
         logger.info("--> restart master again");
         internalCluster().restartNode(masterNode);
         ensureGreen();
 
-        // assert empty role mappings are recovered from "disk"
-        clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
-        assertRoleMappingReservedMetadata(clusterState);
-        roleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
-        assertThat(roleMappings, emptyIterable());
+        // no role mappings
+        assertRoleMappingsInClusterState();
+    }
+
+    public void testFileSettingsReprocessedOnRestartWithoutVersionChange() throws Exception {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+
+        final String masterNode = internalCluster().getMasterName();
+
+        var savedClusterState = setupClusterStateListener(masterNode, "everyone_kibana_alone");
+        awaitFileSettingsWatcher();
+        logger.info("--> write some role mappings, no other file settings");
+        writeJSONFile(masterNode, testJSONOnlyRoleMappings, logger, versionCounter);
+        boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
+        assertTrue(awaitSuccessful);
+
+        assertRoleMappingsInClusterState(
+            new ExpressionRoleMapping(
+                "everyone_kibana_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("kibana_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                true
+            ),
+            new ExpressionRoleMapping(
+                "everyone_fleet_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("fleet_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
+                false
+            )
+        );
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        final FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
+        fileSettingsService.addFileChangedListener(latch::countDown);
+        // Don't increment version but write new file contents to test re-processing on restart
+        writeJSONFileWithoutVersionIncrement(masterNode, testJSONOnlyUpdatedRoleMappings, logger, versionCounter);
+        // Make sure we saw a file settings update so that we know it got processed, but it did not affect cluster state
+        assertTrue(latch.await(20, TimeUnit.SECONDS));
+
+        // Nothing changed yet because version is the same and there was no restart
+        assertRoleMappingsInClusterState(
+            new ExpressionRoleMapping(
+                "everyone_kibana_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("kibana_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                true
+            ),
+            new ExpressionRoleMapping(
+                "everyone_fleet_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("fleet_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
+                false
+            )
+        );
+
+        logger.info("--> restart master");
+        internalCluster().restartNode(masterNode);
+        ensureGreen();
+        awaitFileSettingsWatcher();
+
+        // Assert busy to give mappings time to update
+        assertBusy(
+            () -> assertRoleMappingsInClusterState(
+                new ExpressionRoleMapping(
+                    "everyone_kibana_together",
+                    new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                    List.of("kibana_user", "kibana_admin"),
+                    List.of(),
+                    Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                    true
+                )
+            )
+        );
+
+        cleanupClusterState(masterNode);
+    }
+
+    private void assertRoleMappingsInClusterState(ExpressionRoleMapping... expectedRoleMappings) {
+        var clusterState = clusterAdmin().state(new ClusterStateRequest(TEST_REQUEST_TIMEOUT)).actionGet().getState();
+        String[] expectedRoleMappingNames = Arrays.stream(expectedRoleMappings).map(ExpressionRoleMapping::getName).toArray(String[]::new);
+        assertRoleMappingReservedMetadata(clusterState, expectedRoleMappingNames);
+        var actualRoleMappings = new ArrayList<>(RoleMappingMetadata.getFromClusterState(clusterState).getRoleMappings());
+        assertThat(actualRoleMappings, containsInAnyOrder(expectedRoleMappings));
+    }
+
+    private void cleanupClusterState(String masterNode) throws Exception {
+        // now remove the role mappings via the same settings file
+        var savedClusterState = setupClusterStateListenerForCleanup(masterNode);
+        awaitFileSettingsWatcher();
+        logger.info("--> remove the role mappings with an empty settings file");
+        writeJSONFile(masterNode, emptyJSON, logger, versionCounter);
+        boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
+        assertTrue(awaitSuccessful);
     }
 
     private void assertRoleMappingReservedMetadata(ClusterState clusterState, String... names) {

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/action/ReservedSnapshotLifecycleStateServiceTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/action/ReservedSnapshotLifecycleStateServiceTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.reservedstate.action.ReservedClusterSettingsAction;
 import org.elasticsearch.reservedstate.service.ReservedClusterStateService;
 import org.elasticsearch.reservedstate.service.ReservedStateUpdateTask;
 import org.elasticsearch.reservedstate.service.ReservedStateUpdateTaskExecutor;
+import org.elasticsearch.reservedstate.service.ReservedStateVersionCheck;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -399,7 +400,7 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
         AtomicReference<Exception> x = new AtomicReference<>();
 
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, testJSON)) {
-            controller.process("operator", parser, x::set);
+            controller.process("operator", parser, randomFrom(ReservedStateVersionCheck.values()), x::set);
 
             assertThat(x.get(), instanceOf(IllegalStateException.class));
             assertThat(x.get().getMessage(), containsString("Error processing state change request for operator"));
@@ -419,7 +420,7 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
         );
 
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, testJSON)) {
-            controller.process("operator", parser, Assert::assertNull);
+            controller.process("operator", parser, randomFrom(ReservedStateVersionCheck.values()), Assert::assertNull);
         }
     }
 


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/114295 with following commits:

- 78a43981b64d384ca5fb22ea0a94d327c05e5358