### PR TITLE
Try to simplify geometries that fail with TopologyException

### DIFF
--- a/docs/changelog/115834.yaml
+++ b/docs/changelog/115834.yaml
@@ -1,0 +1,5 @@
+pr: 115834
+summary: Try to simplify geometries that fail with `TopologyException`
+area: Geo
+type: bug
+issues: []

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -307,8 +307,11 @@ public class FeatureFactory {
                         return null;
                     }
                 } catch (TopologyException ex) {
-                    // we should never get here but just to be super safe because a TopologyException will kill the node
-                    throw new IllegalArgumentException(ex);
+                    // Note we should never throw a TopologyException as it kill the node
+                    // unfortunately the intersection method is not perfect and it will throw this error for complex
+                    // geometries even when valid. We can still simplify such geometry so we just return the original and
+                    // let the simplification process handle it.
+                    return geometry;
                 }
             }
         }


### PR DESCRIPTION
During some testing I noticed that some geometries where failing with a topolygy exception when computing the intersection. This error is not seeing when reading from source because we are swallowing the exceptions but it is visible when doing it from the stored value.

This geometries are valid and they can actually be simplified so lets make the clipping algorithm a best effort and return the original geometry in those cases so the simplification can handle it.

Note: I am working on adding a test but we need to clear the license of the geometry I am using and that might take time.