### PR TITLE
[8.16] Do not exclude empty arrays or empty objects in source filtering with Jackson streaming (#112250)

### DIFF
--- a/docs/changelog/112250.yaml
+++ b/docs/changelog/112250.yaml
@@ -1,0 +1,5 @@
+pr: 112250
+summary: Do not exclude empty arrays or empty objects in source filtering
+area: Search
+type: bug
+issues: [109668]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Do not exclude empty arrays or empty objects in source filtering with Jackson streaming (#112250)](https://github.com/elastic/elasticsearch/pull/112250)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)