### PR TITLE
[8.15] Try to simplify geometries that fail with TopologyException (#115834)

### DIFF
--- a/docs/changelog/115834.yaml
+++ b/docs/changelog/115834.yaml
@@ -1,0 +1,5 @@
+pr: 115834
+summary: Try to simplify geometries that fail with `TopologyException`
+area: Geo
+type: bug
+issues: []

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -307,8 +307,11 @@ public class FeatureFactory {
                         return null;
                     }
                 } catch (TopologyException ex) {
-                    // we should never get here but just to be super safe because a TopologyException will kill the node
-                    throw new IllegalArgumentException(ex);
+                    // Note we should never throw a TopologyException as it kill the node
+                    // unfortunately the intersection method is not perfect and it will throw this error for complex
+                    // geometries even when valid. We can still simplify such geometry so we just return the original and
+                    // let the simplification process handle it.
+                    return geometry;
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Try to simplify geometries that fail with TopologyException (#115834)