### PR TITLE
Fix `FileSettingsRoleMappingUpgradeIT` assertions

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
@@ -25,12 +25,10 @@ import org.junit.rules.TestRule;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -104,15 +102,17 @@ public class FileSettingsRoleMappingUpgradeIT extends ParameterizedRollingUpgrad
             // the nodes have all been upgraded. Check they re-processed the role mappings in the settings file on
             // upgrade
             Request clusterStateRequest = new Request("GET", "/_cluster/state/metadata");
-            List<Object> roleMappings = new XContentTestUtils.JsonMapView(entityAsMap(client().performRequest(clusterStateRequest))).get(
-                "metadata.role_mappings.role_mappings"
+            List<Object> clusterStateRoleMappings = new XContentTestUtils.JsonMapView(
+                entityAsMap(client().performRequest(clusterStateRequest))
+            ).get("metadata.role_mappings.role_mappings");
+            assertThat(clusterStateRoleMappings, is(not(nullValue())));
+            assertThat(clusterStateRoleMappings.size(), equalTo(1));
+
+            assertThat(
+                entityAsMap(client().performRequest(new Request("GET", "/_security/role_mapping"))).keySet(),
+                // TODO remove `everyone_kibana` once the clean up migration is in
+                containsInAnyOrder("everyone_kibana", "everyone_kibana-read-only-operator-mapping")
             );
-            assertThat(roleMappings, is(not(nullValue())));
-            assertThat(roleMappings.size(), equalTo(1));
-            assertThat(roleMappings, is(instanceOf(Map.class)));
-            @SuppressWarnings("unchecked")
-            Map<String, Object> roleMapping = (Map<String, Object>) roleMappings;
-            assertThat(roleMapping.keySet(), contains("everyone_kibana-read-only-operator-mapping"));
         }
     }
 }

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FileSettingsRoleMappingUpgradeIT.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -110,8 +110,8 @@ public class FileSettingsRoleMappingUpgradeIT extends ParameterizedRollingUpgrad
 
             assertThat(
                 entityAsMap(client().performRequest(new Request("GET", "/_security/role_mapping"))).keySet(),
-                // TODO remove `everyone_kibana` once the clean up migration is in
-                containsInAnyOrder("everyone_kibana", "everyone_kibana-read-only-operator-mapping")
+                // TODO change this to `contains` once the clean-up migration work is merged
+                hasItem("everyone_kibana-read-only-operator-mapping")
             );
         }
     }


### PR DESCRIPTION
Fixes some faulty assertions in an upgrade test. Test failures only manifest on the 8.16 branch since 9.x does not qualify for these upgrade tests, and the change is not backported to 8.17 yet (unrelated CI failures).

I validated this works by running it locally from the 8.16 branch.

Resolves: https://github.com/elastic/elasticsearch/issues/115410
Resolves: https://github.com/elastic/elasticsearch/issues/115411