### PR TITLE
[ML] Dynamically get of num allocations for ml node models

### DIFF
--- a/docs/changelog/114636.yaml
+++ b/docs/changelog/114636.yaml
@@ -1,0 +1,5 @@
+pr: 114636
+summary: Dynamically get of num allocations
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/changelog/114636.yaml
+++ b/docs/changelog/114636.yaml
@@ -1,5 +1,0 @@
-pr: 114636
-summary: Dynamically get of num allocations
-area: Machine Learning
-type: enhancement
-issues: []

--- a/server/src/main/java/org/elasticsearch/inference/InferenceService.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceService.java
@@ -210,4 +210,8 @@ public interface InferenceService extends Closeable {
     default void defaultConfigs(ActionListener<List<Model>> defaultsListener) {
         defaultsListener.onResponse(List.of());
     }
+
+    default void updateModelsWithDynamicFields(List<Model> model, ActionListener<List<Model>> listener) {
+        listener.onResponse(model);
+    }
 }

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -24,6 +24,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasSize;
@@ -325,5 +326,10 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         } finally {
             deleteModel(modelId);
         }
+    }
+
+    public void testGetZeroModels() throws IOException {
+        var models = getModels("_all", TaskType.RERANK);
+        assertThat(models, empty());
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -9,13 +9,13 @@ package org.elasticsearch.xpack.inference.action;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceServiceRegistry;
-import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnparsedModel;
 import org.elasticsearch.injection.guice.Inject;
@@ -29,8 +29,11 @@ import org.elasticsearch.xpack.inference.common.InferenceExceptions;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 public class TransportGetInferenceModelAction extends HandledTransportAction<
     GetInferenceModelAction.Request,
@@ -96,7 +99,18 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
 
             var model = service.get()
                 .parsePersistedConfig(unparsedModel.inferenceEntityId(), unparsedModel.taskType(), unparsedModel.settings());
-            delegate.onResponse(new GetInferenceModelAction.Response(List.of(model.getConfigurations())));
+
+            service.get()
+                .updateModelsWithDynamicFields(
+                    List.of(model),
+                    delegate.delegateFailureAndWrap(
+                        (l2, updatedModels) -> l2.onResponse(
+                            new GetInferenceModelAction.Response(
+                                updatedModels.stream().map(Model::getConfigurations).collect(Collectors.toList())
+                            )
+                        )
+                    )
+                );
         }));
     }
 
@@ -110,25 +124,47 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
     private void getModelsByTaskType(TaskType taskType, ActionListener<GetInferenceModelAction.Response> listener) {
         modelRegistry.getModelsByTaskType(
             taskType,
-            listener.delegateFailureAndWrap((l, models) -> executor.execute(ActionRunnable.supply(l, () -> parseModels(models))))
+            listener.delegateFailureAndWrap((l, models) -> executor.execute(() -> parseModels(models, listener)))
         );
     }
 
-    private GetInferenceModelAction.Response parseModels(List<UnparsedModel> unparsedModels) {
-        var parsedModels = new ArrayList<ModelConfigurations>();
-
-        for (var unparsedModel : unparsedModels) {
-            var service = serviceRegistry.getService(unparsedModel.service());
-            if (service.isEmpty()) {
-                throw serviceNotFoundException(unparsedModel.service(), unparsedModel.inferenceEntityId());
+    private void parseModels(List<UnparsedModel> unparsedModels, ActionListener<GetInferenceModelAction.Response> listener) {
+        var parsedModelsByService = new HashMap<String, List<Model>>();
+        try {
+            for (var unparsedModel : unparsedModels) {
+                var service = serviceRegistry.getService(unparsedModel.service());
+                if (service.isEmpty()) {
+                    throw serviceNotFoundException(unparsedModel.service(), unparsedModel.inferenceEntityId());
+                }
+                var list = parsedModelsByService.computeIfAbsent(service.get().name(), s -> new ArrayList<>());
+                list.add(
+                    service.get()
+                        .parsePersistedConfig(unparsedModel.inferenceEntityId(), unparsedModel.taskType(), unparsedModel.settings())
+                );
             }
-            parsedModels.add(
-                service.get()
-                    .parsePersistedConfig(unparsedModel.inferenceEntityId(), unparsedModel.taskType(), unparsedModel.settings())
-                    .getConfigurations()
+
+            var groupedListener = new GroupedActionListener<List<Model>>(
+                parsedModelsByService.entrySet().size(),
+                listener.delegateFailureAndWrap((delegate, listOfListOfModels) -> {
+                    var modifiable = new ArrayList<Model>();
+                    for (var l : listOfListOfModels) {
+                        modifiable.addAll(l);
+                    }
+                    modifiable.sort(Comparator.comparing(Model::getInferenceEntityId));
+                    delegate.onResponse(
+                        new GetInferenceModelAction.Response(modifiable.stream().map(Model::getConfigurations).collect(Collectors.toList()))
+                    );
+                })
             );
+
+            for (var entry : parsedModelsByService.entrySet()) {
+                serviceRegistry.getService(entry.getKey())
+                    .get()  // must be non-null to get this far
+                    .updateModelsWithDynamicFields(entry.getValue(), groupedListener);
+            }
+        } catch (Exception e) {
+            listener.onFailure(e);
         }
-        return new GetInferenceModelAction.Response(parsedModels);
     }
 
     private ElasticsearchStatusException serviceNotFoundException(String service, String inferenceId) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -129,6 +129,11 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
     }
 
     private void parseModels(List<UnparsedModel> unparsedModels, ActionListener<GetInferenceModelAction.Response> listener) {
+        if (unparsedModels.isEmpty()) {
+            listener.onResponse(new GetInferenceModelAction.Response(List.of()));
+            return;
+        }
+
         var parsedModelsByService = new HashMap<String, List<Model>>();
         try {
             for (var unparsedModel : unparsedModels) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -117,7 +117,7 @@ public class TransportGetInferenceModelAction extends HandledTransportAction<
     private void getAllModels(boolean persistDefaultEndpoints, ActionListener<GetInferenceModelAction.Response> listener) {
         modelRegistry.getAllModels(
             persistDefaultEndpoints,
-            listener.delegateFailureAndWrap((l, models) -> executor.execute(ActionRunnable.supply(l, () -> parseModels(models))))
+            listener.delegateFailureAndWrap((l, models) -> executor.execute(() -> parseModels(models, listener)))
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
@@ -92,12 +92,7 @@ public abstract class ElasticsearchInternalModel extends Model {
     }
 
     public void updateNumAllocation(Integer numAllocations) {
-        this.internalServiceSettings = new ElasticsearchInternalServiceSettings(
-            numAllocations,
-            this.internalServiceSettings.getNumThreads(),
-            this.internalServiceSettings.modelId(),
-            this.internalServiceSettings.getAdaptiveAllocationsSettings()
-        );
+        this.internalServiceSettings.setNumAllocations(numAllocations);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
@@ -91,7 +91,7 @@ public abstract class ElasticsearchInternalModel extends Model {
         return (ElasticsearchInternalServiceSettings) super.getServiceSettings();
     }
 
-    public void updateNumAllocation(Integer numAllocations) {
+    public void updateNumAllocations(Integer numAllocations) {
         this.internalServiceSettings.setNumAllocations(numAllocations);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalModel.java
@@ -21,7 +21,7 @@ import static org.elasticsearch.xpack.core.ml.inference.assignment.AllocationSta
 
 public abstract class ElasticsearchInternalModel extends Model {
 
-    protected final ElasticsearchInternalServiceSettings internalServiceSettings;
+    protected ElasticsearchInternalServiceSettings internalServiceSettings;
 
     public ElasticsearchInternalModel(
         String inferenceEntityId,
@@ -89,6 +89,15 @@ public abstract class ElasticsearchInternalModel extends Model {
     @Override
     public ElasticsearchInternalServiceSettings getServiceSettings() {
         return (ElasticsearchInternalServiceSettings) super.getServiceSettings();
+    }
+
+    public void updateNumAllocation(Integer numAllocations) {
+        this.internalServiceSettings = new ElasticsearchInternalServiceSettings(
+            numAllocations,
+            this.internalServiceSettings.getNumThreads(),
+            this.internalServiceSettings.modelId(),
+            this.internalServiceSettings.getAdaptiveAllocationsSettings()
+        );
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.core.inference.ChunkingSettingsFeatureFlag;
 import org.elasticsearch.xpack.core.inference.results.InferenceTextEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
+import org.elasticsearch.xpack.core.ml.action.GetDeploymentStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
@@ -56,6 +57,7 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -786,11 +788,47 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         );
     }
 
-    /**
-     * Default configurations that can be out of the box without creating an endpoint first.
-     * @param defaultsListener Config listener
-     */
     @Override
+    public void updateModelsWithDynamicFields(List<Model> models, ActionListener<List<Model>> listener) {
+        var modelsByDeploymentIds = new HashMap<String, ElasticsearchInternalModel>();
+        for (var model : models) {
+            if (model instanceof ElasticsearchInternalModel esModel) {
+                modelsByDeploymentIds.put(esModel.internalServiceSettings.deloymentId(), esModel);
+            } else {
+                listener.onFailure(
+                    new ElasticsearchStatusException(
+                        "Cannot update model [{}] as it is not an Elasticsearch service model",
+                        RestStatus.INTERNAL_SERVER_ERROR,
+                        model.getInferenceEntityId()
+                    )
+                );
+                return;
+            }
+        }
+
+        if (modelsByDeploymentIds.isEmpty()) {
+            listener.onResponse(models);
+            return;
+        }
+
+        String deploymentIds = String.join(",", modelsByDeploymentIds.keySet());
+        client.execute(
+            GetDeploymentStatsAction.INSTANCE,
+            new GetDeploymentStatsAction.Request(deploymentIds),
+            ActionListener.wrap(stats -> {
+                for (var deploymentStats : stats.getStats().results()) {
+                    var model = modelsByDeploymentIds.get(deploymentStats.getDeploymentId());
+                    model.updateNumAllocation(deploymentStats.getNumberOfAllocations());
+                }
+                listener.onResponse(new ArrayList<>(modelsByDeploymentIds.values()));
+            }, e -> {
+                logger.warn("Get deployment stats failed, cannot update the endpoint's number of allocations", e);
+                // continue with the original response
+                listener.onResponse(models);
+            })
+        );
+    }
+
     public void defaultConfigs(ActionListener<List<Model>> defaultsListener) {
         preferredModelVariantFn.accept(defaultsListener.delegateFailureAndWrap((delegate, preferredModelVariant) -> {
             if (PreferredModelVariant.LINUX_X86_OPTIMIZED.equals(preferredModelVariant)) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -790,8 +790,16 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
 
     @Override
     public void updateModelsWithDynamicFields(List<Model> models, ActionListener<List<Model>> listener) {
+
+        if (models.isEmpty()) {
+            listener.onResponse(models);
+            return;
+        }
+
         var modelsByDeploymentIds = new HashMap<String, ElasticsearchInternalModel>();
         for (var model : models) {
+            assert model instanceof ElasticsearchInternalModel;
+
             if (model instanceof ElasticsearchInternalModel esModel) {
                 modelsByDeploymentIds.put(esModel.mlNodeDeploymentId(), esModel);
             } else {
@@ -806,11 +814,6 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             }
         }
 
-        if (modelsByDeploymentIds.isEmpty()) {
-            listener.onResponse(models);
-            return;
-        }
-
         String deploymentIds = String.join(",", modelsByDeploymentIds.keySet());
         client.execute(
             GetDeploymentStatsAction.INSTANCE,
@@ -818,7 +821,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             ActionListener.wrap(stats -> {
                 for (var deploymentStats : stats.getStats().results()) {
                     var model = modelsByDeploymentIds.get(deploymentStats.getDeploymentId());
-                    model.updateNumAllocation(deploymentStats.getNumberOfAllocations());
+                    model.updateNumAllocations(deploymentStats.getNumberOfAllocations());
                 }
                 listener.onResponse(new ArrayList<>(modelsByDeploymentIds.values()));
             }, e -> {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -793,7 +793,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         var modelsByDeploymentIds = new HashMap<String, ElasticsearchInternalModel>();
         for (var model : models) {
             if (model instanceof ElasticsearchInternalModel esModel) {
-                modelsByDeploymentIds.put(esModel.internalServiceSettings.deloymentId(), esModel);
+                modelsByDeploymentIds.put(esModel.mlNodeDeploymentId(), esModel);
             } else {
                 listener.onFailure(
                     new ElasticsearchStatusException(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -194,6 +194,10 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         return modelId;
     }
 
+    public String deloymentId() {
+        return modelId;
+    }
+
     public Integer getNumAllocations() {
         return numAllocations;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -39,7 +39,7 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
     public static final String DEPLOYMENT_ID = "deployment_id";
     public static final String ADAPTIVE_ALLOCATIONS = "adaptive_allocations";
 
-    private final Integer numAllocations;
+    private Integer numAllocations;
     private final int numThreads;
     private final String modelId;
     private final AdaptiveAllocationsSettings adaptiveAllocationsSettings;
@@ -170,6 +170,10 @@ public class ElasticsearchInternalServiceSettings implements ServiceSettings {
         this.deploymentId = in.getTransportVersion().onOrAfter(TransportVersions.ML_INFERENCE_ATTACH_TO_EXISTSING_DEPLOYMENT)
             ? in.readOptionalString()
             : null;
+    }
+
+    public void setNumAllocations(Integer numAllocations) {
+        this.numAllocations = numAllocations;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.elasticsearch;
+
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.test.ESTestCase;
+
+public class ElserInternalModelTests extends ESTestCase {
+    public void testUpdateNumAllocation() {
+        var model = new ElserInternalModel(
+            "foo",
+            TaskType.SPARSE_EMBEDDING,
+            ElasticsearchInternalService.NAME,
+            new ElserInternalServiceSettings(null, 1, "elser", null),
+            new ElserMlNodeTaskSettings(),
+            null
+        );
+
+        model.updateNumAllocation(1);
+        assertEquals(1, model.internalServiceSettings.getNumAllocations().intValue());
+
+        model.updateNumAllocation(null);
+        assertNull(model.internalServiceSettings.getNumAllocations());
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
@@ -22,9 +22,9 @@ public class ElserInternalModelTests extends ESTestCase {
         );
 
         model.updateNumAllocation(1);
-        assertEquals(1, model.internalServiceSettings.getNumAllocations().intValue());
+        assertEquals(1, model.getServiceSettings().getNumAllocations().intValue());
 
         model.updateNumAllocation(null);
-        assertNull(model.internalServiceSettings.getNumAllocations());
+        assertNull(model.getServiceSettings().getNumAllocations());
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserInternalModelTests.java
@@ -21,10 +21,10 @@ public class ElserInternalModelTests extends ESTestCase {
             null
         );
 
-        model.updateNumAllocation(1);
+        model.updateNumAllocations(1);
         assertEquals(1, model.getServiceSettings().getNumAllocations().intValue());
 
-        model.updateNumAllocation(null);
+        model.updateNumAllocations(null);
         assertNull(model.getServiceSettings().getNumAllocations());
     }
 }


### PR DESCRIPTION
Reinstates the ability to dynamically report the number of allocations for ml node models in the Inference API.

Dynamically reading the number of allocations in use on GET is useful for the case where adaptive allocations is enabled and if the model deployment is managed through ml trained models. The `num_allocations` field in `service_settings` is updated with the current value.

```
GET _inference/elser_on_ml

{
  "endpoints": [
    {
      "inference_id": "elser_on_ml",
      "task_type": "sparse_embedding",
      "service": "elasticsearch",
      "service_settings": {
        "num_allocations": 3,            <-- this field is dynamic
        "num_threads": 1,
        "model_id": ".elser_model_2",
        "deployment_id": ".elser_model_2_for_me"
      },
      "chunking_settings": {
        "strategy": "sentence",
        "max_chunk_size": 250,
        "sentence_overlap": 1
      }
    }
  ]
}
```

The change was originally reverted in 2697f857bcceb518baeff8a10fd67b84b65a2e64 due to an error calling the GroupedActionListener with 0 request. That bug is fixed in cce77b90371026666d4f7f04d5f0b1c64e3267ae.

This RP also includes bug fixes forward ported from 8.16 added in #115095 