### PR TITLE
Revert "Add ResolvedExpression wrapper (#114592)"

### DIFF
--- a/docs/changelog/115317.yaml
+++ b/docs/changelog/115317.yaml
@@ -1,0 +1,5 @@
+pr: 115317
+summary: Revert "Add `ResolvedExpression` wrapper"
+area: Indices APIs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -85,7 +84,7 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadA
         String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
         Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(state, request.routing(), request.indices());
         Map<String, AliasFilter> indicesAndFilters = new HashMap<>();
-        Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, request.indices());
+        Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, request.indices());
         for (String index : concreteIndices) {
             final AliasFilter aliasFilter = indicesService.buildAliasFilter(clusterState, index, indicesAndAliases);
             final String[] aliases = indexNameExpressionResolver.indexAliases(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -566,8 +565,8 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
             if (names.length == 1 && (Metadata.ALL.equals(names[0]) || Regex.isMatchAllPattern(names[0]))) {
                 names = new String[] { "**" };
             }
-            Set<ResolvedExpression> resolvedIndexAbstractions = resolver.resolveExpressions(clusterState, indicesOptions, true, names);
-            for (ResolvedExpression s : resolvedIndexAbstractions) {
+            Set<String> resolvedIndexAbstractions = resolver.resolveExpressions(clusterState, indicesOptions, true, names);
+            for (String s : resolvedIndexAbstractions) {
                 enrichIndexAbstraction(clusterState, s, indices, aliases, dataStreams);
             }
             indices.sort(Comparator.comparing(ResolvedIndexAbstraction::getName));
@@ -598,12 +597,12 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
 
         private static void enrichIndexAbstraction(
             ClusterState clusterState,
-            ResolvedExpression indexAbstraction,
+            String indexAbstraction,
             List<ResolvedIndex> indices,
             List<ResolvedAlias> aliases,
             List<ResolvedDataStream> dataStreams
         ) {
-            IndexAbstraction ia = clusterState.metadata().getIndicesLookup().get(indexAbstraction.resource());
+            IndexAbstraction ia = clusterState.metadata().getIndicesLookup().get(indexAbstraction);
             if (ia != null) {
                 switch (ia.getType()) {
                     case CONCRETE_INDEX -> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -21,7 +21,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -134,7 +133,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
     @Override
     protected ShardValidateQueryRequest newShardRequest(int numShards, ShardRouting shard, ValidateQueryRequest request) {
         final ClusterState clusterState = clusterService.state();
-        final Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, request.indices());
+        final Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, request.indices());
         final AliasFilter aliasFilter = searchService.buildAliasFilter(clusterState, shard.getIndexName(), indicesAndAliases);
         return new ShardValidateQueryRequest(shard.shardId(), aliasFilter, request);
     }

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -110,7 +109,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
 
     @Override
     protected void resolveRequest(ClusterState state, InternalRequest request) {
-        final Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(state, request.request().index());
+        final Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(state, request.request().index());
         final AliasFilter aliasFilter = searchService.buildAliasFilter(state, request.concreteIndex(), indicesAndAliases);
         request.request().filteringAlias(aliasFilter);
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -37,7 +37,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
@@ -111,7 +110,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.search.SearchType.DFS_QUERY_THEN_FETCH;
 import static org.elasticsearch.action.search.SearchType.QUERY_THEN_FETCH;
@@ -205,7 +203,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
     private Map<String, OriginalIndices> buildPerIndexOriginalIndices(
         ClusterState clusterState,
-        Set<ResolvedExpression> indicesAndAliases,
+        Set<String> indicesAndAliases,
         String[] indices,
         IndicesOptions indicesOptions
     ) {
@@ -213,9 +211,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         var blocks = clusterState.blocks();
         // optimization: mostly we do not have any blocks so there's no point in the expensive per-index checking
         boolean hasBlocks = blocks.global().isEmpty() == false || blocks.indices().isEmpty() == false;
-        // Get a distinct set of index abstraction names present from the resolved expressions to help with the reverse resolution from
-        // concrete index to the expression that produced it.
-        Set<String> indicesAndAliasesResources = indicesAndAliases.stream().map(ResolvedExpression::resource).collect(Collectors.toSet());
         for (String index : indices) {
             if (hasBlocks) {
                 blocks.indexBlockedRaiseException(ClusterBlockLevel.READ, index);
@@ -232,8 +227,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             String[] finalIndices = Strings.EMPTY_ARRAY;
             if (aliases == null
                 || aliases.length == 0
-                || indicesAndAliasesResources.contains(index)
-                || hasDataStreamRef(clusterState, indicesAndAliasesResources, index)) {
+                || indicesAndAliases.contains(index)
+                || hasDataStreamRef(clusterState, indicesAndAliases, index)) {
                 finalIndices = new String[] { index };
             }
             if (aliases != null) {
@@ -252,11 +247,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         return indicesAndAliases.contains(ret.getParentDataStream().getName());
     }
 
-    Map<String, AliasFilter> buildIndexAliasFilters(
-        ClusterState clusterState,
-        Set<ResolvedExpression> indicesAndAliases,
-        Index[] concreteIndices
-    ) {
+    Map<String, AliasFilter> buildIndexAliasFilters(ClusterState clusterState, Set<String> indicesAndAliases, Index[] concreteIndices) {
         final Map<String, AliasFilter> aliasFilterMap = new HashMap<>();
         for (Index index : concreteIndices) {
             clusterState.blocks().indexBlockedRaiseException(ClusterBlockLevel.READ, index.getName());
@@ -1246,10 +1237,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         } else {
             final Index[] indices = resolvedIndices.getConcreteLocalIndices();
             concreteLocalIndices = Arrays.stream(indices).map(Index::getName).toArray(String[]::new);
-            final Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(
-                clusterState,
-                searchRequest.indices()
-            );
+            final Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, searchRequest.indices());
             aliasFilter = buildIndexAliasFilters(clusterState, indicesAndAliases, indices);
             aliasFilter.putAll(remoteAliasMap);
             localShardIterators = getLocalShardsIterator(
@@ -1822,7 +1810,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         ClusterState clusterState,
         SearchRequest searchRequest,
         String clusterAlias,
-        Set<ResolvedExpression> indicesAndAliases,
+        Set<String> indicesAndAliases,
         String[] concreteIndices
     ) {
         var routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, searchRequest.routing(), searchRequest.indices());

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.Index;
@@ -128,10 +127,7 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
             searchService.getRewriteContext(timeProvider::absoluteStartMillis, resolvedIndices, null),
             listener.delegateFailureAndWrap((delegate, searchRequest) -> {
                 Index[] concreteIndices = resolvedIndices.getConcreteLocalIndices();
-                final Set<ResolvedExpression> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(
-                    clusterState,
-                    searchRequest.indices()
-                );
+                final Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, searchRequest.indices());
                 final Map<String, AliasFilter> aliasFilters = transportSearchAction.buildIndexAliasFilters(
                     clusterState,
                     indicesAndAliases,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -75,15 +75,6 @@ public class IndexNameExpressionResolver {
     }
 
     /**
-     * This contains the resolved expression in the form of the resource.
-     * Soon it will facilitate the index component selector.
-     * @param resource the resolved resolvedExpression
-     */
-    public record ResolvedExpression(String resource) {
-
-    }
-
-    /**
      * Same as {@link #concreteIndexNames(ClusterState, IndicesOptions, String...)}, but the index expressions and options
      * are encapsulated in the specified request.
      */
@@ -200,9 +191,8 @@ public class IndexNameExpressionResolver {
             getSystemIndexAccessPredicate(),
             getNetNewSystemIndexPredicate()
         );
-        final Collection<ResolvedExpression> expressions = resolveExpressions(context, indexExpressions);
+        final Collection<String> expressions = resolveExpressions(context, indexExpressions);
         return expressions.stream()
-            .map(ResolvedExpression::resource)
             .map(x -> state.metadata().getIndicesLookup().get(x))
             .filter(Objects::nonNull)
             .filter(ia -> ia.getType() == Type.DATA_STREAM)
@@ -231,11 +221,10 @@ public class IndexNameExpressionResolver {
             getNetNewSystemIndexPredicate()
         );
 
-        final Collection<ResolvedExpression> expressions = resolveExpressions(context, request.index());
+        final Collection<String> expressions = resolveExpressions(context, request.index());
 
         if (expressions.size() == 1) {
-            ResolvedExpression resolvedExpression = expressions.iterator().next();
-            IndexAbstraction ia = state.metadata().getIndicesLookup().get(resolvedExpression.resource());
+            IndexAbstraction ia = state.metadata().getIndicesLookup().get(expressions.iterator().next());
             if (ia.getType() == Type.ALIAS) {
                 Index writeIndex = ia.getWriteIndex();
                 if (writeIndex == null) {
@@ -257,14 +246,14 @@ public class IndexNameExpressionResolver {
         }
     }
 
-    protected static Collection<ResolvedExpression> resolveExpressions(Context context, String... expressions) {
+    protected static Collection<String> resolveExpressions(Context context, String... expressions) {
         if (context.getOptions().expandWildcardExpressions() == false) {
             if (expressions == null || expressions.length == 0 || expressions.length == 1 && Metadata.ALL.equals(expressions[0])) {
                 return List.of();
             } else {
                 return ExplicitResourceNameFilter.filterUnavailable(
                     context,
-                    DateMathExpressionResolver.resolve(context, Arrays.stream(expressions).map(ResolvedExpression::new).toList())
+                    DateMathExpressionResolver.resolve(context, List.of(expressions))
                 );
             }
         } else {
@@ -275,10 +264,7 @@ public class IndexNameExpressionResolver {
             } else {
                 return WildcardExpressionResolver.resolve(
                     context,
-                    ExplicitResourceNameFilter.filterUnavailable(
-                        context,
-                        DateMathExpressionResolver.resolve(context, Arrays.stream(expressions).map(ResolvedExpression::new).toList())
-                    )
+                    ExplicitResourceNameFilter.filterUnavailable(context, DateMathExpressionResolver.resolve(context, List.of(expressions)))
                 );
             }
         }
@@ -353,12 +339,12 @@ public class IndexNameExpressionResolver {
     }
 
     Index[] concreteIndices(Context context, String... indexExpressions) {
-        final Collection<ResolvedExpression> expressions = resolveExpressions(context, indexExpressions);
+        final Collection<String> expressions = resolveExpressions(context, indexExpressions);
 
         final Set<Index> concreteIndicesResult = Sets.newLinkedHashSetWithExpectedSize(expressions.size());
         final Map<String, IndexAbstraction> indicesLookup = context.getState().metadata().getIndicesLookup();
-        for (ResolvedExpression resolvedExpression : expressions) {
-            final IndexAbstraction indexAbstraction = indicesLookup.get(resolvedExpression.resource());
+        for (String expression : expressions) {
+            final IndexAbstraction indexAbstraction = indicesLookup.get(expression);
             assert indexAbstraction != null;
             if (indexAbstraction.getType() == Type.ALIAS && context.isResolveToWriteIndex()) {
                 Index writeIndex = indexAbstraction.getWriteIndex();
@@ -392,7 +378,7 @@ public class IndexNameExpressionResolver {
                     throw new IllegalArgumentException(
                         indexAbstraction.getType().getDisplayName()
                             + " ["
-                            + resolvedExpression.resource()
+                            + expression
                             + "] has more than one index associated with it "
                             + Arrays.toString(indexNames)
                             + ", can't execute a single index op"
@@ -656,7 +642,7 @@ public class IndexNameExpressionResolver {
      * Utility method that allows to resolve an index expression to its corresponding single write index.
      *
      * @param state             the cluster state containing all the data to resolve to expression to a concrete index
-     * @param request           The request that defines how an alias or an index need to be resolved to a concrete index
+     * @param request           The request that defines how the an alias or an index need to be resolved to a concrete index
      *                          and the expression that can be resolved to an alias or an index name.
      * @throws IllegalArgumentException if the index resolution does not lead to an index, or leads to more than one index
      * @return the write index obtained as a result of the index resolution
@@ -748,7 +734,7 @@ public class IndexNameExpressionResolver {
     /**
      * Resolve an array of expressions to the set of indices and aliases that these expressions match.
      */
-    public Set<ResolvedExpression> resolveExpressions(ClusterState state, String... expressions) {
+    public Set<String> resolveExpressions(ClusterState state, String... expressions) {
         return resolveExpressions(state, IndicesOptions.lenientExpandOpen(), false, expressions);
     }
 
@@ -757,7 +743,7 @@ public class IndexNameExpressionResolver {
      * If {@param preserveDataStreams} is {@code true}, datastreams that are covered by the wildcards from the
      * {@param expressions} are returned as-is, without expanding them further to their respective backing indices.
      */
-    public Set<ResolvedExpression> resolveExpressions(
+    public Set<String> resolveExpressions(
         ClusterState state,
         IndicesOptions indicesOptions,
         boolean preserveDataStreams,
@@ -774,10 +760,10 @@ public class IndexNameExpressionResolver {
             getSystemIndexAccessPredicate(),
             getNetNewSystemIndexPredicate()
         );
-        Collection<ResolvedExpression> resolved = resolveExpressions(context, expressions);
-        if (resolved instanceof Set<ResolvedExpression>) {
+        Collection<String> resolved = resolveExpressions(context, expressions);
+        if (resolved instanceof Set<String>) {
             // unmodifiable without creating a new collection as it might contain many items
-            return Collections.unmodifiableSet((Set<ResolvedExpression>) resolved);
+            return Collections.unmodifiableSet((Set<String>) resolved);
         } else {
             return Set.copyOf(resolved);
         }
@@ -790,7 +776,7 @@ public class IndexNameExpressionResolver {
      * the index itself - null is returned. Returns {@code null} if no filtering is required.
      * <b>NOTE</b>: The provided expressions must have been resolved already via {@link #resolveExpressions}.
      */
-    public String[] filteringAliases(ClusterState state, String index, Set<ResolvedExpression> resolvedExpressions) {
+    public String[] filteringAliases(ClusterState state, String index, Set<String> resolvedExpressions) {
         return indexAliases(state, index, AliasMetadata::filteringRequired, DataStreamAlias::filteringRequired, false, resolvedExpressions);
     }
 
@@ -816,39 +802,39 @@ public class IndexNameExpressionResolver {
         Predicate<AliasMetadata> requiredAlias,
         Predicate<DataStreamAlias> requiredDataStreamAlias,
         boolean skipIdentity,
-        Set<ResolvedExpression> resolvedExpressions
+        Set<String> resolvedExpressions
     ) {
-        if (isAllIndicesExpression(resolvedExpressions)) {
+        if (isAllIndices(resolvedExpressions)) {
             return null;
         }
-        Set<String> resources = resolvedExpressions.stream().map(ResolvedExpression::resource).collect(Collectors.toSet());
+
         final IndexMetadata indexMetadata = state.metadata().getIndices().get(index);
         if (indexMetadata == null) {
             // Shouldn't happen
             throw new IndexNotFoundException(index);
         }
 
-        if (skipIdentity == false && resources.contains(index)) {
+        if (skipIdentity == false && resolvedExpressions.contains(index)) {
             return null;
         }
 
         IndexAbstraction ia = state.metadata().getIndicesLookup().get(index);
         DataStream dataStream = ia.getParentDataStream();
         if (dataStream != null) {
-            if (skipIdentity == false && resources.contains(dataStream.getName())) {
+            if (skipIdentity == false && resolvedExpressions.contains(dataStream.getName())) {
                 // skip the filters when the request targets the data stream name
                 return null;
             }
             Map<String, DataStreamAlias> dataStreamAliases = state.metadata().dataStreamAliases();
             List<DataStreamAlias> aliasesForDataStream;
-            if (iterateIndexAliases(dataStreamAliases.size(), resources.size())) {
+            if (iterateIndexAliases(dataStreamAliases.size(), resolvedExpressions.size())) {
                 aliasesForDataStream = dataStreamAliases.values()
                     .stream()
-                    .filter(dataStreamAlias -> resources.contains(dataStreamAlias.getName()))
+                    .filter(dataStreamAlias -> resolvedExpressions.contains(dataStreamAlias.getName()))
                     .filter(dataStreamAlias -> dataStreamAlias.getDataStreams().contains(dataStream.getName()))
                     .toList();
             } else {
-                aliasesForDataStream = resources.stream()
+                aliasesForDataStream = resolvedExpressions.stream()
                     .map(dataStreamAliases::get)
                     .filter(dataStreamAlias -> dataStreamAlias != null && dataStreamAlias.getDataStreams().contains(dataStream.getName()))
                     .toList();
@@ -873,15 +859,18 @@ public class IndexNameExpressionResolver {
         } else {
             final Map<String, AliasMetadata> indexAliases = indexMetadata.getAliases();
             final AliasMetadata[] aliasCandidates;
-            if (iterateIndexAliases(indexAliases.size(), resources.size())) {
+            if (iterateIndexAliases(indexAliases.size(), resolvedExpressions.size())) {
                 // faster to iterate indexAliases
                 aliasCandidates = indexAliases.values()
                     .stream()
-                    .filter(aliasMetadata -> resources.contains(aliasMetadata.alias()))
+                    .filter(aliasMetadata -> resolvedExpressions.contains(aliasMetadata.alias()))
                     .toArray(AliasMetadata[]::new);
             } else {
                 // faster to iterate resolvedExpressions
-                aliasCandidates = resources.stream().map(indexAliases::get).filter(Objects::nonNull).toArray(AliasMetadata[]::new);
+                aliasCandidates = resolvedExpressions.stream()
+                    .map(indexAliases::get)
+                    .filter(Objects::nonNull)
+                    .toArray(AliasMetadata[]::new);
             }
             List<String> aliases = null;
             for (AliasMetadata aliasMetadata : aliasCandidates) {
@@ -920,7 +909,12 @@ public class IndexNameExpressionResolver {
             getSystemIndexAccessPredicate(),
             getNetNewSystemIndexPredicate()
         );
-        final Collection<ResolvedExpression> resolvedExpressions = resolveExpressions(context, expressions);
+        final Collection<String> resolvedExpressions = resolveExpressions(context, expressions);
+
+        // TODO: it appears that this can never be true?
+        if (isAllIndices(resolvedExpressions)) {
+            return resolveSearchRoutingAllIndices(state.metadata(), routing);
+        }
 
         Map<String, Set<String>> routings = null;
         Set<String> paramRouting = null;
@@ -930,8 +924,8 @@ public class IndexNameExpressionResolver {
             paramRouting = Sets.newHashSet(Strings.splitStringByCommaToArray(routing));
         }
 
-        for (ResolvedExpression resolvedExpression : resolvedExpressions) {
-            IndexAbstraction indexAbstraction = state.metadata().getIndicesLookup().get(resolvedExpression.resource);
+        for (String expression : resolvedExpressions) {
+            IndexAbstraction indexAbstraction = state.metadata().getIndicesLookup().get(expression);
             if (indexAbstraction != null && indexAbstraction.getType() == Type.ALIAS) {
                 for (Index index : indexAbstraction.getIndices()) {
                     String concreteIndex = index.getName();
@@ -969,7 +963,7 @@ public class IndexNameExpressionResolver {
                 }
             } else {
                 // Index
-                routings = collectRoutings(routings, paramRouting, norouting, resolvedExpression.resource());
+                routings = collectRoutings(routings, paramRouting, norouting, expression);
             }
 
         }
@@ -1013,17 +1007,6 @@ public class IndexNameExpressionResolver {
             return routings;
         }
         return null;
-    }
-
-    /**
-     * Identifies whether the array containing index names given as argument refers to all indices
-     * The empty or null array identifies all indices
-     *
-     * @param aliasesOrIndices the array containing index names
-     * @return true if the provided array maps to all indices, false otherwise
-     */
-    public static boolean isAllIndicesExpression(Collection<ResolvedExpression> aliasesOrIndices) {
-        return isAllIndices(aliasesOrIndices.stream().map(ResolvedExpression::resource).toList());
     }
 
     /**
@@ -1266,8 +1249,8 @@ public class IndexNameExpressionResolver {
          * Returns all the indices, datastreams, and aliases, considering the open/closed, system, and hidden context parameters.
          * Depending on the context, returns the names of the datastreams themselves or their backing indices.
          */
-        public static Collection<ResolvedExpression> resolveAll(Context context) {
-            List<ResolvedExpression> concreteIndices = resolveEmptyOrTrivialWildcard(context);
+        public static Collection<String> resolveAll(Context context) {
+            List<String> concreteIndices = resolveEmptyOrTrivialWildcard(context);
 
             if (context.includeDataStreams() == false && context.getOptions().ignoreAliases()) {
                 return concreteIndices;
@@ -1282,7 +1265,7 @@ public class IndexNameExpressionResolver {
                 .filter(ia -> shouldIncludeIfDataStream(ia, context) || shouldIncludeIfAlias(ia, context))
                 .filter(ia -> ia.isSystem() == false || context.systemIndexAccessPredicate.test(ia.getName()));
 
-            Set<ResolvedExpression> resolved = expandToOpenClosed(context, ias).collect(Collectors.toSet());
+            Set<String> resolved = expandToOpenClosed(context, ias).collect(Collectors.toSet());
             resolved.addAll(concreteIndices);
             return resolved;
         }
@@ -1310,17 +1293,17 @@ public class IndexNameExpressionResolver {
          * ultimately returned, instead of the alias or datastream name</li>
          * </ol>
          */
-        public static Collection<ResolvedExpression> resolve(Context context, List<ResolvedExpression> expressions) {
+        public static Collection<String> resolve(Context context, List<String> expressions) {
             ExpressionList expressionList = new ExpressionList(context, expressions);
             // fast exit if there are no wildcards to evaluate
             if (expressionList.hasWildcard() == false) {
                 return expressions;
             }
-            Set<ResolvedExpression> result = new HashSet<>();
+            Set<String> result = new HashSet<>();
             for (ExpressionList.Expression expression : expressionList) {
                 if (expression.isWildcard()) {
                     Stream<IndexAbstraction> matchingResources = matchResourcesToWildcard(context, expression.get());
-                    Stream<ResolvedExpression> matchingOpenClosedNames = expandToOpenClosed(context, matchingResources);
+                    Stream<String> matchingOpenClosedNames = expandToOpenClosed(context, matchingResources);
                     AtomicBoolean emptyWildcardExpansion = new AtomicBoolean(false);
                     if (context.getOptions().allowNoIndices() == false) {
                         emptyWildcardExpansion.set(true);
@@ -1336,9 +1319,9 @@ public class IndexNameExpressionResolver {
                     }
                 } else {
                     if (expression.isExclusion()) {
-                        result.remove(new ResolvedExpression(expression.get()));
+                        result.remove(expression.get());
                     } else {
-                        result.add(expression.resolvedExpression());
+                        result.add(expression.get());
                     }
                 }
             }
@@ -1429,13 +1412,13 @@ public class IndexNameExpressionResolver {
          * Data streams and aliases are interpreted to refer to multiple indices,
          * then all index resources are filtered by their open/closed status.
          */
-        private static Stream<ResolvedExpression> expandToOpenClosed(Context context, Stream<IndexAbstraction> resources) {
+        private static Stream<String> expandToOpenClosed(Context context, Stream<IndexAbstraction> resources) {
             final IndexMetadata.State excludeState = excludeState(context.getOptions());
             return resources.flatMap(indexAbstraction -> {
                 if (context.isPreserveAliases() && indexAbstraction.getType() == Type.ALIAS) {
-                    return Stream.of(new ResolvedExpression(indexAbstraction.getName()));
+                    return Stream.of(indexAbstraction.getName());
                 } else if (context.isPreserveDataStreams() && indexAbstraction.getType() == Type.DATA_STREAM) {
-                    return Stream.of(new ResolvedExpression(indexAbstraction.getName()));
+                    return Stream.of(indexAbstraction.getName());
                 } else {
                     Stream<IndexMetadata> indicesStateStream = Stream.of();
                     if (shouldIncludeRegularIndices(context.getOptions())) {
@@ -1451,20 +1434,18 @@ public class IndexNameExpressionResolver {
                     if (excludeState != null) {
                         indicesStateStream = indicesStateStream.filter(indexMeta -> indexMeta.getState() != excludeState);
                     }
-                    return indicesStateStream.map(indexMeta -> new ResolvedExpression(indexMeta.getIndex().getName()));
+                    return indicesStateStream.map(indexMeta -> indexMeta.getIndex().getName());
                 }
             });
         }
 
-        private static List<ResolvedExpression> resolveEmptyOrTrivialWildcard(Context context) {
+        private static List<String> resolveEmptyOrTrivialWildcard(Context context) {
             final String[] allIndices = resolveEmptyOrTrivialWildcardToAllIndices(context.getOptions(), context.getState().metadata());
-            Stream<String> result;
             if (context.systemIndexAccessLevel == SystemIndexAccessLevel.ALL) {
-                result = Arrays.stream(allIndices);
+                return List.of(allIndices);
             } else {
-                result = resolveEmptyOrTrivialWildcardWithAllowedSystemIndices(context, allIndices).stream();
+                return resolveEmptyOrTrivialWildcardWithAllowedSystemIndices(context, allIndices);
             }
-            return result.map(ResolvedExpression::new).toList();
         }
 
         private static List<String> resolveEmptyOrTrivialWildcardWithAllowedSystemIndices(Context context, String[] allIndices) {
@@ -1526,8 +1507,8 @@ public class IndexNameExpressionResolver {
             // utility class
         }
 
-        public static List<ResolvedExpression> resolve(Context context, List<ResolvedExpression> expressions) {
-            List<ResolvedExpression> result = new ArrayList<>(expressions.size());
+        public static List<String> resolve(Context context, List<String> expressions) {
+            List<String> result = new ArrayList<>(expressions.size());
             for (ExpressionList.Expression expression : new ExpressionList(context, expressions)) {
                 result.add(resolveExpression(expression, context::getStartTime));
             }
@@ -1538,15 +1519,13 @@ public class IndexNameExpressionResolver {
             return resolveExpression(expression, System::currentTimeMillis);
         }
 
-        static ResolvedExpression resolveExpression(ExpressionList.Expression expression, LongSupplier getTime) {
-            String result;
+        static String resolveExpression(ExpressionList.Expression expression, LongSupplier getTime) {
             if (expression.isExclusion()) {
                 // accepts date-math exclusions that are of the form "-<...{}>", i.e. the "-" is outside the "<>" date-math template
-                result = "-" + resolveExpression(expression.get(), getTime);
+                return "-" + resolveExpression(expression.get(), getTime);
             } else {
-                result = resolveExpression(expression.get(), getTime);
+                return resolveExpression(expression.get(), getTime);
             }
-            return new ResolvedExpression(result);
         }
 
         static String resolveExpression(String expression, LongSupplier getTime) {
@@ -1708,26 +1687,25 @@ public class IndexNameExpressionResolver {
          * Returns an expression list with "unavailable" (missing or not acceptable) resource names filtered out.
          * Only explicit resource names are considered for filtering. Wildcard and exclusion expressions are kept in.
          */
-        public static List<ResolvedExpression> filterUnavailable(Context context, List<ResolvedExpression> expressions) {
+        public static List<String> filterUnavailable(Context context, List<String> expressions) {
             ensureRemoteIndicesRequireIgnoreUnavailable(context.getOptions(), expressions);
-            List<ResolvedExpression> result = new ArrayList<>(expressions.size());
+            List<String> result = new ArrayList<>(expressions.size());
             for (ExpressionList.Expression expression : new ExpressionList(context, expressions)) {
                 validateAliasOrIndex(expression);
-                if (expression.isWildcard() || expression.isExclusion() || ensureAliasOrIndexExists(context, expression)) {
-                    result.add(expression.resolvedExpression());
+                if (expression.isWildcard() || expression.isExclusion() || ensureAliasOrIndexExists(context, expression.get())) {
+                    result.add(expression.expression());
                 }
             }
             return result;
         }
 
         /**
-         * This returns `true` if the given {@param resolvedExpression} is of a resource that exists.
-         * Otherwise, it returns `false` if the `ignore_unavailable` option is `true`, or, if `false`, it throws a "not found" type of
+         * This returns `true` if the given {@param name} is of a resource that exists.
+         * Otherwise, it returns `false` if the `ignore_unvailable` option is `true`, or, if `false`, it throws a "not found" type of
          * exception.
          */
         @Nullable
-        private static boolean ensureAliasOrIndexExists(Context context, ExpressionList.Expression expression) {
-            String name = expression.get();
+        private static boolean ensureAliasOrIndexExists(Context context, String name) {
             boolean ignoreUnavailable = context.getOptions().ignoreUnavailable();
             IndexAbstraction indexAbstraction = context.getState().getMetadata().getIndicesLookup().get(name);
             if (indexAbstraction == null) {
@@ -1759,37 +1737,32 @@ public class IndexNameExpressionResolver {
         }
 
         private static void validateAliasOrIndex(ExpressionList.Expression expression) {
-            if (Strings.isEmpty(expression.resolvedExpression().resource())) {
-                throw notFoundException(expression.get());
+            if (Strings.isEmpty(expression.expression())) {
+                throw notFoundException(expression.expression());
             }
             // Expressions can not start with an underscore. This is reserved for APIs. If the check gets here, the API
             // does not exist and the path is interpreted as an expression. If the expression begins with an underscore,
             // throw a specific error that is different from the [[IndexNotFoundException]], which is typically thrown
             // if the expression can't be found.
-            if (expression.resolvedExpression().resource().charAt(0) == '_') {
-                throw new InvalidIndexNameException(expression.get(), "must not start with '_'.");
+            if (expression.expression().charAt(0) == '_') {
+                throw new InvalidIndexNameException(expression.expression(), "must not start with '_'.");
             }
         }
 
-        private static void ensureRemoteIndicesRequireIgnoreUnavailable(
-            IndicesOptions options,
-            List<ResolvedExpression> resolvedExpressions
-        ) {
+        private static void ensureRemoteIndicesRequireIgnoreUnavailable(IndicesOptions options, List<String> indexExpressions) {
             if (options.ignoreUnavailable()) {
                 return;
             }
-            for (ResolvedExpression resolvedExpression : resolvedExpressions) {
-                var index = resolvedExpression.resource();
+            for (String index : indexExpressions) {
                 if (RemoteClusterAware.isRemoteIndexName(index)) {
-                    failOnRemoteIndicesNotIgnoringUnavailable(resolvedExpressions);
+                    failOnRemoteIndicesNotIgnoringUnavailable(indexExpressions);
                 }
             }
         }
 
-        private static void failOnRemoteIndicesNotIgnoringUnavailable(List<ResolvedExpression> resolvedExpressions) {
+        private static void failOnRemoteIndicesNotIgnoringUnavailable(List<String> indexExpressions) {
             List<String> crossClusterIndices = new ArrayList<>();
-            for (ResolvedExpression resolvedExpression : resolvedExpressions) {
-                String index = resolvedExpression.resource();
+            for (String index : indexExpressions) {
                 if (RemoteClusterAware.isRemoteIndexName(index)) {
                     crossClusterIndices.add(index);
                 }
@@ -1807,13 +1780,13 @@ public class IndexNameExpressionResolver {
         private final List<Expression> expressionsList;
         private final boolean hasWildcard;
 
-        public record Expression(ResolvedExpression resolvedExpression, boolean isWildcard, boolean isExclusion) {
+        public record Expression(String expression, boolean isWildcard, boolean isExclusion) {
             public String get() {
                 if (isExclusion()) {
                     // drop the leading "-" if exclusion because it is easier for callers to handle it like this
-                    return resolvedExpression().resource().substring(1);
+                    return expression().substring(1);
                 } else {
-                    return resolvedExpression().resource();
+                    return expression();
                 }
             }
         }
@@ -1822,17 +1795,16 @@ public class IndexNameExpressionResolver {
          * Creates the expression iterable that can be used to easily check which expression item is a wildcard or an exclusion (or both).
          * The {@param context} is used to check if wildcards ought to be considered or not.
          */
-        public ExpressionList(Context context, List<ResolvedExpression> resolvedExpressions) {
-            List<Expression> expressionsList = new ArrayList<>(resolvedExpressions.size());
+        public ExpressionList(Context context, List<String> expressionStrings) {
+            List<Expression> expressionsList = new ArrayList<>(expressionStrings.size());
             boolean wildcardSeen = false;
-            for (ResolvedExpression resolvedExpression : resolvedExpressions) {
-                var expressionString = resolvedExpression.resource();
+            for (String expressionString : expressionStrings) {
                 boolean isExclusion = expressionString.startsWith("-") && wildcardSeen;
                 if (context.getOptions().expandWildcardExpressions() && isWildcard(expressionString)) {
                     wildcardSeen = true;
-                    expressionsList.add(new Expression(resolvedExpression, true, isExclusion));
+                    expressionsList.add(new Expression(expressionString, true, isExclusion));
                 } else {
-                    expressionsList.add(new Expression(resolvedExpression, false, isExclusion));
+                    expressionsList.add(new Expression(expressionString, false, isExclusion));
                 }
             }
             this.expressionsList = expressionsList;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -38,7 +38,6 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -1714,7 +1713,7 @@ public class IndicesService extends AbstractLifecycleComponent
         IndexSettings indexSettings) -> canDeleteIndexContents(index);
     private final IndexDeletionAllowedPredicate ALWAYS_TRUE = (Index index, IndexSettings indexSettings) -> true;
 
-    public AliasFilter buildAliasFilter(ClusterState state, String index, Set<ResolvedExpression> resolvedExpressions) {
+    public AliasFilter buildAliasFilter(ClusterState state, String index, Set<String> resolvedExpressions) {
         /* Being static, parseAliasFilter doesn't have access to whatever guts it needs to parse a query. Instead of passing in a bunch
          * of dependencies we pass in a function that can perform the parsing. */
         CheckedFunction<BytesReference, QueryBuilder, IOException> filterParser = bytes -> {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedSupplier;
@@ -1619,7 +1618,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
     }
 
-    public AliasFilter buildAliasFilter(ClusterState state, String index, Set<ResolvedExpression> resolvedExpressions) {
+    public AliasFilter buildAliasFilter(ClusterState state, String index, Set<String> resolvedExpressions) {
         return indicesService.buildAliasFilter(state, index, resolvedExpressions);
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -230,19 +229,9 @@ public class ResolveIndexTests extends ESTestCase {
             .metadata(buildMetadata(new Object[][] {}, indices))
             .build();
         String[] requestedIndex = new String[] { "<logs-pgsql-prod-{now/d}>" };
-        Set<ResolvedExpression> resolvedIndices = resolver.resolveExpressions(
-            clusterState,
-            IndicesOptions.LENIENT_EXPAND_OPEN,
-            true,
-            requestedIndex
-        );
+        Set<String> resolvedIndices = resolver.resolveExpressions(clusterState, IndicesOptions.LENIENT_EXPAND_OPEN, true, requestedIndex);
         assertThat(resolvedIndices.size(), is(1));
-        assertThat(
-            resolvedIndices,
-            contains(
-                oneOf(new ResolvedExpression("logs-pgsql-prod-" + todaySuffix), new ResolvedExpression("logs-pgsql-prod-" + tomorrowSuffix))
-            )
-        );
+        assertThat(resolvedIndices, contains(oneOf("logs-pgsql-prod-" + todaySuffix, "logs-pgsql-prod-" + tomorrowSuffix)));
     }
 
     public void testSystemIndexAccess() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.Context;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.DateMathExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ResolvedExpression;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
@@ -27,6 +26,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -52,11 +52,11 @@ public class DateMathExpressionResolverTests extends ESTestCase {
 
     public void testNormal() throws Exception {
         int numIndexExpressions = randomIntBetween(1, 9);
-        List<ResolvedExpression> indexExpressions = new ArrayList<>(numIndexExpressions);
+        List<String> indexExpressions = new ArrayList<>(numIndexExpressions);
         for (int i = 0; i < numIndexExpressions; i++) {
-            indexExpressions.add(new ResolvedExpression(randomAlphaOfLength(10)));
+            indexExpressions.add(randomAlphaOfLength(10));
         }
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(context, indexExpressions);
+        List<String> result = DateMathExpressionResolver.resolve(context, indexExpressions);
         assertThat(result.size(), equalTo(indexExpressions.size()));
         for (int i = 0; i < indexExpressions.size(); i++) {
             assertThat(result.get(i), equalTo(indexExpressions.get(i)));
@@ -64,25 +64,25 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     }
 
     public void testExpression() throws Exception {
-        List<ResolvedExpression> indexExpressions = resolvedExpressions("<.marvel-{now}>", "<.watch_history-{now}>", "<logstash-{now}>");
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(context, indexExpressions);
+        List<String> indexExpressions = Arrays.asList("<.marvel-{now}>", "<.watch_history-{now}>", "<logstash-{now}>");
+        List<String> result = DateMathExpressionResolver.resolve(context, indexExpressions);
         assertThat(result.size(), equalTo(3));
-        assertThat(result.get(0).resource(), equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
-        assertThat(result.get(1).resource(), equalTo(".watch_history-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
-        assertThat(result.get(2).resource(), equalTo("logstash-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
+        assertThat(result.get(0), equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
+        assertThat(result.get(1), equalTo(".watch_history-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
+        assertThat(result.get(2), equalTo("logstash-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpressionWithWildcardAndExclusions() {
-        List<ResolvedExpression> indexExpressions = resolvedExpressions(
+        List<String> indexExpressions = Arrays.asList(
             "<-before-inner-{now}>",
             "-<before-outer-{now}>",
             "<wild*card-{now}*>",
             "<-after-inner-{now}>",
             "-<after-outer-{now}>"
         );
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(context, indexExpressions);
+        List<String> result = DateMathExpressionResolver.resolve(context, indexExpressions);
         assertThat(
-            result.stream().map(ResolvedExpression::resource).toList(),
+            result,
             Matchers.contains(
                 equalTo("-before-inner-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))),
                 equalTo("-<before-outer-{now}>"), // doesn't evaluate because it doesn't start with "<" and it is not an exclusion
@@ -98,7 +98,7 @@ public class DateMathExpressionResolverTests extends ESTestCase {
         );
         result = DateMathExpressionResolver.resolve(noWildcardExpandContext, indexExpressions);
         assertThat(
-            result.stream().map(ResolvedExpression::resource).toList(),
+            result,
             Matchers.contains(
                 equalTo("-before-inner-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))),
                 // doesn't evaluate because it doesn't start with "<" and there can't be exclusions without wildcard expansion
@@ -112,24 +112,21 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     }
 
     public void testEmpty() throws Exception {
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(context, List.of());
+        List<String> result = DateMathExpressionResolver.resolve(context, Collections.<String>emptyList());
         assertThat(result.size(), equalTo(0));
     }
 
     public void testExpression_Static() throws Exception {
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(context, resolvedExpressions("<.marvel-test>"));
+        List<String> result = DateMathExpressionResolver.resolve(context, Arrays.asList("<.marvel-test>"));
         assertThat(result.size(), equalTo(1));
-        assertThat(result.get(0).resource(), equalTo(".marvel-test"));
+        assertThat(result.get(0), equalTo(".marvel-test"));
     }
 
     public void testExpression_MultiParts() throws Exception {
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(
-            context,
-            resolvedExpressions("<.text1-{now/d}-text2-{now/M}>")
-        );
+        List<String> result = DateMathExpressionResolver.resolve(context, Arrays.asList("<.text1-{now/d}-text2-{now/M}>"));
         assertThat(result.size(), equalTo(1));
         assertThat(
-            result.get(0).resource(),
+            result.get(0),
             equalTo(
                 ".text1-"
                     + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))
@@ -140,42 +137,33 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     }
 
     public void testExpression_CustomFormat() throws Exception {
-        List<ResolvedExpression> results = DateMathExpressionResolver.resolve(
-            context,
-            resolvedExpressions("<.marvel-{now/d{yyyy.MM.dd}}>")
-        );
+        List<String> results = DateMathExpressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{yyyy.MM.dd}}>"));
         assertThat(results.size(), equalTo(1));
-        assertThat(results.get(0).resource(), equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
+        assertThat(results.get(0), equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpression_EscapeStatic() throws Exception {
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(context, resolvedExpressions("<.mar\\{v\\}el-{now/d}>"));
+        List<String> result = DateMathExpressionResolver.resolve(context, Arrays.asList("<.mar\\{v\\}el-{now/d}>"));
         assertThat(result.size(), equalTo(1));
-        assertThat(result.get(0).resource(), equalTo(".mar{v}el-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
+        assertThat(result.get(0), equalTo(".mar{v}el-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpression_EscapeDateFormat() throws Exception {
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(
-            context,
-            resolvedExpressions("<.marvel-{now/d{'\\{year\\}'yyyy}}>")
-        );
+        List<String> result = DateMathExpressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{'\\{year\\}'yyyy}}>"));
         assertThat(result.size(), equalTo(1));
-        assertThat(result.get(0).resource(), equalTo(".marvel-" + formatDate("'{year}'yyyy", dateFromMillis(context.getStartTime()))));
+        assertThat(result.get(0), equalTo(".marvel-" + formatDate("'{year}'yyyy", dateFromMillis(context.getStartTime()))));
     }
 
     public void testExpression_MixedArray() throws Exception {
-        List<ResolvedExpression> result = DateMathExpressionResolver.resolve(
+        List<String> result = DateMathExpressionResolver.resolve(
             context,
-            resolvedExpressions("name1", "<.marvel-{now/d}>", "name2", "<.logstash-{now/M{uuuu.MM}}>")
+            Arrays.asList("name1", "<.marvel-{now/d}>", "name2", "<.logstash-{now/M{uuuu.MM}}>")
         );
         assertThat(result.size(), equalTo(4));
-        assertThat(result.get(0).resource(), equalTo("name1"));
-        assertThat(result.get(1).resource(), equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
-        assertThat(result.get(2).resource(), equalTo("name2"));
-        assertThat(
-            result.get(3).resource(),
-            equalTo(".logstash-" + formatDate("uuuu.MM", dateFromMillis(context.getStartTime()).withDayOfMonth(1)))
-        );
+        assertThat(result.get(0), equalTo("name1"));
+        assertThat(result.get(1), equalTo(".marvel-" + formatDate("uuuu.MM.dd", dateFromMillis(context.getStartTime()))));
+        assertThat(result.get(2), equalTo("name2"));
+        assertThat(result.get(3), equalTo(".logstash-" + formatDate("uuuu.MM", dateFromMillis(context.getStartTime()).withDayOfMonth(1))));
     }
 
     public void testExpression_CustomTimeZoneInIndexName() throws Exception {
@@ -214,19 +202,19 @@ public class DateMathExpressionResolverTests extends ESTestCase {
             name -> false,
             name -> false
         );
-        List<ResolvedExpression> results = DateMathExpressionResolver.resolve(
+        List<String> results = DateMathExpressionResolver.resolve(
             context,
-            resolvedExpressions("<.marvel-{now/d{yyyy.MM.dd|" + timeZone.getId() + "}}>")
+            Arrays.asList("<.marvel-{now/d{yyyy.MM.dd|" + timeZone.getId() + "}}>")
         );
         assertThat(results.size(), equalTo(1));
         logger.info("timezone: [{}], now [{}], name: [{}]", timeZone, now, results.get(0));
-        assertThat(results.get(0).resource(), equalTo(".marvel-" + formatDate("uuuu.MM.dd", now.withZoneSameInstant(timeZone))));
+        assertThat(results.get(0), equalTo(".marvel-" + formatDate("uuuu.MM.dd", now.withZoneSameInstant(timeZone))));
     }
 
     public void testExpressionInvalidUnescaped() throws Exception {
         Exception e = expectThrows(
             ElasticsearchParseException.class,
-            () -> DateMathExpressionResolver.resolve(context, resolvedExpressions("<.mar}vel-{now/d}>"))
+            () -> DateMathExpressionResolver.resolve(context, Arrays.asList("<.mar}vel-{now/d}>"))
         );
         assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
         assertThat(e.getMessage(), containsString("invalid character at position ["));
@@ -235,7 +223,7 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     public void testExpressionInvalidDateMathFormat() throws Exception {
         Exception e = expectThrows(
             ElasticsearchParseException.class,
-            () -> DateMathExpressionResolver.resolve(context, resolvedExpressions("<.marvel-{now/d{}>"))
+            () -> DateMathExpressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}>"))
         );
         assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
         assertThat(e.getMessage(), containsString("date math placeholder is open ended"));
@@ -244,7 +232,7 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     public void testExpressionInvalidEmptyDateMathFormat() throws Exception {
         Exception e = expectThrows(
             ElasticsearchParseException.class,
-            () -> DateMathExpressionResolver.resolve(context, resolvedExpressions("<.marvel-{now/d{}}>"))
+            () -> DateMathExpressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d{}}>"))
         );
         assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
         assertThat(e.getMessage(), containsString("missing date format"));
@@ -253,13 +241,10 @@ public class DateMathExpressionResolverTests extends ESTestCase {
     public void testExpressionInvalidOpenEnded() throws Exception {
         Exception e = expectThrows(
             ElasticsearchParseException.class,
-            () -> DateMathExpressionResolver.resolve(context, resolvedExpressions("<.marvel-{now/d>"))
+            () -> DateMathExpressionResolver.resolve(context, Arrays.asList("<.marvel-{now/d>"))
         );
         assertThat(e.getMessage(), containsString("invalid dynamic name expression"));
         assertThat(e.getMessage(), containsString("date math placeholder is open ended"));
     }
 
-    private List<ResolvedExpression> resolvedExpressions(String... expressions) {
-        return Arrays.stream(expressions).map(ResolvedExpression::new).toList();
-    }
 }


### PR DESCRIPTION
This reverts commit 4c15cc077887d00ecf0e02c39b42cf01874ab6c4.
This commit introduced an orders of magnitude regression when searching many shards.
Small Rally excerpt:

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/23440631-e7a9-45a0-8be6-5d166fdba22c">
