### PR TITLE
Add SSL configuration for Elastic Inference Service

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -238,6 +238,12 @@ public class XPackSettings {
         (s) -> Hasher.PBKDF2_STRETCH.name()
     );
 
+    public static final Setting<Boolean> EIS_SSL_ENABLED = Setting.boolSetting(
+        "xpack.security.eis.ssl.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
+
     /*
      * Do not allow insecure hashing algorithms to be used for password hashing
      */
@@ -272,6 +278,10 @@ public class XPackSettings {
     // http specific settings
     public static final String HTTP_SSL_PREFIX = SecurityField.setting("http.ssl.");
     private static final SSLConfigurationSettings HTTP_SSL = SSLConfigurationSettings.withPrefix(HTTP_SSL_PREFIX, true);
+
+    public static final String EIS_SSL_PREFIX = SecurityField.setting("eis.ssl.");
+
+    private static final SSLConfigurationSettings EIS_SSL = SSLConfigurationSettings.withPrefix(EIS_SSL_PREFIX, true);
 
     // transport specific settings
     public static final String TRANSPORT_SSL_PREFIX = SecurityField.setting("transport.ssl.");
@@ -312,6 +322,7 @@ public class XPackSettings {
         settings.addAll(TRANSPORT_SSL.getEnabledSettings());
         settings.addAll(REMOTE_CLUSTER_SERVER_SSL.getEnabledSettings());
         settings.addAll(REMOTE_CLUSTER_CLIENT_SSL.getEnabledSettings());
+        settings.addAll(EIS_SSL.getEnabledSettings());
         settings.add(SECURITY_ENABLED);
         settings.add(GRAPH_ENABLED);
         settings.add(MACHINE_LEARNING_ENABLED);
@@ -335,6 +346,7 @@ public class XPackSettings {
         settings.add(DOMAIN_TO_REALM_ASSOC_SETTING);
         settings.add(DOMAIN_UID_LITERAL_USERNAME_SETTING);
         settings.add(DOMAIN_UID_SUFFIX_SETTING);
+        settings.add(EIS_SSL_ENABLED);
         return Collections.unmodifiableList(settings);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -239,7 +239,7 @@ public class XPackSettings {
     );
 
     public static final Setting<Boolean> EIS_SSL_ENABLED = Setting.boolSetting(
-        "xpack.security.eis.ssl.enabled",
+        "xpack.security.inference.elastic.ssl.enabled",
         true,
         Setting.Property.NodeScope
     );
@@ -279,7 +279,7 @@ public class XPackSettings {
     public static final String HTTP_SSL_PREFIX = SecurityField.setting("http.ssl.");
     private static final SSLConfigurationSettings HTTP_SSL = SSLConfigurationSettings.withPrefix(HTTP_SSL_PREFIX, true);
 
-    public static final String EIS_SSL_PREFIX = SecurityField.setting("eis.ssl.");
+    public static final String EIS_SSL_PREFIX = SecurityField.setting("inference.elastic.ssl.");
 
     private static final SSLConfigurationSettings EIS_SSL = SSLConfigurationSettings.withPrefix(EIS_SSL_PREFIX, true);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -240,7 +240,7 @@ public class XPackSettings {
 
     public static final Setting<Boolean> EIS_SSL_ENABLED = Setting.boolSetting(
         "xpack.security.eis.ssl.enabled",
-        false,
+        true,
         Setting.Property.NodeScope
     );
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -202,17 +202,33 @@ public class XPackSettingsTests extends ESTestCase {
             .filter(key -> key.startsWith("xpack.security.inference.elastic.ssl"))
             .toList();
 
-        // None of them allow insecure password
+        // Check if all options are available
         List.of(
-            "xpack.security.inference.elastic.ssl.keystore.password",
-            "xpack.security.inference.elastic.ssl.keystore.key_password",
-            "xpack.security.inference.elastic.ssl.key_passphrase",
+            "xpack.security.inference.elastic.ssl.cipher_suites",
+            "xpack.security.inference.elastic.ssl.supported_protocols",
+            "xpack.security.inference.elastic.ssl.truststore.path",
+            "xpack.security.inference.elastic.ssl.truststore.secure_password",
+            "xpack.security.inference.elastic.ssl.truststore.algorithm",
+            "xpack.security.inference.elastic.ssl.truststore.type",
+            "xpack.security.inference.elastic.ssl.trust_restrictions.path",
+            "xpack.security.inference.elastic.ssl.trust_restrictions.x509_fields",
+            "xpack.security.inference.elastic.ssl.certificate_authorities",
+            "xpack.security.inference.elastic.ssl.client_authentication",
+            "xpack.security.inference.elastic.ssl.verification_mode",
             "xpack.security.inference.elastic.ssl.truststore.password",
+            "xpack.security.inference.elastic.ssl.keystore.path",
+            "xpack.security.inference.elastic.ssl.keystore.secure_password",
+            "xpack.security.inference.elastic.ssl.keystore.algorithm",
+            "xpack.security.inference.elastic.ssl.keystore.type",
+            "xpack.security.inference.elastic.ssl.keystore.secure_key_password",
+            "xpack.security.inference.elastic.ssl.key",
+            "xpack.security.inference.elastic.ssl.secure_key_passphrase",
+            "xpack.security.inference.elastic.ssl.certificate",
             "xpack.security.inference.elastic.ssl.keystore.password",
             "xpack.security.inference.elastic.ssl.keystore.key_password",
             "xpack.security.inference.elastic.ssl.key_passphrase",
-            "xpack.security.inference.elastic.ssl.truststore.password"
-        ).forEach(key -> assertThat(eisSslSettingKeys, not(hasItem(key))));
+            "xpack.security.inference.elastic.ssl.enabled"
+        ).forEach(key -> assertThat(eisSslSettingKeys, hasItem(key)));
     }
 
     private boolean isSecretkeyFactoryAlgoAvailable(String algorithmId) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -188,6 +188,33 @@ public class XPackSettingsTests extends ESTestCase {
         );
     }
 
+    public void testSecurityMustBeEnabledByDefaultForEis() {
+        final Settings.Builder builder = Settings.builder();
+
+        assertThat(XPackSettings.EIS_SSL_ENABLED.get(builder.build()), is(true));
+    }
+
+    public void testEisSslSettings() {
+        final List<Setting<?>> allSettings = XPackSettings.getAllSettings();
+
+        final List<String> eisSslSettingKeys = allSettings.stream()
+            .map(Setting::getKey)
+            .filter(key -> key.startsWith("xpack.security.eis.ssl"))
+            .toList();
+
+        // None of them allow insecure password
+        List.of(
+            "xpack.security.eis.ssl.keystore.password",
+            "xpack.security.eis.ssl.keystore.key_password",
+            "xpack.security.eis.ssl.key_passphrase",
+            "xpack.security.eis.ssl.truststore.password",
+            "xpack.security.eis.ssl.keystore.password",
+            "xpack.security.eis.ssl.keystore.key_password",
+            "xpack.security.eis.ssl.key_passphrase",
+            "xpack.security.eis.ssl.truststore.password"
+        ).forEach(key -> assertThat(eisSslSettingKeys, not(hasItem(key))));
+    }
+
     private boolean isSecretkeyFactoryAlgoAvailable(String algorithmId) {
         try {
             SecretKeyFactory.getInstance(algorithmId);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -199,19 +199,19 @@ public class XPackSettingsTests extends ESTestCase {
 
         final List<String> eisSslSettingKeys = allSettings.stream()
             .map(Setting::getKey)
-            .filter(key -> key.startsWith("xpack.security.eis.ssl"))
+            .filter(key -> key.startsWith("xpack.security.inference.elastic.ssl"))
             .toList();
 
         // None of them allow insecure password
         List.of(
-            "xpack.security.eis.ssl.keystore.password",
-            "xpack.security.eis.ssl.keystore.key_password",
-            "xpack.security.eis.ssl.key_passphrase",
-            "xpack.security.eis.ssl.truststore.password",
-            "xpack.security.eis.ssl.keystore.password",
-            "xpack.security.eis.ssl.keystore.key_password",
-            "xpack.security.eis.ssl.key_passphrase",
-            "xpack.security.eis.ssl.truststore.password"
+            "xpack.security.inference.elastic.ssl.keystore.password",
+            "xpack.security.inference.elastic.ssl.keystore.key_password",
+            "xpack.security.inference.elastic.ssl.key_passphrase",
+            "xpack.security.inference.elastic.ssl.truststore.password",
+            "xpack.security.inference.elastic.ssl.keystore.password",
+            "xpack.security.inference.elastic.ssl.keystore.key_password",
+            "xpack.security.inference.elastic.ssl.key_passphrase",
+            "xpack.security.inference.elastic.ssl.truststore.password"
         ).forEach(key -> assertThat(eisSslSettingKeys, not(hasItem(key))));
     }
 


### PR DESCRIPTION
This PR adds an SSL-related configuration for Elastic Inference Service. 

These configuration options will be used in a follow-up pull request. 

The following options will be supported: 

```
"xpack.security.inference.elastic.ssl.cipher_suites",
"xpack.security.inference.elastic.ssl.supported_protocols",
"xpack.security.inference.elastic.ssl.truststore.path",
"xpack.security.inference.elastic.ssl.truststore.secure_password",
"xpack.security.inference.elastic.ssl.truststore.algorithm",
"xpack.security.inference.elastic.ssl.truststore.type",
"xpack.security.inference.elastic.ssl.trust_restrictions.path",
"xpack.security.inference.elastic.ssl.trust_restrictions.x509_fields",
"xpack.security.inference.elastic.ssl.certificate_authorities",
"xpack.security.inference.elastic.ssl.client_authentication",
"xpack.security.inference.elastic.ssl.verification_mode",
"xpack.security.inference.elastic.ssl.truststore.password",
"xpack.security.inference.elastic.ssl.keystore.path",
"xpack.security.inference.elastic.ssl.keystore.secure_password",
"xpack.security.inference.elastic.ssl.keystore.algorithm",
"xpack.security.inference.elastic.ssl.keystore.type",
"xpack.security.inference.elastic.ssl.keystore.secure_key_password",
"xpack.security.inference.elastic.ssl.key",
"xpack.security.inference.elastic.ssl.secure_key_passphrase",
"xpack.security.inference.elastic.ssl.certificate",
"xpack.security.inference.elastic.ssl.keystore.password",
"xpack.security.inference.elastic.ssl.keystore.key_password",
"xpack.security.inference.elastic.ssl.key_passphrase",
"xpack.security.inference.elastic.ssl.enabled"
```