### PR TITLE
[8.x] [DOCS] Fix link syntax in connectors-API-tutorial.asciidoc (#115635)

### DIFF
--- a/docs/reference/connector/docs/connectors-API-tutorial.asciidoc
+++ b/docs/reference/connector/docs/connectors-API-tutorial.asciidoc
@@ -367,7 +367,7 @@ Refer to the individual connectors-references,connector references for these con
 ====
 We're using a self-managed connector in this tutorial.
 To use these APIs with an Elastic managed connector, there's some extra setup for API keys.
-Refer to native-connectors-manage-API-keys for details.
+Refer to <<es-native-connectors-manage-API-keys>> for details.
 ====
 
 We're now ready to sync our PostgreSQL data to {es}.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Fix link syntax in connectors-API-tutorial.asciidoc (#115635)](https://github.com/elastic/elasticsearch/pull/115635)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)