### PR TITLE
plugin(apm-data): amend logs-apm component template

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm@settings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm@settings.yaml
@@ -5,5 +5,6 @@ _meta:
   managed: true
 template:
   settings:
-    codec: best_compression
-    index.mode: standard
+    index:
+      codec: best_compression
+      mode: standard

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm@settings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm@settings.yaml
@@ -6,4 +6,4 @@ _meta:
 template:
   settings:
     codec: best_compression
-    mode: standard
+    index.mode: standard


### PR DESCRIPTION
Restore standard mode after LogsDB took precedence. Related: #114501

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅ 
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? ✅ 
- If submitting code, have you built your formula locally prior to submission with `gradle check`? 🚫 
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. ✅ 
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? ✅ 
