### PR TITLE
[ML] Set max allocations to 32 in default configs

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -859,7 +859,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 null,
                 1,
                 useLinuxOptimizedModel ? ELSER_V2_MODEL_LINUX_X86 : ELSER_V2_MODEL,
-                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 8)
+                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
             ),
             ElserMlNodeTaskSettings.DEFAULT,
             null // default chunking settings
@@ -872,7 +872,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 null,
                 1,
                 useLinuxOptimizedModel ? MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86 : MULTILINGUAL_E5_SMALL_MODEL_ID,
-                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 8)
+                new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
             ),
             null // default chunking settings
         );


### PR DESCRIPTION
The reason for 32 instead of unlimited is because it is easier to raise a limit than reduce one. 32 allocations is the practical limits in some environments. 