### PR TITLE
Optimize IndexTemplateRegistry#clusterChanged

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -28,6 +28,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -189,9 +191,14 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
         if (ignoreMissingComponentTemplates == null) {
             return componentTemplates;
         }
-        return componentTemplates.stream()
-            .filter(componentTemplate -> ignoreMissingComponentTemplates.contains(componentTemplate) == false)
-            .toList();
+        // note: this loop is unrolled rather than streaming-style because it's hot enough to show up in a flamegraph
+        List<String> required = new ArrayList<>(componentTemplates.size());
+        for (String template : componentTemplates) {
+            if (ignoreMissingComponentTemplates.contains(template) == false) {
+                required.add(template);
+            }
+        }
+        return Collections.unmodifiableList(required);
     }
 
     @Nullable


### PR DESCRIPTION
The streaming code in these loops is hot enough to show up in a flamegraph, unrolling them isn't significantly less readable and it is faster.

Note: I'm optimizing the `GeoIpDownloaderTaskExecutor#clusterChanged` (coming in a future PR) and this jumped out at me in the flamegraphs as something nearby that was easy enough to improve while I was in the area.