### PR TITLE
ESQL: Fix `REVERSE` with backspace character

### DIFF
--- a/docs/changelog/115245.yaml
+++ b/docs/changelog/115245.yaml
@@ -1,0 +1,7 @@
+pr: 115245
+summary: "ESQL: Fix `REVERSE` with backspace character"
+area: ES|QL
+type: bug
+issues:
+ - 115227
+ - 115228

--- a/docs/changelog/115245.yaml
+++ b/docs/changelog/115245.yaml
@@ -3,5 +3,6 @@ summary: "ESQL: Fix `REVERSE` with backspace character"
 area: ES|QL
 type: bug
 issues:
+ - 114372
  - 115227
  - 115228

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -346,12 +346,8 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/115129
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/115135
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
-  method: testEvaluateInManyThreads {TestCase=<long unicode TEXT>}
-  issue: https://github.com/elastic/elasticsearch/issues/115227
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.string.ReverseTests
-  method: testEvaluateInManyThreads {TestCase=<long unicode KEYWORD>}
-  issue: https://github.com/elastic/elasticsearch/issues/115228
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/115213
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry)}
   issue: https://github.com/elastic/elasticsearch/issues/115231

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -176,9 +176,6 @@ tests:
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test81JavaOptsInJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/113313
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/113325
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
   issue: https://github.com/elastic/elasticsearch/issues/113343

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -176,6 +176,9 @@ tests:
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test81JavaOptsInJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/113313
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+  issue: https://github.com/elastic/elasticsearch/issues/113325
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
   issue: https://github.com/elastic/elasticsearch/issues/113343
@@ -343,8 +346,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/115129
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   issue: https://github.com/elastic/elasticsearch/issues/115135
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/115213
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry)}
   issue: https://github.com/elastic/elasticsearch/issues/115231

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -79,8 +78,6 @@ public class Reverse extends UnaryScalarFunction {
 
     /**
      * Reverses a unicode string, keeping grapheme clusters together
-     * @param str
-     * @return
      */
     public static String reverseStringWithUnicodeCharacters(String str) {
         BreakIterator boundary = BreakIterator.getCharacterInstance(Locale.ROOT);
@@ -100,10 +97,12 @@ public class Reverse extends UnaryScalarFunction {
         return reversed.toString();
     }
 
-    private static boolean isOneByteUTF8(BytesRef ref) {
+    private static boolean reverseBytesIsReverseUnicode(BytesRef ref) {
         int end = ref.offset + ref.length;
         for (int i = ref.offset; i < end; i++) {
-            if (ref.bytes[i] < 0) {
+            if (ref.bytes[i] < 0 // Anything encoded in multibyte utf-8
+                || ref.bytes[i] == 0x28 // Backspace
+            ) {
                 return false;
             }
         }
@@ -112,13 +111,13 @@ public class Reverse extends UnaryScalarFunction {
 
     @Evaluator
     static BytesRef process(BytesRef val) {
-        if (isOneByteUTF8(val)) {
+        if (reverseBytesIsReverseUnicode(val)) {
             // this is the fast path. we know we can just reverse the bytes.
             BytesRef reversed = BytesRef.deepCopyOf(val);
             reverseArray(reversed.bytes, reversed.offset, reversed.length);
             return reversed;
         }
-        return BytesRefs.toBytesRef(reverseStringWithUnicodeCharacters(val.utf8ToString()));
+        return new BytesRef(reverseStringWithUnicodeCharacters(val.utf8ToString()));
     }
 
     @Override


### PR DESCRIPTION
If the text contains a backspace character aka `0x28` aka ctrl-H then we should use the slow reverse path. This is going to be quite rare but our test data is sure good at making rare, fun stuff.

Closes #115228
Closes #115227
Closes #114372
