### PR TITLE
[ML] New names for the default inference endpoints

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -85,8 +85,8 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
     );
 
     public static final int EMBEDDING_MAX_BATCH_SIZE = 10;
-    public static final String DEFAULT_ELSER_ID = ".elser-2";
-    public static final String DEFAULT_E5_ID = ".multi-e5-small";
+    public static final String DEFAULT_ELSER_ID = ".elser-2-elasticsearch";
+    public static final String DEFAULT_E5_ID = ".multilingual-e5-small-elasticsearch";
 
     private static final Logger logger = LogManager.getLogger(ElasticsearchInternalService.class);
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(ElasticsearchInternalService.class);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -1561,8 +1561,8 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
 
     public void testIsDefaultId() {
         var service = createService(mock(Client.class));
-        assertTrue(service.isDefaultId(".elser-2"));
-        assertTrue(service.isDefaultId(".multi-e5-small"));
+        assertTrue(service.isDefaultId(".elser-2-elasticsearch"));
+        assertTrue(service.isDefaultId(".multilingual-e5-small-elasticsearch"));
         assertFalse(service.isDefaultId("foo"));
     }
 


### PR DESCRIPTION
The new names are **.elser-2-elasticsearch** and **.multilingual-e5-small-elasticsearch**

The rational behind this choice is 
1. The inference Ids cannot be the same as the model Ids which excludes `.elser_model_2` and `.multilingual-e5-small`
2. The `.` prefix means the config is internally managed
3. The `-elasticsearch` suffix indicates that the endpoint uses the `elasticsearch` service

Including the service name in the id opens up the option of having default endpoints for the same model hosted by different services e.g. `.elser-2-eis`.

Non issue as the default configs are behind a feature flag