### PR TITLE
Use jna cleaner thread filter in spawner tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -349,8 +349,6 @@ tests:
 - class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
   method: testEveryActionIsEitherOperatorOnlyOrNonOperator
   issue: https://github.com/elastic/elasticsearch/issues/102992
-- class: org.elasticsearch.bootstrap.SpawnerNoBootstrapTests
-  issue: https://github.com/elastic/elasticsearch/issues/114555
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_int4_flat/Vector similarity with filter only}
   issue: https://github.com/elastic/elasticsearch/issues/115475

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.plugins.PluginTestUtil;
 import org.elasticsearch.test.GraalVMThreadsFilter;
+import org.elasticsearch.test.JnaCleanerThreadsFilter;
 import org.elasticsearch.test.MockLog;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ import static org.hamcrest.Matchers.is;
  * that prevents the Spawner class from doing its job. Also needs to run in a separate JVM to other
  * tests that extend ESTestCase for the same reason.
  */
-@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class, JnaCleanerThreadsFilter.class })
 public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
     private static final String CONTROLLER_SOURCE = """


### PR DESCRIPTION
This commit filters out jna cleaner threads specifically in the spawner tests (which have a different set of filters from ESTestCase because they extend LuceneTestCase).

closes #114555