### PR TITLE
[8.x] Unmute recently failing CCQ tests (#115218)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -292,9 +292,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test022InstallPluginsFromLocalArchive
   issue: https://github.com/elastic/elasticsearch/issues/111063
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/esql/esql-across-clusters/line_196}
-  issue: https://github.com/elastic/elasticsearch/issues/114488
 - class: org.elasticsearch.gradle.internal.PublishPluginFuncTest
   issue: https://github.com/elastic/elasticsearch/issues/114492
 - class: org.elasticsearch.xpack.inference.DefaultElserIT

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -378,9 +378,6 @@ tests:
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/800_rrf_with_text_similarity_reranker_retriever/explain using rrf retriever and text-similarity}
   issue: https://github.com/elastic/elasticsearch/issues/114757
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/esql/esql-across-clusters/line_197}
-  issue: https://github.com/elastic/elasticsearch/issues/114947
 - class: org.elasticsearch.xpack.enrich.EnrichRestIT
   method: test {p0=enrich/50_data_stream/enrich documents over _bulk via a data stream}
   issue: https://github.com/elastic/elasticsearch/issues/114769


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Unmute recently failing CCQ tests (#115218)](https://github.com/elastic/elasticsearch/pull/115218)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)