### PR TITLE
[8.x] Always check the parent breaker with zero bytes in PreallocatedCircuitBreakerService (#115181)

### DIFF
--- a/docs/changelog/115181.yaml
+++ b/docs/changelog/115181.yaml
@@ -1,0 +1,5 @@
+pr: 115181
+summary: Always check the parent breaker with zero bytes in `PreallocatedCircuitBreakerService`
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/PreallocatedCircuitBreakerService.java
@@ -109,8 +109,8 @@ public class PreallocatedCircuitBreakerService extends CircuitBreakerService imp
             if (closed) {
                 throw new IllegalStateException("already closed");
             }
-            if (preallocationUsed == preallocated) {
-                // Preallocation buffer was full before this request
+            if (preallocationUsed == preallocated || bytes == 0L) {
+                // Preallocation buffer was full before this request or we are checking the parent circuit breaker
                 next.addEstimateBytesAndMaybeBreak(bytes, label);
                 return;
             }


### PR DESCRIPTION
Backports the following commits to 8.x:
- Always check the parent breaker with zero bytes in PreallocatedCircuitBreakerService (https://github.com/elastic/elasticsearch/pull/115181)