### PR TITLE
[8.13] Update 8.12.0.asciidoc (#115303)

### DIFF
--- a/docs/reference/release-notes/8.12.0.asciidoc
+++ b/docs/reference/release-notes/8.12.0.asciidoc
@@ -11,7 +11,7 @@ Also see <<breaking-changes-8.12,Breaking changes in 8.12>>.
 +
 When using `int8_hnsw` and the default `confidence_interval` (or any `confidence_interval` less than `1.0`) and when
 there are deleted documents in the segments, quantiles may fail to build and prevent merging.
-
++
 This issue is fixed in 8.12.1.
 
 * When upgrading clusters from version 8.11.4 or earlier, if your cluster contains non-master-eligible nodes,


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.15` to `8.13`:
 - [Update 8.12.0.asciidoc (#115303)](https://github.com/elastic/elasticsearch/pull/115303)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)