### PR TITLE
Dont run datetime tests with CLDR

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -43,8 +43,7 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
     public static void checkJvmProperties() {
         String localeProviders = System.getProperty("java.locale.providers", "");
         boolean runtimeJdk8 = JavaVersion.current().getVersion().get(0) == 8;
-        assert (runtimeJdk8 && localeProviders.equals("SPI,JRE"))
-            || (false == runtimeJdk8 && localeProviders.contains("SPI"))
+        assert (runtimeJdk8 && localeProviders.equals("SPI,JRE")) || (false == runtimeJdk8 && localeProviders.contains("SPI"))
             : "`-Djava.locale.providers` needs to be set";
         assumeFalse(
             "won't work in jdk8 because SPI mechanism is not looking at classpath - needs ISOCalendarDataProvider in jre's ext/libs",

--- a/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/joda/JavaJodaTimeDuellingTests.java
@@ -41,14 +41,16 @@ public class JavaJodaTimeDuellingTests extends ESTestCase {
 
     @BeforeClass
     public static void checkJvmProperties() {
+        String localeProviders = System.getProperty("java.locale.providers", "");
         boolean runtimeJdk8 = JavaVersion.current().getVersion().get(0) == 8;
-        assert (runtimeJdk8 && (System.getProperty("java.locale.providers", "").equals("SPI,JRE")))
-            || (false == runtimeJdk8 && (System.getProperty("java.locale.providers", "").contains("SPI")))
+        assert (runtimeJdk8 && localeProviders.equals("SPI,JRE"))
+            || (false == runtimeJdk8 && localeProviders.contains("SPI"))
             : "`-Djava.locale.providers` needs to be set";
         assumeFalse(
-            "won't work in jdk8 " + "because SPI mechanism is not looking at classpath - needs ISOCalendarDataProvider in jre's ext/libs",
+            "won't work in jdk8 because SPI mechanism is not looking at classpath - needs ISOCalendarDataProvider in jre's ext/libs",
             runtimeJdk8
         );
+        assumeFalse("CLDR messes up several datatime checks, ignore these", localeProviders.contains("CLDR"));
     }
 
     public void testIncorrectFormat() {


### PR DESCRIPTION
CLDR changes datetime outputs - so just ignore the tests with CLDR. Fixes #115413