### PR TITLE
[8.x] Query rules retriever  (#114855)

### DIFF
--- a/docs/changelog/114855.yaml
+++ b/docs/changelog/114855.yaml
@@ -1,0 +1,5 @@
+pr: 114855
+summary: Add query rules retriever
+area: Relevance
+type: enhancement
+issues: [ ]

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -182,6 +182,9 @@ public class TransportVersions {
     public static final TransportVersion SIMULATE_MAPPING_ADDITION = def(8_777_00_0);
     public static final TransportVersion INTRODUCE_ALL_APPLICABLE_SELECTOR = def(8_778_00_0);
     public static final TransportVersion INDEX_MODE_LOOKUP = def(8_779_00_0);
+    public static final TransportVersion INDEX_REQUEST_REMOVE_METERING = def(8_780_00_0);
+    public static final TransportVersion CPU_STAT_STRING_PARSING = def(8_781_00_0);
+    public static final TransportVersion QUERY_RULES_RETRIEVER = def(8_782_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -218,6 +218,10 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
         this.rankDocs = rankDocs;
     }
 
+    public RankDoc[] getRankDocs() {
+        return rankDocs;
+    }
+
     /**
      * Gets the filters for this retriever.
      */

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilderWrapper.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilderWrapper.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.retriever;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.rank.RankDoc;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A wrapper that can be used to modify the behaviour of an existing {@link RetrieverBuilder}.
+ */
+public abstract class RetrieverBuilderWrapper<T extends RetrieverBuilder> extends RetrieverBuilder {
+    protected final RetrieverBuilder in;
+
+    protected RetrieverBuilderWrapper(RetrieverBuilder in) {
+        this.in = in;
+    }
+
+    protected abstract T clone(RetrieverBuilder sub);
+
+    @Override
+    public RetrieverBuilder rewrite(QueryRewriteContext ctx) throws IOException {
+        var inRewrite = in.rewrite(ctx);
+        if (inRewrite != in) {
+            return clone(inRewrite);
+        }
+        return this;
+    }
+
+    @Override
+    public QueryBuilder topDocsQuery() {
+        return in.topDocsQuery();
+    }
+
+    @Override
+    public RetrieverBuilder minScore(Float minScore) {
+        return in.minScore(minScore);
+    }
+
+    @Override
+    public List<QueryBuilder> getPreFilterQueryBuilders() {
+        return in.preFilterQueryBuilders;
+    }
+
+    @Override
+    public ActionRequestValidationException validate(
+        SearchSourceBuilder source,
+        ActionRequestValidationException validationException,
+        boolean isScroll,
+        boolean allowPartialSearchResults
+    ) {
+        return in.validate(source, validationException, isScroll, allowPartialSearchResults);
+    }
+
+    @Override
+    public RetrieverBuilder retrieverName(String retrieverName) {
+        return in.retrieverName(retrieverName);
+    }
+
+    @Override
+    public void setRankDocs(RankDoc[] rankDocs) {
+        in.setRankDocs(rankDocs);
+    }
+
+    @Override
+    public RankDoc[] getRankDocs() {
+        return in.getRankDocs();
+    }
+
+    @Override
+    public boolean isCompound() {
+        return in.isCompound();
+    }
+
+    @Override
+    public QueryBuilder explainQuery() {
+        return in.explainQuery();
+    }
+
+    @Override
+    public Float minScore() {
+        return in.minScore();
+    }
+
+    @Override
+    public boolean isFragment() {
+        return in.isFragment();
+    }
+
+    @Override
+    public String toString() {
+        return in.toString();
+    }
+
+    @Override
+    public String retrieverName() {
+        return in.retrieverName();
+    }
+
+    @Override
+    public void extractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder, boolean compoundUsed) {
+        in.extractToSearchSourceBuilder(searchSourceBuilder, compoundUsed);
+    }
+
+    @Override
+    public String getName() {
+        return in.getName();
+    }
+
+    @Override
+    protected void doToXContent(XContentBuilder builder, Params params) throws IOException {
+        in.doToXContent(builder, params);
+    }
+
+    @Override
+    protected boolean doEquals(Object o) {
+        // Handle the edge case where we need to unwrap the incoming retriever
+        if (o instanceof RetrieverBuilderWrapper<?> wrapper) {
+            return in.doEquals(wrapper.in);
+        } else {
+            return in.doEquals(o);
+        }
+    }
+
+    @Override
+    protected int doHashCode() {
+        return in.doHashCode();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/search/retriever/TestRetrieverBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/retriever/TestRetrieverBuilder.java
@@ -89,6 +89,8 @@ public class TestRetrieverBuilder extends RetrieverBuilder {
 
     @Override
     public boolean doEquals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         TestRetrieverBuilder that = (TestRetrieverBuilder) o;
         return Objects.equals(value, that.value);
     }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/rules/80_query_rules_retriever.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/rules/80_query_rules_retriever.yml
@@ -1,0 +1,414 @@
+setup:
+  - requires:
+      cluster_features: 'query_rule_retriever_supported'
+      reason: 'test requires query rule retriever implementation'
+
+  - do:
+      indices.create:
+        index: test-index1
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      bulk:
+        refresh: true
+        index: test-index1
+        body:
+          - index:
+              _id: foo
+          - { "text": "foo - pinned doc for foo" }
+          - index:
+              _id: bar
+          - { "text": "bar - exclude doc for bar" }
+          - index:
+              _id: baz
+          - { "text": "baz - no rule attached" }
+          - index:
+              _id: foo_no_rule
+          - { "text": "text search result for foo with no rule attached" }
+          - index:
+              _id: bar_no_rule
+          - { "text": "text search result for bar with no rule attached" }
+          - index:
+              _id: foo2
+          - { "text": "foo2 - second pinned doc for foo" }
+
+  - do:
+      query_rules.put_ruleset:
+        ruleset_id: test-ruleset
+        body:
+          rules:
+            - rule_id: foo
+              type: pinned
+              criteria:
+                - type: exact
+                  metadata: foo
+                  values: [ foo ]
+              actions:
+                ids:
+                  - foo
+                  - foo2
+            - rule_id: bar
+              type: exclude
+              criteria:
+                - type: exact
+                  metadata: bar
+                  values: [ bar ]
+              actions:
+                ids:
+                  - bar
+
+---
+"standalone query rules retriever":
+
+  - do:
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.1._id: foo2 }
+  - match: { hits.hits.2._id: bar_no_rule }
+
+---
+"query rules retriever combined with rrf":
+
+  - do:
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                rrf:
+                  retrievers: [
+                    {
+                      standard: {
+                        query: {
+                          query_string: {
+                            query: bar
+                          }
+                        }
+                      }
+                    },
+                    {
+                      standard: {
+                        query: {
+                          query_string: {
+                            query: baz
+                          }
+                        }
+                      }
+                    }
+                  ]
+
+  - match: { hits.total.value: 4 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.1._id: foo2 }
+
+
+---
+"query rules retriever combined with rrf and pagination":
+
+  - do:
+      search:
+        index: test-index1
+        body:
+          size: 1
+          from: 1
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                rrf:
+                  retrievers: [
+                    {
+                      standard: {
+                        query: {
+                          query_string: {
+                            query: bar
+                          }
+                        }
+                      }
+                    },
+                    {
+                      standard: {
+                        query: {
+                          query_string: {
+                            query: baz
+                          }
+                        }
+                      }
+                    }
+                  ]
+
+  - match: { hits.total.value: 4 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: foo2 }
+
+---
+"query rules allowed to be defined as a sub-retriever":
+
+  - do:
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rrf:
+              retrievers: [
+                {
+                  standard: {
+                    query: {
+                      query_string: {
+                        query: bar
+                      }
+                    }
+                  }
+                },
+                {
+                  rule: {
+                    match_criteria: {
+                      foo: foo,
+                      bar: bar
+                    },
+                    ruleset_ids: test-ruleset,
+                    retriever: {
+                      standard: {
+                        query: {
+                          query_string: {
+                            query: baz
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+
+  - match: { hits.total.value: 5 }
+
+---
+"query rules retriever supports explicit sort on score":
+
+  - do:
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+                  sort: [ "_score" ]
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.1._id: foo2 }
+  - match: { hits.hits.2._id: bar_no_rule }
+
+---
+"query rules retriever supports explicit sort on score with secondary sort allowed":
+
+  - do:
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+                  sort: [ "_score", { "text.keyword": "asc" } ]
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.1._id: foo2 }
+  - match: { hits.hits.2._id: bar_no_rule }
+
+
+---
+"query rules retriever supports rank window size":
+  - skip:
+      features: headers
+
+  - do:
+      headers:
+        # Force JSON content type so that we use a parser that interprets the floating-point score as a double
+        Content-Type: application/json
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+              rank_window_size: 1
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.0._score: 1.7014124E38 }
+  - match: { hits.hits.1._score: 0 }
+  - match: { hits.hits.2._score: 0 }
+
+  - do:
+      headers:
+        # Force JSON content type so that we use a parser that interprets the floating-point score as a double
+        Content-Type: application/json
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+              rank_window_size: 2
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.0._score: 1.7014124E38 }
+  - match: { hits.hits.1._id: foo2 }
+  - match: { hits.hits.1._score: 1.7014122E38 }
+  - match: { hits.hits.2._id: bar_no_rule }
+  - match: { hits.hits.2._score: 0 }
+
+  - do:
+      headers:
+        # Force JSON content type so that we use a parser that interprets the floating-point score as a double
+        Content-Type: application/json
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+              rank_window_size: 10
+
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.0._score: 1.7014124E38 }
+  - match: { hits.hits.1._id: foo2 }
+  - match: { hits.hits.1._score: 1.7014122E38 }
+  - match: { hits.hits.2._id: bar_no_rule }
+  - match: { hits.hits.2._score: 0.87832844 }
+
+---
+"query rules will error if sorting by anything other than score":
+
+  - do:
+      catch: /\[rule\] retriever only supports sort by score/
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+                  sort: [ { "_id": "desc" } ]
+
+---
+"query rules retriever explains pinned documents as constant score queries":
+  - skip:
+      features: [ headers ]
+
+  - do:
+      headers:
+        # Force JSON content type so that we use a parser that interprets the floating-point score as a double
+        Content-Type: application/json
+      search:
+        index: test-index1
+        body:
+          retriever:
+            rule:
+              match_criteria:
+                foo: foo
+                bar: bar
+              ruleset_ids:
+                test-ruleset
+              retriever:
+                standard:
+                  query:
+                    query_string:
+                      query: bar
+          explain: true
+
+  - match: { hits.hits.0._id: foo }
+  - match: { hits.hits.0._explanation.value: 1.7014124E38 }
+  - match: { hits.hits.0._explanation.description: "query rules evaluated rules from rulesets [test-ruleset] and match criteria {bar=bar, foo=foo}" }
+  - match: { hits.hits.0._explanation.details.0.value: 1 }
+  - match: { hits.hits.0._explanation.details.0.description: "doc [0] with an original score of [1.7014124E38] is at rank [1] from the following source queries." }
+  - match: { hits.hits.0._explanation.details.0.details.0.description: "sum of:" }
+  - match: { hits.hits.0._explanation.details.0.details.0.details.0.description: "max of:" }
+  - match: { hits.hits.0._explanation.details.0.details.0.details.0.details.0.description: "max of:" }
+  - match: { hits.hits.0._explanation.details.0.details.0.details.0.details.0.details.0.description: "ConstantScore(_id:([7e 8a]))^1.7014124E38" }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -19,6 +19,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -28,6 +30,7 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.application.analytics.action.DeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.GetAnalyticsCollectionAction;
@@ -175,6 +178,7 @@ import org.elasticsearch.xpack.application.rules.action.TransportListQueryRulese
 import org.elasticsearch.xpack.application.rules.action.TransportPutQueryRuleAction;
 import org.elasticsearch.xpack.application.rules.action.TransportPutQueryRulesetAction;
 import org.elasticsearch.xpack.application.rules.action.TransportTestQueryRulesetAction;
+import org.elasticsearch.xpack.application.rules.retriever.QueryRuleRetrieverBuilder;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.action.DeleteSearchApplicationAction;
 import org.elasticsearch.xpack.application.search.action.GetSearchApplicationAction;
@@ -236,6 +240,12 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
     protected XPackLicenseState getLicenseState() {
         return XPackPlugin.getSharedLicenseState();
     }
+
+    public static final LicensedFeature.Momentary QUERY_RULES_RETRIEVER_FEATURE = LicensedFeature.momentary(
+        null,
+        "rule-retriever",
+        License.OperationMode.ENTERPRISE
+    );
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
@@ -505,5 +515,10 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         return singletonList(
             new QuerySpec<>(RuleQueryBuilder.NAME, RuleQueryBuilder::new, p -> RuleQueryBuilder.fromXContent(p, getLicenseState()))
         );
+    }
+
+    @Override
+    public List<RetrieverSpec<?>> getRetrievers() {
+        return List.of(new RetrieverSpec<>(new ParseField(QueryRuleRetrieverBuilder.NAME), QueryRuleRetrieverBuilder::fromXContent));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeatures.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchFeatures.java
@@ -12,6 +12,7 @@ import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
+import org.elasticsearch.xpack.application.rules.retriever.QueryRuleRetrieverBuilder;
 
 import java.util.Map;
 import java.util.Set;
@@ -22,7 +23,7 @@ public class EnterpriseSearchFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of(QUERY_RULES_TEST_API);
+        return Set.of(QUERY_RULES_TEST_API, QueryRuleRetrieverBuilder.QUERY_RULE_RETRIEVERS_SUPPORTED);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.rules.retriever;
+
+import org.apache.lucene.search.ScoreDoc;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.search.builder.PointInTimeBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.rank.RankDoc;
+import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
+import org.elasticsearch.search.retriever.RetrieverBuilder;
+import org.elasticsearch.search.retriever.RetrieverBuilderWrapper;
+import org.elasticsearch.search.retriever.RetrieverParserContext;
+import org.elasticsearch.search.retriever.rankdoc.RankDocsQueryBuilder;
+import org.elasticsearch.search.sort.ScoreSortBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.application.EnterpriseSearch;
+import org.elasticsearch.xpack.application.rules.RuleQueryBuilder;
+import org.elasticsearch.xpack.core.XPackPlugin;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * A query rule retriever applies query rules defined in one or more rulesets to the underlying retriever.
+ */
+public final class QueryRuleRetrieverBuilder extends CompoundRetrieverBuilder<QueryRuleRetrieverBuilder> {
+
+    public static final String NAME = "rule";
+    public static final NodeFeature QUERY_RULE_RETRIEVERS_SUPPORTED = new NodeFeature("query_rule_retriever_supported");
+
+    public static final ParseField RULESET_IDS_FIELD = new ParseField("ruleset_ids");
+    public static final ParseField MATCH_CRITERIA_FIELD = new ParseField("match_criteria");
+    public static final ParseField RETRIEVER_FIELD = new ParseField("retriever");
+    public static final ParseField RANK_WINDOW_SIZE_FIELD = new ParseField("rank_window_size");
+
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<QueryRuleRetrieverBuilder, RetrieverParserContext> PARSER = new ConstructingObjectParser<>(
+        NAME,
+        args -> {
+            List<String> rulesetIds = (List<String>) args[0];
+            Map<String, Object> matchCriteria = (Map<String, Object>) args[1];
+            RetrieverBuilder retrieverBuilder = (RetrieverBuilder) args[2];
+            int rankWindowSize = args[3] == null ? DEFAULT_RANK_WINDOW_SIZE : (int) args[3];
+            return new QueryRuleRetrieverBuilder(rulesetIds, matchCriteria, retrieverBuilder, rankWindowSize);
+        }
+    );
+
+    static {
+        PARSER.declareStringArray(constructorArg(), RULESET_IDS_FIELD);
+        PARSER.declareObject(constructorArg(), (p, c) -> p.map(), MATCH_CRITERIA_FIELD);
+        PARSER.declareNamedObject(constructorArg(), (p, c, n) -> {
+            RetrieverBuilder innerRetriever = p.namedObject(RetrieverBuilder.class, n, c);
+            c.trackRetrieverUsage(innerRetriever.getName());
+            return innerRetriever;
+        }, RETRIEVER_FIELD);
+        PARSER.declareInt(optionalConstructorArg(), RANK_WINDOW_SIZE_FIELD);
+        RetrieverBuilder.declareBaseParserFields(NAME, PARSER);
+    }
+
+    public static QueryRuleRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
+        if (context.clusterSupportsFeature(QUERY_RULE_RETRIEVERS_SUPPORTED) == false) {
+            throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + NAME + "]");
+        }
+        if (EnterpriseSearch.QUERY_RULES_RETRIEVER_FEATURE.check(XPackPlugin.getSharedLicenseState()) == false) {
+            throw LicenseUtils.newComplianceException("Query Rules");
+        }
+        try {
+            return PARSER.apply(parser, context);
+        } catch (Exception e) {
+            throw new ParsingException(parser.getTokenLocation(), e.getMessage(), e);
+        }
+    }
+
+    private final List<String> rulesetIds;
+    private final Map<String, Object> matchCriteria;
+
+    public QueryRuleRetrieverBuilder(
+        List<String> rulesetIds,
+        Map<String, Object> matchCriteria,
+        RetrieverBuilder retrieverBuilder,
+        int rankWindowSize
+    ) {
+        super(new ArrayList<>(), rankWindowSize);
+        this.rulesetIds = rulesetIds;
+        this.matchCriteria = matchCriteria;
+        addChild(new QueryRuleRetrieverBuilderWrapper(retrieverBuilder));
+    }
+
+    public QueryRuleRetrieverBuilder(
+        List<String> rulesetIds,
+        Map<String, Object> matchCriteria,
+        List<RetrieverSource> retrieverSource,
+        int rankWindowSize,
+        String retrieverName
+    ) {
+        super(retrieverSource, rankWindowSize);
+        this.rulesetIds = rulesetIds;
+        this.matchCriteria = matchCriteria;
+        this.retrieverName = retrieverName;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    public int rankWindowSize() {
+        return rankWindowSize;
+    }
+
+    @Override
+    protected SearchSourceBuilder createSearchSourceBuilder(PointInTimeBuilder pit, RetrieverBuilder retrieverBuilder) {
+        var ret = super.createSearchSourceBuilder(pit, retrieverBuilder);
+        checkValidSort(ret.sorts());
+        ret.query(new RuleQueryBuilder(ret.query(), matchCriteria, rulesetIds));
+        return ret;
+    }
+
+    private static void checkValidSort(List<SortBuilder<?>> sortBuilders) {
+        if (sortBuilders.isEmpty()) {
+            return;
+        }
+
+        if (sortBuilders.getFirst() instanceof ScoreSortBuilder == false) {
+            throw new IllegalArgumentException("[" + NAME + "] retriever only supports sort by score, got: " + sortBuilders);
+        }
+    }
+
+    @Override
+    public void doToXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.array(RULESET_IDS_FIELD.getPreferredName(), rulesetIds.toArray());
+        builder.startObject(MATCH_CRITERIA_FIELD.getPreferredName());
+        builder.mapContents(matchCriteria);
+        builder.endObject();
+        builder.field(RETRIEVER_FIELD.getPreferredName(), innerRetrievers.getFirst().retriever());
+        // We need to explicitly include this here as it's not propagated by the wrapper
+        builder.field(RANK_WINDOW_SIZE_FIELD.getPreferredName(), rankWindowSize);
+    }
+
+    @Override
+    protected QueryRuleRetrieverBuilder clone(List<RetrieverSource> newChildRetrievers) {
+        return new QueryRuleRetrieverBuilder(rulesetIds, matchCriteria, newChildRetrievers, rankWindowSize, retrieverName);
+    }
+
+    @Override
+    protected RankDoc[] combineInnerRetrieverResults(List<ScoreDoc[]> rankResults) {
+        assert rankResults.size() == 1;
+        ScoreDoc[] scoreDocs = rankResults.getFirst();
+        RankDoc[] rankDocs = new RuleQueryRankDoc[scoreDocs.length];
+        for (int i = 0; i < scoreDocs.length; i++) {
+            ScoreDoc scoreDoc = scoreDocs[i];
+            rankDocs[i] = new RuleQueryRankDoc(scoreDoc.doc, scoreDoc.score, scoreDoc.shardIndex, rulesetIds, matchCriteria);
+            rankDocs[i].rank = i + 1;
+        }
+        return rankDocs;
+    }
+
+    @Override
+    public boolean doEquals(Object o) {
+        QueryRuleRetrieverBuilder that = (QueryRuleRetrieverBuilder) o;
+        return super.doEquals(o) && Objects.equals(rulesetIds, that.rulesetIds) && Objects.equals(matchCriteria, that.matchCriteria);
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(super.doHashCode(), rulesetIds, matchCriteria);
+    }
+
+    /**
+     * We need to wrap the QueryRulesRetrieverBuilder in order to ensure that the top docs query that is generated
+     * by this retriever correctly generates and executes a Rule query.
+     */
+    class QueryRuleRetrieverBuilderWrapper extends RetrieverBuilderWrapper<QueryRuleRetrieverBuilderWrapper> {
+        protected QueryRuleRetrieverBuilderWrapper(RetrieverBuilder in) {
+            super(in);
+        }
+
+        @Override
+        protected QueryRuleRetrieverBuilderWrapper clone(RetrieverBuilder in) {
+            return new QueryRuleRetrieverBuilderWrapper(in);
+        }
+
+        @Override
+        public QueryBuilder topDocsQuery() {
+            return new RuleQueryBuilder(in.topDocsQuery(), matchCriteria, rulesetIds);
+        }
+
+        @Override
+        public QueryBuilder explainQuery() {
+            return new RankDocsQueryBuilder(
+                in.getRankDocs(),
+                new QueryBuilder[] { new RuleQueryBuilder(in.explainQuery(), matchCriteria, rulesetIds) },
+                true
+            );
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilder.java
@@ -141,7 +141,7 @@ public final class QueryRuleRetrieverBuilder extends CompoundRetrieverBuilder<Qu
             return;
         }
 
-        if (sortBuilders.getFirst() instanceof ScoreSortBuilder == false) {
+        if (sortBuilders.get(0) instanceof ScoreSortBuilder == false) {
             throw new IllegalArgumentException("[" + NAME + "] retriever only supports sort by score, got: " + sortBuilders);
         }
     }
@@ -152,7 +152,7 @@ public final class QueryRuleRetrieverBuilder extends CompoundRetrieverBuilder<Qu
         builder.startObject(MATCH_CRITERIA_FIELD.getPreferredName());
         builder.mapContents(matchCriteria);
         builder.endObject();
-        builder.field(RETRIEVER_FIELD.getPreferredName(), innerRetrievers.getFirst().retriever());
+        builder.field(RETRIEVER_FIELD.getPreferredName(), innerRetrievers.get(0).retriever());
         // We need to explicitly include this here as it's not propagated by the wrapper
         builder.field(RANK_WINDOW_SIZE_FIELD.getPreferredName(), rankWindowSize);
     }
@@ -165,7 +165,7 @@ public final class QueryRuleRetrieverBuilder extends CompoundRetrieverBuilder<Qu
     @Override
     protected RankDoc[] combineInnerRetrieverResults(List<ScoreDoc[]> rankResults) {
         assert rankResults.size() == 1;
-        ScoreDoc[] scoreDocs = rankResults.getFirst();
+        ScoreDoc[] scoreDocs = rankResults.get(0);
         RankDoc[] rankDocs = new RuleQueryRankDoc[scoreDocs.length];
         for (int i = 0; i < scoreDocs.length; i++) {
             ScoreDoc scoreDoc = scoreDocs[i];

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/RuleQueryRankDoc.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/RuleQueryRankDoc.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.rules.retriever;
+
+import org.apache.lucene.search.Explanation;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.search.rank.RankDoc;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class RuleQueryRankDoc extends RankDoc {
+
+    public static final String NAME = "query_rule_rank_doc";
+
+    public final List<String> rulesetIds;
+    public final Map<String, Object> matchCriteria;
+
+    public RuleQueryRankDoc(int doc, float score, int shardIndex, List<String> rulesetIds, Map<String, Object> matchCriteria) {
+        super(doc, score, shardIndex);
+        this.rulesetIds = rulesetIds;
+        this.matchCriteria = matchCriteria;
+    }
+
+    public RuleQueryRankDoc(StreamInput in) throws IOException {
+        super(in);
+        rulesetIds = in.readStringCollectionAsImmutableList();
+        matchCriteria = in.readGenericMap();
+    }
+
+    @Override
+    public Explanation explain(Explanation[] sources, String[] queryNames) {
+
+        return Explanation.match(
+            score,
+            "query rules evaluated rules from rulesets " + rulesetIds + " and match criteria " + matchCriteria,
+            sources
+        );
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        out.writeStringCollection(rulesetIds);
+        out.writeGenericMap(matchCriteria);
+    }
+
+    @Override
+    public boolean doEquals(RankDoc rd) {
+        RuleQueryRankDoc rqrd = (RuleQueryRankDoc) rd;
+        return Objects.equals(rulesetIds, rqrd.rulesetIds) && Objects.equals(matchCriteria, rqrd.matchCriteria);
+    }
+
+    @Override
+    public int doHashCode() {
+        return Objects.hash(rulesetIds, matchCriteria);
+    }
+
+    @Override
+    public String toString() {
+        return "QueryRuleRankDoc{"
+            + "doc="
+            + doc
+            + ", shardIndex="
+            + shardIndex
+            + ", score="
+            + score
+            + ", rulesetIds="
+            + rulesetIds
+            + ", matchCriteria="
+            + matchCriteria
+            + "}";
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected void doToXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.array("rulesetIds", rulesetIds.toArray());
+        builder.startObject("matchCriteria");
+        builder.mapContents(matchCriteria);
+        builder.endObject();
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersions.QUERY_RULES_RETRIEVER;
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/retriever/QueryRuleRetrieverBuilderTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.rules.retriever;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.retriever.RetrieverBuilder;
+import org.elasticsearch.search.retriever.RetrieverParserContext;
+import org.elasticsearch.search.retriever.TestRetrieverBuilder;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.usage.SearchUsage;
+import org.elasticsearch.usage.SearchUsageHolder;
+import org.elasticsearch.usage.UsageService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.application.EnterpriseSearchModuleTestUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class QueryRuleRetrieverBuilderTests extends AbstractXContentTestCase<QueryRuleRetrieverBuilder> {
+
+    public static QueryRuleRetrieverBuilder createRandomQueryRuleRetrieverBuilder() {
+        return new QueryRuleRetrieverBuilder(
+            randomBoolean()
+                ? List.of(randomAlphaOfLengthBetween(5, 10))
+                : List.of(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10)),
+            EnterpriseSearchModuleTestUtils.randomMatchCriteria(),
+            TestRetrieverBuilder.createRandomTestRetrieverBuilder(),
+            randomIntBetween(1, 100)
+        );
+    }
+
+    @Override
+    protected QueryRuleRetrieverBuilder createTestInstance() {
+        return createRandomQueryRuleRetrieverBuilder();
+    }
+
+    @Override
+    protected QueryRuleRetrieverBuilder doParseInstance(XContentParser parser) throws IOException {
+        return (QueryRuleRetrieverBuilder) RetrieverBuilder.parseTopLevelRetrieverBuilder(
+            parser,
+            new RetrieverParserContext(
+                new SearchUsage(),
+                nf -> nf == RetrieverBuilder.RETRIEVERS_SUPPORTED || nf == QueryRuleRetrieverBuilder.QUERY_RULE_RETRIEVERS_SUPPORTED
+            )
+        );
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    @Override
+    protected String[] getShuffleFieldsExceptions() {
+        return new String[] {
+            QueryRuleRetrieverBuilder.MATCH_CRITERIA_FIELD.getPreferredName(),
+            QueryRuleRetrieverBuilder.RULESET_IDS_FIELD.getPreferredName() };
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        List<NamedXContentRegistry.Entry> entries = new SearchModule(Settings.EMPTY, List.of()).getNamedXContents();
+        entries.add(
+            new NamedXContentRegistry.Entry(
+                RetrieverBuilder.class,
+                TestRetrieverBuilder.TEST_SPEC.getName(),
+                (p, c) -> TestRetrieverBuilder.TEST_SPEC.getParser().fromXContent(p, (RetrieverParserContext) c),
+                TestRetrieverBuilder.TEST_SPEC.getName().getForRestApiVersion()
+            )
+        );
+        entries.add(
+            new NamedXContentRegistry.Entry(
+                RetrieverBuilder.class,
+                new ParseField(QueryRuleRetrieverBuilder.NAME),
+                (p, c) -> QueryRuleRetrieverBuilder.PARSER.apply(p, (RetrieverParserContext) c)
+            )
+        );
+        return new NamedXContentRegistry(entries);
+    }
+
+    public void testParserDefaults() throws IOException {
+        // Inner retriever content only sent to parser
+        String json = """
+            {
+                "match_criteria": { "foo": "bar" },
+                "ruleset_ids": [ "baz" ],
+                "retriever": { "standard": { "query": { "query_string": { "query": "i like pugs" } } } }
+            }""";
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            QueryRuleRetrieverBuilder parsed = QueryRuleRetrieverBuilder.PARSER.parse(
+                parser,
+                new RetrieverParserContext(new SearchUsage(), nf -> true)
+            );
+            assertEquals(DEFAULT_RANK_WINDOW_SIZE, parsed.rankWindowSize());
+        }
+    }
+
+    public void testQueryRuleRetrieverParsing() throws IOException {
+        String restContent = """
+            {
+                "retriever": {
+                    "rule": {
+                        "retriever": {
+                            "test": {
+                                "value": "my-test-retriever"
+                            }
+                        },
+                        "ruleset_ids": [
+                            "baz"
+                        ],
+                        "match_criteria": {
+                            "key": "value"
+                        },
+                        "rank_window_size": 100,
+                        "_name": "my_rule_retriever"
+                    }
+                }
+            }""";
+
+        SearchUsageHolder searchUsageHolder = new UsageService().getSearchUsageHolder();
+        try (XContentParser jsonParser = createParser(JsonXContent.jsonXContent, restContent)) {
+            SearchSourceBuilder source = new SearchSourceBuilder().parseXContent(jsonParser, true, searchUsageHolder, nf -> true);
+            assertThat(source.retriever(), instanceOf(QueryRuleRetrieverBuilder.class));
+            QueryRuleRetrieverBuilder parsed = (QueryRuleRetrieverBuilder) source.retriever();
+            assertThat(parsed.retrieverName(), equalTo("my_rule_retriever"));
+            try (XContentParser parseSerialized = createParser(JsonXContent.jsonXContent, Strings.toString(source))) {
+                SearchSourceBuilder deserializedSource = new SearchSourceBuilder().parseXContent(
+                    parseSerialized,
+                    true,
+                    searchUsageHolder,
+                    nf -> true
+                );
+                assertThat(deserializedSource.retriever(), instanceOf(QueryRuleRetrieverBuilder.class));
+                QueryRuleRetrieverBuilder deserialized = (QueryRuleRetrieverBuilder) source.retriever();
+                assertThat(parsed, equalTo(deserialized));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - Query rules retriever  (#114855) (690ad1ea)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)