### PR TITLE
Enable preview features on native modules during IntelliJ import

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -122,6 +122,36 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
       .findAll { it != null }
   }
 
+  // force IntelliJ to generate *.iml files for each imported module
+  tasks.register("enableExternalConfiguration") {
+    group = 'ide'
+    description = 'Enable per-module *.iml files'
+
+    doLast {
+      modifyXml('.idea/misc.xml') {xml ->
+        def externalStorageConfig = xml.component.find { it.'@name' == 'ExternalStorageConfigurationManager' }
+        if (externalStorageConfig) {
+          xml.remove(externalStorageConfig)
+        }
+      }
+    }
+  }
+
+  // modifies the idea module config to enable preview features on 'elasticsearch-native' module
+  tasks.register("enablePreviewFeatures") {
+    group = 'ide'
+    description = 'Enables preview features on native library module'
+    dependsOn tasks.named("enableExternalConfiguration")
+
+    doLast {
+      ['main', 'test'].each { sourceSet ->
+        modifyXml(".idea/modules/libs/native/elasticsearch.libs.elasticsearch-native.${sourceSet}.iml") { xml ->
+          xml.component.find { it.'@name' == 'NewModuleRootManager' }?.'@LANGUAGE_LEVEL' = 'JDK_21_PREVIEW'
+        }
+      }
+    }
+  }
+
   tasks.register('buildDependencyArtifacts') {
     group = 'ide'
     description = 'Builds artifacts needed as dependency for IDE modules'
@@ -149,7 +179,10 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
           testRunner = 'choose_per_test'
         }
         taskTriggers {
-          afterSync tasks.named('configureIdeCheckstyle'), tasks.named('configureIdeaGradleJvm'), tasks.named('buildDependencyArtifacts')
+          afterSync tasks.named('configureIdeCheckstyle'),
+            tasks.named('configureIdeaGradleJvm'),
+            tasks.named('buildDependencyArtifacts'),
+            tasks.named('enablePreviewFeatures')
         }
         encodings {
           encoding = 'UTF-8'

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -38,7 +38,7 @@ public interface NativeAccess {
     ProcessLimits getProcessLimits();
 
     /**
-     * Attempt to lock this process's virtual memory address space into physical RAM.
+     * Attempt to lock this process's virtualj memory address space into physical RAM.
      */
     void tryLockMemory();
 

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -38,7 +38,7 @@ public interface NativeAccess {
     ProcessLimits getProcessLimits();
 
     /**
-     * Attempt to lock this process's virtualj memory address space into physical RAM.
+     * Attempt to lock this process's virtual memory address space into physical RAM.
      */
     void tryLockMemory();
 


### PR DESCRIPTION
This should solve the problem of running unit tests inside IntelliJ using the platform runner. This was caused by the IDE not passing the `--enable-preview` flag to the `elasticsearch-native` module as is required. We explicitly configure this flag in the Gradle build, but IntelliJ doesn't seem to pick this up. Instead, we have to explicit set the module language level to "21 (Preview)" which isn't conveniently possible via APIs or build model configuration. Instead we have to modify the module `.iml` file. Additionally, we have to tell the IDE to generate these files, which involves mucking around in the `.idea/misc.xml` file. It's not elegant, but should work. IntelliJ is also weird about when it initially generates these files, so on fresh imports it might take a failed build/test attempt + a follow up import to settle things.