### PR TITLE
Fix file settings service restart IT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -241,9 +241,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280
-- class: org.elasticsearch.xpack.security.FileSettingsRoleMappingsRestartIT
-  method: testFileSettingsReprocessedOnRestartWithoutVersionChange
-  issue: https://github.com/elastic/elasticsearch/issues/115450
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/115528

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -175,7 +175,7 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
             )
         );
 
-        // now remove the role mappings via the same settings file
+        // now remove the role mappings via an empty settings file
         cleanupClusterStateAndAssertNoMappings(masterNode);
 
         // and restart the master to confirm the role mappings are all gone


### PR DESCRIPTION
The test is failing on windows FS fixtures, due to what I believe is the following race condition (still have not been able to reproduce):

- we treat file settings service processing as complete as soon as we get a cluster-state changed event in `setupClusterStateListener` with the expected metadata key
- immediately after, we attempt to overwrite the file 

I think there is a narrow window between receiving the cluster-state changed event and the call to overwrite the file when the file is still open. To this end, I'm simplifying the test and making it more robust by:

- ensuring (like we do in other similar tests that are _not_ failing) that we not only await the cluster-state changed event but also make sure that we are checking cluster-state at the correct version (analogous to this old improvement to other test suites: https://github.com/elastic/elasticsearch/pull/89468)
- simplifying the test for now to avoid a potentially flakey section: we assert that file settings without a version change do not get re-applied in a running service but we don't have a reliable way of asserting that the file settings change was ever picked up by the service. To avoid additional flakiness, and reliably cover the base-case of coverage, I'm removing this section for now and will re-add it once I have a non-flakey way of making the necessary assertion

Resolves: https://github.com/elastic/elasticsearch/issues/115450