### PR TITLE
[8.x] [otel-data] Add more kubernetes aliases (#115429)

### DIFF
--- a/docs/changelog/115429.yaml
+++ b/docs/changelog/115429.yaml
@@ -1,0 +1,5 @@
+pr: 115429
+summary: "[otel-data] Add more kubernetes aliases"
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
@@ -56,19 +56,43 @@ template:
               os.version:
                 type: keyword
                 ignore_above: 1024
+              k8s.container.name:
+                type: keyword
+                ignore_above: 1024
+              k8s.cronjob.name:
+                type: keyword
+                ignore_above: 1024
+              k8s.daemonset.name:
+                type: keyword
+                ignore_above: 1024
               k8s.deployment.name:
+                type: keyword
+                ignore_above: 1024
+              k8s.job.name:
                 type: keyword
                 ignore_above: 1024
               k8s.namespace.name:
                 type: keyword
                 ignore_above: 1024
+              k8s.node.hostname:
+                type: keyword
+                ignore_above: 1024
               k8s.node.name:
+                type: keyword
+                ignore_above: 1024
+              k8s.node.uid:
                 type: keyword
                 ignore_above: 1024
               k8s.pod.name:
                 type: keyword
                 ignore_above: 1024
               k8s.pod.uid:
+                type: keyword
+                ignore_above: 1024
+              k8s.replicaset.name:
+                type: keyword
+                ignore_above: 1024
+              k8s.statefulset.name:
                 type: keyword
                 ignore_above: 1024
       service.node.name:
@@ -122,6 +146,30 @@ template:
       kubernetes.pod.uid:
         type: alias
         path: resource.attributes.k8s.pod.uid
+      kubernetes.container.name:
+        type: alias
+        path: resource.attributes.k8s.container.name
+      kubernetes.cronjob.name:
+        type: alias
+        path: resource.attributes.k8s.cronjob.name
+      kubernetes.job.name:
+        type: alias
+        path: resource.attributes.k8s.job.name
+      kubernetes.statefulset.name:
+        type: alias
+        path: resource.attributes.k8s.statefulset.name
+      kubernetes.daemonset.name:
+        type: alias
+        path: resource.attributes.k8s.daemonset.name
+      kubernetes.replicaset.name:
+        type: alias
+        path: resource.attributes.k8s.replicaset.name
+      kubernetes.node.uid:
+        type: alias
+        path: resource.attributes.k8s.node.uid
+      kubernetes.node.hostname:
+        type: alias
+        path: resource.attributes.k8s.node.hostname
 # Below are non-ECS fields that may be used by Kibana.
       service.language.name:
         type: alias

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
@@ -187,3 +187,40 @@ host.name pass-through:
   - length: { hits.hits: 1 }
   - match: { hits.hits.0.fields.resource\.attributes\.host\.name: [ "localhost" ] }
   - match: { hits.hits.0.fields.host\.name: [ "localhost" ] }
+---
+"kubernetes.* -> resource.attributes.k8s.* aliases":
+  - do:
+      bulk:
+        index: logs-generic.otel-default
+        refresh: true
+        body:
+          - create: { }
+          - "@timestamp": 2024-07-18T14:48:33.467654000Z
+            data_stream:
+              dataset: generic.otel
+              namespace: default
+            resource:
+              attributes:
+                k8s.container.name: myContainerName
+                k8s.cronjob.name: myCronJobName
+                k8s.job.name: myJobName
+                k8s.statefulset.name: myStatefulsetName
+                k8s.daemonset.name: myDaemonsetName
+                k8s.replicaset.name: myReplicasetName
+                k8s.node.uid: myNodeUid
+                k8s.node.hostname: myNodeHostname
+  - is_false: errors
+  - do:
+      search:
+        index: logs-generic.otel-default
+        body:
+          fields: ["kubernetes.container.name", "kubernetes.cronjob.name", "kubernetes.job.name", "kubernetes.statefulset.name", "kubernetes.daemonset.name", "kubernetes.replicaset.name", "kubernetes.node.uid", "kubernetes.node.hostname" ]
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0.fields.kubernetes\.container\.name : ["myContainerName"] }
+  - match: { hits.hits.0.fields.kubernetes\.cronjob\.name : ["myCronJobName"] }
+  - match: { hits.hits.0.fields.kubernetes\.job\.name : ["myJobName"] }
+  - match: { hits.hits.0.fields.kubernetes\.statefulset\.name : ["myStatefulsetName"] }
+  - match: { hits.hits.0.fields.kubernetes\.daemonset\.name : ["myDaemonsetName"] }
+  - match: { hits.hits.0.fields.kubernetes\.replicaset\.name : ["myReplicasetName"] }
+  - match: { hits.hits.0.fields.kubernetes\.node\.uid : ["myNodeUid"] }
+  - match: { hits.hits.0.fields.kubernetes\.node\.hostname : ["myNodeHostname"] }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[otel-data] Add more kubernetes aliases (#115429)](https://github.com/elastic/elasticsearch/pull/115429)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)