### PR TITLE
Change some IndexInput to RandomAccessInput in ES87TSDBDocValuesProducer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
@@ -132,7 +132,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
             return DocValues.emptyBinary();
         }
 
-        final IndexInput bytesSlice = data.slice("fixed-binary", entry.dataOffset, entry.dataLength);
+        final RandomAccessInput bytesSlice = data.randomAccessSlice(entry.dataOffset, entry.dataLength);
 
         if (entry.docsWithFieldOffset == -1) {
             // dense
@@ -144,8 +144,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
 
                     @Override
                     public BytesRef binaryValue() throws IOException {
-                        bytesSlice.seek((long) doc * length);
-                        bytesSlice.readBytes(bytes.bytes, 0, length);
+                        bytesSlice.readBytes((long) doc * length, bytes.bytes, 0, length);
                         return bytes;
                     }
                 };
@@ -160,8 +159,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
                     public BytesRef binaryValue() throws IOException {
                         long startOffset = addresses.get(doc);
                         bytes.length = (int) (addresses.get(doc + 1L) - startOffset);
-                        bytesSlice.seek(startOffset);
-                        bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
+                        bytesSlice.readBytes(startOffset, bytes.bytes, 0, bytes.length);
                         return bytes;
                     }
                 };
@@ -184,8 +182,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
 
                     @Override
                     public BytesRef binaryValue() throws IOException {
-                        bytesSlice.seek((long) disi.index() * length);
-                        bytesSlice.readBytes(bytes.bytes, 0, length);
+                        bytesSlice.readBytes((long) disi.index() * length, bytes.bytes, 0, length);
                         return bytes;
                     }
                 };
@@ -201,8 +198,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
                         final int index = disi.index();
                         long startOffset = addresses.get(index);
                         bytes.length = (int) (addresses.get(index + 1L) - startOffset);
-                        bytesSlice.seek(startOffset);
-                        bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
+                        bytesSlice.readBytes(startOffset, bytes.bytes, 0, bytes.length);
                         return bytes;
                     }
                 };
@@ -407,7 +403,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         final IndexInput bytes;
         final long blockMask;
         final LongValues indexAddresses;
-        final IndexInput indexBytes;
+        final RandomAccessInput indexBytes;
         final BytesRef term;
         long ord = -1;
 
@@ -427,7 +423,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
                 entry.termsIndexAddressesLength
             );
             indexAddresses = DirectMonotonicReader.getInstance(entry.termsIndexAddressesMeta, indexAddressesSlice);
-            indexBytes = data.slice("terms-index", entry.termsIndexOffset, entry.termsIndexLength);
+            indexBytes = data.randomAccessSlice(entry.termsIndexOffset, entry.termsIndexLength);
             term = new BytesRef(entry.maxTermLength);
 
             // add the max term length for the dictionary
@@ -485,8 +481,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
             assert index >= 0 && index <= (entry.termsDictSize - 1) >>> entry.termsDictIndexShift;
             final long start = indexAddresses.get(index);
             term.length = (int) (indexAddresses.get(index + 1) - start);
-            indexBytes.seek(start);
-            indexBytes.readBytes(term.bytes, 0, term.length);
+            indexBytes.readBytes(start, term.bytes, 0, term.length);
             return term;
         }
 


### PR DESCRIPTION
Some IndexInput in ES87TSDBDocValuesProducer are only used in the combination of #seek + #readBytes. In those cases is better to use a RandomAccessInput as it is a lighter object that does not keep state.