### PR TITLE
[ML] Fix NPE in Get Deployment Stats

### DIFF
--- a/docs/changelog/115404.yaml
+++ b/docs/changelog/115404.yaml
@@ -1,0 +1,5 @@
+pr: 115404
+summary: Fix NPE in Get Deployment Stats
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -220,7 +220,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
 
                 // add nodes from the failures that were not in the task responses
                 for (var nodeRoutingState : nodeToRoutingStates.entrySet()) {
-                    if (visitedNodes.contains(nodeRoutingState.getKey()) == false) {
+                    if ((visitedNodes.contains(nodeRoutingState.getKey()) == false) && nodes.nodeExists(nodeRoutingState.getKey())) {
                         updatedNodeStats.add(
                             AssignmentStats.NodeStats.forNotStartedState(
                                 nodes.get(nodeRoutingState.getKey()),


### PR DESCRIPTION
If a node has been removed from the cluster and the trained model assignments have not been updated yet the GET stats action can have an inconsistent view where it thinks a model is deployed on the node that has been removed. The error only occurs where the deployment was in the failed stated on the removed node. The fix here is simply to check that the node still exists before creating the stats for that failed route. 

The problem was found from this stack trace
```
[WARN ][r.suppressed             ] [es01] path: /_ml/trained_models/_stats, params: {size=10000} java.lang.NullPointerException: Cannot invoke "org.elasticsearch.cluster.node.DiscoveryNode.getId()" because the return value of "org.elasticsearch.xpack.core.ml.inference.assignment.AssignmentStats$NodeStats.getNode()" is null
	at org.elasticsearch.ml@8.11.0-SNAPSHOT/org.elasticsearch.xpack.ml.action.TransportGetDeploymentStatsAction.lambda$addFailedRoutes$5(TransportGetDeploymentStatsAction.java:235)
	at java.base/java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:473)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:220)
	at java.base/java.util.Arrays.sort(Arrays.java:1307)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1721)
	at org.elasticsearch.ml@8.11.0-SNAPSHOT/org.elasticsearch.xpack.ml.action.TransportGetDeploymentStatsAction.addFailedRoutes(TransportGetDeploymentStatsAction.java:235)
	at org.elasticsearch.ml@8.11.0-SNAPSHOT/org.elasticsearch.xpack.ml.action.TransportGetDeploymentStatsAction.lambda$doExecute$4(TransportGetDeploymentStatsAction.java:141)

```

