### PR TITLE
[8.16] Ignore _field_names warning in testRollupAfterRestart (#115563)

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -468,6 +468,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
             final Request bulkRequest = new Request("POST", "/_bulk");
             bulkRequest.setJsonEntity(bulk.toString());
+            bulkRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(fieldNamesFieldOk()));
             client().performRequest(bulkRequest);
 
             // create the rollup job


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Ignore _field_names warning in testRollupAfterRestart (#115563)](https://github.com/elastic/elasticsearch/pull/115563)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)