### PR TITLE
[8.15] Don't run mixed cluster tests against the current version (#115377)

### DIFF
--- a/x-pack/plugin/downsample/qa/mixed-cluster/build.gradle
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/build.gradle
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -26,7 +26,7 @@ restResources {
 }
 
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter("8.10.0");
+  return bwcVersion.onOrAfter("8.10.0") && bwcVersion != VersionProperties.elasticsearchVersion
 }
 
 BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -1,5 +1,6 @@
 
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -27,7 +28,7 @@ GradleUtils.extendSourceSet(project, "javaRestTest", "yamlRestTest")
 
 // ESQL is available in 8.11 or later
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter(Version.fromString("8.11.0"));
+  return bwcVersion.onOrAfter(Version.fromString("8.11.0")) && bwcVersion != VersionProperties.elasticsearchVersion
 }
 
 BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->

--- a/x-pack/plugin/inference/qa/mixed-cluster/build.gradle
+++ b/x-pack/plugin/inference/qa/mixed-cluster/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 // inference is available in 8.11 or later
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter(Version.fromString("8.11.0"));
+  return bwcVersion.onOrAfter(Version.fromString("8.11.0")) && bwcVersion != VersionProperties.elasticsearchVersion
 }
 
 BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Don't run mixed cluster tests against the current version (#115377)