### PR TITLE
[8.15] Guard blob store local directory creation with doPrivileged (#115459)

### DIFF
--- a/docs/changelog/115459.yaml
+++ b/docs/changelog/115459.yaml
@@ -1,0 +1,5 @@
+pr: 115459
+summary: Guard blob store local directory creation with `doPrivileged`
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobStore.java
@@ -18,6 +18,8 @@ import org.elasticsearch.core.IOUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.List;
 
@@ -55,11 +57,14 @@ public class FsBlobStore implements BlobStore {
     public BlobContainer blobContainer(BlobPath path) {
         Path f = buildPath(path);
         if (readOnly == false) {
-            try {
-                Files.createDirectories(f);
-            } catch (IOException ex) {
-                throw new ElasticsearchException("failed to create blob container", ex);
-            }
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                try {
+                    Files.createDirectories(f);
+                } catch (IOException ex) {
+                    throw new ElasticsearchException("failed to create blob container", ex);
+                }
+                return null;
+            });
         }
         return new FsBlobContainer(this, path, f);
     }


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Guard blob store local directory creation with doPrivileged (#115459)