### PR TITLE
Slightly more generous assertions for cartesian centroid tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CentroidCalculatorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CentroidCalculatorTests.java
@@ -428,7 +428,7 @@ public abstract class CentroidCalculatorTests extends ESTestCase {
             // Most data (notably geo data) has values within bounds, and an absolute delta makes more sense.
             double delta = (value > 1e28 || value < -1e28) ? Math.abs(value / 1e6)
                 : (value > 1e20 || value < -1e20) ? Math.abs(value / 1e10)
-                : (value > 1e9 || value < -1e9) ? Math.abs(value / 1e15)
+                : (value > 1e8 || value < -1e8) ? Math.abs(value / 1e15)
                 : DELTA;
             return closeTo(value, delta);
         }


### PR DESCRIPTION
Fixes #107994

Since this test was never muted, it is clear that it hardly ever fails. Backporting is just in case.