### PR TITLE
[8.16] [DOCS] Test trivial commit (#115579)

### DIFF
--- a/docs/reference/search/search-your-data/search-application-overview.asciidoc
+++ b/docs/reference/search/search-your-data/search-application-overview.asciidoc
@@ -74,7 +74,7 @@ To create a new search application in {kib}:
 . Name your search application.
 . Select *Create*.
 
-Your search application should now be available in the list of search applications.
+Your search application should now be available in the list.
 
 //[.screenshot]
 // image::../../images/search-applications/search-applications-create.png[Create search application screen]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.15` to `8.16`:
 - [[DOCS] Test trivial commit (#115579)](https://github.com/elastic/elasticsearch/pull/115579)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)