### PR TITLE
ESQL: Fix test muting

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -375,9 +375,6 @@ tests:
 - class: org.elasticsearch.xpack.enrich.EnrichIT
   method: testEnrichSpecialTypes
   issue: https://github.com/elastic/elasticsearch/issues/114773
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {string.ReverseGraphemeClusters}
-  issue: https://github.com/elastic/elasticsearch/issues/114560
 - class: org.elasticsearch.license.LicensingTests
   issue: https://github.com/elastic/elasticsearch/issues/114865
 - class: org.elasticsearch.xpack.enrich.EnrichIT

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -36,7 +36,7 @@ public class EsqlCapabilities {
          * Support for reversing whole grapheme clusters. This is not supported
          * on JDK versions less than 20.
          */
-        FN_REVERSE_GRAPHEME_CLUSTERS(Runtime.version().feature() < 20),
+        FN_REVERSE_GRAPHEME_CLUSTERS(Runtime.version().feature() >= 20),
 
         /**
          * Support for function {@code CBRT}. Done in #108574.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -259,6 +259,10 @@ public class CsvTests extends ESTestCase {
                     testCase.requiredCapabilities,
                     everyItem(in(EsqlCapabilities.capabilities(true)))
                 );
+                assumeTrue(
+                    "Capability is not included in the enabled list capabilities on a snapshot build. Spelling mistake?",
+                    EsqlCapabilities.capabilities(false).containsAll(testCase.requiredCapabilities)
+                );
             } else {
                 for (EsqlCapabilities.Cap c : EsqlCapabilities.Cap.values()) {
                     if (false == c.isEnabled()) {


### PR DESCRIPTION
Fix the test muting on the test for grapheme clusters - it should only allow the test if we're on the 20+ jvm.

Closes #114536
