### PR TITLE
ESQL: Fix `REVERSE` with backspace character (#115245)

### DIFF
--- a/docs/changelog/115245.yaml
+++ b/docs/changelog/115245.yaml
@@ -1,0 +1,8 @@
+pr: 115245
+summary: "ESQL: Fix `REVERSE` with backspace character"
+area: ES|QL
+type: bug
+issues:
+ - 114372
+ - 115227
+ - 115228

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Reverse.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -79,8 +78,6 @@ public class Reverse extends UnaryScalarFunction {
 
     /**
      * Reverses a unicode string, keeping grapheme clusters together
-     * @param str
-     * @return
      */
     public static String reverseStringWithUnicodeCharacters(String str) {
         BreakIterator boundary = BreakIterator.getCharacterInstance(Locale.ROOT);
@@ -100,10 +97,12 @@ public class Reverse extends UnaryScalarFunction {
         return reversed.toString();
     }
 
-    private static boolean isOneByteUTF8(BytesRef ref) {
+    private static boolean reverseBytesIsReverseUnicode(BytesRef ref) {
         int end = ref.offset + ref.length;
         for (int i = ref.offset; i < end; i++) {
-            if (ref.bytes[i] < 0) {
+            if (ref.bytes[i] < 0 // Anything encoded in multibyte utf-8
+                || ref.bytes[i] == 0x28 // Backspace
+            ) {
                 return false;
             }
         }
@@ -112,13 +111,13 @@ public class Reverse extends UnaryScalarFunction {
 
     @Evaluator
     static BytesRef process(BytesRef val) {
-        if (isOneByteUTF8(val)) {
+        if (reverseBytesIsReverseUnicode(val)) {
             // this is the fast path. we know we can just reverse the bytes.
             BytesRef reversed = BytesRef.deepCopyOf(val);
             reverseArray(reversed.bytes, reversed.offset, reversed.length);
             return reversed;
         }
-        return BytesRefs.toBytesRef(reverseStringWithUnicodeCharacters(val.utf8ToString()));
+        return new BytesRef(reverseStringWithUnicodeCharacters(val.utf8ToString()));
     }
 
     @Override


### PR DESCRIPTION
If the text contains a backspace character aka `0x28` aka ctrl-H then we should use the slow reverse path. This is going to be quite rare but our test data is sure good at making rare, fun stuff.

Closes #115228
Closes #115227
Closes #114372
