### PR TITLE
Reorder docs sidebar

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -6,7 +6,7 @@ include::links.asciidoc[]
 
 include::landing-page.asciidoc[]
 
-include::release-notes/highlights.asciidoc[]
+// overview / install
 
 include::intro.asciidoc[]
 
@@ -14,33 +14,37 @@ include::quickstart/index.asciidoc[]
 
 include::setup.asciidoc[]
 
-include::upgrade.asciidoc[]
-
-include::index-modules.asciidoc[]
-
-include::mapping.asciidoc[]
-
-include::analysis.asciidoc[]
-
-include::indices/index-templates.asciidoc[]
-
-include::data-streams/data-streams.asciidoc[]
-
-include::ingest.asciidoc[]
-
-include::alias.asciidoc[]
+// search solution
 
 include::search/search-your-data/search-your-data.asciidoc[]
 
 include::reranking/index.asciidoc[]
 
-include::query-dsl.asciidoc[]
+// data management
 
-include::aggregations.asciidoc[]
+include::index-modules.asciidoc[]
 
-include::geospatial-analysis.asciidoc[]
+include::indices/index-templates.asciidoc[]
+
+include::alias.asciidoc[]
+
+include::mapping.asciidoc[]
+
+include::analysis.asciidoc[]
+
+include::ingest.asciidoc[]
 
 include::connector/docs/index.asciidoc[]
+
+include::data-streams/data-streams.asciidoc[]
+
+include::data-management.asciidoc[]
+
+include::data-rollup-transform.asciidoc[]
+
+// analysis tools
+
+include::query-dsl.asciidoc[]
 
 include::eql/eql.asciidoc[]
 
@@ -50,34 +54,48 @@ include::sql/index.asciidoc[]
 
 include::scripting.asciidoc[]
 
-include::data-management.asciidoc[]
+include::aggregations.asciidoc[]
 
-include::autoscaling/index.asciidoc[]
-
-include::monitoring/index.asciidoc[]
-
-include::data-rollup-transform.asciidoc[]
-
-include::high-availability.asciidoc[]
-
-include::snapshot-restore/index.asciidoc[]
-
-include::security/index.asciidoc[]
+include::geospatial-analysis.asciidoc[]
 
 include::watcher/index.asciidoc[]
 
-include::commands/index.asciidoc[]
+// cluster management
+
+include::monitoring/index.asciidoc[]
+
+include::security/index.asciidoc[]
+
+// production tasks
+
+include::high-availability.asciidoc[]
 
 include::how-to.asciidoc[]
 
-include::troubleshooting.asciidoc[]
+include::autoscaling/index.asciidoc[]
+
+include::snapshot-restore/index.asciidoc[]
+
+// reference
 
 include::rest-api/index.asciidoc[]
 
+include::commands/index.asciidoc[]
+
+include::troubleshooting.asciidoc[]
+
+// upgrades
+
+include::upgrade.asciidoc[]
+
 include::migration/index.asciidoc[]
+
+include::release-notes/highlights.asciidoc[]
 
 include::release-notes.asciidoc[]
 
 include::dependencies-versions.asciidoc[]
+
+// etc
 
 include::redirects.asciidoc[]

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -6,6 +6,8 @@ include::links.asciidoc[]
 
 include::landing-page.asciidoc[]
 
+include::release-notes/highlights.asciidoc[]
+
 // overview / install
 
 include::intro.asciidoc[]
@@ -89,8 +91,6 @@ include::troubleshooting.asciidoc[]
 include::upgrade.asciidoc[]
 
 include::migration/index.asciidoc[]
-
-include::release-notes/highlights.asciidoc[]
 
 include::release-notes.asciidoc[]
 

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -6,8 +6,6 @@ include::links.asciidoc[]
 
 include::landing-page.asciidoc[]
 
-include::release-notes/highlights.asciidoc[]
-
 // overview / install
 
 include::intro.asciidoc[]
@@ -91,6 +89,8 @@ include::troubleshooting.asciidoc[]
 include::upgrade.asciidoc[]
 
 include::migration/index.asciidoc[]
+
+include::release-notes/highlights.asciidoc[]
 
 include::release-notes.asciidoc[]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,5 +1,6 @@
+[chapter]
 [[release-highlights]]
-== What's new in {minor-version}
+= What's new in {minor-version}
 
 coming::[{minor-version}]
 
@@ -37,7 +38,7 @@ endif::[]
 
 [discrete]
 [[esql_inlinestats]]
-=== ESQL: INLINESTATS
+== ESQL: INLINESTATS
 This adds the `INLINESTATS` command to ESQL which performs a STATS and
 then enriches the results into the output stream. So, this query:
 
@@ -62,7 +63,7 @@ Produces output like:
 
 [discrete]
 [[always_allow_rebalancing_by_default]]
-=== Always allow rebalancing by default
+== Always allow rebalancing by default
 In earlier versions of {es} the `cluster.routing.allocation.allow_rebalance` setting defaults to
 `indices_all_active` which blocks all rebalancing moves while the cluster is in `yellow` or `red` health. This was
 appropriate for the legacy allocator which might do too many rebalancing moves otherwise. Today's allocator has
@@ -74,7 +75,7 @@ version 8.16 `allow_rebalance` setting defaults to `always` unless the legacy al
 
 [discrete]
 [[add_global_retention_in_data_stream_lifecycle]]
-=== Add global retention in data stream lifecycle
+== Add global retention in data stream lifecycle
 Data stream lifecycle now supports configuring retention on a cluster level,
 namely global retention. Global retention \nallows us to configure two different
 retentions:
@@ -88,7 +89,7 @@ data stream lifecycle and it allows any data stream \ndata to be deleted after t
 
 [discrete]
 [[enable_zstandard_compression_for_indices_with_index_codec_set_to_best_compression]]
-=== Enable ZStandard compression for indices with index.codec set to best_compression
+== Enable ZStandard compression for indices with index.codec set to best_compression
 Before DEFLATE compression was used to compress stored fields in indices with index.codec index setting set to
 best_compression, with this change ZStandard is used as compression algorithm to stored fields for indices with
 index.codec index setting set to best_compression. The usage ZStandard results in less storage usage with a


### PR DESCRIPTION
This PR reorders the sidebar in the docs.

The new order groups topics into loosely related sections: 

- overview/install
- search solution
- data management
- analysis tools
- cluster management
- going to production
- reference content
- upgrades

This is the first step in a larger IA effort: 
- Some sections will be renamed to make their contents clearer
- Some sections will be grouped together
- We plan to create some conceptual content for these various areas to help people to understand which topics apply to their use case

| before | after |
| --- | --- |
| <img width="241" alt="image" src="https://github.com/user-attachments/assets/45f842f3-3322-41ad-bb37-331024219db9">| <img width="257" alt="image" src="https://github.com/user-attachments/assets/5144f2e9-e359-41c7-92a2-d76ec6b50121"> |
