### PR TITLE
[8.15] Update quickstart overview, add local install instructions (#115746)

### DIFF
--- a/docs/reference/quickstart/full-text-filtering-tutorial.asciidoc
+++ b/docs/reference/quickstart/full-text-filtering-tutorial.asciidoc
@@ -20,6 +20,19 @@ The goal is to create search queries that enable users to:
 To achieve these goals we'll use different Elasticsearch queries to perform full-text search, apply filters, and combine multiple search criteria.
 
 [discrete]
+[[full-text-filter-tutorial-requirements]]
+=== Requirements
+
+You'll need a running {es} cluster, together with {kib} to use the Dev Tools API Console.
+Run the following command in your terminal to set up a <<run-elasticsearch-locally,single-node local cluster in Docker>>:
+
+[source,sh]
+----
+curl -fsSL https://elastic.co/start-local | sh
+----
+// NOTCONSOLE
+
+[discrete]
 [[full-text-filter-tutorial-create-index]]
 === Step 1: Create an index
 

--- a/docs/reference/quickstart/getting-started.asciidoc
+++ b/docs/reference/quickstart/getting-started.asciidoc
@@ -14,12 +14,17 @@ The code examples in this tutorial are in {kibana-ref}/console-kibana.html[Conso
 ====
 
 [discrete]
-[[getting-started-prerequisites]]
-=== Prerequisites
+[[getting-started-requirements]]
+=== Requirements
 
-Before you begin, you need to have a running {es} cluster.
-The fastest way to get started is with a <<run-elasticsearch-locally,local development environment>>.
-Refer to <<elasticsearch-intro-deploy,Run {es}>> for other deployment options.
+You'll need a running {es} cluster, together with {kib} to use the Dev Tools API Console.
+Run the following command in your terminal to set up a <<run-elasticsearch-locally,single-node local cluster in Docker>>:
+
+[source,sh]
+----
+curl -fsSL https://elastic.co/start-local | sh
+----
+// NOTCONSOLE
 
 ////
 [source,console]

--- a/docs/reference/quickstart/index.asciidoc
+++ b/docs/reference/quickstart/index.asciidoc
@@ -9,7 +9,15 @@ Unless otherwise noted, these examples will use queries written in <<query-dsl,Q
 == Requirements
 
 You'll need a running {es} cluster, together with {kib} to use the Dev Tools API Console.
-Get started <<run-elasticsearch-locally,locally in Docker>> , or see our <<elasticsearch-intro-deploy,other deployment options>>.
+Run the following command in your terminal to set up a <<run-elasticsearch-locally,single-node local cluster in Docker>>:
+
+[source,sh]
+----
+curl -fsSL https://elastic.co/start-local | sh
+----
+// NOTCONSOLE
+
+Alternatively, refer to our <<elasticsearch-intro-deploy,other deployment options>>.
 
 [discrete]
 [[quickstart-list]]
@@ -17,15 +25,18 @@ Get started <<run-elasticsearch-locally,locally in Docker>> , or see our <<elast
 
 * <<getting-started,Basics: Index and search data using {es} APIs>>. Learn about indices, documents, and mappings, and perform a basic search using the Query DSL.
 * <<full-text-filter-tutorial, Basics: Full-text search and filtering>>. Learn about different options for querying data, including full-text search and filtering, using the Query DSL.
+* <<semantic-search-semantic-text, Semantic search>>: Learn how to create embeddings for your data with `semantic_text` and query using the `semantic` query.
+** <<semantic-text-hybrid-search, Hybrid search with `semantic_text`>>: Learn how to combine semantic search with full-text search.
+* <<bring-your-own-vectors, Bring your own dense vector embeddings>>: Learn how to ingest dense vector embeddings into {es}.
 
-[discrete]
-[[quickstart-python-links]]
-== Working in Python
+.Working in Python
+******************
 
 If you're interested in using {es} with Python, check out Elastic Search Labs:
 
 * https://github.com/elastic/elasticsearch-labs[`elasticsearch-labs` repository]: Contains a range of Python https://github.com/elastic/elasticsearch-labs/tree/main/notebooks[notebooks] and https://github.com/elastic/elasticsearch-labs/tree/main/example-apps[example apps].
 * https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome[Tutorial]: This walks you through building a complete search solution with {es} from the ground up using Flask.
+******************
 
 include::getting-started.asciidoc[]
 include::full-text-filtering-tutorial.asciidoc[]

--- a/docs/reference/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/run-elasticsearch-locally.asciidoc
@@ -42,6 +42,7 @@ To set up {es} and {kib} locally, run the `start-local` script:
 curl -fsSL https://elastic.co/start-local | sh
 ----
 // NOTCONSOLE
+// REVIEWED[OCT.28.2024]
 
 This script creates an `elastic-start-local` folder containing configuration files and starts both {es} and {kib} using Docker.
 
@@ -50,28 +51,12 @@ After running the script, you can access Elastic services at the following endpo
 * *{es}*: http://localhost:9200
 * *{kib}*: http://localhost:5601
 
-The script generates a random password for the `elastic` user, which is displayed at the end of the installation and stored in the `.env` file.
+The script generates a random password for the `elastic` user, and an API key, stored in the `.env` file.
 
 [CAUTION]
 ====
 This setup is for local testing only. HTTPS is disabled, and Basic authentication is used for {es}. For security, {es} and {kib} are accessible only through `localhost`.
 ====
-
-[discrete]
-[[api-access]]
-=== API access
-
-An API key for {es} is generated and stored in the `.env` file as `ES_LOCAL_API_KEY`.
-Use this key to connect to {es} with a https://www.elastic.co/guide/en/elasticsearch/client/index.html[programming language client] or the <<rest-apis,REST API>>.
-
-From the `elastic-start-local` folder, check the connection to Elasticsearch using `curl`:
-
-[source,sh]
-----     
-source .env
-curl $ES_LOCAL_URL -H "Authorization: ApiKey ${ES_LOCAL_API_KEY}"
-----
-// NOTCONSOLE
 
 [discrete]
 [[local-dev-additional-info]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Update quickstart overview, add local install instructions (#115746)](https://github.com/elastic/elasticsearch/pull/115746)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)