### PR TITLE
Fixing DatabaseNodeServiceIT testNonGzippedDatabase and testGzippedDatabase race condition (#115463)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -309,9 +309,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
   method: testPutE5Small_withPlatformAgnosticVariant
   issue: https://github.com/elastic/elasticsearch/issues/113983
-- class: org.elasticsearch.ingest.geoip.DatabaseNodeServiceIT
-  method: testGzippedDatabase
-  issue: https://github.com/elastic/elasticsearch/issues/113752
 - class: org.elasticsearch.datastreams.LazyRolloverDuringDisruptionIT
   method: testRolloverIsExecutedOnce
   issue: https://github.com/elastic/elasticsearch/issues/112634


### PR DESCRIPTION
Every once in a while, DatabaseNodeService::checkDatabases gets called at just the wrong time and deletes the database we are using in these tests. This PR adds an assertBusy to retry when this happens.
Closes #113752
Closes #113821