### PR TITLE
Use index setting to track migration version index created on

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/CleanupRoleMappingDuplicatesMigrationIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/CleanupRoleMappingDuplicatesMigrationIT.java
@@ -301,20 +301,6 @@ public class CleanupRoleMappingDuplicatesMigrationIT extends SecurityIntegTestCa
         assertAllRoleMappings("everyone_kibana_alone", "everyone_fleet_alone");
     }
 
-    public void testNewIndexSkipMigration() {
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        final String masterNode = internalCluster().getMasterName();
-        ensureGreen();
-        CountDownLatch awaitMigrations = awaitMigrationVersionUpdates(
-            masterNode,
-            SecurityMigrations.CLEANUP_ROLE_MAPPING_DUPLICATES_MIGRATION_VERSION
-        );
-        // Create a native role mapping to create security index and trigger migration
-        createNativeRoleMapping("everyone_kibana_alone");
-        // Make sure no migration ran (set to current version without applying prior migrations)
-        safeAwait(awaitMigrations);
-    }
-
     /**
      * Make sure all versions are applied to cluster state sequentially
      */

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/SecurityMigrationsIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/support/SecurityMigrationsIntegTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.support;
+
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.SecurityIntegTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
+import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
+import static org.elasticsearch.xpack.core.security.action.UpdateIndexMigrationVersionAction.MIGRATION_VERSION_CUSTOM_DATA_KEY;
+import static org.elasticsearch.xpack.core.security.action.UpdateIndexMigrationVersionAction.MIGRATION_VERSION_CUSTOM_KEY;
+import static org.elasticsearch.xpack.core.security.test.TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
+public class SecurityMigrationsIntegTests extends SecurityIntegTestCase {
+
+    public void testNewIndexSkipMigration() {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        final String masterNode = internalCluster().getMasterName();
+        ensureGreen();
+        CountDownLatch awaitMigrations = awaitMigrationVersionUpdates(masterNode, SecurityMigrations.MIGRATIONS_BY_VERSION.lastKey());
+        createSecurityIndexWithMigrationAndIndexVersion(SecurityMigrations.MIGRATIONS_BY_VERSION.lastKey(), IndexVersion.current());
+        safeAwait(awaitMigrations);
+    }
+
+    public void testIndexNotOnLatestMigrationVersionRunAllMigrations() {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        final String masterNode = internalCluster().getMasterName();
+        ensureGreen();
+        CountDownLatch awaitMigrations = awaitMigrationVersionUpdates(
+            masterNode,
+            SecurityMigrations.MIGRATIONS_BY_VERSION.keySet().stream().mapToInt(Integer::intValue).toArray()
+        );
+
+        // Migration version = 3 means it's not equal to current migration version and therefore all migrations will run
+        createSecurityIndexWithMigrationAndIndexVersion(3, IndexVersion.current());
+        safeAwait(awaitMigrations);
+    }
+
+    public void testIndexNotOnLatestIndexVersionFallbackRunAllMigrations() {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        final String masterNode = internalCluster().getMasterName();
+        ensureGreen();
+        CountDownLatch awaitMigrations = awaitMigrationVersionUpdates(
+            masterNode,
+            SecurityMigrations.MIGRATIONS_BY_VERSION.keySet().stream().mapToInt(Integer::intValue).toArray()
+        );
+
+        // Migration version = 1 was handled by index version, test fallback by providing old IndexVersion
+        createSecurityIndexWithMigrationAndIndexVersion(1, IndexVersions.V_7_11_0);
+        safeAwait(awaitMigrations);
+    }
+
+    public void testIndexOnLatestIndexVersionFallbackSkipAllMigrations() {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        final String masterNode = internalCluster().getMasterName();
+        ensureGreen();
+        CountDownLatch awaitMigrations = awaitMigrationVersionUpdates(masterNode, SecurityMigrations.MIGRATIONS_BY_VERSION.lastKey());
+
+        // Migration version = 1 was handled by index version, test fallback by providing current IndexVersion
+        createSecurityIndexWithMigrationAndIndexVersion(1, IndexVersion.current());
+        safeAwait(awaitMigrations);
+    }
+
+    private void createSecurityIndexWithMigrationAndIndexVersion(int migrationVersion, IndexVersion indexVersionCreated) {
+        SystemIndexDescriptor mainIndexDescriptor = new SecuritySystemIndices(Settings.EMPTY).getSystemIndexDescriptors()
+            .stream()
+            .toList()
+            .get(0);
+        CreateIndexRequest request = new CreateIndexRequest(INTERNAL_SECURITY_MAIN_INDEX_7).origin(SECURITY_ORIGIN)
+            .settings(
+                Settings.builder()
+                    .put(mainIndexDescriptor.getSettings())
+                    .put(SecuritySystemIndices.MAIN_INDEX_CREATED_ON_MIGRATION_VERSION.getKey(), migrationVersion)
+                    .put(SETTING_INDEX_VERSION_CREATED.getKey(), indexVersionCreated)
+            )
+            .mapping(mainIndexDescriptor.getMappings())
+            .alias(new Alias(".security"))
+            .waitForActiveShards(ActiveShardCount.ALL);
+        admin().indices().create(request).actionGet();
+    }
+
+    @Override
+    protected boolean forbidPrivateIndexSettings() {
+        // This allows us to set SETTING_INDEX_VERSION_CREATED
+        return false;
+    }
+
+    /**
+     * Make sure all versions are applied to cluster state sequentially
+     */
+    private CountDownLatch awaitMigrationVersionUpdates(String node, final int... versions) {
+        final ClusterService clusterService = internalCluster().clusterService(node);
+        final CountDownLatch allVersionsCountDown = new CountDownLatch(1);
+        final AtomicInteger currentVersionIdx = new AtomicInteger(0);
+        clusterService.addListener(new ClusterStateListener() {
+            @Override
+            public void clusterChanged(ClusterChangedEvent event) {
+                int currentMigrationVersion = getCurrentMigrationVersion(event.state());
+                if (currentMigrationVersion > 0) {
+                    assertThat(versions[currentVersionIdx.get()], lessThanOrEqualTo(currentMigrationVersion));
+                    if (versions[currentVersionIdx.get()] == currentMigrationVersion) {
+                        currentVersionIdx.incrementAndGet();
+                    }
+
+                    if (currentVersionIdx.get() >= versions.length) {
+                        clusterService.removeListener(this);
+                        allVersionsCountDown.countDown();
+                    }
+                }
+            }
+        });
+
+        return allVersionsCountDown;
+    }
+
+    private int getCurrentMigrationVersion(ClusterState state) {
+        IndexMetadata indexMetadata = state.metadata().getIndices().get(INTERNAL_SECURITY_MAIN_INDEX_7);
+        if (indexMetadata == null || indexMetadata.getCustomData(MIGRATION_VERSION_CUSTOM_KEY) == null) {
+            return 0;
+        }
+        return Integer.parseInt(indexMetadata.getCustomData(MIGRATION_VERSION_CUSTOM_KEY).get(MIGRATION_VERSION_CUSTOM_DATA_KEY));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1469,6 +1469,7 @@ public class Security extends Plugin
         settingsList.add(CachingServiceAccountTokenStore.CACHE_MAX_TOKENS_SETTING);
         settingsList.add(SimpleRole.CACHE_SIZE_SETTING);
         settingsList.add(NativeRoleMappingStore.LAST_LOAD_CACHE_ENABLED_SETTING);
+        settingsList.add(SecuritySystemIndices.MAIN_INDEX_CREATED_ON_MIGRATION_VERSION);
 
         // hide settings
         settingsList.add(Setting.stringListSetting(SecurityField.setting("hide_settings"), Property.NodeScope, Property.Filtered));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1224,7 +1224,7 @@ public class Security extends Plugin
 
     private void applyPendingSecurityMigrations(SecurityIndexManager.State newState) {
         // If no migrations have been applied and the security index is on the latest version (new index), all migrations can be skipped
-        if (newState.migrationsVersion == 0 && newState.createdOnLatestVersion) {
+        if (newState.migrationsVersion == 0 && newState.createdOnLatestMigrationVersion) {
             submitPersistentMigrationTask(SecurityMigrations.MIGRATIONS_BY_VERSION.lastKey(), false);
             return;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
@@ -14,8 +14,8 @@ import org.elasticsearch.features.NodeFeature;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MIGRATION_FRAMEWORK;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION;
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MIGRATION_FRAMEWORK;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_PROFILE_ORIGIN_FEATURE;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_ROLES_METADATA_FLATTENED;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_ROLE_MAPPING_CLEANUP;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
@@ -25,7 +25,12 @@ public class SecurityFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of(SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION, SECURITY_ROLE_MAPPING_CLEANUP, SECURITY_ROLES_METADATA_FLATTENED, SECURITY_MIGRATION_FRAMEWORK);
+        return Set.of(
+            SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION,
+            SECURITY_ROLE_MAPPING_CLEANUP,
+            SECURITY_ROLES_METADATA_FLATTENED,
+            SECURITY_MIGRATION_FRAMEWORK
+        );
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MIGRATION_FRAMEWORK;
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_PROFILE_ORIGIN_FEATURE;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_ROLES_METADATA_FLATTENED;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_ROLE_MAPPING_CLEANUP;
@@ -24,7 +25,7 @@ public class SecurityFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of(SECURITY_ROLE_MAPPING_CLEANUP, SECURITY_ROLES_METADATA_FLATTENED, SECURITY_MIGRATION_FRAMEWORK);
+        return Set.of(SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION, SECURITY_ROLE_MAPPING_CLEANUP, SECURITY_ROLES_METADATA_FLATTENED, SECURITY_MIGRATION_FRAMEWORK);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
@@ -258,7 +258,7 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
         // * the security index has been created anew (using the latest index version),
         // i.e. it is NOT created in a previous ES version that potentially didn't index the role metadata
         // * or, the .security index has been migrated (using an internal update-by-query) such that the metadata is queryable
-        return frozenSecurityIndex.isCreatedOnLatestVersion()
+        return frozenSecurityIndex.isCreatedOnLatestMigrationVersion()
             || securityIndex.isMigrationsVersionAtLeast(ROLE_METADATA_FLATTENED_MIGRATION_VERSION);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -676,7 +676,7 @@ public class SecurityIndexManager implements ClusterStateListener {
                     Settings filteredIndexSettings = descriptorForVersion.getSettings();
                     if (state.securityFeatures.contains(SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION) == false) {
                         filteredIndexSettings = descriptorForVersion.getSettings()
-                            .filter(key -> key.equals(SecuritySystemIndices.MAIN_INDEX_CREATED_ON_MIGRATION_VERSION.getKey()));
+                            .filter(key -> key.equals(SecuritySystemIndices.MAIN_INDEX_CREATED_ON_MIGRATION_VERSION.getKey()) == false);
                     }
 
                     // Although `TransportCreateIndexAction` is capable of automatically applying the right mappings, settings and aliases

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -70,8 +70,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.security.action.UpdateIndexMigrationVersionAction.MIGRATION_VERSION_CUSTOM_DATA_KEY;
 import static org.elasticsearch.xpack.core.security.action.UpdateIndexMigrationVersionAction.MIGRATION_VERSION_CUSTOM_KEY;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.State.UNRECOVERED_STATE;
-import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MIGRATION_FRAMEWORK;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION;
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MIGRATION_FRAMEWORK;
 
 /**
  * Manages the lifecycle, mapping and data upgrades/migrations of the {@code RestrictedIndicesNames#SECURITY_MAIN_ALIAS}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -269,10 +269,19 @@ public class SecurityIndexManager implements ClusterStateListener {
      */
 
     private static boolean isCreatedOnLatestVersion(IndexMetadata indexMetadata) {
-        final IndexVersion indexVersionCreated = indexMetadata != null
-            ? SETTING_INDEX_VERSION_CREATED.get(indexMetadata.getSettings())
-            : null;
-        return indexVersionCreated != null && indexVersionCreated.onOrAfter(IndexVersion.current());
+        if (indexMetadata == null) {
+            return false;
+        }
+
+        final Integer indexCreatedOnMigrationVersion = SecuritySystemIndices.MAIN_INDEX_CREATED_ON_MIGRATION_VERSION.get(
+            indexMetadata.getSettings()
+        );
+
+        // 1 is the first migration, before the MAIN_INDEX_CREATED_ON_MIGRATION_VERSION was introduced
+        if (indexCreatedOnMigrationVersion > 1) {
+            return indexCreatedOnMigrationVersion.equals(SecurityMigrations.MIGRATIONS_BY_VERSION.lastKey());
+        }
+        return SETTING_INDEX_VERSION_CREATED.get(indexMetadata.getSettings()).onOrAfter(IndexVersion.current());
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrations.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrations.java
@@ -45,6 +45,9 @@ import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Role
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SecurityMainIndexMappingVersion.ADD_MANAGE_ROLES_PRIVILEGE;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SecurityMainIndexMappingVersion.ADD_REMOTE_CLUSTER_AND_DESCRIPTION_FIELDS;
 
+/**
+ * Interface for creating SecurityMigrations that will be automatically applied once to existing .security indices
+ */
 public class SecurityMigrations {
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrations.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrations.java
@@ -45,14 +45,10 @@ import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Role
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SecurityMainIndexMappingVersion.ADD_MANAGE_ROLES_PRIVILEGE;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SecurityMainIndexMappingVersion.ADD_REMOTE_CLUSTER_AND_DESCRIPTION_FIELDS;
 
-/**
- * Interface for creating SecurityMigrations that will be automatically applied once to existing .security indices
- */
 public class SecurityMigrations {
 
     /**
      * Interface for creating SecurityMigrations that will be automatically applied once to existing .security indices
-     * IMPORTANT: A new index version needs to be added to {@link org.elasticsearch.index.IndexVersions} for the migration to be triggered
      */
     public interface SecurityMigration {
         /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -62,6 +62,9 @@ public class SecuritySystemIndices {
     public static final NodeFeature SECURITY_PROFILE_ORIGIN_FEATURE = new NodeFeature("security.security_profile_origin");
     public static final NodeFeature SECURITY_MIGRATION_FRAMEWORK = new NodeFeature("security.migration_framework");
     public static final NodeFeature SECURITY_ROLES_METADATA_FLATTENED = new NodeFeature("security.roles_metadata_flattened");
+    public static final NodeFeature SECURITY_MAIN_INDEX_CREATED_ON_MIGRATION_VERSION = new NodeFeature(
+        "security.main_index_created_on_migration_version"
+    );
     public static final NodeFeature SECURITY_ROLE_MAPPING_CLEANUP = new NodeFeature("security.role_mapping_cleanup");
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.VersionId;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
@@ -62,6 +63,16 @@ public class SecuritySystemIndices {
     public static final NodeFeature SECURITY_MIGRATION_FRAMEWORK = new NodeFeature("security.migration_framework");
     public static final NodeFeature SECURITY_ROLES_METADATA_FLATTENED = new NodeFeature("security.roles_metadata_flattened");
     public static final NodeFeature SECURITY_ROLE_MAPPING_CLEANUP = new NodeFeature("security.role_mapping_cleanup");
+
+    /**
+     * The latest version of the security migration when the main security index was created
+     */
+    public static final Setting<Integer> MAIN_INDEX_CREATED_ON_MIGRATION_VERSION = Setting.intSetting(
+        "index.security.migration.version",
+        0,
+        Setting.Property.IndexScope,
+        Setting.Property.Final
+    );
 
     /**
      * Security managed index mappings used to be updated based on the product version. They are now updated based on per-index mappings
@@ -158,6 +169,7 @@ public class SecuritySystemIndices {
             .put(DataTier.TIER_PREFERENCE, "data_hot,data_content")
             .put(IndexMetadata.SETTING_PRIORITY, 1000)
             .put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), INTERNAL_MAIN_INDEX_FORMAT)
+            .put(MAIN_INDEX_CREATED_ON_MIGRATION_VERSION.getKey(), SecurityMigrations.MIGRATIONS_BY_VERSION.lastKey())
             .put("analysis.filter.email.type", "pattern_capture")
             .put("analysis.filter.email.preserve_original", true)
             .putList("analysis.filter.email.patterns", List.of("([^@]+)", "(\\p{L}+)", "(\\d+)", "@(.+)"))

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -209,7 +209,10 @@ public class SecurityTests extends ESTestCase {
         settings = Security.additionalSettings(settings, true);
         Set<Setting<?>> allowedSettings = new HashSet<>(Security.getSettings(null));
         allowedSettings.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterSettings clusterSettings = new ClusterSettings(settings, allowedSettings);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            allowedSettings.stream().filter(Setting::hasNodeScope).collect(Collectors.toSet())
+        );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(threadPool.relativeTimeInMillis()).thenReturn(1L);
         threadContext = new ThreadContext(Settings.EMPTY);


### PR DESCRIPTION
This adds an index setting to the security index to allow us to automatically track on what migration version an index was created. This information can be used to make a decision to skip running any migrations at all, since we can know that an index was created after a certain migration version or not. 

Before this change the [IndexVersion](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/IndexVersions.java) had to be manually bumped to make sure new migrations were not accidentally missed, which is error prone and heavy handed. 

The new [NodeFeature](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/features/NodeFeature.java) ensures that all nodes are on or after the version that introduced the new index setting. If they're not, the node feature should not be added to a new .security index and therefore the index migrations will never be skipped. This is acceptable. Most a of the time a new `.security` index will be created on a cluster where all 
nodes have the new feature and in the case where all nodes do not have the new feature, running a migration for a new index is a noop, and shouldn't cause any issues. 