### PR TITLE
Unmute testPopulationOfCacheWhenLoadingPrivilegesForAllApplications

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -20,9 +20,6 @@ tests:
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests
-  method: testPopulationOfCacheWhenLoadingPrivilegesForAllApplications
-  issue: https://github.com/elastic/elasticsearch/issues/110789
 - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
   method: testSystemPropertyDisabled
   issue: https://github.com/elastic/elasticsearch/issues/110949


### PR DESCRIPTION
Unmutes the test which was not unmuted when the fix was added.

Closes https://github.com/elastic/elasticsearch/issues/110789