### PR TITLE
[ML] Prevent NPE if model assignment is removed while waiting to start

### DIFF
--- a/docs/changelog/115430.yaml
+++ b/docs/changelog/115430.yaml
@@ -1,0 +1,5 @@
+pr: 115430
+summary: Prevent NPE if model assignment is removed while waiting to start
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -671,7 +671,11 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 deploymentId
             ).orElse(null);
             if (trainedModelAssignment == null) {
-                // Something weird happened, it should NEVER be null...
+                // The assignment may be null if it was stopped by another action while waiting
+                this.exception = new ElasticsearchStatusException(
+                    "Error waiting for the model deployment to start. The trained model assignment was removed while waiting",
+                    RestStatus.BAD_REQUEST
+                );
                 logger.trace(() -> format("[%s] assignment was null while waiting for state [%s]", deploymentId, waitForState));
                 return true;
             }


### PR DESCRIPTION
The error was seen the stack trace below from a CI test. The test timed out as the model was starting then went into post test clean up which deleted all the model assignments while the start deployment action was waiting for the deployment to start. The `DeploymentStartedPredicate` predicate code did not expect this could happen and didn't handle the case beyond logging the unexpected. The solution here is record the event with an exception. 

Here we see the model start up immediately follow by the test clean up `feature reset`
```
[2024-10-23T02:38:14,940][INFO ][o.e.x.m.i.d.DeploymentManager] [test-cluster-0] [.multi-e5-small] Starting model deployment of model [.multilingual-e5-small_linux-x86_64]
[2024-10-23T02:38:28,257][INFO ][o.e.x.m.MachineLearning  ] [test-cluster-0] Starting machine learning feature reset
```

Stack trace
```
[2024-10-23T02:38:28,666][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [test-cluster-0] fatal error in thread [elasticsearch[test-cluster-0][clusterApplierService#updateTask][T#1]], exiting
java.lang.AssertionError: java.lang.IllegalStateException: unexpected exception processing cluster state version [62] in context [ClusterStateObserver[null]]
	at org.elasticsearch.cluster.ClusterStateObserver$ObserverClusterStateListener.logUnexpectedException(ClusterStateObserver.java:325) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.ClusterStateObserver$ObserverClusterStateListener.clusterChanged(ClusterStateObserver.java:229) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListener(ClusterApplierService.java:565) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListeners(ClusterApplierService.java:552) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:510) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:432) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:157) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:956) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:218) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:184) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.lang.Thread.run(Thread.java:1570) ~[?:?]
Caused by: java.lang.IllegalStateException: unexpected exception processing cluster state version [62] in context [ClusterStateObserver[null]]
	at org.elasticsearch.cluster.ClusterStateObserver$ObserverClusterStateListener.logUnexpectedException(ClusterStateObserver.java:317) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	... 12 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignment.getDeploymentId()" because "assignment" is null
	at org.elasticsearch.xpack.ml.action.TransportStartTrainedModelDeploymentAction$1.onResponse(TransportStartTrainedModelDeploymentAction.java:340) ~[?:?]
	at org.elasticsearch.xpack.ml.action.TransportStartTrainedModelDeploymentAction$1.onResponse(TransportStartTrainedModelDeploymentAction.java:334) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentService$1.onNewClusterState(TrainedModelAssignmentService.java:106) ~[?:?]
	at org.elasticsearch.cluster.ClusterStateObserver$ContextPreservingListener.onNewClusterState(ClusterStateObserver.java:376) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	at org.elasticsearch.cluster.ClusterStateObserver$ObserverClusterStateListener.clusterChanged(ClusterStateObserver.java:227) ~[elasticsearch-9.0.0-SNAPSHOT.jar:?]
	... 11 more
```