### PR TITLE
[8.16] [Build] Fix checkstyle exclusions on windows (#115185)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/PlatformUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/PlatformUtils.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.util;
+
+import java.util.stream.Collectors;
+
+public class PlatformUtils {
+
+    public static String normalize(String input) {
+        return input.lines()
+            .map(it -> it.replace('\\', '/'))
+            .map(it -> it.replaceAll("\\d+\\.\\d\\ds", "0.00s"))
+            .map(it -> it.replace("file:/./", "file:./"))
+            .collect(Collectors.joining("\n"));
+    }
+}

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -1,6 +1,7 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask;
 import org.elasticsearch.gradle.internal.util.SourceDirectoryCommandLineArgumentProvider;
+import static org.elasticsearch.gradle.util.PlatformUtils.normalize
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -56,7 +57,7 @@ def generatedSourceDir = projectDirectory.dir("src/main/generated")
 tasks.named("compileJava").configure {
   options.compilerArgumentProviders.add(new SourceDirectoryCommandLineArgumentProvider(generatedSourceDir))
   // IntelliJ sticks generated files here and we can't stop it....
-  exclude { it.file.toString().contains("src/main/generated-src/generated") }
+  exclude { normalize(it.file.toString()).contains("src/main/generated-src/generated") }
 }
 
 interface Injected {
@@ -262,8 +263,8 @@ tasks.register("regen") {
 tasks.named("spotlessJava") { dependsOn stringTemplates }
 tasks.named('checkstyleMain').configure {
   excludes = [ "**/*.java.st" ]
-  exclude { it.file.toString().contains("src/main/generated-src/generated") }
-  exclude { it.file.toString().contains("src/main/generated") }
+  exclude { normalize(it.file.toString()).contains("src/main/generated-src/generated") }
+  exclude { normalize(it.file.toString()).contains("src/main/generated") }
 }
 
 def prop(Type, type, TYPE, BYTES, Array) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Build] Fix checkstyle exclusions on windows (#115185)](https://github.com/elastic/elasticsearch/pull/115185)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)