### PR TITLE
Fixed flaky test after PR that disallows functions to return TEXT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -282,9 +282,6 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/115631
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testMvAppendValidation
-  issue: https://github.com/elastic/elasticsearch/issues/115636
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1879,6 +1880,7 @@ public class AnalyzerTests extends ESTestCase {
         Supplier<Integer> supplier = () -> randomInt(fields.length - 1);
         int first = supplier.get();
         int second = randomValueOtherThan(first, supplier);
+        Function<String, String> noText = (type) -> type.equals("text") ? "keyword" : type;
 
         String signature = "mv_append(" + fields[first][0] + ", " + fields[second][0] + ")";
         verifyUnsupported(
@@ -1886,7 +1888,7 @@ public class AnalyzerTests extends ESTestCase {
             "second argument of ["
                 + signature
                 + "] must be ["
-                + fields[first][1]
+                + noText.apply(fields[first][1])
                 + "], found value ["
                 + fields[second][0]
                 + "] type ["

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1881,6 +1881,10 @@ public class AnalyzerTests extends ESTestCase {
         int first = supplier.get();
         int second = randomValueOtherThan(first, supplier);
         Function<String, String> noText = (type) -> type.equals("text") ? "keyword" : type;
+        assumeTrue(
+            "Ignore tests with TEXT and KEYWORD combinations because they are now valid",
+            noText.apply(fields[first][0]).equals(noText.apply(fields[second][0])) == false
+        );
 
         String signature = "mv_append(" + fields[first][0] + ", " + fields[second][0] + ")";
         verifyUnsupported(


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/114334 disallows functions from returning TEXT, and this affected error messages also. This Analyzer test was flaky because it randomly selected from a list of type combinations, only occasionally hitting the case where it asserted incorrectly on a TEXT error message.

Fixes #115636
