### PR TITLE
[8.x] Use settings from LogsdbIndexModeSettingsProvider in SyntheticSourceIndexSettingsProvider (#115437)

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -52,7 +52,7 @@ public class LogsDBPlugin extends Plugin {
             return List.of(logsdbIndexModeSettingsProvider);
         }
         return List.of(
-            new SyntheticSourceIndexSettingsProvider(licenseService, parameters.mapperServiceFactory()),
+            new SyntheticSourceIndexSettingsProvider(licenseService, parameters.mapperServiceFactory(), logsdbIndexModeSettingsProvider),
             logsdbIndexModeSettingsProvider
         );
     }

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java
@@ -48,19 +48,16 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
         final Settings settings,
         final List<CompressedXContent> combinedTemplateMappings
     ) {
-        if (isLogsdbEnabled == false || dataStreamName == null) {
-            return Settings.EMPTY;
-        }
+        return getLogsdbModeSetting(dataStreamName, settings);
+    }
 
-        final IndexMode indexMode = resolveIndexMode(settings.get(IndexSettings.MODE.getKey()));
-        if (indexMode != null) {
-            return Settings.EMPTY;
-        }
-
-        if (matchesLogsPattern(dataStreamName)) {
+    Settings getLogsdbModeSetting(final String dataStreamName, final Settings settings) {
+        if (isLogsdbEnabled
+            && dataStreamName != null
+            && resolveIndexMode(settings.get(IndexSettings.MODE.getKey())) == null
+            && matchesLogsPattern(dataStreamName)) {
             return Settings.builder().put("index.mode", IndexMode.LOGSDB.getName()).build();
         }
-
         return Settings.EMPTY;
     }
 
@@ -71,5 +68,4 @@ final class LogsdbIndexModeSettingsProvider implements IndexSettingProvider {
     private IndexMode resolveIndexMode(final String mode) {
         return mode != null ? Enum.valueOf(IndexMode.class, mode.toUpperCase(Locale.ROOT)) : null;
     }
-
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use settings from LogsdbIndexModeSettingsProvider in SyntheticSourceIndexSettingsProvider (#115437)](https://github.com/elastic/elasticsearch/pull/115437)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)