### PR TITLE
Forward port SystemIndexMappingsVersions TransportAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -82,6 +82,7 @@ import org.elasticsearch.action.admin.cluster.storedscripts.TransportGetScriptLa
 import org.elasticsearch.action.admin.cluster.storedscripts.TransportGetStoredScriptAction;
 import org.elasticsearch.action.admin.cluster.storedscripts.TransportPutStoredScriptAction;
 import org.elasticsearch.action.admin.cluster.tasks.TransportPendingClusterTasksAction;
+import org.elasticsearch.action.admin.cluster.version.TransportSystemIndexMappingsVersionsAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.TransportIndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
@@ -626,6 +627,7 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportRemoteInfoAction.TYPE, TransportRemoteInfoAction.class);
         actions.register(TransportNodesCapabilitiesAction.TYPE, TransportNodesCapabilitiesAction.class);
         actions.register(TransportNodesFeaturesAction.TYPE, TransportNodesFeaturesAction.class);
+        actions.register(TransportSystemIndexMappingsVersionsAction.TYPE, TransportSystemIndexMappingsVersionsAction.class);
         actions.register(RemoteClusterNodesAction.TYPE, RemoteClusterNodesAction.TransportAction.class);
         actions.register(TransportNodesStatsAction.TYPE, TransportNodesStatsAction.class);
         actions.register(TransportNodesUsageAction.TYPE, TransportNodesUsageAction.class);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/version/SystemIndexMappingsVersions.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/version/SystemIndexMappingsVersions.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.cluster.version;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class SystemIndexMappingsVersions extends BaseNodeResponse {
+
+    private final Map<String, SystemIndexDescriptor.MappingsVersion> systemIndexMappingsVersions;
+
+    public SystemIndexMappingsVersions(StreamInput in) throws IOException {
+        super(in);
+        systemIndexMappingsVersions = in.readMap(StreamInput::readString, SystemIndexDescriptor.MappingsVersion::new);
+    }
+
+    public SystemIndexMappingsVersions(Map<String, SystemIndexDescriptor.MappingsVersion> systemIndexMappingsVersions, DiscoveryNode node) {
+        super(node);
+        this.systemIndexMappingsVersions = Map.copyOf(systemIndexMappingsVersions);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeMap(systemIndexMappingsVersions, (o, v) -> v.writeTo(o));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/version/SystemIndexMappingsVersionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/version/SystemIndexMappingsVersionsRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.cluster.version;
+
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+
+public class SystemIndexMappingsVersionsRequest extends BaseNodesRequest {
+    public SystemIndexMappingsVersionsRequest(String... nodes) {
+        super(nodes);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/version/SystemIndexMappingsVersionsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/version/SystemIndexMappingsVersionsResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.cluster.version;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SystemIndexMappingsVersionsResponse extends BaseNodesResponse<SystemIndexMappingsVersions> {
+    public SystemIndexMappingsVersionsResponse(
+        ClusterName clusterName,
+        List<SystemIndexMappingsVersions> nodes,
+        List<FailedNodeException> failures
+    ) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<SystemIndexMappingsVersions> readNodesFrom(StreamInput in) throws IOException {
+        return TransportAction.localOnly();
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<SystemIndexMappingsVersions> nodes) throws IOException {
+        TransportAction.localOnly();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/version/TransportSystemIndexMappingsVersionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/version/TransportSystemIndexMappingsVersionsAction.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.cluster.version;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.UpdateForV10;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+@UpdateForV10(owner = UpdateForV10.Owner.CORE_INFRA)
+// This can be removed in v10. It may be called by v8 nodes to v9 nodes.
+public class TransportSystemIndexMappingsVersionsAction extends TransportNodesAction<
+    SystemIndexMappingsVersionsRequest,
+    SystemIndexMappingsVersionsResponse,
+    TransportSystemIndexMappingsVersionsAction.Request,
+    SystemIndexMappingsVersions,
+    Void> {
+
+    public static final ActionType<SystemIndexMappingsVersionsResponse> TYPE = new ActionType<>("cluster:monitor/versions");
+
+    private final CompatibilityVersions compatibilityVersions;
+
+    @Inject
+    public TransportSystemIndexMappingsVersionsAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        CompatibilityVersions compatibilityVersions
+    ) {
+        super(
+            TYPE.name(),
+            clusterService,
+            transportService,
+            actionFilters,
+            TransportSystemIndexMappingsVersionsAction.Request::new,
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+        );
+        this.compatibilityVersions = compatibilityVersions;
+    }
+
+    @Override
+    protected SystemIndexMappingsVersionsResponse newResponse(
+        SystemIndexMappingsVersionsRequest request,
+        List<SystemIndexMappingsVersions> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new SystemIndexMappingsVersionsResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected Request newNodeRequest(SystemIndexMappingsVersionsRequest request) {
+        return new Request();
+    }
+
+    @Override
+    protected SystemIndexMappingsVersions newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new SystemIndexMappingsVersions(in);
+    }
+
+    @Override
+    protected SystemIndexMappingsVersions nodeOperation(Request request, Task task) {
+        return new SystemIndexMappingsVersions(compatibilityVersions.systemIndexMappingsVersion(), transportService.getLocalNode());
+    }
+
+    public static class Request extends TransportRequest {
+        public Request(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public Request() {}
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -376,6 +376,7 @@ public class Constants {
         "cluster:monitor/text_structure/test_grok_pattern",
         "cluster:monitor/transform/get",
         "cluster:monitor/transform/stats/get",
+        "cluster:monitor/versions",
         "cluster:monitor/xpack/analytics/stats",
         "cluster:monitor/xpack/enrich/coordinator_stats",
         "cluster:monitor/xpack/enrich/stats",


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/115771 introduced a clusterlistener to "fixup" system indices mapping versions in cluster state, which may be missing in some scenarios.

The fix includes a TransportAction to read and collect SystemIndexMappingsVersions; v9 nodes may still receive a request to handle this transport action (e.g. if you have a mixed cluster with some old v8.x nodes and v8.last nodes). Therefore v9 nodes  should still have the TransportAction, but they do not need the fixup listener.

This PR ports the TA (and only the TA) to the main branch.