### PR TITLE
[8.x] Add tests for license changes while using data streams (#115478)

### DIFF
--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenceDowngradeIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenceDowngradeIT.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DataStreamLicenceDowngradeIT extends DataStreamLicenseChangeIT {
+    @Override
+    protected void applyInitialLicense() throws IOException {
+        startTrial();
+    }
+
+    @Override
+    protected void licenseChange() throws IOException {
+        startBasic();
+    }
+
+    @Override
+    protected List<TestCase> cases() {
+        return List.of(new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "logs-test-regular";
+            }
+
+            @Override
+            public String indexMode() {
+                return "logsdb";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        }, new TestCase() {
+            private static final String sourceModeOverride = """
+                {
+                  "template": {
+                    "settings": {
+                      "index": {
+                        "mapping.source.mode": "SYNTHETIC"
+                      }
+                    }
+                  }
+                }""";
+
+            @Override
+            public String dataStreamName() {
+                return "logs-test-explicit-synthetic";
+            }
+
+            @Override
+            public String indexMode() {
+                return "logsdb";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                assertOK(createDataStream(client(), dataStreamName()));
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                rolloverDataStream(client(), dataStreamName());
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        }, new TestCase() {
+            private static final String sourceModeOverride = """
+                {
+                  "template": {
+                    "settings": {
+                      "index": {
+                        "mapping.source.mode": "STORED"
+                      }
+                    }
+                  }
+                }""";
+
+            @Override
+            public String dataStreamName() {
+                return "logs-test-explicit-stored";
+            }
+
+            @Override
+            public String indexMode() {
+                return "logsdb";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                assertOK(createDataStream(client(), dataStreamName()));
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                rolloverDataStream(client(), dataStreamName());
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        }, new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "tsdb-test-regular";
+            }
+
+            @Override
+            public String indexMode() {
+                return "time_series";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                var componentTemplate = """
+                    {
+                      "template": {
+                        "settings": {
+                          "index": {
+                            "mode": "time_series",
+                            "routing_path": ["dim"]
+                          }
+                        },
+                        "mappings": {
+                          "properties": {
+                            "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+                assertOK(putComponentTemplate(client(), "tsdb-test-regular-component", componentTemplate));
+
+                var template = """
+                    {
+                      "index_patterns": ["tsdb-test-regular"],
+                      "priority": 100,
+                      "data_stream": {},
+                      "composed_of": ["tsdb-test-regular-component"]
+                    }
+                    """;
+
+                putTemplate(client(), "tsdb-test-regular-template", template);
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        }, new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "tsdb-test-synthetic";
+            }
+
+            @Override
+            public String indexMode() {
+                return "time_series";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                var componentTemplate = """
+                    {
+                      "template": {
+                        "settings": {
+                          "index": {
+                            "mode": "time_series",
+                            "routing_path": ["dim"],
+                            "mapping.source.mode": "SYNTHETIC"
+                          }
+                        },
+                        "mappings": {
+                          "properties": {
+                            "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+                assertOK(putComponentTemplate(client(), "tsdb-test-synthetic-component", componentTemplate));
+
+                var template = """
+                    {
+                      "index_patterns": ["tsdb-test-synthetic"],
+                      "priority": 100,
+                      "data_stream": {},
+                      "composed_of": ["tsdb-test-synthetic-component"]
+                    }
+                    """;
+
+                putTemplate(client(), "tsdb-test-synthetic-template", template);
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        }, new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "tsdb-test-stored";
+            }
+
+            @Override
+            public String indexMode() {
+                return "time_series";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                var componentTemplate = """
+                    {
+                      "template": {
+                        "settings": {
+                          "index": {
+                            "mode": "time_series",
+                            "routing_path": ["dim"],
+                            "mapping.source.mode": "STORED"
+                          }
+                        },
+                        "mappings": {
+                          "properties": {
+                            "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+                assertOK(putComponentTemplate(client(), "tsdb-test-stored-component", componentTemplate));
+
+                var template = """
+                    {
+                      "index_patterns": ["tsdb-test-stored"],
+                      "priority": 100,
+                      "data_stream": {},
+                      "composed_of": ["tsdb-test-stored-component"]
+                    }
+                    """;
+
+                putTemplate(client(), "tsdb-test-stored-template", template);
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        },
+
+            new TestCase() {
+                @Override
+                public String dataStreamName() {
+                    return "standard";
+                }
+
+                @Override
+                public String indexMode() {
+                    return "standard";
+                }
+
+                @Override
+                public void prepareDataStream() throws IOException {
+                    var template = """
+                        {
+                          "index_patterns": ["standard"],
+                          "priority": 100,
+                          "data_stream": {},
+                          "composed_of": []
+                        }
+                        """;
+
+                    putTemplate(client(), "standard-template", template);
+                    assertOK(createDataStream(client(), dataStreamName()));
+                }
+
+                @Override
+                public void rollover() throws IOException {
+                    rolloverDataStream(client(), dataStreamName());
+                }
+
+                @Override
+                public SourceFieldMapper.Mode initialMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+
+                @Override
+                public SourceFieldMapper.Mode finalMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+            },
+            new TestCase() {
+                @Override
+                public String dataStreamName() {
+                    return "standard-synthetic";
+                }
+
+                @Override
+                public String indexMode() {
+                    return "standard";
+                }
+
+                @Override
+                public void prepareDataStream() throws IOException {
+                    var componentTemplate = """
+                        {
+                          "template": {
+                            "settings": {
+                              "index": {
+                                "mapping.source.mode": "SYNTHETIC"
+                              }
+                            }
+                          }
+                        }
+                        """;
+                    assertOK(putComponentTemplate(client(), "standard-synthetic-component", componentTemplate));
+
+                    var template = """
+                        {
+                          "index_patterns": ["standard-synthetic"],
+                          "priority": 100,
+                          "data_stream": {},
+                          "composed_of": ["standard-synthetic-component"]
+                        }
+                        """;
+
+                    putTemplate(client(), "standard-synthetic-template", template);
+                    assertOK(createDataStream(client(), dataStreamName()));
+                }
+
+                @Override
+                public void rollover() throws IOException {
+                    rolloverDataStream(client(), dataStreamName());
+                }
+
+                @Override
+                public SourceFieldMapper.Mode initialMode() {
+                    return SourceFieldMapper.Mode.SYNTHETIC;
+                }
+
+                @Override
+                public SourceFieldMapper.Mode finalMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+            },
+            new TestCase() {
+                @Override
+                public String dataStreamName() {
+                    return "standard-stored";
+                }
+
+                @Override
+                public String indexMode() {
+                    return "standard";
+                }
+
+                @Override
+                public void prepareDataStream() throws IOException {
+                    var componentTemplate = """
+                        {
+                          "template": {
+                            "settings": {
+                              "index": {
+                                "mapping.source.mode": "STORED"
+                              }
+                            }
+                          }
+                        }
+                        """;
+                    assertOK(putComponentTemplate(client(), "standard-stored-component", componentTemplate));
+
+                    var template = """
+                        {
+                          "index_patterns": ["standard-stored"],
+                          "priority": 100,
+                          "data_stream": {},
+                          "composed_of": ["standard-stored-component"]
+                        }
+                        """;
+
+                    putTemplate(client(), "standard-stored-template", template);
+                    assertOK(createDataStream(client(), dataStreamName()));
+                }
+
+                @Override
+                public void rollover() throws IOException {
+                    rolloverDataStream(client(), dataStreamName());
+                }
+
+                @Override
+                public SourceFieldMapper.Mode initialMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+
+                @Override
+                public SourceFieldMapper.Mode finalMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+            }
+        );
+    }
+}

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenseChangeIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenseChangeIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class DataStreamLicenseChangeIT extends LogsIndexModeRestTestIT {
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .module("data-streams")
+        .module("x-pack-stack")
+        .setting("cluster.logsdb.enabled", "true")
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "basic")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    protected interface TestCase {
+        String dataStreamName();
+
+        void prepareDataStream() throws IOException;
+
+        String indexMode();
+
+        SourceFieldMapper.Mode initialMode();
+
+        SourceFieldMapper.Mode finalMode();
+
+        void rollover() throws IOException;
+    }
+
+    protected abstract void licenseChange() throws IOException;
+
+    protected abstract void applyInitialLicense() throws IOException;
+
+    protected abstract List<TestCase> cases();
+
+    public void testLicenseChange() throws IOException {
+        applyInitialLicense();
+
+        for (var testCase : cases()) {
+            testCase.prepareDataStream();
+
+            var indexMode = (String) getSetting(client(), getDataStreamBackingIndex(client(), testCase.dataStreamName(), 0), "index.mode");
+            assertEquals(testCase.indexMode(), indexMode);
+
+            var sourceMode = (String) getSetting(
+                client(),
+                getDataStreamBackingIndex(client(), testCase.dataStreamName(), 0),
+                "index.mapping.source.mode"
+            );
+            assertEquals(testCase.initialMode().toString(), sourceMode);
+        }
+
+        licenseChange();
+
+        for (var testCase : cases()) {
+            testCase.rollover();
+
+            var indexMode = (String) getSetting(client(), getDataStreamBackingIndex(client(), testCase.dataStreamName(), 1), "index.mode");
+            assertEquals(testCase.indexMode(), indexMode);
+
+            var sourceMode = (String) getSetting(
+                client(),
+                getDataStreamBackingIndex(client(), testCase.dataStreamName(), 1),
+                "index.mapping.source.mode"
+            );
+            assertEquals(testCase.finalMode().toString(), sourceMode);
+        }
+    }
+
+    protected static void startBasic() throws IOException {
+        Request startTrial = new Request("POST", "/_license/start_basic");
+        startTrial.addParameter("acknowledge", "true");
+        assertOK(client().performRequest(startTrial));
+    }
+
+    protected static void startTrial() throws IOException {
+        Request startTrial = new Request("POST", "/_license/start_trial");
+        startTrial.addParameter("acknowledge", "true");
+        assertOK(client().performRequest(startTrial));
+    }
+
+    protected static Response removeComponentTemplate(final RestClient client, final String componentTemplate) throws IOException {
+        final Request request = new Request("DELETE", "/_component_template/" + componentTemplate);
+        return client.performRequest(request);
+    }
+}

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenseUpgradeIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/DataStreamLicenseUpgradeIT.java
@@ -1,0 +1,487 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DataStreamLicenseUpgradeIT extends DataStreamLicenseChangeIT {
+    @Override
+    protected void applyInitialLicense() {}
+
+    @Override
+    protected void licenseChange() throws IOException {
+        startTrial();
+    }
+
+    @Override
+    protected List<TestCase> cases() {
+        return List.of(new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "logs-test-regular";
+            }
+
+            @Override
+            public String indexMode() {
+                return "logsdb";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+        }, new TestCase() {
+            private static final String sourceModeOverride = """
+                {
+                  "template": {
+                    "settings": {
+                      "index": {
+                        "mapping.source.mode": "SYNTHETIC"
+                      }
+                    }
+                  }
+                }""";
+
+            @Override
+            public String dataStreamName() {
+                return "logs-test-explicit-synthetic";
+            }
+
+            @Override
+            public String indexMode() {
+                return "logsdb";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                assertOK(createDataStream(client(), dataStreamName()));
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                rolloverDataStream(client(), dataStreamName());
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+        }, new TestCase() {
+            private static final String sourceModeOverride = """
+                {
+                  "template": {
+                    "settings": {
+                      "index": {
+                        "mapping.source.mode": "STORED"
+                      }
+                    }
+                  }
+                }""";
+
+            @Override
+            public String dataStreamName() {
+                return "logs-test-explicit-stored";
+            }
+
+            @Override
+            public String indexMode() {
+                return "logsdb";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                assertOK(createDataStream(client(), dataStreamName()));
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                assertOK(putComponentTemplate(client(), "logs@custom", sourceModeOverride));
+                rolloverDataStream(client(), dataStreamName());
+                assertOK(removeComponentTemplate(client(), "logs@custom"));
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        }, new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "tsdb-test-regular";
+            }
+
+            @Override
+            public String indexMode() {
+                return "time_series";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                var componentTemplate = """
+                    {
+                      "template": {
+                        "settings": {
+                          "index": {
+                            "mode": "time_series",
+                            "routing_path": ["dim"]
+                          }
+                        },
+                        "mappings": {
+                          "properties": {
+                            "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+                assertOK(putComponentTemplate(client(), "tsdb-test-regular-component", componentTemplate));
+
+                var template = """
+                    {
+                      "index_patterns": ["tsdb-test-regular"],
+                      "priority": 100,
+                      "data_stream": {},
+                      "composed_of": ["tsdb-test-regular-component"]
+                    }
+                    """;
+
+                putTemplate(client(), "tsdb-test-regular-template", template);
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+        }, new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "tsdb-test-synthetic";
+            }
+
+            @Override
+            public String indexMode() {
+                return "time_series";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                var componentTemplate = """
+                    {
+                      "template": {
+                        "settings": {
+                          "index": {
+                            "mode": "time_series",
+                            "routing_path": ["dim"],
+                            "mapping.source.mode": "SYNTHETIC"
+                          }
+                        },
+                        "mappings": {
+                          "properties": {
+                            "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+                assertOK(putComponentTemplate(client(), "tsdb-test-synthetic-component", componentTemplate));
+
+                var template = """
+                    {
+                      "index_patterns": ["tsdb-test-synthetic"],
+                      "priority": 100,
+                      "data_stream": {},
+                      "composed_of": ["tsdb-test-synthetic-component"]
+                    }
+                    """;
+
+                putTemplate(client(), "tsdb-test-synthetic-template", template);
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.SYNTHETIC;
+            }
+        }, new TestCase() {
+            @Override
+            public String dataStreamName() {
+                return "tsdb-test-stored";
+            }
+
+            @Override
+            public String indexMode() {
+                return "time_series";
+            }
+
+            @Override
+            public void prepareDataStream() throws IOException {
+                var componentTemplate = """
+                    {
+                      "template": {
+                        "settings": {
+                          "index": {
+                            "mode": "time_series",
+                            "routing_path": ["dim"],
+                            "mapping.source.mode": "STORED"
+                          }
+                        },
+                        "mappings": {
+                          "properties": {
+                            "dim": {
+                              "type": "keyword",
+                              "time_series_dimension": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+                assertOK(putComponentTemplate(client(), "tsdb-test-stored-component", componentTemplate));
+
+                var template = """
+                    {
+                      "index_patterns": ["tsdb-test-stored"],
+                      "priority": 100,
+                      "data_stream": {},
+                      "composed_of": ["tsdb-test-stored-component"]
+                    }
+                    """;
+
+                putTemplate(client(), "tsdb-test-stored-template", template);
+                assertOK(createDataStream(client(), dataStreamName()));
+            }
+
+            @Override
+            public void rollover() throws IOException {
+                rolloverDataStream(client(), dataStreamName());
+            }
+
+            @Override
+            public SourceFieldMapper.Mode initialMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+
+            @Override
+            public SourceFieldMapper.Mode finalMode() {
+                return SourceFieldMapper.Mode.STORED;
+            }
+        },
+
+            new TestCase() {
+                @Override
+                public String dataStreamName() {
+                    return "standard";
+                }
+
+                @Override
+                public String indexMode() {
+                    return "standard";
+                }
+
+                @Override
+                public void prepareDataStream() throws IOException {
+                    var template = """
+                        {
+                          "index_patterns": ["standard"],
+                          "priority": 100,
+                          "data_stream": {},
+                          "composed_of": []
+                        }
+                        """;
+
+                    putTemplate(client(), "standard-template", template);
+                    assertOK(createDataStream(client(), dataStreamName()));
+                }
+
+                @Override
+                public void rollover() throws IOException {
+                    rolloverDataStream(client(), dataStreamName());
+                }
+
+                @Override
+                public SourceFieldMapper.Mode initialMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+
+                @Override
+                public SourceFieldMapper.Mode finalMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+            },
+            new TestCase() {
+                @Override
+                public String dataStreamName() {
+                    return "standard-synthetic";
+                }
+
+                @Override
+                public String indexMode() {
+                    return "standard";
+                }
+
+                @Override
+                public void prepareDataStream() throws IOException {
+                    var componentTemplate = """
+                        {
+                          "template": {
+                            "settings": {
+                              "index": {
+                                "mapping.source.mode": "SYNTHETIC"
+                              }
+                            }
+                          }
+                        }
+                        """;
+                    assertOK(putComponentTemplate(client(), "standard-synthetic-component", componentTemplate));
+
+                    var template = """
+                        {
+                          "index_patterns": ["standard-synthetic"],
+                          "priority": 100,
+                          "data_stream": {},
+                          "composed_of": ["standard-synthetic-component"]
+                        }
+                        """;
+
+                    putTemplate(client(), "standard-synthetic-template", template);
+                    assertOK(createDataStream(client(), dataStreamName()));
+                }
+
+                @Override
+                public void rollover() throws IOException {
+                    rolloverDataStream(client(), dataStreamName());
+                }
+
+                @Override
+                public SourceFieldMapper.Mode initialMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+
+                @Override
+                public SourceFieldMapper.Mode finalMode() {
+                    return SourceFieldMapper.Mode.SYNTHETIC;
+                }
+            },
+            new TestCase() {
+                @Override
+                public String dataStreamName() {
+                    return "standard-stored";
+                }
+
+                @Override
+                public String indexMode() {
+                    return "standard";
+                }
+
+                @Override
+                public void prepareDataStream() throws IOException {
+                    var componentTemplate = """
+                        {
+                          "template": {
+                            "settings": {
+                              "index": {
+                                "mapping.source.mode": "STORED"
+                              }
+                            }
+                          }
+                        }
+                        """;
+                    assertOK(putComponentTemplate(client(), "standard-stored-component", componentTemplate));
+
+                    var template = """
+                        {
+                          "index_patterns": ["standard-stored"],
+                          "priority": 100,
+                          "data_stream": {},
+                          "composed_of": ["standard-stored-component"]
+                        }
+                        """;
+
+                    putTemplate(client(), "standard-stored-template", template);
+                    assertOK(createDataStream(client(), dataStreamName()));
+                }
+
+                @Override
+                public void rollover() throws IOException {
+                    rolloverDataStream(client(), dataStreamName());
+                }
+
+                @Override
+                public SourceFieldMapper.Mode initialMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+
+                @Override
+                public SourceFieldMapper.Mode finalMode() {
+                    return SourceFieldMapper.Mode.STORED;
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add tests for license changes while using data streams (#115478)