### PR TITLE
Update BlobCacheBufferedIndexInput::readVLong to correctly handle negative long values

### DIFF
--- a/docs/changelog/115594.yaml
+++ b/docs/changelog/115594.yaml
@@ -1,0 +1,6 @@
+pr: 115594
+summary: Update `BlobCacheBufferedIndexInput::readVLong` to correctly handle negative
+  long values
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/BlobCacheBufferedIndexInput.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/BlobCacheBufferedIndexInput.java
@@ -175,7 +175,7 @@ public abstract class BlobCacheBufferedIndexInput extends IndexInput implements 
 
     @Override
     public final long readVLong() throws IOException {
-        if (9 <= buffer.remaining()) {
+        if (10 <= buffer.remaining()) {
             return ByteBufferStreamInput.readVLong(buffer);
         } else {
             return super.readVLong();


### PR DESCRIPTION
Update BlobCacheBufferedIndexInput::readVLong to correctly handle negative long values, which can be 10 bytes long.

I'll add a test for this in a followup PR, just wanna quash the bug quickly.