### PR TITLE
[8.x] Fixed hyperlink in search.asciidoc (#115156)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -38,7 +38,7 @@ must have the `read` index privilege for the alias's data streams or indices.
 
 Allows you to execute a search query and get back search hits that match the
 query. You can provide search queries using the <<search-api-query-params-q,`q`
-query string parameter>> or <<search-search,request body>>.
+query string parameter>> or <<search-search-api-request-body,request body>>.
 
 [[search-search-api-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fixed hyperlink in search.asciidoc (#115156)](https://github.com/elastic/elasticsearch/pull/115156)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)