### PR TITLE
[8.x] CsvTestsDataLoader::deleteInferenceEndpoint should use Delete Inference API with task-type

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -321,8 +321,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
   method: testPutE5Small_withPlatformSpecificVariant
   issue: https://github.com/elastic/elasticsearch/issues/113950
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  issue: https://github.com/elastic/elasticsearch/issues/115315
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/80_transform_jobs_crud/Test GET, start, and stop old cluster batch transforms}
   issue: https://github.com/elastic/elasticsearch/issues/115319

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -272,7 +272,7 @@ public class CsvTestsDataLoader {
 
     public static void deleteInferenceEndpoint(RestClient client) throws IOException {
         try {
-            client.performRequest(new Request("DELETE", "_inference/test_sparse_inference"));
+            client.performRequest(new Request("DELETE", "_inference/sparse_embedding/test_sparse_inference"));
         } catch (ResponseException e) {
             // 404 here means the endpoint was not created
             if (e.getResponse().getStatusLine().getStatusCode() != 404) {


### PR DESCRIPTION
This commit updates `CsvTestsDataLoader::deleteInferenceEndpoint` to use the form of the Delete Inference API that accepts a `task type`.

The test infrastructure attempts to delete the inference endpoint with a request of the form `DELETE /_inference/<inference_id>`. This form was introduced in 8.13 (see https://github.com/elastic/elasticsearch/pull/104483). Previously, the task type was the only supported form, e.g.  `DELETE /_inference/<task_type>/<inference_id>`. 

Since the task-type form is supported on both recent and less recent Elasticsearch versions, then it's probably most straightforward to just use that form in the `8.x` branch.

Additional, this commit unmutes the org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT test suite, since this fix allows the suite to complete successfully.

closes #115315