### PR TITLE
Do not fallback to the local cluster in ES|QL if remote cluster could not be resolved

### DIFF
--- a/docs/changelog/115775.yaml
+++ b/docs/changelog/115775.yaml
@@ -1,0 +1,7 @@
+pr: 115775
+summary: Do not fallback to the local cluster in ES|QL if remote cluster could not
+  be resolved
+area: Search
+type: bug
+issues:
+ - 115262

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
@@ -734,10 +734,13 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
 
         VerificationException ex = assertThrows(
             VerificationException.class,
-            () -> runQuery("FROM xremote*:web_traffic | WHERE verb==\"GET\" | KEEP is_https, user_Agent, verb | STATS count(*)", false)
+            () -> runQuery(
+                "FROM nosuchcluster*:web_traffic | WHERE verb==\"GET\" | KEEP is_https, user_Agent, verb | STATS count(*)",
+                false
+            )
         );
 
-        assertEquals("No matching clusters xremote*:web_traffic", ex.getMessage());
+        assertEquals("No matching clusters [nosuchcluster*:web_traffic]", ex.getMessage());
     }
 
     private static void assertClusterMetadataInResponse(EsqlQueryResponse resp, boolean responseExpectMeta) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
@@ -726,6 +727,17 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             throw new AssertionError(e);
         }));
         assertTrue(latch.await(30, TimeUnit.SECONDS));
+    }
+
+    public void testSearchesWhereClusterExpressionCannotBeResolved() {
+        setupTwoClusters();
+
+        VerificationException ex = assertThrows(
+            VerificationException.class,
+            () -> runQuery("FROM xremote*:web_traffic | WHERE verb==\"GET\" | KEEP is_https, user_Agent, verb | STATS count(*)", false)
+        );
+
+        assertEquals("No matching clusters xremote*:web_traffic", ex.getMessage());
     }
 
     private static void assertClusterMetadataInResponse(EsqlQueryResponse resp, boolean responseExpectMeta) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -291,7 +291,7 @@ public class EsqlSession {
             if (clusterIndices.size() == 1) {
                 OriginalIndices localCluster = clusterIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
                 if (localCluster != null && localCluster.indices() == Strings.EMPTY_ARRAY) {
-                    throw new VerificationException("No matching clusters " + table.index());
+                    throw new VerificationException("No matching clusters [" + table.index() + "]");
                 }
             }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -23,6 +23,7 @@ import org.elasticsearch.indices.IndicesExpressionGrouper;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
@@ -283,6 +284,17 @@ public class EsqlSession {
             var fieldNames = fieldNames(parsed, enrichPolicyMatchFields);
 
             Map<String, OriginalIndices> clusterIndices = indicesExpressionGrouper.groupIndices(IndicesOptions.DEFAULT, table.index());
+            // If groupIndices() could not resolve the wildcard-ed cluster, it returns the local cluster
+            // and sets the indices to an empty array. If this scenario is not explicitly handled, any
+            // searches involving the unresolved cluster will fall back and return results from local
+            // cluster.
+            if (clusterIndices.size() == 1) {
+                OriginalIndices localCluster = clusterIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+                if (localCluster != null && localCluster.indices() == Strings.EMPTY_ARRAY) {
+                    throw new VerificationException("No matching clusters " + table.index());
+                }
+            }
+
             for (Map.Entry<String, OriginalIndices> entry : clusterIndices.entrySet()) {
                 final String clusterAlias = entry.getKey();
                 String indexExpr = Strings.arrayToCommaDelimitedString(entry.getValue().indices());


### PR DESCRIPTION
If the remote cluster is represented by a wildcard expression that could not be resolved, the search op falls back and returns results from local cluster. Consider:

```
POST /_query
{
  "query": "FROM xremote*:web_traffic |\n WHERE verb==\"GET\" |\nKEEP is_https, user_Agent, verb | STATS count(*)"
}
```

Without this proposed fix, results are returned from the local cluster because `xremote` does not exist. Instead, now, we throw `VerificationException` to let user know that the search op could not proceed.

Fixes https://github.com/elastic/elasticsearch/issues/115262.