### PR TITLE
[8.16] Close exchanges in HttpClientTests

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
@@ -47,6 +47,7 @@ public class HttpClientTests extends ESTestCase {
         server.createContext("/404/", exchange -> {
             try {
                 exchange.sendResponseHeaders(404, 0);
+                exchange.close();
             } catch (Exception e) {
                 fail(e);
             }
@@ -102,6 +103,7 @@ public class HttpClientTests extends ESTestCase {
                     exchange.getResponseHeaders().add("Location", "/" + destination + "/");
                 }
                 exchange.sendResponseHeaders(302, 0);
+                exchange.close();
             } catch (Exception e) {
                 fail(e);
             }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -388,8 +388,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/114839
 - class: org.elasticsearch.xpack.security.authc.ldap.GroupMappingIT
   issue: https://github.com/elastic/elasticsearch/issues/115221
-- class: org.elasticsearch.ingest.geoip.HttpClientTests
-  issue: https://github.com/elastic/elasticsearch/issues/115169
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/115059, closes https://github.com/elastic/elasticsearch/issues/115169.