### PR TITLE
Remove "Use ELSER By Default For Semantic Text" Changelog Entry

### DIFF
--- a/docs/changelog/113563.yaml
+++ b/docs/changelog/113563.yaml
@@ -1,5 +1,0 @@
-pr: 113563
-summary: Use ELSER By Default For Semantic Text
-area: Mapping
-type: enhancement
-issues: []


### PR DESCRIPTION
Remove the "Use ELSER By Default For Semantic Text" changelog entry. This functionality is behind a feature flag, so it should not be publicized through the changelog.
