### PR TITLE
Use `index.mapping.source.mode` in binary field docs

### DIFF
--- a/docs/reference/mapping/types/binary.asciidoc
+++ b/docs/reference/mapping/types/binary.asciidoc
@@ -68,8 +68,16 @@ Synthetic source may sort `binary` values in order of their byte representation.
 ----
 PUT idx
 {
+  "settings": {
+    "index": {
+      "mapping": {
+        "source": {
+          "mode": "synthetic"
+        }
+      }
+    }
+  },
   "mappings": {
-    "_source": { "mode": "synthetic" },
     "properties": {
       "binary": { "type": "binary", "doc_values": true }
     }


### PR DESCRIPTION
Update the documentation after fixing `isSyntheticSourceEnabled`.
At this point the documentation does not use `_source.mode` anymore.