### PR TITLE
[8.15] [DOCS] `_cat/shards`: clarify required permissions for restricted indices (#115650)

### DIFF
--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -30,7 +30,7 @@ For data streams, the API returns information about the stream's backing indices
 * If the {es} {security-features} are enabled, you must have the `monitor` or
 `manage` <<privileges-list-cluster,cluster privilege>> to use this API.
 You must also have the `monitor` or `manage` <<privileges-list-indices,index privilege>>
-for any data stream, index, or alias you retrieve.
+to view the full information for any data stream, index, or alias you retrieve.
 
 [[cat-shards-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[DOCS] `_cat/shards`: clarify required permissions for restricted indices (#115650)](https://github.com/elastic/elasticsearch/pull/115650)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)