### PR TITLE
Refactor PipelineConfiguration#getVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -99,18 +99,13 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
     }
 
     public Integer getVersion() {
-        var configMap = getConfigAsMap();
-        if (configMap.containsKey("version")) {
-            Object o = configMap.get("version");
-            if (o == null) {
-                return null;
-            } else if (o instanceof Number number) {
-                return number.intValue();
-            } else {
-                throw new IllegalStateException("unexpected version type [" + o.getClass().getName() + "]");
-            }
-        } else {
+        Object o = getConfigAsMap().get("version");
+        if (o == null) {
             return null;
+        } else if (o instanceof Number number) {
+            return number.intValue();
+        } else {
+            throw new IllegalStateException("unexpected version type [" + o.getClass().getName() + "]");
         }
     }
 


### PR DESCRIPTION
There's no benefit in calling `containsKey` and then `get` -- we can just call `get` and eat the `null` value. Since this code handles the absence of a key and the presence of a `null` value in the exact same way, it's less code to just collapse the two paths together. It's also imperceptibly faster, but that doesn't really matter.