### PR TITLE
[8.x] Unmute TestFeatureLicenseTrackingIT testFeatureTrackingInferenceModelPipeline (#115340)

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureLicenseTrackingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureLicenseTrackingIT.java
@@ -118,7 +118,6 @@ public class TestFeatureLicenseTrackingIT extends MlSingleNodeTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102381")
     public void testFeatureTrackingInferenceModelPipeline() throws Exception {
         String modelId = "test-load-models-classification-license-tracking";
         Map<String, String> oneHotEncoding = new HashMap<>();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Unmute TestFeatureLicenseTrackingIT testFeatureTrackingInferenceModelPipeline (#115340)