### PR TITLE
[8.x] [ML] Prevent NPE if model assignment is removed while waiting to start (#115430)

### DIFF
--- a/docs/changelog/115430.yaml
+++ b/docs/changelog/115430.yaml
@@ -1,0 +1,5 @@
+pr: 115430
+summary: Prevent NPE if model assignment is removed while waiting to start
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -671,7 +671,11 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 deploymentId
             ).orElse(null);
             if (trainedModelAssignment == null) {
-                // Something weird happened, it should NEVER be null...
+                // The assignment may be null if it was stopped by another action while waiting
+                this.exception = new ElasticsearchStatusException(
+                    "Error waiting for the model deployment to start. The trained model assignment was removed while waiting",
+                    RestStatus.BAD_REQUEST
+                );
                 logger.trace(() -> format("[%s] assignment was null while waiting for state [%s]", deploymentId, waitForState));
                 return true;
             }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Prevent NPE if model assignment is removed while waiting to start (#115430)