### PR TITLE
[CI] Fix for race condition in interval watcher scheduler tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -258,21 +258,9 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry)}
   issue: https://github.com/elastic/elasticsearch/issues/115231
-- class: org.elasticsearch.xpack.watcher.trigger.schedule.engine.TickerScheduleEngineTests
-  method: testAddWithNoLastCheckedTimeButHasActivationTimeExecutesBeforeInitialInterval
-  issue: https://github.com/elastic/elasticsearch/issues/115339
-- class: org.elasticsearch.xpack.watcher.trigger.schedule.engine.TickerScheduleEngineTests
-  method: testWatchWithLastCheckedTimeExecutesBeforeInitialInterval
-  issue: https://github.com/elastic/elasticsearch/issues/115354
-- class: org.elasticsearch.xpack.watcher.trigger.schedule.engine.TickerScheduleEngineTests
-  method: testAddWithLastCheckedTimeExecutesBeforeInitialInterval
-  issue: https://github.com/elastic/elasticsearch/issues/115356
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testInferDeploysDefaultE5
   issue: https://github.com/elastic/elasticsearch/issues/115361
-- class: org.elasticsearch.xpack.watcher.trigger.schedule.engine.TickerScheduleEngineTests
-  method: testWatchWithNoLastCheckedTimeButHasActivationTimeExecutesBeforeInitialInterval
-  issue: https://github.com/elastic/elasticsearch/issues/115368
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleEngineTests.java
@@ -312,14 +312,13 @@ public class TickerScheduleEngineTests extends ESTestCase {
 
         engine.register(events -> {
             for (TriggerEvent ignored : events) {
-                if (runCount.get() == 0) {
+                if (runCount.getAndIncrement() == 0) {
                     logger.info("job first fire");
                     firstLatch.countDown();
                 } else {
                     logger.info("job second fire");
                     secondLatch.countDown();
                 }
-                runCount.incrementAndGet();
             }
         });
 
@@ -375,14 +374,13 @@ public class TickerScheduleEngineTests extends ESTestCase {
 
         engine.register(events -> {
             for (TriggerEvent ignored : events) {
-                if (runCount.get() == 0) {
+                if (runCount.getAndIncrement() == 0) {
                     logger.info("job first fire");
                     firstLatch.countDown();
                 } else {
                     logger.info("job second fire");
                     secondLatch.countDown();
                 }
-                runCount.incrementAndGet();
             }
         });
 
@@ -428,14 +426,13 @@ public class TickerScheduleEngineTests extends ESTestCase {
 
         engine.register(events -> {
             for (TriggerEvent ignored : events) {
-                if (runCount.get() == 0) {
+                if (runCount.getAndIncrement() == 0) {
                     logger.info("job first fire");
                     firstLatch.countDown();
                 } else {
                     logger.info("job second fire");
                     secondLatch.countDown();
                 }
-                runCount.incrementAndGet();
             }
         });
 
@@ -492,14 +489,13 @@ public class TickerScheduleEngineTests extends ESTestCase {
 
         engine.register(events -> {
             for (TriggerEvent ignored : events) {
-                if (runCount.get() == 0) {
+                if (runCount.getAndIncrement() == 0) {
                     logger.info("job first fire");
                     firstLatch.countDown();
                 } else {
                     logger.info("job second fire");
                     secondLatch.countDown();
                 }
-                runCount.incrementAndGet();
             }
         });
 


### PR DESCRIPTION
Fixes #115339, #115354, #115356 and #115368

This PR fixes a race condition in the new tests for the updated watcher interval scheduler. Previously it was possible for the assertion to be evaluated before the watch thread had incremented the run counter.