### PR TITLE
[8.x] ES|QL: relax tests on usage stats (#115214)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -83,4 +83,3 @@ setup:
   - match: {esql.functions.cos: $functions_cos}
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
-  - length: {esql.functions: 117}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ES|QL: relax tests on usage stats (#115214)