### PR TITLE
Avoid resolving project dependencies in 'resolveAllDependencies' task

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -12,8 +12,11 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.FileCollectionDependency;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
@@ -23,11 +26,7 @@ import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
-
 import javax.inject.Inject;
-
-import static org.elasticsearch.gradle.DistributionDownloadPlugin.DISTRO_EXTRACTED_CONFIG_PREFIX;
-import static org.elasticsearch.gradle.internal.test.rest.compat.compat.LegacyYamlRestCompatTestPlugin.BWC_MINOR_CONFIG_NAME;
 
 public abstract class ResolveAllDependencies extends DefaultTask {
 
@@ -37,18 +36,32 @@ public abstract class ResolveAllDependencies extends DefaultTask {
     protected abstract JavaToolchainService getJavaToolchainService();
 
     private final ObjectFactory objectFactory;
+    private final ProviderFactory providerFactory;
 
     private Collection<Configuration> configs;
 
     @Inject
-    public ResolveAllDependencies(ObjectFactory objectFactory) {
+    public ResolveAllDependencies(ObjectFactory objectFactory, ProviderFactory providerFactory) {
         this.objectFactory = objectFactory;
+        this.providerFactory = providerFactory;
     }
 
     @InputFiles
     public FileCollection getResolvedArtifacts() {
         return objectFactory.fileCollection()
-            .from(configs.stream().filter(ResolveAllDependencies::canBeResolved).collect(Collectors.toList()));
+            .from(configs.stream()
+                .filter(ResolveAllDependencies::canBeResolved)
+                .map(c -> {
+                    // Make a copy of the configuration, omitting file collection dependencies to avoid building project artifacts
+                    Configuration copy = c.copyRecursive(d -> d instanceof FileCollectionDependency == false);
+                    copy.setCanBeConsumed(false);
+                    return copy;
+                })
+                // Include only module dependencies, ignoring things like project dependencies so we don't unnecessarily build stuff
+                .map(c -> c.getIncoming().artifactView(v -> v.lenient(true).componentFilter(i -> i instanceof ModuleComponentIdentifier)))
+                .map(artifactView -> providerFactory.provider(artifactView::getFiles))
+                .collect(Collectors.toList())
+            );
     }
 
     @TaskAction
@@ -95,8 +108,8 @@ public abstract class ResolveAllDependencies extends DefaultTask {
                 return false;
             }
         }
-        return configuration.getName().startsWith(DISTRO_EXTRACTED_CONFIG_PREFIX) == false
-            && configuration.getName().equals(BWC_MINOR_CONFIG_NAME) == false;
+
+        return true;
     }
 
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -26,6 +26,7 @@ import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
 public abstract class ResolveAllDependencies extends DefaultTask {
@@ -48,20 +49,16 @@ public abstract class ResolveAllDependencies extends DefaultTask {
 
     @InputFiles
     public FileCollection getResolvedArtifacts() {
-        return objectFactory.fileCollection()
-            .from(configs.stream()
-                .filter(ResolveAllDependencies::canBeResolved)
-                .map(c -> {
-                    // Make a copy of the configuration, omitting file collection dependencies to avoid building project artifacts
-                    Configuration copy = c.copyRecursive(d -> d instanceof FileCollectionDependency == false);
-                    copy.setCanBeConsumed(false);
-                    return copy;
-                })
-                // Include only module dependencies, ignoring things like project dependencies so we don't unnecessarily build stuff
-                .map(c -> c.getIncoming().artifactView(v -> v.lenient(true).componentFilter(i -> i instanceof ModuleComponentIdentifier)))
-                .map(artifactView -> providerFactory.provider(artifactView::getFiles))
-                .collect(Collectors.toList())
-            );
+        return objectFactory.fileCollection().from(configs.stream().filter(ResolveAllDependencies::canBeResolved).map(c -> {
+            // Make a copy of the configuration, omitting file collection dependencies to avoid building project artifacts
+            Configuration copy = c.copyRecursive(d -> d instanceof FileCollectionDependency == false);
+            copy.setCanBeConsumed(false);
+            return copy;
+        })
+            // Include only module dependencies, ignoring things like project dependencies so we don't unnecessarily build stuff
+            .map(c -> c.getIncoming().artifactView(v -> v.lenient(true).componentFilter(i -> i instanceof ModuleComponentIdentifier)))
+            .map(artifactView -> providerFactory.provider(artifactView::getFiles))
+            .collect(Collectors.toList()));
     }
 
     @TaskAction


### PR DESCRIPTION
This makes some changes to the `ResolveallDependencies` task to avoid resolving project and file dependencies. This should mean we ending up building less stuff in the build and mostly just download external module artifacts.