### PR TITLE
Relax condition for H3 bins crossing the dateline

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitorTests.java
@@ -83,9 +83,10 @@ public class GeoHexVisitorTests extends ESTestCase {
             visitor.reset(centerChild);
             reader.visit(visitor);
             if (hasArea) {
-                if (h3CrossesDateline && visitor.getLeftX() > visitor.getRightX()) {
-                    // if both polygons crosses the dateline it cannot be inside due to the polygon splitting technique
-                    assertEquals("failing h3: " + h3, GeoRelation.QUERY_CROSSES, visitor.relation());
+                if (h3CrossesDateline) {
+                    // if the h3 crosses the dateline, we might get CROSSES due to the polygon splitting technique. We can't
+                    // be sure which one is the correct one, so we just check that it is not DISJOINT
+                    assertNotSame("failing h3: " + h3, GeoRelation.QUERY_DISJOINT, visitor.relation());
                 } else {
                     assertEquals("failing h3: " + h3, GeoRelation.QUERY_INSIDE, visitor.relation());
                 }


### PR DESCRIPTION
This test checks that the center child of a hex is inside of the parent hex. This works well except for hex that crosses the dateline where that might not hold true due to the polygon splitting technique. We are currently assuming that this does not hold true if both hex, the parent and the child crosses the dateline. This seems to break as well if the child hex touches but not crosses the dateline.

This is complex to add to the test and it is not critical, therefore let's relax the condition and just check the for h3 binds crossing the dateline, we return something different to Disjoint.

fixes https://github.com/elastic/elasticsearch/issues/115219