### PR TITLE
Adding breaking change entry for retrievers

### DIFF
--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -4,9 +4,19 @@ area: Ranking
 type: breaking
 issues: []
 breaking:
-  title: Adding breaking change entry for retrievers
+  title: Reworking RRF retriever to be evaluated during rewrite phase
   area: Ranking
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: |-
+    In this release (8.16), we have introduced major changes to the retrievers framework and how they can be evaluated,
+    focusing mainly on compound retrievers like `rrf` and `text_similarity_reranker`, which allowed us to support
+    additional search features like highlighting, collapsing, explaining, and aggregations.
+    To ensure consistency and avoid unexpected failures, we have introduced a new cluster_feature that ensures that
+    all nodes must satisfy, in order for the `rrf` and `text_similarity_reranker` retriever queries to be evaluated.
+    This guarantees that all nodes are able to take advantage of the new framework and provide compatible responses.
+    As part of the rework, we have removed the `_rank` property from the responses of an `rrf` retriever.
+  impact: |-
+    - Users will not be able to use the `rrf` and `text_similarity_reranker` retrievers in a mixed cluster scenario
+    with previous releases (i.e. prior to 8.16), and the request will throw an `UnsupportedOperationException`.
+    - `_rank` has now been removed from the output of the `rrf` retrievers so trying to directly parse the field
+    will throw an exception
   notable: false

--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -1,11 +1,11 @@
 pr: 115399
 summary: Adding breaking change entry for retrievers
-area: Ranking
+area: Search
 type: breaking
 issues: []
 breaking:
   title: Reworking RRF retriever to be evaluated during rewrite phase
-  area: Ranking
+  area: REST API
   details: |-
     In this release (8.16), we have introduced major changes to the retrievers framework and how they can be evaluated,
     focusing mainly on compound retrievers like `rrf` and `text_similarity_reranker`, which allowed us to support

--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -7,12 +7,20 @@ breaking:
   title: Reworking RRF retriever to be evaluated during rewrite phase
   area: REST API
   details: |-
-    In this release (8.16), we have introduced major changes to the retrievers framework and how they can be evaluated,
-    focusing mainly on compound retrievers like `rrf` and `text_similarity_reranker`, which allowed us to support
-    additional search features like collapsing, explaining, aggregations, and highlighting.
-    To ensure consistency and avoid unexpected failures, `rrf` and `text_similarity_reranker` retriever queries are no longer compatible
-    with previous releases ( <= 8.15).
-    As part of the rework, we have also removed the `_rank` property from the responses of an `rrf` retriever.
+    In this release (8.16), we have introduced major changes to the retrievers framework 
+    and how they can be evaluated, focusing mainly on compound retrievers 
+    like `rrf` and `text_similarity_reranker`, which allowed us to support full 
+    composability (i.e. any retriever can be nested under any compound retriever), 
+    as well as supporting additional search features like collapsing, explaining, 
+    aggregations, and highlighting.
+    
+    To ensure consistency, and given that this rework is not available until 8.16, 
+    `rrf` and `text_similarity_reranker`  retriever queries would now  
+    throw an exception in a mixed cluster scenario, where there are nodes 
+    both in current or later (i.e. >= 8.16) and previous ( <= 8.15) versions.
+    
+    As part of the rework, we have also removed the `_rank` property from 
+    the responses of an `rrf` retriever.
   impact: |-
     - Users will not be able to use the `rrf` and `text_similarity_reranker` retrievers in a mixed cluster scenario
     with previous releases (i.e. prior to 8.16), and the request will throw an `IllegalArgumentException`.

--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -1,0 +1,12 @@
+pr: 115399
+summary: Adding breaking change entry for retrievers
+area: Ranking
+type: breaking
+issues: []
+breaking:
+  title: Adding breaking change entry for retrievers
+  area: Ranking
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -16,7 +16,7 @@ breaking:
     As part of the rework, we have also removed the `_rank` property from the responses of an `rrf` retriever.
   impact: |-
     - Users will not be able to use the `rrf` and `text_similarity_reranker` retrievers in a mixed cluster scenario
-    with previous releases (i.e. prior to 8.16), and the request will throw a `ParsingException`.
+    with previous releases (i.e. prior to 8.16), and the request will throw an `IllegalArgumentException`.
     - `_rank` has now been removed from the output of the `rrf` retrievers so trying to directly parse the field
     will throw an exception
   notable: false

--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -10,9 +10,8 @@ breaking:
     In this release (8.16), we have introduced major changes to the retrievers framework and how they can be evaluated,
     focusing mainly on compound retrievers like `rrf` and `text_similarity_reranker`, which allowed us to support
     additional search features like collapsing, explaining, aggregations, and highlighting.
-    To ensure consistency and avoid unexpected failures, we have introduced a new cluster_feature that
-    all nodes must satisfy, in order for the `rrf` and `text_similarity_reranker` retriever queries to be evaluated.
-    This guarantees that all nodes are able to take advantage of the new framework and provide compatible responses.
+    To ensure consistency and avoid unexpected failures, `rrf` and `text_similarity_reranker` retriever queries are no longer compatible
+    with previous releases ( <= 8.15).
     As part of the rework, we have also removed the `_rank` property from the responses of an `rrf` retriever.
   impact: |-
     - Users will not be able to use the `rrf` and `text_similarity_reranker` retrievers in a mixed cluster scenario

--- a/docs/changelog/115399.yaml
+++ b/docs/changelog/115399.yaml
@@ -9,14 +9,14 @@ breaking:
   details: |-
     In this release (8.16), we have introduced major changes to the retrievers framework and how they can be evaluated,
     focusing mainly on compound retrievers like `rrf` and `text_similarity_reranker`, which allowed us to support
-    additional search features like highlighting, collapsing, explaining, and aggregations.
-    To ensure consistency and avoid unexpected failures, we have introduced a new cluster_feature that ensures that
+    additional search features like collapsing, explaining, aggregations, and highlighting.
+    To ensure consistency and avoid unexpected failures, we have introduced a new cluster_feature that
     all nodes must satisfy, in order for the `rrf` and `text_similarity_reranker` retriever queries to be evaluated.
     This guarantees that all nodes are able to take advantage of the new framework and provide compatible responses.
-    As part of the rework, we have removed the `_rank` property from the responses of an `rrf` retriever.
+    As part of the rework, we have also removed the `_rank` property from the responses of an `rrf` retriever.
   impact: |-
     - Users will not be able to use the `rrf` and `text_similarity_reranker` retrievers in a mixed cluster scenario
-    with previous releases (i.e. prior to 8.16), and the request will throw an `UnsupportedOperationException`.
+    with previous releases (i.e. prior to 8.16), and the request will throw a `ParsingException`.
     - `_rank` has now been removed from the output of the `rrf` retrievers so trying to directly parse the field
     will throw an exception
   notable: false

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -81,8 +81,7 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
             throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + TextSimilarityRankBuilder.NAME + "]");
         }
         if (context.clusterSupportsFeature(TEXT_SIMILARITY_RERANKER_COMPOSITION_SUPPORTED) == false) {
-            throw new ParsingException(
-                parser.getTokenLocation(),
+            throw new IllegalArgumentException(
                 "[text_similarity_reranker] retriever composition feature is not supported by all nodes in the cluster"
             );
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -81,7 +81,8 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
             throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + TextSimilarityRankBuilder.NAME + "]");
         }
         if (context.clusterSupportsFeature(TEXT_SIMILARITY_RERANKER_COMPOSITION_SUPPORTED) == false) {
-            throw new UnsupportedOperationException(
+            throw new ParsingException(
+                parser.getTokenLocation(),
                 "[text_similarity_reranker] retriever composition feature is not supported by all nodes in the cluster"
             );
         }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -39,6 +39,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * meaning it has a set of child retrievers that each return a set of
  * top docs that will then be combined and ranked according to the rrf
  * formula.
+ *
+ * Breaking change
  */
 public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetrieverBuilder> {
 

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -83,10 +83,7 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
             throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + NAME + "]");
         }
         if (context.clusterSupportsFeature(RRF_RETRIEVER_COMPOSITION_SUPPORTED) == false) {
-            throw new ParsingException(
-                parser.getTokenLocation(),
-                "[rrf] retriever composition feature is not supported by all nodes in the cluster"
-            );
+            throw new IllegalArgumentException("[rrf] retriever composition feature is not supported by all nodes in the cluster");
         }
         if (RRFRankPlugin.RANK_RRF_FEATURE.check(XPackPlugin.getSharedLicenseState()) == false) {
             throw LicenseUtils.newComplianceException("Reciprocal Rank Fusion (RRF)");

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -39,8 +39,6 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * meaning it has a set of child retrievers that each return a set of
  * top docs that will then be combined and ranked according to the rrf
  * formula.
- *
- * Breaking change
  */
 public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetrieverBuilder> {
 

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -83,7 +83,10 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
             throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + NAME + "]");
         }
         if (context.clusterSupportsFeature(RRF_RETRIEVER_COMPOSITION_SUPPORTED) == false) {
-            throw new UnsupportedOperationException("[rrf] retriever composition feature is not supported by all nodes in the cluster");
+            throw new ParsingException(
+                parser.getTokenLocation(),
+                "[rrf] retriever composition feature is not supported by all nodes in the cluster"
+            );
         }
         if (RRFRankPlugin.RANK_RRF_FEATURE.check(XPackPlugin.getSharedLicenseState()) == false) {
             throw LicenseUtils.newComplianceException("Reciprocal Rank Fusion (RRF)");


### PR DESCRIPTION
Updating exception thrown when cluster_feature is not present for `rrf` and `text_similarity_reranker` and adding breaking change entry for the work taken place in 8.16  (https://github.com/elastic/elasticsearch/pull/112648)