### PR TITLE
[8.x] Add challenge tests for logsdb that utilize stored source (#115606)

### DIFF
--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/DataGenerationHelper.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/DataGenerationHelper.java
@@ -89,6 +89,7 @@ public class DataGenerationHelper {
     }
 
     void logsDbSettings(Settings.Builder builder) {
+        builder.put("index.mode", "logsdb");
         if (keepArraySource) {
             builder.put(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING.getKey(), "arrays");
         }

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.java
@@ -7,17 +7,10 @@
 
 package org.elasticsearch.xpack.logsdb.qa;
 
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Locale;
-
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * This test compares behavior of a logsdb data stream and a standard index mode data stream
@@ -51,28 +44,5 @@ public class LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT extends 
     @Override
     public void contenderMappings(XContentBuilder builder) throws IOException {
         dataGenerationHelper.standardMapping(builder);
-    }
-
-    @Override
-    public Response indexContenderDocuments(CheckedSupplier<List<XContentBuilder>, IOException> documentsSupplier) throws IOException {
-        var reindexRequest = new Request("POST", "/_reindex?refresh=true");
-        reindexRequest.setJsonEntity(String.format(Locale.ROOT, """
-            {
-                "source": {
-                    "index": "%s"
-                },
-                "dest": {
-                  "index": "%s",
-                  "op_type": "create"
-                }
-            }
-            """, getBaselineDataStreamName(), getContenderDataStreamName()));
-        var response = client.performRequest(reindexRequest);
-        assertOK(response);
-
-        var body = entityAsMap(response);
-        assertThat("encountered failures when performing reindex:\n " + body, body.get("failures"), equalTo(List.of()));
-
-        return response;
     }
 }

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/LogsDbVersusReindexedIntoStoredSourceChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/LogsDbVersusReindexedIntoStoredSourceChallengeRestIT.java
@@ -13,17 +13,16 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * This test compares behavior of a logsdb data stream and a data stream containing
- * data reindexed from initial data stream.
+ * This test compares behavior of a standard mode data stream and a logsdb data stream using stored source.
  * There should be no differences between such two data streams.
  */
-public class LogsDbVersusReindexedLogsDbChallengeRestIT extends ReindexChallengeRestIT {
+public class LogsDbVersusReindexedIntoStoredSourceChallengeRestIT extends ReindexChallengeRestIT {
     public String getBaselineDataStreamName() {
         return "logs-apache-baseline";
     }
 
     public String getContenderDataStreamName() {
-        return "logs-apache-reindexed-contender";
+        return "logs-apache-reindexed";
     }
 
     @Override
@@ -34,6 +33,7 @@ public class LogsDbVersusReindexedLogsDbChallengeRestIT extends ReindexChallenge
     @Override
     public void contenderSettings(Settings.Builder builder) {
         dataGenerationHelper.logsDbSettings(builder);
+        builder.put("index.mapping.source.mode", "stored");
     }
 
     @Override

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsStoredSourceChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsStoredSourceChallengeRestIT.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb.qa;
+
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * This test compares behavior of a standard mode data stream and a logsdb data stream using stored source.
+ * There should be no differences between such two data streams.
+ */
+public class StandardVersusLogsStoredSourceChallengeRestIT extends StandardVersusLogsIndexModeRandomDataChallengeRestIT {
+    @Override
+    public void contenderSettings(Settings.Builder builder) {
+        super.contenderSettings(builder);
+        builder.put("index.mapping.source.mode", "stored");
+    }
+}

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT.java
@@ -13,22 +13,23 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * This test compares behavior of a logsdb data stream and a data stream containing
- * data reindexed from initial data stream.
+ * This test compares behavior of a logsdb data stream using stored source and a logsdb data stream
+ * containing data reindexed from initial data stream.
  * There should be no differences between such two data streams.
  */
-public class LogsDbVersusReindexedLogsDbChallengeRestIT extends ReindexChallengeRestIT {
+public class StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT extends ReindexChallengeRestIT {
     public String getBaselineDataStreamName() {
         return "logs-apache-baseline";
     }
 
     public String getContenderDataStreamName() {
-        return "logs-apache-reindexed-contender";
+        return "logs-apache-reindexed";
     }
 
     @Override
     public void baselineSettings(Settings.Builder builder) {
         dataGenerationHelper.logsDbSettings(builder);
+        builder.put("index.mapping.source.mode", "stored");
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add challenge tests for logsdb that utilize stored source (#115606)](https://github.com/elastic/elasticsearch/pull/115606)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)