### PR TITLE
Show -Dlicense.key value in test repro info (#66179)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -79,7 +79,6 @@ public class ReproduceInfoPrinter extends RunListener {
         String task = System.getProperty("tests.task");
         // TODO: enforce (intellij still runs the runner?) or use default "test" but that won't work for integ
         b.append("'" + task + "'");
-
         GradleMessageBuilder gradleMessageBuilder = new GradleMessageBuilder(b);
         gradleMessageBuilder.appendAllOpts(failure.getDescription());
 
@@ -159,6 +158,7 @@ public class ReproduceInfoPrinter extends RunListener {
             appendOpt("tests.distribution", System.getProperty("tests.distribution"));
             appendOpt("compiler.java", System.getProperty("compiler.java"));
             appendOpt("runtime.java", System.getProperty("runtime.java"));
+	    appendOpt("license.key", System.getProperty("licence.key"));
             appendOpt("javax.net.ssl.keyStorePassword", System.getProperty("javax.net.ssl.keyStorePassword"));
             appendOpt("javax.net.ssl.trustStorePassword", System.getProperty("javax.net.ssl.trustStorePassword"));
             return this;

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -69,10 +69,11 @@ processResources {
   } else {
     throw new IllegalArgumentException('Property license.key must be set for release build')
   }
-  if (Files.exists(Paths.get(licenseKey)) == false) {
+  File licenseKeyFile = rootProject.file(licenseKey)
+  if (licenseKeyFile.exists() == false) {
     throw new IllegalArgumentException('license.key at specified path [' + licenseKey + '] does not exist')
   }
-  from(licenseKey) {
+  from(licenseKeyFile) {
     rename { String filename -> 'public.key' }
   }
 }


### PR DESCRIPTION
backports #66179 to 6.8 to fix the same issues
When a -Dlicense.key sys property is passed to the build we want to consider
this in the test reproduction info message
Absolute Paths tried to be converted to relative paths relative to workspace
root to allow simply copy & paste
Also fixes a inconsistency for checking license existence in x-pack plugin core build