### PR TITLE
[8.x] ESQL: Mute categorize test also sync

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -309,6 +309,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {categorize.Categorize ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/113721
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+  method: test {categorize.Categorize SYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/113722
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testMinimumVersionSameAsNewVersion
   issue: https://github.com/elastic/elasticsearch/issues/114593


### PR DESCRIPTION
The test is already muted on main, but now it's causing bwc tests to fail for backports to 8.x as well.
