### PR TITLE
[8.x] Expose cluster-state role mappings in APIs (#114951)

### DIFF
--- a/docs/changelog/114951.yaml
+++ b/docs/changelog/114951.yaml
@@ -1,0 +1,5 @@
+pr: 114951
+summary: Expose cluster-state role mappings in APIs
+area: Authentication
+type: bug
+issues: []

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
@@ -25,9 +25,12 @@ import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -106,6 +109,10 @@ public class FileSettingsRoleMappingUpgradeIT extends ParameterizedRollingUpgrad
             );
             assertThat(roleMappings, is(not(nullValue())));
             assertThat(roleMappings.size(), equalTo(1));
+            assertThat(roleMappings, is(instanceOf(Map.class)));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> roleMapping = (Map<String, Object>) roleMappings;
+            assertThat(roleMapping.keySet(), contains("everyone_kibana-read-only-operator-mapping"));
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
@@ -54,6 +54,18 @@ import static org.elasticsearch.common.Strings.format;
  */
 public class ExpressionRoleMapping implements ToXContentObject, Writeable {
 
+    /**
+     * Reserved suffix for read-only operator-defined role mappings.
+     * This suffix is added to the name of all cluster-state role mappings returned via
+     * the {@code TransportGetRoleMappingsAction} action.
+     */
+    public static final String READ_ONLY_ROLE_MAPPING_SUFFIX = "-read-only-operator-mapping";
+    /**
+     * Reserved metadata field to mark role mappings as read-only.
+     * This field is added to the metadata of all cluster-state role mappings returned via
+     * the {@code TransportGetRoleMappingsAction} action.
+     */
+    public static final String READ_ONLY_ROLE_MAPPING_METADATA_FLAG = "_read_only";
     private static final ObjectParser<Builder, String> PARSER = new ObjectParser<>("role-mapping", Builder::new);
 
     /**
@@ -134,6 +146,28 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
         }
         this.expression = ExpressionParser.readExpression(in);
         this.metadata = in.readGenericMap();
+    }
+
+    public static boolean hasReadOnlySuffix(String name) {
+        return name.endsWith(READ_ONLY_ROLE_MAPPING_SUFFIX);
+    }
+
+    public static void validateNoReadOnlySuffix(String name) {
+        if (hasReadOnlySuffix(name)) {
+            throw new IllegalArgumentException(
+                "Invalid mapping name [" + name + "]. [" + READ_ONLY_ROLE_MAPPING_SUFFIX + "] is not an allowed suffix"
+            );
+        }
+    }
+
+    public static String addReadOnlySuffix(String name) {
+        return name + READ_ONLY_ROLE_MAPPING_SUFFIX;
+    }
+
+    public static String removeReadOnlySuffixIfPresent(String name) {
+        return name.endsWith(READ_ONLY_ROLE_MAPPING_SUFFIX)
+            ? name.substring(0, name.length() - READ_ONLY_ROLE_MAPPING_SUFFIX.length())
+            : name;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleMappingMetadata.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.authz;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
@@ -26,8 +28,10 @@ import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRole
 import java.io.IOException;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -36,7 +40,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 
 public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Custom> implements Metadata.Custom {
 
+    private static final Logger logger = LogManager.getLogger(RoleMappingMetadata.class);
+
     public static final String TYPE = "role_mappings";
+    public static final String METADATA_NAME_FIELD = "_es_reserved_role_mapping_name";
+    public static final String FALLBACK_NAME = "name_not_available_after_deserialization";
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<RoleMappingMetadata, Void> PARSER = new ConstructingObjectParser<>(
@@ -46,12 +54,7 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
     );
 
     static {
-        PARSER.declareObjectArray(
-            constructorArg(),
-            // role mapping names are lost when the role mapping metadata is serialized
-            (p, c) -> ExpressionRoleMapping.parse("name_not_available_after_deserialization", p),
-            new ParseField(TYPE)
-        );
+        PARSER.declareObjectArray(constructorArg(), (p, c) -> parseWithNameFromMetadata(p), new ParseField(TYPE));
     }
 
     private static final RoleMappingMetadata EMPTY = new RoleMappingMetadata(Set.of());
@@ -152,5 +155,65 @@ public final class RoleMappingMetadata extends AbstractNamedDiffable<Metadata.Cu
         // but the role mappings themselves (stored here by the {@link RoleMappingMetadata})
         // are not persisted.
         return ALL_CONTEXTS;
+    }
+
+    /**
+     * Ensures role mapping names are preserved when stored on disk using XContent format,
+     * which omits names. This method copies the role mapping's name into a reserved metadata field
+     * during serialization, allowing recovery during deserialization (e.g., after a master-node restart).
+     * {@link #parseWithNameFromMetadata(XContentParser)} restores the name during parsing.
+     */
+    public static ExpressionRoleMapping copyWithNameInMetadata(ExpressionRoleMapping roleMapping) {
+        Map<String, Object> metadata = new HashMap<>(roleMapping.getMetadata());
+        // note: can't use Maps.copyWith... since these create maps that don't support `null` values in map entries
+        if (metadata.put(METADATA_NAME_FIELD, roleMapping.getName()) != null) {
+            logger.error(
+                "Metadata field [{}] is reserved and will be overwritten with an internal system value. "
+                    + "Rename this field in your role mapping configuration.",
+                METADATA_NAME_FIELD
+            );
+        }
+        return new ExpressionRoleMapping(
+            roleMapping.getName(),
+            roleMapping.getExpression(),
+            roleMapping.getRoles(),
+            roleMapping.getRoleTemplates(),
+            metadata,
+            roleMapping.isEnabled()
+        );
+    }
+
+    /**
+     * If a role mapping does not yet have a name persisted in metadata, it will use a constant fallback name. This method checks if a
+     * role mapping has the fallback name.
+     */
+    public static boolean hasFallbackName(ExpressionRoleMapping expressionRoleMapping) {
+        return expressionRoleMapping.getName().equals(FALLBACK_NAME);
+    }
+
+    /**
+     * Parse a role mapping from XContent, restoring the name from a reserved metadata field.
+     * Used to parse a role mapping annotated with its name in metadata via @see {@link #copyWithNameInMetadata(ExpressionRoleMapping)}.
+     */
+    public static ExpressionRoleMapping parseWithNameFromMetadata(XContentParser parser) throws IOException {
+        ExpressionRoleMapping roleMapping = ExpressionRoleMapping.parse(FALLBACK_NAME, parser);
+        return new ExpressionRoleMapping(
+            getNameFromMetadata(roleMapping),
+            roleMapping.getExpression(),
+            roleMapping.getRoles(),
+            roleMapping.getRoleTemplates(),
+            roleMapping.getMetadata(),
+            roleMapping.isEnabled()
+        );
+    }
+
+    private static String getNameFromMetadata(ExpressionRoleMapping roleMapping) {
+        Map<String, Object> metadata = roleMapping.getMetadata();
+        if (metadata.containsKey(METADATA_NAME_FIELD) && metadata.get(METADATA_NAME_FIELD) instanceof String name) {
+            return name;
+        } else {
+            // This is valid the first time we recover from cluster-state: the old format metadata won't have a name stored in metadata yet
+            return FALLBACK_NAME;
+        }
     }
 }

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityOnTrialLicenseRestTestCase.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityOnTrialLicenseRestTestCase.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.TestSecurityClient;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -41,9 +42,7 @@ import static org.hamcrest.Matchers.equalTo;
 public abstract class SecurityOnTrialLicenseRestTestCase extends ESRestTestCase {
     private TestSecurityClient securityClient;
 
-    @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .nodes(2)
+    public static LocalClusterConfigProvider commonTrialSecurityClusterConfig = cluster -> cluster.nodes(2)
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.ml.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
@@ -62,8 +61,10 @@ public abstract class SecurityOnTrialLicenseRestTestCase extends ESRestTestCase 
         .user("admin_user", "admin-password", ROOT_USER_ROLE, true)
         .user("security_test_user", "security-test-password", "security_test_role", false)
         .user("x_pack_rest_user", "x-pack-test-password", ROOT_USER_ROLE, true)
-        .user("cat_test_user", "cat-test-password", "cat_test_role", false)
-        .build();
+        .user("cat_test_user", "cat-test-password", "cat_test_role", false);
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().apply(commonTrialSecurityClusterConfig).build();
 
     @Override
     protected String getTestRestCluster() {

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/rolemapping/RoleMappingRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/rolemapping/RoleMappingRestIT.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rolemapping;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
+import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression;
+import org.elasticsearch.xpack.security.SecurityOnTrialLicenseRestTestCase;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RoleMappingRestIT extends ESRestTestCase {
+    private static final String settingsJson = """
+        {
+             "metadata": {
+                 "version": "1",
+                 "compatibility": "8.4.0"
+             },
+             "state": {
+                 "role_mappings": {
+                       "role-mapping-1": {
+                          "enabled": true,
+                          "roles": [ "role_1" ],
+                          "rules": { "field": { "username": "no_user" } },
+                          "metadata": {
+                             "uuid" : "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7",
+                             "_foo": "something",
+                             "_es_reserved_role_mapping_name": "ignored"
+                          }
+                       },
+                       "role-mapping-2": {
+                          "enabled": true,
+                          "roles": [ "role_2" ],
+                          "rules": { "field": { "username": "no_user" } }
+                       },
+                       "role-mapping-3": {
+                          "enabled": true,
+                          "roles": [ "role_3" ],
+                          "rules": { "field": { "username": "no_user" } },
+                          "metadata": {
+                             "_read_only" : { "field": 1 },
+                             "_es_reserved_role_mapping_name": { "still_ignored": true }
+                          }
+                       }
+                 }
+             }
+        }""";
+    private static final ExpressionRoleMapping clusterStateMapping1 = new ExpressionRoleMapping(
+        "role-mapping-1-read-only-operator-mapping",
+        new FieldExpression("username", List.of(new FieldExpression.FieldValue("no_user"))),
+        List.of("role_1"),
+        null,
+        Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something", "_read_only", true),
+        true
+    );
+    private static final ExpressionRoleMapping clusterStateMapping2 = new ExpressionRoleMapping(
+        "role-mapping-2-read-only-operator-mapping",
+        new FieldExpression("username", List.of(new FieldExpression.FieldValue("no_user"))),
+        List.of("role_2"),
+        null,
+        Map.of("_read_only", true),
+        true
+    );
+    private static final ExpressionRoleMapping clusterStateMapping3 = new ExpressionRoleMapping(
+        "role-mapping-3-read-only-operator-mapping",
+        new FieldExpression("username", List.of(new FieldExpression.FieldValue("no_user"))),
+        List.of("role_3"),
+        null,
+        Map.of("_read_only", true),
+        true
+    );
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .apply(SecurityOnTrialLicenseRestTestCase.commonTrialSecurityClusterConfig)
+        .configFile("operator/settings.json", Resource.fromString(settingsJson))
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    public void testGetRoleMappings() throws IOException {
+        expectMappings(List.of(clusterStateMapping1, clusterStateMapping2, clusterStateMapping3));
+        expectMappings(List.of(clusterStateMapping1), "role-mapping-1");
+        expectMappings(List.of(clusterStateMapping1, clusterStateMapping3), "role-mapping-1", "role-mapping-3");
+        expectMappings(List.of(clusterStateMapping1), clusterStateMapping1.getName());
+        expectMappings(List.of(clusterStateMapping1), clusterStateMapping1.getName(), "role-mapping-1");
+
+        expect404(() -> getMappings("role-mapping-4"));
+        expect404(() -> getMappings("role-mapping-4-read-only-operator-mapping"));
+
+        ExpressionRoleMapping nativeMapping1 = expressionRoleMapping("role-mapping-1");
+        putMapping(nativeMapping1, createOrUpdateWarning(nativeMapping1.getName()));
+
+        ExpressionRoleMapping nativeMapping4 = expressionRoleMapping("role-mapping-4");
+        putMapping(nativeMapping4);
+
+        expectMappings(List.of(clusterStateMapping1, clusterStateMapping2, clusterStateMapping3, nativeMapping1, nativeMapping4));
+        expectMappings(List.of(clusterStateMapping1, nativeMapping1), "role-mapping-1");
+        expectMappings(List.of(clusterStateMapping1, nativeMapping1), "role-mapping-1", clusterStateMapping1.getName());
+        expectMappings(List.of(clusterStateMapping1), clusterStateMapping1.getName());
+        expectMappings(List.of(nativeMapping4), "role-mapping-4");
+        expectMappings(List.of(nativeMapping4), "role-mapping-4", "role-mapping-4-read-only-operator-mapping");
+    }
+
+    public void testPutAndDeleteRoleMappings() throws IOException {
+        {
+            var ex = expectThrows(
+                ResponseException.class,
+                () -> putMapping(expressionRoleMapping("role-mapping-1-read-only-operator-mapping"))
+            );
+            assertThat(
+                ex.getMessage(),
+                containsString(
+                    "Invalid mapping name [role-mapping-1-read-only-operator-mapping]. "
+                        + "[-read-only-operator-mapping] is not an allowed suffix"
+                )
+            );
+        }
+
+        // Also fails even if a CS role mapping with that name does not exist
+        {
+            var ex = expectThrows(
+                ResponseException.class,
+                () -> putMapping(expressionRoleMapping("role-mapping-4-read-only-operator-mapping"))
+            );
+            assertThat(
+                ex.getMessage(),
+                containsString(
+                    "Invalid mapping name [role-mapping-4-read-only-operator-mapping]. "
+                        + "[-read-only-operator-mapping] is not an allowed suffix"
+                )
+            );
+        }
+
+        assertOK(putMapping(expressionRoleMapping("role-mapping-1"), createOrUpdateWarning("role-mapping-1")));
+
+        assertOK(deleteMapping("role-mapping-1", deletionWarning("role-mapping-1")));
+
+        // 404 without warnings if no native mapping exists
+        expect404(() -> deleteMapping("role-mapping-1"));
+    }
+
+    private static void expect404(ThrowingRunnable clientCall) {
+        var ex = expectThrows(ResponseException.class, clientCall);
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));
+    }
+
+    private static Response putMapping(ExpressionRoleMapping roleMapping) throws IOException {
+        return putMapping(roleMapping, null);
+    }
+
+    private static Response putMapping(ExpressionRoleMapping roleMapping, @Nullable String warning) throws IOException {
+        Request request = new Request("PUT", "/_security/role_mapping/" + roleMapping.getName());
+        XContentBuilder xContent = roleMapping.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+        request.setJsonEntity(BytesReference.bytes(xContent).utf8ToString());
+        if (warning != null) {
+            request.setOptions(
+                RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> warnings.equals(List.of(warning)) == false).build()
+            );
+        }
+        return client().performRequest(request);
+    }
+
+    private static Response deleteMapping(String name) throws IOException {
+        return deleteMapping(name, null);
+    }
+
+    private static Response deleteMapping(String name, @Nullable String warning) throws IOException {
+        Request request = new Request("DELETE", "/_security/role_mapping/" + name);
+        if (warning != null) {
+            request.setOptions(
+                RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> warnings.equals(List.of(warning)) == false).build()
+            );
+        }
+        return client().performRequest(request);
+    }
+
+    private static ExpressionRoleMapping expressionRoleMapping(String name) {
+        return new ExpressionRoleMapping(
+            name,
+            new FieldExpression("username", List.of(new FieldExpression.FieldValue(randomAlphaOfLength(10)))),
+            List.of(randomAlphaOfLength(5)),
+            null,
+            Map.of(),
+            true
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void expectMappings(List<ExpressionRoleMapping> expectedMappings, String... requestedMappingNames) throws IOException {
+        Map<String, Object> map = responseAsMap(getMappings(requestedMappingNames));
+        assertThat(
+            map.keySet(),
+            containsInAnyOrder(expectedMappings.stream().map(ExpressionRoleMapping::getName).toList().toArray(new String[0]))
+        );
+        List<ExpressionRoleMapping> actualMappings = new ArrayList<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            XContentParser body = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, (Map<String, ?>) entry.getValue());
+            ExpressionRoleMapping actual = ExpressionRoleMapping.parse(entry.getKey(), body);
+            actualMappings.add(actual);
+        }
+        assertThat(actualMappings, containsInAnyOrder(expectedMappings.toArray(new ExpressionRoleMapping[0])));
+    }
+
+    private static Response getMappings(String... requestedMappingNames) throws IOException {
+        return client().performRequest(new Request("GET", "/_security/role_mapping/" + String.join(",", requestedMappingNames)));
+    }
+
+    @Override
+    protected Settings restAdminSettings() {
+        String token = basicAuthHeaderValue("admin_user", new SecureString("admin-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        String token = basicAuthHeaderValue("admin_user", new SecureString("admin-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    private static String createOrUpdateWarning(String mappingName) {
+        return "A read-only role mapping with the same name ["
+            + mappingName
+            + "] has been previously defined in a configuration file. "
+            + "Both role mappings will be used to determine role assignments.";
+    }
+
+    private static String deletionWarning(String mappingName) {
+        return "A read-only role mapping with the same name ["
+            + mappingName
+            + "] has previously been defined in a configuration file. "
+            + "The native role mapping was deleted, but the read-only mapping will remain active "
+            + "and will be used to determine role assignments.";
+    };
+}

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsR
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequestBuilder;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingResponse;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
@@ -45,6 +46,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +65,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
@@ -271,21 +272,28 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             assertThat(resolveRolesFuture.get(), containsInAnyOrder("kibana_user", "fleet_user"));
         }
 
-        // the role mappings are not retrievable by the role mapping action (which only accesses "native" i.e. index-based role mappings)
-        var request = new GetRoleMappingsRequest();
-        request.setNames("everyone_kibana", "everyone_fleet");
-        var response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
-        assertFalse(response.hasMappings());
-        assertThat(response.mappings(), emptyArray());
+        // the role mappings are retrievable by the role mapping action for BWC
+        assertGetResponseHasMappings(true, "everyone_kibana", "everyone_fleet");
 
-        // role mappings (with the same names) can also be stored in the "native" store
-        var putRoleMappingResponse = client().execute(PutRoleMappingAction.INSTANCE, sampleRestRequest("everyone_kibana")).actionGet();
-        assertTrue(putRoleMappingResponse.isCreated());
-        putRoleMappingResponse = client().execute(PutRoleMappingAction.INSTANCE, sampleRestRequest("everyone_fleet")).actionGet();
-        assertTrue(putRoleMappingResponse.isCreated());
+        // role mappings (with the same names) can be stored in the "native" store
+        {
+            PutRoleMappingResponse response = client().execute(PutRoleMappingAction.INSTANCE, sampleRestRequest("everyone_kibana"))
+                .actionGet();
+            assertTrue(response.isCreated());
+            response = client().execute(PutRoleMappingAction.INSTANCE, sampleRestRequest("everyone_fleet")).actionGet();
+            assertTrue(response.isCreated());
+        }
+        {
+            // deleting role mappings that exist in the native store and in cluster-state should result in success
+            var response = client().execute(DeleteRoleMappingAction.INSTANCE, deleteRequest("everyone_kibana")).actionGet();
+            assertTrue(response.isFound());
+            response = client().execute(DeleteRoleMappingAction.INSTANCE, deleteRequest("everyone_fleet")).actionGet();
+            assertTrue(response.isFound());
+        }
+
     }
 
-    public void testRoleMappingsApplied() throws Exception {
+    public void testClusterStateRoleMappingsAddedThenDeleted() throws Exception {
         ensureGreen();
 
         var savedClusterState = setupClusterStateListener(internalCluster().getMasterName(), "everyone_kibana");
@@ -293,6 +301,12 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
 
         assertRoleMappingsSaveOK(savedClusterState.v1(), savedClusterState.v2());
         logger.info("---> cleanup cluster settings...");
+
+        {
+            // Deleting non-existent native role mappings returns not found even if they exist in config file
+            var response = client().execute(DeleteRoleMappingAction.INSTANCE, deleteRequest("everyone_kibana")).get();
+            assertFalse(response.isFound());
+        }
 
         savedClusterState = setupClusterStateListenerForCleanup(internalCluster().getMasterName());
 
@@ -308,40 +322,15 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             clusterStateResponse.getState().metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey())
         );
 
-        // native role mappings are not affected by the removal of the cluster-state based ones
+        // cluster-state role mapping was removed and is not returned in the API anymore
         {
             var request = new GetRoleMappingsRequest();
             request.setNames("everyone_kibana", "everyone_fleet");
             var response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
-            assertTrue(response.hasMappings());
-            assertThat(
-                Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
-                containsInAnyOrder("everyone_kibana", "everyone_fleet")
-            );
+            assertFalse(response.hasMappings());
         }
 
-        // and roles are resolved based on the native role mappings
-        for (UserRoleMapper userRoleMapper : internalCluster().getInstances(UserRoleMapper.class)) {
-            PlainActionFuture<Set<String>> resolveRolesFuture = new PlainActionFuture<>();
-            userRoleMapper.resolveRoles(
-                new UserRoleMapper.UserData("anyUsername", null, List.of(), Map.of(), mock(RealmConfig.class)),
-                resolveRolesFuture
-            );
-            assertThat(resolveRolesFuture.get(), contains("kibana_user_native"));
-        }
-
-        {
-            var request = new DeleteRoleMappingRequest();
-            request.setName("everyone_kibana");
-            var response = client().execute(DeleteRoleMappingAction.INSTANCE, request).get();
-            assertTrue(response.isFound());
-            request = new DeleteRoleMappingRequest();
-            request.setName("everyone_fleet");
-            response = client().execute(DeleteRoleMappingAction.INSTANCE, request).get();
-            assertTrue(response.isFound());
-        }
-
-        // no roles are resolved now, because both native and cluster-state based stores have been cleared
+        // no role mappings means no roles are resolved
         for (UserRoleMapper userRoleMapper : internalCluster().getInstances(UserRoleMapper.class)) {
             PlainActionFuture<Set<String>> resolveRolesFuture = new PlainActionFuture<>();
             userRoleMapper.resolveRoles(
@@ -350,6 +339,79 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             );
             assertThat(resolveRolesFuture.get(), empty());
         }
+    }
+
+    public void testGetRoleMappings() throws Exception {
+        ensureGreen();
+
+        final List<String> nativeMappings = List.of("everyone_kibana", "_everyone_kibana", "zzz_mapping", "123_mapping");
+        for (var mapping : nativeMappings) {
+            client().execute(PutRoleMappingAction.INSTANCE, sampleRestRequest(mapping)).actionGet();
+        }
+
+        var savedClusterState = setupClusterStateListener(internalCluster().getMasterName(), "everyone_kibana");
+        writeJSONFile(internalCluster().getMasterName(), testJSON, logger, versionCounter);
+        boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
+        assertTrue(awaitSuccessful);
+
+        var request = new GetRoleMappingsRequest();
+        var response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
+        assertTrue(response.hasMappings());
+        assertThat(
+            Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
+            containsInAnyOrder(
+                "everyone_kibana",
+                ExpressionRoleMapping.addReadOnlySuffix("everyone_kibana"),
+                "_everyone_kibana",
+                ExpressionRoleMapping.addReadOnlySuffix("everyone_fleet"),
+                "zzz_mapping",
+                "123_mapping"
+            )
+        );
+
+        List<Boolean> readOnlyFlags = new ArrayList<>();
+        for (ExpressionRoleMapping mapping : response.mappings()) {
+            boolean isReadOnly = ExpressionRoleMapping.hasReadOnlySuffix(mapping.getName())
+                && mapping.getMetadata().get("_read_only") != null;
+            readOnlyFlags.add(isReadOnly);
+        }
+        // assert that cluster-state role mappings come last
+        assertThat(readOnlyFlags, contains(false, false, false, false, true, true));
+
+        // it's possible to delete overlapping native role mapping
+        assertTrue(client().execute(DeleteRoleMappingAction.INSTANCE, deleteRequest("everyone_kibana")).actionGet().isFound());
+
+        // Fetch a specific file based role
+        request = new GetRoleMappingsRequest();
+        request.setNames(ExpressionRoleMapping.addReadOnlySuffix("everyone_kibana"));
+        response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
+        assertTrue(response.hasMappings());
+        assertThat(
+            Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
+            containsInAnyOrder(ExpressionRoleMapping.addReadOnlySuffix("everyone_kibana"))
+        );
+
+        savedClusterState = setupClusterStateListenerForCleanup(internalCluster().getMasterName());
+        writeJSONFile(internalCluster().getMasterName(), emptyJSON, logger, versionCounter);
+        awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
+        assertTrue(awaitSuccessful);
+
+        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
+            new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(savedClusterState.v2().get())
+        ).get();
+
+        assertNull(
+            clusterStateResponse.getState().metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey())
+        );
+
+        // Make sure remaining native mappings can still be fetched
+        request = new GetRoleMappingsRequest();
+        response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
+        assertTrue(response.hasMappings());
+        assertThat(
+            Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
+            containsInAnyOrder("_everyone_kibana", "zzz_mapping", "123_mapping")
+        );
     }
 
     public static Tuple<CountDownLatch, AtomicLong> setupClusterStateListenerForError(
@@ -434,11 +496,8 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
             boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
             assertTrue(awaitSuccessful);
 
-            // no native role mappings exist
-            var request = new GetRoleMappingsRequest();
-            request.setNames("everyone_kibana", "everyone_fleet");
-            var response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
-            assertFalse(response.hasMappings());
+            // even if index is closed, cluster-state role mappings are still returned
+            assertGetResponseHasMappings(true, "everyone_kibana", "everyone_fleet");
 
             // cluster state settings are also applied
             var clusterStateResponse = clusterAdmin().state(
@@ -477,6 +536,12 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         }
     }
 
+    private DeleteRoleMappingRequest deleteRequest(String name) {
+        var request = new DeleteRoleMappingRequest();
+        request.setName(name);
+        return request;
+    }
+
     private PutRoleMappingRequest sampleRestRequest(String name) throws Exception {
         var json = """
             {
@@ -494,5 +559,20 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         ) {
             return new PutRoleMappingRequestBuilder(null).source(name, parser).request();
         }
+    }
+
+    private static void assertGetResponseHasMappings(boolean readOnly, String... mappings) throws InterruptedException, ExecutionException {
+        var request = new GetRoleMappingsRequest();
+        request.setNames(mappings);
+        var response = client().execute(GetRoleMappingsAction.INSTANCE, request).get();
+        assertTrue(response.hasMappings());
+        assertThat(
+            Arrays.stream(response.mappings()).map(ExpressionRoleMapping::getName).toList(),
+            containsInAnyOrder(
+                Arrays.stream(mappings)
+                    .map(mapping -> readOnly ? ExpressionRoleMapping.addReadOnlySuffix(mapping) : mapping)
+                    .toArray(String[]::new)
+            )
+        );
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -30,6 +30,7 @@ import static org.elasticsearch.integration.RoleMappingFileSettingsIT.setupClust
 import static org.elasticsearch.integration.RoleMappingFileSettingsIT.setupClusterStateListenerForCleanup;
 import static org.elasticsearch.integration.RoleMappingFileSettingsIT.writeJSONFile;
 import static org.elasticsearch.integration.RoleMappingFileSettingsIT.writeJSONFileWithoutVersionIncrement;
+import static org.elasticsearch.xpack.core.security.authz.RoleMappingMetadata.METADATA_NAME_FIELD;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
@@ -123,7 +124,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                 new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                 List.of("kibana_user"),
                 List.of(),
-                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something", METADATA_NAME_FIELD, "everyone_kibana_alone"),
                 true
             ),
             new ExpressionRoleMapping(
@@ -131,7 +132,14 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                 new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                 List.of("fleet_user"),
                 List.of(),
-                Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
+                Map.of(
+                    "uuid",
+                    "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7",
+                    "_foo",
+                    "something_else",
+                    METADATA_NAME_FIELD,
+                    "everyone_fleet_alone"
+                ),
                 false
             )
         );
@@ -141,26 +149,29 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         ensureGreen();
         awaitFileSettingsWatcher();
 
-        // assert busy to give mappings time to update after restart; otherwise, the role mapping names might be dummy values
-        // `name_not_available_after_deserialization`
-        assertBusy(
-            () -> assertRoleMappingsInClusterState(
-                new ExpressionRoleMapping(
-                    "everyone_kibana_alone",
-                    new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
-                    List.of("kibana_user"),
-                    List.of(),
-                    Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
-                    true
+        assertRoleMappingsInClusterState(
+            new ExpressionRoleMapping(
+                "everyone_kibana_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("kibana_user"),
+                List.of(),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something", METADATA_NAME_FIELD, "everyone_kibana_alone"),
+                true
+            ),
+            new ExpressionRoleMapping(
+                "everyone_fleet_alone",
+                new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
+                List.of("fleet_user"),
+                List.of(),
+                Map.of(
+                    "uuid",
+                    "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7",
+                    "_foo",
+                    "something_else",
+                    METADATA_NAME_FIELD,
+                    "everyone_fleet_alone"
                 ),
-                new ExpressionRoleMapping(
-                    "everyone_fleet_alone",
-                    new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
-                    List.of("fleet_user"),
-                    List.of(),
-                    Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
-                    false
-                )
+                false
             )
         );
 
@@ -197,7 +208,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                 new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                 List.of("kibana_user"),
                 List.of(),
-                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something", METADATA_NAME_FIELD, "everyone_kibana_alone"),
                 true
             ),
             new ExpressionRoleMapping(
@@ -205,7 +216,14 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                 new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                 List.of("fleet_user"),
                 List.of(),
-                Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
+                Map.of(
+                    "uuid",
+                    "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7",
+                    "_foo",
+                    "something_else",
+                    METADATA_NAME_FIELD,
+                    "everyone_fleet_alone"
+                ),
                 false
             )
         );
@@ -225,7 +243,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                 new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                 List.of("kibana_user"),
                 List.of(),
-                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something", METADATA_NAME_FIELD, "everyone_kibana_alone"),
                 true
             ),
             new ExpressionRoleMapping(
@@ -233,7 +251,14 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                 new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                 List.of("fleet_user"),
                 List.of(),
-                Map.of("uuid", "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7", "_foo", "something_else"),
+                Map.of(
+                    "uuid",
+                    "b9a59ba9-6b92-4be3-bb8d-02bb270cb3a7",
+                    "_foo",
+                    "something_else",
+                    METADATA_NAME_FIELD,
+                    "everyone_fleet_alone"
+                ),
                 false
             )
         );
@@ -251,7 +276,14 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
                     new FieldExpression("username", List.of(new FieldExpression.FieldValue("*"))),
                     List.of("kibana_user", "kibana_admin"),
                     List.of(),
-                    Map.of("uuid", "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7", "_foo", "something"),
+                    Map.of(
+                        "uuid",
+                        "b9a59ba9-6b92-4be2-bb8d-02bb270cb3a7",
+                        "_foo",
+                        "something",
+                        METADATA_NAME_FIELD,
+                        "everyone_kibana_together"
+                    ),
                     true
                 )
             )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -896,6 +896,7 @@ public class Security extends Plugin
         components.add(nativeUsersStore);
         components.add(new PluginComponentBinding<>(NativeRoleMappingStore.class, nativeRoleMappingStore));
         components.add(new PluginComponentBinding<>(UserRoleMapper.class, userRoleMapper));
+        components.add(clusterStateRoleMapper);
         components.add(reservedRealm);
         components.add(realms);
         this.realms.set(realms);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportDeleteRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportDeleteRoleMappingAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.action.rolemapping;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -16,17 +17,19 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingResponse;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 
 public class TransportDeleteRoleMappingAction extends HandledTransportAction<DeleteRoleMappingRequest, DeleteRoleMappingResponse> {
-
     private final NativeRoleMappingStore roleMappingStore;
+    private final ClusterStateRoleMapper clusterStateRoleMapper;
 
     @Inject
     public TransportDeleteRoleMappingAction(
         ActionFilters actionFilters,
         TransportService transportService,
-        NativeRoleMappingStore roleMappingStore
+        NativeRoleMappingStore roleMappingStore,
+        ClusterStateRoleMapper clusterStateRoleMapper
     ) {
         super(
             DeleteRoleMappingAction.NAME,
@@ -36,10 +39,24 @@ public class TransportDeleteRoleMappingAction extends HandledTransportAction<Del
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.roleMappingStore = roleMappingStore;
+        this.clusterStateRoleMapper = clusterStateRoleMapper;
     }
 
     @Override
     protected void doExecute(Task task, DeleteRoleMappingRequest request, ActionListener<DeleteRoleMappingResponse> listener) {
-        roleMappingStore.deleteRoleMapping(request, listener.safeMap(DeleteRoleMappingResponse::new));
+        roleMappingStore.deleteRoleMapping(request, listener.safeMap(found -> {
+            if (found && clusterStateRoleMapper.hasMapping(request.getName())) {
+                // Allow to delete a mapping with the same name in the native role mapping store as the file_settings namespace, but
+                // add a warning header to signal to the caller that this could be a problem.
+                HeaderWarning.addWarning(
+                    "A read-only role mapping with the same name ["
+                        + request.getName()
+                        + "] has previously been defined in a configuration file. "
+                        + "The native role mapping was deleted, but the read-only mapping will remain active "
+                        + "and will be used to determine role assignments."
+                );
+            }
+            return new DeleteRoleMappingResponse(found);
+        }));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.security.action.rolemapping;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -17,21 +19,31 @@ import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsA
 import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsResponse;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
+import org.elasticsearch.xpack.core.security.authz.RoleMappingMetadata;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TransportGetRoleMappingsAction extends HandledTransportAction<GetRoleMappingsRequest, GetRoleMappingsResponse> {
+    private static final Logger logger = LogManager.getLogger(TransportGetRoleMappingsAction.class);
 
     private final NativeRoleMappingStore roleMappingStore;
+    private final ClusterStateRoleMapper clusterStateRoleMapper;
 
     @Inject
     public TransportGetRoleMappingsAction(
         ActionFilters actionFilters,
         TransportService transportService,
-        NativeRoleMappingStore nativeRoleMappingStore
+        NativeRoleMappingStore nativeRoleMappingStore,
+        ClusterStateRoleMapper clusterStateRoleMapper
     ) {
         super(
             GetRoleMappingsAction.NAME,
@@ -41,19 +53,84 @@ public class TransportGetRoleMappingsAction extends HandledTransportAction<GetRo
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.roleMappingStore = nativeRoleMappingStore;
+        this.clusterStateRoleMapper = clusterStateRoleMapper;
     }
 
     @Override
     protected void doExecute(Task task, final GetRoleMappingsRequest request, final ActionListener<GetRoleMappingsResponse> listener) {
         final Set<String> names;
         if (request.getNames() == null || request.getNames().length == 0) {
-            names = null;
+            names = Set.of();
         } else {
             names = new HashSet<>(Arrays.asList(request.getNames()));
         }
-        this.roleMappingStore.getRoleMappings(names, ActionListener.wrap(mappings -> {
-            ExpressionRoleMapping[] array = mappings.toArray(new ExpressionRoleMapping[mappings.size()]);
-            listener.onResponse(new GetRoleMappingsResponse(array));
+        roleMappingStore.getRoleMappings(names, ActionListener.wrap(nativeRoleMappings -> {
+            final Collection<ExpressionRoleMapping> clusterStateRoleMappings = clusterStateRoleMapper.getMappings(
+                // if the API was queried with a reserved suffix for any of the names, we need to remove it because role mappings are
+                // stored without it in cluster-state
+                removeReadOnlySuffixIfPresent(names)
+            );
+            listener.onResponse(buildResponse(clusterStateRoleMappings, nativeRoleMappings));
         }, listener::onFailure));
+    }
+
+    private GetRoleMappingsResponse buildResponse(
+        Collection<ExpressionRoleMapping> clusterStateMappings,
+        Collection<ExpressionRoleMapping> nativeMappings
+    ) {
+        Stream<ExpressionRoleMapping> translatedClusterStateMappings = clusterStateMappings.stream().filter(roleMapping -> {
+            if (RoleMappingMetadata.hasFallbackName(roleMapping)) {
+                logger.warn(
+                    "Role mapping retrieved from cluster-state with an ambiguous name. It will be omitted from the API response."
+                        + "This is likely a transient issue during node start-up."
+                );
+                return false;
+            }
+            return true;
+        }).map(this::translateClusterStateMapping);
+        return new GetRoleMappingsResponse(
+            Stream.concat(nativeMappings.stream(), translatedClusterStateMappings).toArray(ExpressionRoleMapping[]::new)
+        );
+    }
+
+    private Set<String> removeReadOnlySuffixIfPresent(Set<String> names) {
+        return names.stream().map(ExpressionRoleMapping::removeReadOnlySuffixIfPresent).collect(Collectors.toSet());
+    }
+
+    /**
+     * Translator method for ensuring unique API names and marking cluster-state role mappings as read-only.
+     * Role mappings retrieved from cluster-state are surfaced through both the transport and REST layers,
+     * along with native role mappings. Unlike native role mappings, cluster-state role mappings are
+     * read-only and cannot be modified via APIs. It is possible for cluster-state and native role mappings
+     * to have overlapping names.
+     *
+     * <p>
+     * This does the following:
+     * </p>
+     *
+     * <ol>
+     *   <li>Appends a reserved suffix to cluster-state role mapping names to avoid conflicts with native role mappings.</li>
+     *   <li>Marks the metadata of cluster-state role mappings with a reserved read-only flag.</li>
+     *   <li>Removes internal metadata flag used in processing (see {@link RoleMappingMetadata#METADATA_NAME_FIELD}).</li>
+     * </ol>
+     */
+    private ExpressionRoleMapping translateClusterStateMapping(ExpressionRoleMapping mapping) {
+        Map<String, Object> metadata = new HashMap<>(mapping.getMetadata());
+        if (metadata.put(ExpressionRoleMapping.READ_ONLY_ROLE_MAPPING_METADATA_FLAG, true) != null) {
+            logger.error(
+                "Metadata field [{}] is reserved and will be overwritten with an internal system value. "
+                    + "Rename this field in your role mapping configuration.",
+                ExpressionRoleMapping.READ_ONLY_ROLE_MAPPING_METADATA_FLAG
+            );
+        }
+        metadata.remove(RoleMappingMetadata.METADATA_NAME_FIELD);
+        return new ExpressionRoleMapping(
+            ExpressionRoleMapping.addReadOnlySuffix(mapping.getName()),
+            mapping.getExpression(),
+            mapping.getRoles(),
+            mapping.getRoleTemplates(),
+            metadata,
+            mapping.isEnabled()
+        );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.action.rolemapping;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
@@ -16,24 +17,41 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingAction;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingResponse;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
+
+import static org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping.validateNoReadOnlySuffix;
 
 public class TransportPutRoleMappingAction extends HandledTransportAction<PutRoleMappingRequest, PutRoleMappingResponse> {
 
     private final NativeRoleMappingStore roleMappingStore;
+    private final ClusterStateRoleMapper clusterStateRoleMapper;
 
     @Inject
     public TransportPutRoleMappingAction(
         ActionFilters actionFilters,
         TransportService transportService,
-        NativeRoleMappingStore roleMappingStore
+        NativeRoleMappingStore roleMappingStore,
+        ClusterStateRoleMapper clusterStateRoleMapper
     ) {
         super(PutRoleMappingAction.NAME, transportService, actionFilters, PutRoleMappingRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.roleMappingStore = roleMappingStore;
+        this.clusterStateRoleMapper = clusterStateRoleMapper;
     }
 
     @Override
     protected void doExecute(Task task, final PutRoleMappingRequest request, final ActionListener<PutRoleMappingResponse> listener) {
+        validateNoReadOnlySuffix(request.getName());
+        if (clusterStateRoleMapper.hasMapping(request.getName())) {
+            // Allow to define a mapping with the same name in the native role mapping store as the file_settings namespace, but add a
+            // warning header to signal to the caller that this could be a problem.
+            HeaderWarning.addWarning(
+                "A read-only role mapping with the same name ["
+                    + request.getName()
+                    + "] has been previously defined in a configuration file. "
+                    + "Both role mappings will be used to determine role assignments."
+            );
+        }
         roleMappingStore.putRoleMapping(
             request,
             ActionListener.wrap(created -> listener.onResponse(new PutRoleMappingResponse(created)), listener::onFailure)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsActionTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.action.rolemapping;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -19,21 +18,26 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsResponse;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.arrayContaining;
+import static org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping.READ_ONLY_ROLE_MAPPING_METADATA_FLAG;
+import static org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping.READ_ONLY_ROLE_MAPPING_SUFFIX;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -42,8 +46,10 @@ public class TransportGetRoleMappingsActionTests extends ESTestCase {
 
     private NativeRoleMappingStore store;
     private TransportGetRoleMappingsAction action;
-    private AtomicReference<Set<String>> namesRef;
-    private List<ExpressionRoleMapping> result;
+    private AtomicReference<Set<String>> nativeNamesRef;
+    private AtomicReference<Set<String>> clusterStateNamesRef;
+    private List<ExpressionRoleMapping> nativeMappings;
+    private Set<ExpressionRoleMapping> clusterStateMappings;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -58,68 +64,219 @@ public class TransportGetRoleMappingsActionTests extends ESTestCase {
             null,
             Collections.emptySet()
         );
-        action = new TransportGetRoleMappingsAction(mock(ActionFilters.class), transportService, store);
+        ClusterStateRoleMapper clusterStateRoleMapper = mock();
+        action = new TransportGetRoleMappingsAction(mock(ActionFilters.class), transportService, store, clusterStateRoleMapper);
 
-        namesRef = new AtomicReference<>(null);
-        result = Collections.emptyList();
+        nativeNamesRef = new AtomicReference<>(null);
+        clusterStateNamesRef = new AtomicReference<>(null);
+        nativeMappings = Collections.emptyList();
+        clusterStateMappings = Collections.emptySet();
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assert args.length == 1;
+            clusterStateNamesRef.set((Set<String>) args[0]);
+            return clusterStateMappings;
+        }).when(clusterStateRoleMapper).getMappings(anySet());
 
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             assert args.length == 2;
-            namesRef.set((Set<String>) args[0]);
+            nativeNamesRef.set((Set<String>) args[0]);
             ActionListener<List<ExpressionRoleMapping>> listener = (ActionListener<List<ExpressionRoleMapping>>) args[1];
-            listener.onResponse(result);
+            listener.onResponse(nativeMappings);
             return null;
         }).when(store).getRoleMappings(nullable(Set.class), any(ActionListener.class));
     }
 
-    public void testGetSingleRole() throws Exception {
+    public void testGetSingleRoleMappingNativeOnly() throws Exception {
+        testGetMappings(List.of(mapping("everyone")), Collections.emptySet(), Set.of("everyone"), Set.of("everyone"), "everyone");
+    }
+
+    public void testGetMultipleNamedRoleMappingsNativeOnly() throws Exception {
+        testGetMappings(
+            List.of(mapping("admin"), mapping("engineering"), mapping("sales"), mapping("finance")),
+            Collections.emptySet(),
+            Set.of("admin", "engineering", "sales", "finance"),
+            Set.of("admin", "engineering", "sales", "finance"),
+            "admin",
+            "engineering",
+            "sales",
+            "finance"
+        );
+    }
+
+    public void testGetAllRoleMappingsNativeOnly() throws Exception {
+        testGetMappings(
+            List.of(mapping("admin"), mapping("engineering"), mapping("sales"), mapping("finance")),
+            Collections.emptySet(),
+            Set.of(),
+            Set.of()
+        );
+    }
+
+    public void testGetSingleRoleMappingClusterStateOnly() throws Exception {
+        testGetMappings(List.of(), Set.of(mapping("everyone")), Set.of("everyone"), Set.of("everyone"), "everyone");
+    }
+
+    public void testGetMultipleNamedRoleMappingsClusterStateOnly() throws Exception {
+        testGetMappings(
+            List.of(),
+            Set.of(mapping("admin"), mapping("engineering"), mapping("sales"), mapping("finance")),
+            Set.of("admin", "engineering", "sales", "finance"),
+            Set.of("admin", "engineering", "sales", "finance"),
+            "admin",
+            "engineering",
+            "sales",
+            "finance"
+        );
+    }
+
+    public void testGetAllRoleMappingsClusterStateOnly() throws Exception {
+        testGetMappings(
+            List.of(),
+            Set.of(mapping("admin"), mapping("engineering"), mapping("sales"), mapping("finance")),
+            Set.of(),
+            Set.of()
+        );
+    }
+
+    public void testGetSingleRoleMappingBoth() throws Exception {
+        testGetMappings(List.of(mapping("everyone")), Set.of(mapping("everyone")), Set.of("everyone"), Set.of("everyone"), "everyone");
+    }
+
+    public void testGetMultipleNamedRoleMappingsBoth() throws Exception {
+        testGetMappings(
+            List.of(mapping("admin"), mapping("engineering")),
+            Set.of(mapping("sales"), mapping("finance")),
+            Set.of("admin", "engineering", "sales", "finance"),
+            Set.of("admin", "engineering", "sales", "finance"),
+            "admin",
+            "engineering",
+            "sales",
+            "finance"
+        );
+    }
+
+    public void testGetAllRoleMappingsClusterBoth() throws Exception {
+        testGetMappings(List.of(mapping("admin"), mapping("engineering")), Set.of(mapping("admin"), mapping("sales")), Set.of(), Set.of());
+    }
+
+    public void testGetSingleRoleMappingQueryWithReadOnlySuffix() throws Exception {
+        testGetMappings(
+            List.of(),
+            Set.of(mapping("everyone")),
+            // suffix not stripped for native store query
+            Set.of("everyone" + READ_ONLY_ROLE_MAPPING_SUFFIX),
+            // suffix is stripped for cluster state store
+            Set.of("everyone"),
+            "everyone" + READ_ONLY_ROLE_MAPPING_SUFFIX
+        );
+
+        testGetMappings(
+            List.of(),
+            Set.of(mapping("everyoneread-only-operator-mapping")),
+            Set.of(
+                "everyoneread-only-operator-mapping",
+                "everyone-read-only-operator-mapping-",
+                "everyone-read-only-operator-mapping-more"
+            ),
+            // suffix that is similar but not the same is not stripped
+            Set.of(
+                "everyoneread-only-operator-mapping",
+                "everyone-read-only-operator-mapping-",
+                "everyone-read-only-operator-mapping-more"
+            ),
+            "everyoneread-only-operator-mapping",
+            "everyone-read-only-operator-mapping-",
+            "everyone-read-only-operator-mapping-more"
+        );
+
+        testGetMappings(
+            List.of(mapping("everyone")),
+            Set.of(mapping("everyone")),
+            // suffix not stripped for native store query
+            Set.of("everyone" + READ_ONLY_ROLE_MAPPING_SUFFIX, "everyone"),
+            // suffix is stripped for cluster state store
+            Set.of("everyone"),
+            "everyone" + READ_ONLY_ROLE_MAPPING_SUFFIX,
+            "everyone"
+        );
+    }
+
+    public void testClusterStateRoleMappingWithFallbackNameOmitted() throws ExecutionException, InterruptedException {
+        testGetMappings(
+            List.of(),
+            Set.of(mapping("name_not_available_after_deserialization")),
+            Set.of(),
+            Set.of("name_not_available_after_deserialization"),
+            Set.of("name_not_available_after_deserialization"),
+            "name_not_available_after_deserialization"
+        );
+
+        testGetMappings(
+            List.of(mapping("name_not_available_after_deserialization")),
+            Set.of(mapping("name_not_available_after_deserialization")),
+            Set.of(),
+            Set.of("name_not_available_after_deserialization"),
+            Set.of("name_not_available_after_deserialization"),
+            "name_not_available_after_deserialization"
+        );
+    }
+
+    private void testGetMappings(
+        List<ExpressionRoleMapping> returnedNativeMappings,
+        Set<ExpressionRoleMapping> returnedClusterStateMappings,
+        Set<String> expectedNativeNames,
+        Set<String> expectedClusterStateNames,
+        String... names
+    ) throws InterruptedException, ExecutionException {
+        testGetMappings(
+            returnedNativeMappings,
+            returnedClusterStateMappings,
+            returnedClusterStateMappings.stream().map(this::expectedClusterStateMapping).collect(Collectors.toSet()),
+            expectedNativeNames,
+            expectedClusterStateNames,
+            names
+        );
+    }
+
+    private void testGetMappings(
+        List<ExpressionRoleMapping> returnedNativeMappings,
+        Set<ExpressionRoleMapping> returnedClusterStateMappings,
+        Set<ExpressionRoleMapping> expectedClusterStateMappings,
+        Set<String> expectedNativeNames,
+        Set<String> expectedClusterStateNames,
+        String... names
+    ) throws InterruptedException, ExecutionException {
         final PlainActionFuture<GetRoleMappingsResponse> future = new PlainActionFuture<>();
         final GetRoleMappingsRequest request = new GetRoleMappingsRequest();
-        request.setNames("everyone");
+        request.setNames(names);
 
-        final ExpressionRoleMapping mapping = mock(ExpressionRoleMapping.class);
-        result = Collections.singletonList(mapping);
+        nativeMappings = returnedNativeMappings;
+        clusterStateMappings = returnedClusterStateMappings;
         action.doExecute(mock(Task.class), request, future);
         assertThat(future.get(), notNullValue());
-        assertThat(future.get().mappings(), arrayContaining(mapping));
-        assertThat(namesRef.get(), containsInAnyOrder("everyone"));
+        List<ExpressionRoleMapping> combined = new ArrayList<>(returnedNativeMappings);
+        combined.addAll(expectedClusterStateMappings);
+        ExpressionRoleMapping[] actualMappings = future.get().mappings();
+        assertThat(actualMappings, arrayContainingInAnyOrder(combined.toArray(new ExpressionRoleMapping[0])));
+        assertThat(nativeNamesRef.get(), containsInAnyOrder(expectedNativeNames.toArray(new String[0])));
+        assertThat(clusterStateNamesRef.get(), containsInAnyOrder(expectedClusterStateNames.toArray(new String[0])));
     }
 
-    public void testGetMultipleNamedRoles() throws Exception {
-        final PlainActionFuture<GetRoleMappingsResponse> future = new PlainActionFuture<>();
-        final GetRoleMappingsRequest request = new GetRoleMappingsRequest();
-        request.setNames("admin", "engineering", "sales", "finance");
-
-        final ExpressionRoleMapping mapping1 = mock(ExpressionRoleMapping.class);
-        final ExpressionRoleMapping mapping2 = mock(ExpressionRoleMapping.class);
-        final ExpressionRoleMapping mapping3 = mock(ExpressionRoleMapping.class);
-        result = Arrays.asList(mapping1, mapping2, mapping3);
-
-        action.doExecute(mock(Task.class), request, future);
-
-        final GetRoleMappingsResponse response = future.get();
-        assertThat(response, notNullValue());
-        assertThat(response.mappings(), arrayContainingInAnyOrder(mapping1, mapping2, mapping3));
-        assertThat(namesRef.get(), containsInAnyOrder("admin", "engineering", "sales", "finance"));
+    private ExpressionRoleMapping mapping(String name) {
+        return new ExpressionRoleMapping(name, null, null, null, Map.of(), true);
     }
 
-    public void testGetAllRoles() throws Exception {
-        final PlainActionFuture<GetRoleMappingsResponse> future = new PlainActionFuture<>();
-        final GetRoleMappingsRequest request = new GetRoleMappingsRequest();
-        request.setNames(Strings.EMPTY_ARRAY);
-
-        final ExpressionRoleMapping mapping1 = mock(ExpressionRoleMapping.class);
-        final ExpressionRoleMapping mapping2 = mock(ExpressionRoleMapping.class);
-        final ExpressionRoleMapping mapping3 = mock(ExpressionRoleMapping.class);
-        result = Arrays.asList(mapping1, mapping2, mapping3);
-
-        action.doExecute(mock(Task.class), request, future);
-
-        final GetRoleMappingsResponse response = future.get();
-        assertThat(response, notNullValue());
-        assertThat(response.mappings(), arrayContainingInAnyOrder(mapping1, mapping2, mapping3));
-        assertThat(namesRef.get(), Matchers.nullValue(Set.class));
+    private ExpressionRoleMapping expectedClusterStateMapping(ExpressionRoleMapping mapping) {
+        return new ExpressionRoleMapping(
+            mapping.getName() + READ_ONLY_ROLE_MAPPING_SUFFIX,
+            null,
+            null,
+            null,
+            Map.of(READ_ONLY_ROLE_MAPPING_METADATA_FLAG, true),
+            true
+        );
     }
-
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingActionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRe
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingResponse;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression;
+import org.elasticsearch.xpack.security.authc.support.mapper.ClusterStateRoleMapper;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 import org.junit.Before;
 
@@ -29,18 +30,21 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportPutRoleMappingActionTests extends ESTestCase {
 
     private NativeRoleMappingStore store;
     private TransportPutRoleMappingAction action;
     private AtomicReference<PutRoleMappingRequest> requestRef;
+    private ClusterStateRoleMapper clusterStateRoleMapper;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -55,7 +59,9 @@ public class TransportPutRoleMappingActionTests extends ESTestCase {
             null,
             Collections.emptySet()
         );
-        action = new TransportPutRoleMappingAction(mock(ActionFilters.class), transportService, store);
+        clusterStateRoleMapper = mock();
+        when(clusterStateRoleMapper.hasMapping(any())).thenReturn(false);
+        action = new TransportPutRoleMappingAction(mock(ActionFilters.class), transportService, store, clusterStateRoleMapper);
 
         requestRef = new AtomicReference<>(null);
 
@@ -83,6 +89,41 @@ public class TransportPutRoleMappingActionTests extends ESTestCase {
         assertThat(mapping.getRoles(), contains("superuser"));
         assertThat(mapping.getMetadata(), aMapWithSize(1));
         assertThat(mapping.getMetadata().get("dumb"), equalTo(true));
+    }
+
+    public void testValidMappingClashingClusterStateMapping() throws Exception {
+        final FieldExpression expression = new FieldExpression("username", Collections.singletonList(new FieldExpression.FieldValue("*")));
+        final PutRoleMappingResponse response = put("anarchy", expression, "superuser", Collections.singletonMap("dumb", true));
+        when(clusterStateRoleMapper.hasMapping(any())).thenReturn(true);
+
+        assertThat(response.isCreated(), equalTo(true));
+
+        final ExpressionRoleMapping mapping = requestRef.get().getMapping();
+        assertThat(mapping.getExpression(), is(expression));
+        assertThat(mapping.isEnabled(), equalTo(true));
+        assertThat(mapping.getName(), equalTo("anarchy"));
+        assertThat(mapping.getRoles(), iterableWithSize(1));
+        assertThat(mapping.getRoles(), contains("superuser"));
+        assertThat(mapping.getMetadata(), aMapWithSize(1));
+        assertThat(mapping.getMetadata().get("dumb"), equalTo(true));
+    }
+
+    public void testInvalidSuffix() {
+        final FieldExpression expression = new FieldExpression("username", Collections.singletonList(new FieldExpression.FieldValue("*")));
+        String name = ExpressionRoleMapping.addReadOnlySuffix("anarchy");
+        final var ex = expectThrows(IllegalArgumentException.class, () -> {
+            put(name, expression, "superuser", Collections.singletonMap("dumb", true));
+        });
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "Invalid mapping name ["
+                    + name
+                    + "]. ["
+                    + ExpressionRoleMapping.READ_ONLY_ROLE_MAPPING_SUFFIX
+                    + "] is not an allowed suffix"
+            )
+        );
     }
 
     private PutRoleMappingResponse put(String name, FieldExpression expression, String role, Map<String, Object> metadata)


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/114951 with following commit:
- 6855db5b44e957429588dd645165650e970fd001