### PR TITLE
Ensure thread context set for streaming (#115683)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -137,7 +137,10 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
                         netty4HttpRequest = new Netty4HttpRequest(readSequence++, fullHttpRequest);
                         currentRequestStream = null;
                     } else {
-                        var contentStream = new Netty4HttpRequestBodyStream(ctx.channel());
+                        var contentStream = new Netty4HttpRequestBodyStream(
+                            ctx.channel(),
+                            serverTransport.getThreadPool().getThreadContext()
+                        );
                         currentRequestStream = contentStream;
                         netty4HttpRequest = new Netty4HttpRequest(readSequence++, request, contentStream);
                     }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestBodyStream.java
@@ -16,6 +16,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.transport.netty4.Netty4Utils;
@@ -34,14 +35,18 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     private final Channel channel;
     private final ChannelFutureListener closeListener = future -> doClose();
     private final List<ChunkHandler> tracingHandlers = new ArrayList<>(4);
+    private final ThreadContext threadContext;
     private ByteBuf buf;
     private boolean hasLast = false;
     private boolean requested = false;
     private boolean closing = false;
     private HttpBody.ChunkHandler handler;
+    private ThreadContext.StoredContext requestContext;
 
-    public Netty4HttpRequestBodyStream(Channel channel) {
+    public Netty4HttpRequestBodyStream(Channel channel, ThreadContext threadContext) {
         this.channel = channel;
+        this.threadContext = threadContext;
+        this.requestContext = threadContext.newStoredContext();
         Netty4Utils.addListener(channel.closeFuture(), closeListener);
         channel.config().setAutoRead(false);
     }
@@ -66,6 +71,7 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     public void next() {
         assert closing == false : "cannot request next chunk on closing stream";
         assert handler != null : "handler must be set before requesting next chunk";
+        requestContext = threadContext.newStoredContext();
         channel.eventLoop().submit(() -> {
             requested = true;
             if (buf == null) {
@@ -109,11 +115,6 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
     }
 
     // visible for test
-    Channel channel() {
-        return channel;
-    }
-
-    // visible for test
     ByteBuf buf() {
         return buf;
     }
@@ -129,10 +130,12 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
         var bytesRef = Netty4Utils.toReleasableBytesReference(buf);
         requested = false;
         buf = null;
-        for (var tracer : tracingHandlers) {
-            tracer.onNext(bytesRef, hasLast);
+        try (var ignored = threadContext.restoreExistingContext(requestContext)) {
+            for (var tracer : tracingHandlers) {
+                tracer.onNext(bytesRef, hasLast);
+            }
+            handler.onNext(bytesRef, hasLast);
         }
-        handler.onNext(bytesRef, hasLast);
         if (hasLast) {
             channel.config().setAutoRead(true);
             channel.closeFuture().removeListener(closeListener);
@@ -150,11 +153,13 @@ public class Netty4HttpRequestBodyStream implements HttpBody.Stream {
 
     private void doClose() {
         closing = true;
-        for (var tracer : tracingHandlers) {
-            Releasables.closeExpectNoException(tracer);
-        }
-        if (handler != null) {
-            handler.close();
+        try (var ignored = threadContext.restoreExistingContext(requestContext)) {
+            for (var tracer : tracingHandlers) {
+                Releasables.closeExpectNoException(tracer);
+            }
+            if (handler != null) {
+                handler.close();
+            }
         }
         if (buf != null) {
             buf.release();

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -17,7 +17,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -43,12 +42,10 @@ public class IncrementalBulkService {
     private final Client client;
     private final AtomicBoolean enabledForTests = new AtomicBoolean(true);
     private final IndexingPressure indexingPressure;
-    private final ThreadContext threadContext;
 
-    public IncrementalBulkService(Client client, IndexingPressure indexingPressure, ThreadContext threadContext) {
+    public IncrementalBulkService(Client client, IndexingPressure indexingPressure) {
         this.client = client;
         this.indexingPressure = indexingPressure;
-        this.threadContext = threadContext;
     }
 
     public Handler newBulkRequest() {
@@ -58,7 +55,7 @@ public class IncrementalBulkService {
 
     public Handler newBulkRequest(@Nullable String waitForActiveShards, @Nullable TimeValue timeout, @Nullable String refresh) {
         ensureEnabled();
-        return new Handler(client, threadContext, indexingPressure, waitForActiveShards, timeout, refresh);
+        return new Handler(client, indexingPressure, waitForActiveShards, timeout, refresh);
     }
 
     private void ensureEnabled() {
@@ -94,7 +91,6 @@ public class IncrementalBulkService {
         public static final BulkRequest.IncrementalState EMPTY_STATE = new BulkRequest.IncrementalState(Collections.emptyMap(), true);
 
         private final Client client;
-        private final ThreadContext threadContext;
         private final IndexingPressure indexingPressure;
         private final ActiveShardCount waitForActiveShards;
         private final TimeValue timeout;
@@ -106,22 +102,18 @@ public class IncrementalBulkService {
         private boolean globalFailure = false;
         private boolean incrementalRequestSubmitted = false;
         private boolean bulkInProgress = false;
-        private ThreadContext.StoredContext requestContext;
         private Exception bulkActionLevelFailure = null;
         private long currentBulkSize = 0L;
         private BulkRequest bulkRequest = null;
 
         protected Handler(
             Client client,
-            ThreadContext threadContext,
             IndexingPressure indexingPressure,
             @Nullable String waitForActiveShards,
             @Nullable TimeValue timeout,
             @Nullable String refresh
         ) {
             this.client = client;
-            this.threadContext = threadContext;
-            this.requestContext = threadContext.newStoredContext();
             this.indexingPressure = indexingPressure;
             this.waitForActiveShards = waitForActiveShards != null ? ActiveShardCount.parseString(waitForActiveShards) : null;
             this.timeout = timeout;
@@ -141,31 +133,28 @@ public class IncrementalBulkService {
                     if (shouldBackOff()) {
                         final boolean isFirstRequest = incrementalRequestSubmitted == false;
                         incrementalRequestSubmitted = true;
-                        try (var ignored = threadContext.restoreExistingContext(requestContext)) {
-                            final ArrayList<Releasable> toRelease = new ArrayList<>(releasables);
-                            releasables.clear();
-                            bulkInProgress = true;
-                            client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
+                        final ArrayList<Releasable> toRelease = new ArrayList<>(releasables);
+                        releasables.clear();
+                        bulkInProgress = true;
+                        client.bulk(bulkRequest, ActionListener.runAfter(new ActionListener<>() {
 
-                                @Override
-                                public void onResponse(BulkResponse bulkResponse) {
-                                    handleBulkSuccess(bulkResponse);
-                                    createNewBulkRequest(
-                                        new BulkRequest.IncrementalState(bulkResponse.getIncrementalState().shardLevelFailures(), true)
-                                    );
-                                }
+                            @Override
+                            public void onResponse(BulkResponse bulkResponse) {
+                                handleBulkSuccess(bulkResponse);
+                                createNewBulkRequest(
+                                    new BulkRequest.IncrementalState(bulkResponse.getIncrementalState().shardLevelFailures(), true)
+                                );
+                            }
 
-                                @Override
-                                public void onFailure(Exception e) {
-                                    handleBulkFailure(isFirstRequest, e);
-                                }
-                            }, () -> {
-                                bulkInProgress = false;
-                                requestContext = threadContext.newStoredContext();
-                                toRelease.forEach(Releasable::close);
-                                nextItems.run();
-                            }));
-                        }
+                            @Override
+                            public void onFailure(Exception e) {
+                                handleBulkFailure(isFirstRequest, e);
+                            }
+                        }, () -> {
+                            bulkInProgress = false;
+                            toRelease.forEach(Releasable::close);
+                            nextItems.run();
+                        }));
                     } else {
                         nextItems.run();
                     }
@@ -187,28 +176,26 @@ public class IncrementalBulkService {
             } else {
                 assert bulkRequest != null;
                 if (internalAddItems(items, releasable)) {
-                    try (var ignored = threadContext.restoreExistingContext(requestContext)) {
-                        final ArrayList<Releasable> toRelease = new ArrayList<>(releasables);
-                        releasables.clear();
-                        // We do not need to set this back to false as this will be the last request.
-                        bulkInProgress = true;
-                        client.bulk(bulkRequest, ActionListener.runBefore(new ActionListener<>() {
+                    final ArrayList<Releasable> toRelease = new ArrayList<>(releasables);
+                    releasables.clear();
+                    // We do not need to set this back to false as this will be the last request.
+                    bulkInProgress = true;
+                    client.bulk(bulkRequest, ActionListener.runBefore(new ActionListener<>() {
 
-                            private final boolean isFirstRequest = incrementalRequestSubmitted == false;
+                        private final boolean isFirstRequest = incrementalRequestSubmitted == false;
 
-                            @Override
-                            public void onResponse(BulkResponse bulkResponse) {
-                                handleBulkSuccess(bulkResponse);
-                                listener.onResponse(combineResponses());
-                            }
+                        @Override
+                        public void onResponse(BulkResponse bulkResponse) {
+                            handleBulkSuccess(bulkResponse);
+                            listener.onResponse(combineResponses());
+                        }
 
-                            @Override
-                            public void onFailure(Exception e) {
-                                handleBulkFailure(isFirstRequest, e);
-                                errorResponse(listener);
-                            }
-                        }, () -> toRelease.forEach(Releasable::close)));
-                    }
+                        @Override
+                        public void onFailure(Exception e) {
+                            handleBulkFailure(isFirstRequest, e);
+                            errorResponse(listener);
+                        }
+                    }, () -> toRelease.forEach(Releasable::close)));
                 } else {
                     errorResponse(listener);
                 }

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -916,11 +916,7 @@ class NodeConstruction {
         terminationHandler = getSinglePlugin(terminationHandlers, TerminationHandler.class).orElse(null);
 
         final IndexingPressure indexingLimits = new IndexingPressure(settings);
-        final IncrementalBulkService incrementalBulkService = new IncrementalBulkService(
-            client,
-            indexingLimits,
-            threadPool.getThreadContext()
-        );
+        final IncrementalBulkService incrementalBulkService = new IncrementalBulkService(client, indexingLimits);
 
         ActionModule actionModule = new ActionModule(
             settings,

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -132,6 +132,7 @@ public abstract class BaseRestHandler implements RestHandler {
             if (request.isStreamedContent()) {
                 assert action instanceof RequestBodyChunkConsumer;
                 var chunkConsumer = (RequestBodyChunkConsumer) action;
+
                 request.contentStream().setHandler(new HttpBody.ChunkHandler() {
                     @Override
                     public void onNext(ReleasableBytesReference chunk, boolean isLast) {

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -183,8 +183,7 @@ public class RestBulkAction extends BaseRestHandler {
             this.defaultListExecutedPipelines = request.paramAsBoolean("list_executed_pipelines", false);
             this.defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false);
             this.defaultRequireDataStream = request.paramAsBoolean(DocWriteRequest.REQUIRE_DATA_STREAM, false);
-            // TODO: Fix type deprecation logging
-            this.parser = new BulkRequestParser(false, request.getRestApiVersion());
+            this.parser = new BulkRequestParser(true, request.getRestApiVersion());
             this.handlerSupplier = handlerSupplier;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/ActionModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionModuleTests.java
@@ -131,7 +131,7 @@ public class ActionModuleTests extends ESTestCase {
             null,
             List.of(),
             RestExtension.allowAll(),
-            new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+            new IncrementalBulkService(null, null)
         );
         actionModule.initRestHandlers(null, null);
         // At this point the easiest way to confirm that a handler is loaded is to try to register another one on top of it and to fail
@@ -196,7 +196,7 @@ public class ActionModuleTests extends ESTestCase {
                 null,
                 List.of(),
                 RestExtension.allowAll(),
-                new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+                new IncrementalBulkService(null, null)
             );
             Exception e = expectThrows(IllegalArgumentException.class, () -> actionModule.initRestHandlers(null, null));
             assertThat(e.getMessage(), startsWith("Cannot replace existing handler for [/_nodes] for method: GET"));
@@ -254,7 +254,7 @@ public class ActionModuleTests extends ESTestCase {
                 null,
                 List.of(),
                 RestExtension.allowAll(),
-                new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+                new IncrementalBulkService(null, null)
             );
             actionModule.initRestHandlers(null, null);
             // At this point the easiest way to confirm that a handler is loaded is to try to register another one on top of it and to fail
@@ -305,7 +305,7 @@ public class ActionModuleTests extends ESTestCase {
                     null,
                     List.of(),
                     RestExtension.allowAll(),
-                    new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+                    new IncrementalBulkService(null, null)
                 )
             );
             assertThat(
@@ -347,7 +347,7 @@ public class ActionModuleTests extends ESTestCase {
                     null,
                     List.of(),
                     RestExtension.allowAll(),
-                    new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+                    new IncrementalBulkService(null, null)
                 )
             );
             assertThat(

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -1179,7 +1179,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             null,
             List.of(),
             RestExtension.allowAll(),
-            new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+            new IncrementalBulkService(null, null)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -20,8 +20,6 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.http.HttpBody;
 import org.elasticsearch.index.IndexVersion;
@@ -67,7 +65,7 @@ public class RestBulkActionTests extends ESTestCase {
             params.put("pipeline", "timestamps");
             new RestBulkAction(
                 settings(IndexVersion.current()).build(),
-                new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
+                new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class))
             ).handleRequest(
                 new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk").withParams(params).withContent(new BytesArray("""
                     {"index":{"_id":"1"}}
@@ -102,7 +100,7 @@ public class RestBulkActionTests extends ESTestCase {
             {
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -126,7 +124,7 @@ public class RestBulkActionTests extends ESTestCase {
                 bulkCalled.set(false);
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -149,7 +147,7 @@ public class RestBulkActionTests extends ESTestCase {
                 bulkCalled.set(false);
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -173,7 +171,7 @@ public class RestBulkActionTests extends ESTestCase {
                 bulkCalled.set(false);
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), new ThreadContext(Settings.EMPTY))
+                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class))
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -229,7 +227,7 @@ public class RestBulkActionTests extends ESTestCase {
         RestBulkAction.ChunkHandler chunkHandler = new RestBulkAction.ChunkHandler(
             true,
             request,
-            () -> new IncrementalBulkService.Handler(null, new ThreadContext(Settings.EMPTY), null, null, null, null) {
+            () -> new IncrementalBulkService.Handler(null, null, null, null, null) {
 
                 @Override
                 public void addItems(List<DocWriteRequest<?>> items, Releasable releasable, Runnable nextItems) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -824,7 +824,7 @@ public class SecurityTests extends ESTestCase {
                 null,
                 List.of(),
                 RestExtension.allowAll(),
-                new IncrementalBulkService(null, null, new ThreadContext(Settings.EMPTY))
+                new IncrementalBulkService(null, null)
             );
             actionModule.initRestHandlers(null, null);
 


### PR DESCRIPTION
Currently the thread context is lost between streaming context switches.
This commit ensures that each time the thread context is properly set
before providing new data to the stream.