### PR TITLE
[8.x] Unmute SearchWithMinCompatibleSearchNodeIT tests muted for 7.17 (#115386)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -26,12 +26,6 @@ tests:
 - class: org.elasticsearch.upgrades.SecurityIndexRolesMetadataMigrationIT
   method: testMetadataMigratedAfterUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/110232
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testMinVersionAsNewVersion
-  issue: https://github.com/elastic/elasticsearch/issues/95384
-- class: org.elasticsearch.backwards.SearchWithMinCompatibleSearchNodeIT
-  method: testCcsMinimizeRoundtripsIsFalse
-  issue: https://github.com/elastic/elasticsearch/issues/101974
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Unmute SearchWithMinCompatibleSearchNodeIT tests muted for 7.17 (#115386)](https://github.com/elastic/elasticsearch/pull/115386)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)