### PR TITLE
[8.x] Lazy initialize HttpRouteStatsTracker in MethodHandlers (#114107)

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/HttpRouteStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRouteStats.java
@@ -49,6 +49,8 @@ public record HttpRouteStats(
     long[] responseTimeHistogram
 ) implements Writeable, ToXContentObject {
 
+    public static final HttpRouteStats EMPTY = new HttpRouteStats(0, 0, new long[0], 0, 0, new long[0], new long[0]);
+
     public HttpRouteStats(StreamInput in) throws IOException {
         this(in.readVLong(), in.readVLong(), in.readVLongArray(), in.readVLong(), in.readVLong(), in.readVLongArray(), in.readVLongArray());
     }

--- a/server/src/main/java/org/elasticsearch/rest/MethodHandlers.java
+++ b/server/src/main/java/org/elasticsearch/rest/MethodHandlers.java
@@ -13,6 +13,8 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.http.HttpRouteStats;
 import org.elasticsearch.http.HttpRouteStatsTracker;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
@@ -25,7 +27,18 @@ final class MethodHandlers {
     private final String path;
     private final Map<RestRequest.Method, Map<RestApiVersion, RestHandler>> methodHandlers;
 
-    private final HttpRouteStatsTracker statsTracker = new HttpRouteStatsTracker();
+    @SuppressWarnings("unused") // only accessed via #STATS_TRACKER_HANDLE, lazy initialized because instances consume non-trivial heap
+    private volatile HttpRouteStatsTracker statsTracker;
+
+    private static final VarHandle STATS_TRACKER_HANDLE;
+
+    static {
+        try {
+            STATS_TRACKER_HANDLE = MethodHandles.lookup().findVarHandle(MethodHandlers.class, "statsTracker", HttpRouteStatsTracker.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     MethodHandlers(String path) {
         this.path = path;
@@ -73,19 +86,26 @@ final class MethodHandlers {
         return methodHandlers.keySet();
     }
 
-    public void addRequestStats(int contentLength) {
-        statsTracker.addRequestStats(contentLength);
-    }
-
-    public void addResponseStats(long contentLength) {
-        statsTracker.addResponseStats(contentLength);
-    }
-
-    public void addResponseTime(long timeMillis) {
-        statsTracker.addResponseTime(timeMillis);
-    }
-
     public HttpRouteStats getStats() {
-        return statsTracker.getStats();
+        var tracker = existingStatsTracker();
+        if (tracker == null) {
+            return HttpRouteStats.EMPTY;
+        }
+        return tracker.getStats();
+    }
+
+    public HttpRouteStatsTracker statsTracker() {
+        var tracker = existingStatsTracker();
+        if (tracker == null) {
+            var newTracker = new HttpRouteStatsTracker();
+            if ((tracker = (HttpRouteStatsTracker) STATS_TRACKER_HANDLE.compareAndExchange(this, null, newTracker)) == null) {
+                tracker = newTracker;
+            }
+        }
+        return tracker;
+    }
+
+    private HttpRouteStatsTracker existingStatsTracker() {
+        return (HttpRouteStatsTracker) STATS_TRACKER_HANDLE.getAcquire(this);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Lazy initialize HttpRouteStatsTracker in MethodHandlers (#114107)