### PR TITLE
Change Reindexing metrics unit from millis to seconds

### DIFF
--- a/docs/changelog/115721.yaml
+++ b/docs/changelog/115721.yaml
@@ -1,0 +1,5 @@
+pr: 115721
+summary: Change Reindexing metrics unit from millis to seconds
+area: Reindex
+type: enhancement
+issues: []

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexMetrics.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexMetrics.java
@@ -19,7 +19,7 @@ public class ReindexMetrics {
     private final LongHistogram reindexTimeSecsHistogram;
 
     public ReindexMetrics(MeterRegistry meterRegistry) {
-        this(meterRegistry.registerLongHistogram(REINDEX_TIME_HISTOGRAM, "Time to reindex by search", "millis"));
+        this(meterRegistry.registerLongHistogram(REINDEX_TIME_HISTOGRAM, "Time to reindex by search", "seconds"));
     }
 
     private ReindexMetrics(LongHistogram reindexTimeSecsHistogram) {


### PR DESCRIPTION
A very small change to fix the units for reindexing took time. It is collected in seconds not milliseconds.