### PR TITLE
fixed testCCSClusterDetailsWhereAllShardsSkippedInCanMatch

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -267,9 +267,6 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/115631
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testCCSClusterDetailsWhereAllShardsSkippedInCanMatch
-  issue: https://github.com/elastic/elasticsearch/issues/115652
 - class: org.elasticsearch.index.get.GetResultTests
   method: testToAndFromXContent
   issue: https://github.com/elastic/elasticsearch/issues/115688

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -287,7 +287,6 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         try {
             responseId = response.getId();
             assertNotNull(response.getSearchResponse());
-            assertTrue(response.isRunning());
             SearchResponse.Clusters clusters = response.getSearchResponse().getClusters();
             assertThat(clusters.getTotal(), equalTo(2));
             if (dfs) {


### PR DESCRIPTION
With the introduction of https://github.com/elastic/elasticsearch/pull/115314 when we are skipping all the shards because of a coordinator rewrite we might be much faster than the previous execution (that always contacts at least one shard) and because of this we cannot assert on the fact that the current response is running.
Resolves:  https://github.com/elastic/elasticsearch/issues/115652