### PR TITLE
Do not run lookup index YAML with two shards

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/10_basic.yml
@@ -153,7 +153,7 @@
 ---
 "Create lookup index":
   - requires:
-      test_runner_features: [ capabilities ]
+      test_runner_features: [ capabilities, default_shards ]
       capabilities:
         - method: PUT
           path: /{index}
@@ -176,7 +176,7 @@
 ---
 "Create lookup index with one shard":
   - requires:
-      test_runner_features: [ capabilities ]
+      test_runner_features: [ capabilities, default_shards ]
       capabilities:
         - method: PUT
           path: /{index}


### PR DESCRIPTION
We can randomly inject a global template that defaults to 2 shards instead of 1. This causes the lookup index YAML tests to fail. To avoid this, the change requires specifying the default_shards setting for these tests.