### PR TITLE
Load the slowLogFieldProviders at construction time

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -263,6 +263,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator;
     private final MapperMetrics mapperMetrics;
     private final PostRecoveryMerger postRecoveryMerger;
+    private final List<? extends SlowLogFieldProvider> slowLogFieldProviders;
 
     @Override
     protected void doStart() {
@@ -381,6 +382,8 @@ public class IndicesService extends AbstractLifecycleComponent
         this.timestampFieldMapperService = new TimestampFieldMapperService(settings, threadPool, this);
 
         this.postRecoveryMerger = new PostRecoveryMerger(settings, threadPool.executor(ThreadPool.Names.FORCE_MERGE), this::getShardOrNull);
+
+        this.slowLogFieldProviders = pluginsService.loadServiceProviders(SlowLogFieldProvider.class);
     }
 
     private static final String DANGLING_INDICES_UPDATE_THREAD_NAME = "DanglingIndices#updateTask";
@@ -1438,7 +1441,6 @@ public class IndicesService extends AbstractLifecycleComponent
 
     // pkg-private for testing
     SlowLogFieldProvider loadSlowLogFieldProvider() {
-        List<? extends SlowLogFieldProvider> slowLogFieldProviders = pluginsService.loadServiceProviders(SlowLogFieldProvider.class);
         return new SlowLogFieldProvider() {
             @Override
             public void init(IndexSettings indexSettings) {


### PR DESCRIPTION
Follow up to #105621

At least as far as I can tell, this was doing a classpath scan every time we create an index. It seems like doing the scan at construction time and then hanging onto the providers for the rest of time is reasonable, but maybe there's something I don't know (like whether more of these providers can be added at runtime?).

I just happened to notice this in a flamegraph while I was doing other optimization-related things:

![image](https://github.com/user-attachments/assets/c14b8369-ed1a-4862-8e66-7b5074442ba4)


