### PR TITLE
[Inference API] Improve chunked results error message

### DIFF
--- a/docs/changelog/115807.yaml
+++ b/docs/changelog/115807.yaml
@@ -1,0 +1,5 @@
+pr: 115807
+summary: "[Inference API] Improve chunked results error message"
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
@@ -14,7 +14,8 @@ public class ResultUtils {
 
     public static ElasticsearchStatusException createInvalidChunkedResultException(String expectedResultName, String receivedResultName) {
         return new ElasticsearchStatusException(
-            "Received incompatible results. Check that your model_id matches the task_type of this endpoint. Expected chunked output of type [{}] but received [{}].",
+            "Received incompatible results. Check that your model_id matches the task_type of this endpoint. "
+                + "Expected chunked output of type [{}] but received [{}].",
             RestStatus.CONFLICT,
             expectedResultName,
             receivedResultName

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
@@ -14,7 +14,7 @@ public class ResultUtils {
 
     public static ElasticsearchStatusException createInvalidChunkedResultException(String expectedResultName, String receivedResultName) {
         return new ElasticsearchStatusException(
-            "Expected a chunked inference [{}] received [{}]",
+            "Received incompatible results. Check that your model_id matches the task_type of this endpoint. Expected chunked output of type [{}] but received [{}].",
             RestStatus.INTERNAL_SERVER_ERROR,
             expectedResultName,
             receivedResultName

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
@@ -15,7 +15,7 @@ public class ResultUtils {
     public static ElasticsearchStatusException createInvalidChunkedResultException(String expectedResultName, String receivedResultName) {
         return new ElasticsearchStatusException(
             "Received incompatible results. Check that your model_id matches the task_type of this endpoint. Expected chunked output of type [{}] but received [{}].",
-            RestStatus.INTERNAL_SERVER_ERROR,
+            RestStatus.CONFLICT,
             expectedResultName,
             receivedResultName
         );


### PR DESCRIPTION
previously putting a model with the wrong task type could result in a 500 error with this message:
``` json
{
      "index": "test-chunking",
      "id": "awd",
      "cause": {
        "type": "exception",
        "reason": "Exception when running inference id [test-chunking] on field [content]",
        "caused_by": {
          "type": "status_exception",
          "reason": "Expected a chunked inference [text_embedding_result] received [text_expansion_result]"
        }
      },
      "status": 500
    }
```

but this has been updated to a 409 error with this message:
`Received incompatible results. Check that your model_id matches the task_type of this endpoint. Expected chunked output of type [{}] but received [{}].`
