### PR TITLE
Guard blob store local directory creation with doPrivileged

### DIFF
--- a/docs/changelog/115459.yaml
+++ b/docs/changelog/115459.yaml
@@ -1,0 +1,5 @@
+pr: 115459
+summary: Guard blob store local directory creation with `doPrivileged`
+area: Infra/Core
+type: bug
+issues: []


### PR DESCRIPTION
The blob store may be triggered to create a local directory while in a reduced privilege context. This commit guards the creation of directories with doPrivileged.