### PR TITLE
[8.16] ESQL: Add support for multivalue fields in Arrow output (#114774)

### DIFF
--- a/docs/changelog/114774.yaml
+++ b/docs/changelog/114774.yaml
@@ -1,0 +1,5 @@
+pr: 114774
+summary: "ESQL: Add support for multivalue fields in Arrow output"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/arrow/build.gradle
+++ b/x-pack/plugin/esql/arrow/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
   testImplementation project(':test:framework')
   testImplementation('org.apache.arrow:arrow-memory-unsafe:16.1.0')
+  testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}")
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/esql/arrow/src/test/java/org/elasticsearch/xpack/esql/arrow/ArrowResponseTests.java
+++ b/x-pack/plugin/esql/arrow/src/test/java/org/elasticsearch/xpack/esql/arrow/ArrowResponseTests.java
@@ -752,7 +752,7 @@ public class ArrowResponseTests extends ESTestCase {
                 values.add(blockGetter.apply((BlockT) block, i, scratch));
                 scratch = new BytesRef(); // do not overwrite previous value
             }
-            return values.size() == 1 ? values.getFirst() : values;
+            return values.size() == 1 ? values.get(0) : values;
         }
 
         @Override
@@ -766,7 +766,7 @@ public class ArrowResponseTests extends ESTestCase {
                 for (int i = listVector.getElementStartIndex(position); i < listVector.getElementEndIndex(position); i++) {
                     values.add(vectorGetter.apply((VectorT) valueVec, i));
                 }
-                return values.size() == 1 ? values.getFirst() : values;
+                return values.size() == 1 ? values.get(0) : values;
             } else {
                 return vectorGetter.apply((VectorT) arrowVec, position);
             }


### PR DESCRIPTION
Backports the following commits to 8.16:
 - ESQL: Add support for multivalue fields in Arrow output (#114774)