### PR TITLE
[8.x] Set assignment state to "started" in case of zero allocations

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -533,6 +533,9 @@ public final class TrainedModelAssignment implements SimpleDiffable<TrainedModel
             if (assignmentState.equals(AssignmentState.STOPPING)) {
                 return assignmentState;
             }
+            if (taskParams.getNumberOfAllocations() == 0) {
+                return AssignmentState.STARTED;
+            }
             if (nodeRoutingTable.values().stream().anyMatch(r -> r.getState().equals(RoutingState.STARTED))) {
                 return AssignmentState.STARTED;
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
@@ -172,6 +172,11 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         assertThat(builder.calculateAssignmentState(), equalTo(AssignmentState.STARTING));
     }
 
+    public void testCalculateAssignmentState_GivenNumAllocationsIsZero() {
+        TrainedModelAssignment.Builder builder = TrainedModelAssignment.Builder.empty(randomTaskParams(0), null);
+        assertThat(builder.calculateAssignmentState(), equalTo(AssignmentState.STARTED));
+    }
+
     public void testCalculateAssignmentState_GivenOneStartedAssignment() {
         TrainedModelAssignment.Builder builder = TrainedModelAssignment.Builder.empty(randomTaskParams(5), null);
         builder.addRoutingEntry("node-1", new RoutingInfo(4, 4, RoutingState.STARTING, ""));


### PR DESCRIPTION
backport #115824 