### PR TITLE
[8.16] Adding validation for incompatibility of compound retrievers and scroll (#115106)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -2208,7 +2208,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         boolean allowPartialSearchResults
     ) {
         if (retriever() != null) {
-            validationException = retriever().validate(this, validationException, allowPartialSearchResults);
+            validationException = retriever().validate(this, validationException, isScroll, allowPartialSearchResults);
             List<String> specified = new ArrayList<>();
             if (subSearches().isEmpty() == false) {
                 specified.add(QUERY_FIELD.getPreferredName());

--- a/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
@@ -172,9 +172,10 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
     public ActionRequestValidationException validate(
         SearchSourceBuilder source,
         ActionRequestValidationException validationException,
+        boolean isScroll,
         boolean allowPartialSearchResults
     ) {
-        validationException = super.validate(source, validationException, allowPartialSearchResults);
+        validationException = super.validate(source, validationException, isScroll, allowPartialSearchResults);
         if (source.size() > rankWindowSize) {
             validationException = addValidationError(
                 "["
@@ -190,12 +191,15 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
         }
         if (allowPartialSearchResults) {
             validationException = addValidationError(
-                "cannot specify a compound retriever and [allow_partial_search_results]",
+                "cannot specify [" + getName() + "] and [allow_partial_search_results]",
                 validationException
             );
         }
+        if (isScroll) {
+            validationException = addValidationError("cannot specify [" + getName() + "] and [scroll]", validationException);
+        }
         for (RetrieverSource innerRetriever : innerRetrievers) {
-            validationException = innerRetriever.retriever().validate(source, validationException, allowPartialSearchResults);
+            validationException = innerRetriever.retriever().validate(source, validationException, isScroll, allowPartialSearchResults);
         }
         return validationException;
     }

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -239,6 +239,7 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
     public ActionRequestValidationException validate(
         SearchSourceBuilder source,
         ActionRequestValidationException validationException,
+        boolean isScroll,
         boolean allowPartialSearchResults
     ) {
         return validationException;

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -272,9 +272,22 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             assertNotNull(validationErrors);
             assertEquals(1, validationErrors.validationErrors().size());
             assertEquals(
-                "cannot specify a compound retriever and [allow_partial_search_results]",
+                "cannot specify [test_compound_retriever_builder] and [allow_partial_search_results]",
                 validationErrors.validationErrors().get(0)
             );
+        }
+        {
+            // scroll and compound retriever
+            SearchRequest searchRequest = createSearchRequest().source(
+                new SearchSourceBuilder().retriever(new TestCompoundRetrieverBuilder(randomIntBetween(1, 10)))
+            );
+            searchRequest.allowPartialSearchResults(false);
+            searchRequest.scroll(TimeValue.timeValueMinutes(1));
+            searchRequest.requestCache(false);
+            ActionRequestValidationException validationErrors = searchRequest.validate();
+            assertNotNull(validationErrors);
+            assertEquals(1, validationErrors.validationErrors().size());
+            assertEquals("cannot specify [test_compound_retriever_builder] and [scroll]", validationErrors.validationErrors().get(0));
         }
         {
             // allow_partial_results and non-compound retriever


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Adding validation for incompatibility of compound retrievers and scroll (#115106)