### PR TITLE
Fixing ingest simulate yaml rest test when global legacy template is present

### DIFF
--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
@@ -1537,6 +1537,8 @@ setup:
   - not_exists: docs.0.doc.error
 
   - do:
+      allowed_warnings:
+        - "index [foo-1] matches multiple legacy templates [global, my-legacy-template], composable templates will only match a single template"
       indices.create:
         index: foo-1
   - match: { acknowledged: true }


### PR DESCRIPTION
Sometimes the test framework adds a global legacy template. When this happens, a test that is using another legacy template to create an index emits a warning since the index matches two legacy templates. This PR allows that warning.