### PR TITLE
[8.16] Reorder docs sidebar (#115360)

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -6,7 +6,7 @@ include::links.asciidoc[]
 
 include::landing-page.asciidoc[]
 
-include::release-notes/highlights.asciidoc[]
+// overview / install
 
 include::intro.asciidoc[]
 
@@ -14,33 +14,37 @@ include::quickstart/index.asciidoc[]
 
 include::setup.asciidoc[]
 
-include::upgrade.asciidoc[]
-
-include::index-modules.asciidoc[]
-
-include::mapping.asciidoc[]
-
-include::analysis.asciidoc[]
-
-include::indices/index-templates.asciidoc[]
-
-include::data-streams/data-streams.asciidoc[]
-
-include::ingest.asciidoc[]
-
-include::alias.asciidoc[]
+// search solution
 
 include::search/search-your-data/search-your-data.asciidoc[]
 
 include::reranking/index.asciidoc[]
 
-include::query-dsl.asciidoc[]
+// data management
 
-include::aggregations.asciidoc[]
+include::index-modules.asciidoc[]
 
-include::geospatial-analysis.asciidoc[]
+include::indices/index-templates.asciidoc[]
+
+include::alias.asciidoc[]
+
+include::mapping.asciidoc[]
+
+include::analysis.asciidoc[]
+
+include::ingest.asciidoc[]
 
 include::connector/docs/index.asciidoc[]
+
+include::data-streams/data-streams.asciidoc[]
+
+include::data-management.asciidoc[]
+
+include::data-rollup-transform.asciidoc[]
+
+// analysis tools
+
+include::query-dsl.asciidoc[]
 
 include::eql/eql.asciidoc[]
 
@@ -50,34 +54,48 @@ include::sql/index.asciidoc[]
 
 include::scripting.asciidoc[]
 
-include::data-management.asciidoc[]
+include::aggregations.asciidoc[]
 
-include::autoscaling/index.asciidoc[]
-
-include::monitoring/index.asciidoc[]
-
-include::data-rollup-transform.asciidoc[]
-
-include::high-availability.asciidoc[]
-
-include::snapshot-restore/index.asciidoc[]
-
-include::security/index.asciidoc[]
+include::geospatial-analysis.asciidoc[]
 
 include::watcher/index.asciidoc[]
 
-include::commands/index.asciidoc[]
+// cluster management
+
+include::monitoring/index.asciidoc[]
+
+include::security/index.asciidoc[]
+
+// production tasks
+
+include::high-availability.asciidoc[]
 
 include::how-to.asciidoc[]
 
-include::troubleshooting.asciidoc[]
+include::autoscaling/index.asciidoc[]
+
+include::snapshot-restore/index.asciidoc[]
+
+// reference
 
 include::rest-api/index.asciidoc[]
 
+include::commands/index.asciidoc[]
+
+include::troubleshooting.asciidoc[]
+
+// upgrades
+
+include::upgrade.asciidoc[]
+
 include::migration/index.asciidoc[]
+
+include::release-notes/highlights.asciidoc[]
 
 include::release-notes.asciidoc[]
 
 include::dependencies-versions.asciidoc[]
+
+// etc
 
 include::redirects.asciidoc[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,5 +1,6 @@
+[chapter]
 [[release-highlights]]
-== What's new in {minor-version}
+= What's new in {minor-version}
 
 coming::[{minor-version}]
 
@@ -34,7 +35,7 @@ endif::[]
 
 [discrete]
 [[esql_inlinestats]]
-=== ESQL: INLINESTATS
+== ESQL: INLINESTATS
 This adds the `INLINESTATS` command to ESQL which performs a STATS and
 then enriches the results into the output stream. So, this query:
 
@@ -59,7 +60,7 @@ Produces output like:
 
 [discrete]
 [[always_allow_rebalancing_by_default]]
-=== Always allow rebalancing by default
+== Always allow rebalancing by default
 In earlier versions of {es} the `cluster.routing.allocation.allow_rebalance` setting defaults to
 `indices_all_active` which blocks all rebalancing moves while the cluster is in `yellow` or `red` health. This was
 appropriate for the legacy allocator which might do too many rebalancing moves otherwise. Today's allocator has
@@ -71,7 +72,7 @@ version 8.16 `allow_rebalance` setting defaults to `always` unless the legacy al
 
 [discrete]
 [[add_global_retention_in_data_stream_lifecycle]]
-=== Add global retention in data stream lifecycle
+== Add global retention in data stream lifecycle
 Data stream lifecycle now supports configuring retention on a cluster level,
 namely global retention. Global retention \nallows us to configure two different
 retentions:
@@ -85,7 +86,7 @@ data stream lifecycle and it allows any data stream \ndata to be deleted after t
 
 [discrete]
 [[enable_zstandard_compression_for_indices_with_index_codec_set_to_best_compression]]
-=== Enable ZStandard compression for indices with index.codec set to best_compression
+== Enable ZStandard compression for indices with index.codec set to best_compression
 Before DEFLATE compression was used to compress stored fields in indices with index.codec index setting set to
 best_compression, with this change ZStandard is used as compression algorithm to stored fields for indices with
 index.codec index setting set to best_compression. The usage ZStandard results in less storage usage with a


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Reorder docs sidebar (#115360)](https://github.com/elastic/elasticsearch/pull/115360)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)