### PR TITLE
[8.15] (Doc+) link video for resolving max shards open (#115480)

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -569,6 +569,8 @@ PUT _cluster/settings
 }
 ----
 
+See this https://www.youtube.com/watch?v=tZKbDegt4-M[fixing "max shards open" video] for an example troubleshooting walkthrough. For more information, see <<troubleshooting-shards-capacity-issues,Troubleshooting shards capacity>>.
+
 [discrete]
 [[troubleshooting-max-docs-limit]]
 ==== Number of documents in the shard cannot exceed [2147483519]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [(Doc+) link video for resolving max shards open (#115480)](https://github.com/elastic/elasticsearch/pull/115480)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)