### PR TITLE
[8.15] Close exchanges in HttpClientTests

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
@@ -46,6 +46,7 @@ public class HttpClientTests extends ESTestCase {
         server.createContext("/404/", exchange -> {
             try {
                 exchange.sendResponseHeaders(404, 0);
+                exchange.close();
             } catch (Exception e) {
                 fail(e);
             }
@@ -101,6 +102,7 @@ public class HttpClientTests extends ESTestCase {
                     exchange.getResponseHeaders().add("Location", "/" + destination + "/");
                 }
                 exchange.sendResponseHeaders(302, 0);
+                exchange.close();
             } catch (Exception e) {
                 fail(e);
             }


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/115059, closes https://github.com/elastic/elasticsearch/issues/115169.