### PR TITLE
[8.16] Make some chunked xcontent more efficient (#115512)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -158,13 +158,13 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContent.builder(params).object(ob -> {
-            ob.field(ERRORS, hasFailures());
-            ob.field(TOOK, tookInMillis);
+        return ChunkedToXContent.builder(params).object(ob -> ob.append((b, p) -> {
+            b.field(ERRORS, hasFailures());
+            b.field(TOOK, tookInMillis);
             if (ingestTookInMillis != BulkResponse.NO_INGEST_TOOK) {
-                ob.field(INGEST_TOOK, ingestTookInMillis);
+                b.field(INGEST_TOOK, ingestTookInMillis);
             }
-            ob.array(ITEMS, Iterators.forArray(responses));
-        });
+            return b;
+        }).array(ITEMS, Iterators.forArray(responses)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentBuilder.java
@@ -58,9 +58,7 @@ public class ChunkedToXContentBuilder implements Iterator<ToXContent> {
      * Creates an object, with the specified {@code contents}
      */
     public ChunkedToXContentBuilder xContentObject(ToXContent contents) {
-        startObject();
-        append(contents);
-        endObject();
+        addChunk((b, p) -> contents.toXContent(b.startObject(), p).endObject());
         return this;
     }
 
@@ -68,9 +66,7 @@ public class ChunkedToXContentBuilder implements Iterator<ToXContent> {
      * Creates an object named {@code name}, with the specified {@code contents}
      */
     public ChunkedToXContentBuilder xContentObject(String name, ToXContent contents) {
-        startObject(name);
-        append(contents);
-        endObject();
+        addChunk((b, p) -> contents.toXContent(b.startObject(name), p).endObject());
         return this;
     }
 


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Make some chunked xcontent more efficient (#115512)