### PR TITLE
[8.x] Guard blob store local directory creation with doPrivileged (#115459)

### DIFF
--- a/docs/changelog/115459.yaml
+++ b/docs/changelog/115459.yaml
@@ -1,0 +1,5 @@
+pr: 115459
+summary: Guard blob store local directory creation with `doPrivileged`
+area: Infra/Core
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Guard blob store local directory creation with doPrivileged (#115459)