### PR TITLE
[ML] Avoid use of GroupedActionListener when the group size is zero

### DIFF
--- a/docs/changelog/115363.yaml
+++ b/docs/changelog/115363.yaml
@@ -1,0 +1,5 @@
+pr: 115363
+summary: Avoid use of `GroupedActionListener` when the group size is zero
+area: Machine Learning
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
@@ -35,8 +35,9 @@ public final class GroupedActionListener<T> extends DelegatingActionListener<T, 
      * Creates a new listener
      * @param groupSize the group size
      * @param delegate the delegate listener
+     * @throws IllegalArgumentException if groupSize is less than or equal to 0
      */
-    public GroupedActionListener(int groupSize, ActionListener<Collection<T>> delegate) {
+    public GroupedActionListener(int groupSize, ActionListener<Collection<T>> delegate) throws IllegalArgumentException {
         super(delegate);
         if (groupSize <= 0) {
             assert false : "illegal group size [" + groupSize + "]";


### PR DESCRIPTION
fix for https://github.com/elastic/elasticsearch/issues/115362

when the list of unparedModels is empty, we should simply return an empty list, which I believe was the behaviour before this bug was introduced. 