### PR TITLE
[8.16] Fix lingering license warning header in IP filter (#115510)

### DIFF
--- a/docs/changelog/115510.yaml
+++ b/docs/changelog/115510.yaml
@@ -1,0 +1,6 @@
+pr: 115510
+summary: Fix lingering license warning header in IP filter
+area: License
+type: bug
+issues:
+ - 114865

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -330,8 +330,6 @@ tests:
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/800_rrf_with_text_similarity_reranker_retriever/explain using rrf retriever and text-similarity}
   issue: https://github.com/elastic/elasticsearch/issues/114757
-- class: org.elasticsearch.license.LicensingTests
-  issue: https://github.com/elastic/elasticsearch/issues/114865
 - class: org.elasticsearch.xpack.security.authc.ldap.GroupMappingIT
   issue: https://github.com/elastic/elasticsearch/issues/115221
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/license/LicensingTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
 import org.hamcrest.Matchers;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 
 import java.nio.file.Files;
@@ -241,6 +242,7 @@ public class LicensingTests extends SecurityIntegTestCase {
         Header[] headers = null;
         try {
             getRestClient().performRequest(request);
+            Assert.fail("expected response exception");
         } catch (ResponseException e) {
             headers = e.getResponse().getHeaders();
             List<String> afterWarningHeaders = getWarningHeaders(headers);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransport.java
@@ -104,7 +104,7 @@ public class SecurityNetty4ServerTransport extends SecurityNetty4Transport {
 
     private void maybeAddIPFilter(final Channel ch, final String name) {
         if (authenticator != null) {
-            ch.pipeline().addFirst("ipfilter", new IpFilterRemoteAddressFilter(authenticator, name));
+            ch.pipeline().addFirst("ipfilter", new IpFilterRemoteAddressFilter(authenticator, name, getThreadPool().getThreadContext()));
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.TestUtils;
@@ -90,10 +91,11 @@ public class IpFilterRemoteAddressFilterTests extends ESTestCase {
             ipFilter.setBoundHttpTransportAddress(httpTransport.boundAddress());
         }
 
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         if (isHttpEnabled) {
-            handler = new IpFilterRemoteAddressFilter(ipFilter, IPFilter.HTTP_PROFILE_NAME);
+            handler = new IpFilterRemoteAddressFilter(ipFilter, IPFilter.HTTP_PROFILE_NAME, threadContext);
         } else {
-            handler = new IpFilterRemoteAddressFilter(ipFilter, "default");
+            handler = new IpFilterRemoteAddressFilter(ipFilter, "default", threadContext);
         }
     }
 
@@ -106,7 +108,11 @@ public class IpFilterRemoteAddressFilterTests extends ESTestCase {
     }
 
     public void testFilteringWorksForRemoteClusterPort() throws Exception {
-        handler = new IpFilterRemoteAddressFilter(ipFilter, RemoteClusterPortSettings.REMOTE_CLUSTER_PROFILE);
+        handler = new IpFilterRemoteAddressFilter(
+            ipFilter,
+            RemoteClusterPortSettings.REMOTE_CLUSTER_PROFILE,
+            new ThreadContext(Settings.EMPTY)
+        );
         InetSocketAddress localhostAddr = new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 12345);
         assertThat(handler.accept(mock(ChannelHandlerContext.class), localhostAddr), is(true));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Fix lingering license warning header in IP filter (#115510)](https://github.com/elastic/elasticsearch/pull/115510)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)