### PR TITLE
[8.x] Change backwards test configuration to use trial license (#115226)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -416,12 +416,23 @@ tests:
 - class: org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapperTests
   method: testBlockLoaderFromRowStrideReaderWithSyntheticSource
   issue: https://github.com/elastic/elasticsearch/issues/115076
-- class: org.elasticsearch.xpack.enrich.EnrichIT
-  method: testEnrichSpecialTypes
-  issue: https://github.com/elastic/elasticsearch/issues/114773
-- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
-  method: testPutE5Small_withPlatformSpecificVariant
-  issue: https://github.com/elastic/elasticsearch/issues/113950
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+  method: test {string.ValuesGrouped}
+  issue: https://github.com/elastic/elasticsearch/issues/115126
+- class: org.elasticsearch.xpack.esql.action.CrossClustersQueryIT
+  method: testCCSExecutionOnSearchesWithLimit0
+  issue: https://github.com/elastic/elasticsearch/issues/115129
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+  issue: https://github.com/elastic/elasticsearch/issues/115135
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
+  method: testEvaluateInManyThreads {TestCase=<long unicode TEXT>}
+  issue: https://github.com/elastic/elasticsearch/issues/115227
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
+  method: testEvaluateInManyThreads {TestCase=<long unicode KEYWORD>}
+  issue: https://github.com/elastic/elasticsearch/issues/115228
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry)}
+  issue: https://github.com/elastic/elasticsearch/issues/115231
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -416,23 +416,12 @@ tests:
 - class: org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapperTests
   method: testBlockLoaderFromRowStrideReaderWithSyntheticSource
   issue: https://github.com/elastic/elasticsearch/issues/115076
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {string.ValuesGrouped}
-  issue: https://github.com/elastic/elasticsearch/issues/115126
-- class: org.elasticsearch.xpack.esql.action.CrossClustersQueryIT
-  method: testCCSExecutionOnSearchesWithLimit0
-  issue: https://github.com/elastic/elasticsearch/issues/115129
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/115135
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
-  method: testEvaluateInManyThreads {TestCase=<long unicode TEXT>}
-  issue: https://github.com/elastic/elasticsearch/issues/115227
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
-  method: testEvaluateInManyThreads {TestCase=<long unicode KEYWORD>}
-  issue: https://github.com/elastic/elasticsearch/issues/115228
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry)}
-  issue: https://github.com/elastic/elasticsearch/issues/115231
+- class: org.elasticsearch.xpack.enrich.EnrichIT
+  method: testEnrichSpecialTypes
+  issue: https://github.com/elastic/elasticsearch/issues/114773
+- class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
+  method: testPutE5Small_withPlatformSpecificVariant
+  issue: https://github.com/elastic/elasticsearch/issues/113950
 
 # Examples:
 #

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -71,6 +71,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       numberOfNodes = 4
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
+      setting "xpack.license.self_generated.type", "trial"
       /* There is a chance we have more master changes than "normal", so to avoid this test from failing,
        we increase the threshold (as this purpose of this test isn't to test that specific indicator). */
       if (bwcVersion.onOrAfter(Version.fromString("8.4.0"))) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Change backwards test configuration to use trial license (#115226)](https://github.com/elastic/elasticsearch/pull/115226)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)