### PR TITLE
[8.x] Unmute test that was fixed by #112145 (#115682)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -83,8 +83,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJobAfterMissingIndex
   issue: https://github.com/elastic/elasticsearch/issues/112088
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/112147
 - class: org.elasticsearch.smoketest.WatcherYamlRestIT
   method: test {p0=watcher/usage/10_basic/Test watcher usage stats output}
   issue: https://github.com/elastic/elasticsearch/issues/112189


### PR DESCRIPTION
The template warning was fixed by
https://github.com/elastic/elasticsearch/pull/112145

closed.

This unmutes the test.

Closes #112147

(cherry picked from commit 9dae38e7efde09eba269385d426774d634373204)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #115682