### PR TITLE
[8.x] Unmute BlockHashRandomizedTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -401,9 +401,6 @@ tests:
 - class: org.elasticsearch.xpack.enrich.EnrichIT
   method: testDeleteExistingPipeline
   issue: https://github.com/elastic/elasticsearch/issues/114775
-- class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
-  method: test {forcePackedHash=false groups=1 maxValuesPerPosition=1 dups=2 allowedTypes=[Ordinals[dictionarySize=10]]}
-  issue: https://github.com/elastic/elasticsearch/issues/115105
 - class: org.elasticsearch.index.mapper.TextFieldMapperTests
   method: testBlockLoaderFromRowStrideReaderWithSyntheticSource
   issue: https://github.com/elastic/elasticsearch/issues/115066


### PR DESCRIPTION
The test was fixed in https://github.com/elastic/elasticsearch/pull/115270

fixes https://github.com/elastic/elasticsearch/issues/115105