### PR TITLE
Always flush response body in AbstractBlobContainerRetriesTestCase#sendIncompleteContent with JDK23

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -418,7 +418,9 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         if (bytesToSend > 0) {
             exchange.getResponseBody().write(bytes, rangeStart, bytesToSend);
         }
-        if (randomBoolean()) {
+        if (randomBoolean() || Runtime.version().feature() >= 23) {
+            // For now in JDK23 we need to always flush. See https://bugs.openjdk.org/browse/JDK-8331847.
+            // TODO: remove the JDK version check once that bug is fixed
             exchange.getResponseBody().flush();
         }
         return bytesToSend;

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -420,7 +420,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         }
         if (randomBoolean() || Runtime.version().feature() >= 23) {
             // For now in JDK23 we need to always flush. See https://bugs.openjdk.org/browse/JDK-8331847.
-            // TODO: remove the JDK version check once that bug is fixed
+            // TODO: remove the JDK version check once that issue is fixed
             exchange.getResponseBody().flush();
         }
         return bytesToSend;


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/115172