### PR TITLE
Remove old synthetic source config in mappings

### DIFF
--- a/modules/mapper-extras/src/internalClusterTest/java/org/elasticsearch/index/mapper/MatchOnlyTextMapperIT.java
+++ b/modules/mapper-extras/src/internalClusterTest/java/org/elasticsearch/index/mapper/MatchOnlyTextMapperIT.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugins.Plugin;
@@ -89,13 +90,14 @@ public class MatchOnlyTextMapperIT extends ESIntegTestCase {
         // load the source.
 
         String mappings = """
-            { "_source" : { "mode" : "synthetic" },
+            {
               "properties" : {
                 "message" : { "type" : "match_only_text" }
               }
             }
             """;
-        assertAcked(prepareCreate("test").setMapping(mappings));
+        Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.mapping.source.mode", "synthetic");
+        assertAcked(prepareCreate("test").setSettings(settings).setMapping(mappings));
         BulkRequestBuilder bulk = client().prepareBulk("test").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         for (int i = 0; i < 2000; i++) {
             bulk.add(

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -64,19 +64,19 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
     }
 
     public void testExistsStandardSource() throws IOException {
-        assertExistsQuery(createMapperService(testMapping(false)));
+        assertExistsQuery(createMapperService(fieldMapping(b -> b.field("type", "match_only_text"))));
     }
 
     public void testExistsSyntheticSource() throws IOException {
-        assertExistsQuery(createMapperService(testMapping(true)));
+        assertExistsQuery(createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "match_only_text"))));
     }
 
     public void testPhraseQueryStandardSource() throws IOException {
-        assertPhraseQuery(createMapperService(testMapping(false)));
+        assertPhraseQuery(createMapperService(fieldMapping(b -> b.field("type", "match_only_text"))));
     }
 
     public void testPhraseQuerySyntheticSource() throws IOException {
-        assertPhraseQuery(createMapperService(testMapping(true)));
+        assertPhraseQuery(createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "match_only_text"))));
     }
 
     private void assertPhraseQuery(MapperService mapperService) throws IOException {
@@ -102,13 +102,6 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
             b -> { b.field("meta", Collections.singletonMap("format", "mysql.access")); },
             m -> assertEquals(Collections.singletonMap("format", "mysql.access"), m.fieldType().meta())
         );
-    }
-
-    private static XContentBuilder testMapping(boolean syntheticSource) throws IOException {
-        if (syntheticSource) {
-            return syntheticSourceMapping(b -> b.startObject("field").field("type", "match_only_text").endObject());
-        }
-        return fieldMapping(b -> b.field("type", "match_only_text"));
     }
 
     @Override
@@ -256,7 +249,7 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
     }
 
     public void testDocValuesLoadedFromSynthetic() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceFieldMapping(b -> b.field("type", "match_only_text")));
+        MapperService mapper = createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "match_only_text")));
         assertScriptDocValues(mapper, "foo", equalTo(List.of("foo")));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -84,12 +84,12 @@ public class DocCountFieldMapperTests extends MetadataMapperTestCase {
     }
 
     public void testSyntheticSource() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {}));
+        DocumentMapper mapper = createSytheticSourceMapperService(topMapping(b -> {})).documentMapper();
         assertThat(syntheticSource(mapper, b -> b.field(CONTENT_TYPE, 10)), equalTo("{\"_doc_count\":10}"));
     }
 
     public void testSyntheticSourceMany() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceMapping(b -> b.startObject("doc").field("type", "integer").endObject()));
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> b.startObject("doc").field("type", "integer").endObject()));
         List<Integer> counts = randomList(2, 10000, () -> between(1, Integer.MAX_VALUE));
         withLuceneIndex(mapper, iw -> {
             int d = 0;
@@ -116,7 +116,7 @@ public class DocCountFieldMapperTests extends MetadataMapperTestCase {
     }
 
     public void testSyntheticSourceManyDoNotHave() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceMapping(b -> b.startObject("doc").field("type", "integer").endObject()));
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> b.startObject("doc").field("type", "integer").endObject()));
         List<Integer> counts = randomList(2, 10000, () -> randomBoolean() ? null : between(1, Integer.MAX_VALUE));
         withLuceneIndex(mapper, iw -> {
             int d = 0;

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperConfigurationTests.java
@@ -130,8 +130,8 @@ public class IgnoredSourceFieldMapperConfigurationTests extends MapperServiceTes
         for (var entry : customSettings.entrySet()) {
             settings.put(entry.getKey(), entry.getValue());
         }
-
-        return createMapperService(settings.build(), syntheticSourceMapping(mapping));
+        settings.put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), SourceFieldMapper.Mode.SYNTHETIC);
+        return createMapperService(settings.build(), mapping(mapping));
     }
 
     protected void validateRoundTripReader(String syntheticSource, DirectoryReader reader, DirectoryReader roundTripReader)

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -30,9 +30,10 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         return createMapperService(
             Settings.builder()
                 .put("index.mapping.total_fields.limit", 2)
+                .put("index.mapping.source.mode", "synthetic")
                 .put("index.mapping.total_fields.ignore_dynamic_beyond_limit", true)
                 .build(),
-            syntheticSourceMapping(b -> {
+            mapping(b -> {
                 b.startObject("foo").field("type", "keyword").endObject();
                 b.startObject("bar").field("type", "object").endObject();
             })
@@ -52,6 +53,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     private MapperService createMapperServiceWithStoredArraySource(XContentBuilder mappings) throws IOException {
         Settings settings = Settings.builder()
             .put(getIndexSettings())
+            .put("index.mapping.source.mode", "synthetic")
             .put(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING.getKey(), "arrays")
             .build();
         return createMapperService(settings, mappings);
@@ -236,10 +238,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
     public void testDisabledRootObjectSingleField() throws IOException {
         String name = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject();
-            b.field("enabled", false);
-        })).documentMapper();
+        DocumentMapper documentMapper = createSytheticSourceMapperService(topMapping(b -> { b.field("enabled", false); })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> { b.field("name", name); });
         assertEquals(String.format(Locale.ROOT, """
             {"name":"%s"}""", name), syntheticSource);
@@ -250,10 +249,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         int intValue = randomInt();
         String stringValue = randomAlphaOfLength(20);
 
-        DocumentMapper documentMapper = createMapperService(topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject();
-            b.field("enabled", false);
-        })).documentMapper();
+        DocumentMapper documentMapper = createSytheticSourceMapperService(topMapping(b -> b.field("enabled", false))).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
             b.field("boolean_value", booleanValue);
             b.startObject("path");
@@ -292,7 +288,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
     public void testDisabledObjectSingleField() throws IOException {
         String name = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("enabled", false).endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -308,7 +304,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
     public void testDisabledObjectContainsArray() throws IOException {
         String name = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("enabled", false).endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -328,7 +324,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         int intValue = randomInt();
         String stringValue = randomAlphaOfLength(20);
 
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path").field("type", "object").field("enabled", false).endObject();
         })).documentMapper();
@@ -372,7 +368,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         boolean booleanValue = randomBoolean();
         int intValue = randomInt();
         String name = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -404,7 +400,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDisabledSubobjectContainsArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -447,7 +443,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         int intValue = randomInt();
         String foo = randomAlphaOfLength(20);
         String bar = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -507,7 +503,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceRootValueArray() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("int_value").field("type", "integer").endObject();
             b.startObject("bool_value").field("type", "boolean").endObject();
         })).documentMapper();
@@ -520,7 +516,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceRootValueArrayDisabled() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("int_value").field("type", "integer").field(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, "none").endObject();
             b.startObject("bool_value").field("type", "boolean").endObject();
         })).documentMapper();
@@ -533,7 +529,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceSingleLeafElement() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("int_value").field("type", "integer").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> b.array("int_value", new int[] { 10 }));
@@ -543,7 +539,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceSingleLeafElementAndNull() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("value").field("type", "keyword").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> b.array("value", new String[] { "foo", null }));
@@ -551,7 +547,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceSingleObjectElement() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("path").startObject("properties");
             {
                 b.startObject("int_value").field("type", "integer").endObject();
@@ -565,7 +561,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testFieldStoredArraySourceRootValueArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("int_value").field("type", "integer").field(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, "arrays").endObject();
             b.startObject("string_value").field("type", "keyword").field(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, "all").endObject();
             b.startObject("bool_value").field("type", "boolean").endObject();
@@ -580,7 +576,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testFieldStoredSourceRootValue() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("default").field("type", "float").field(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, "none").endObject();
             b.startObject("source_kept").field("type", "float").field(Mapper.SYNTHETIC_SOURCE_KEEP_PARAM, "all").endObject();
             b.startObject("bool_value").field("type", "boolean").endObject();
@@ -595,7 +591,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceRootObjectArray() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -620,7 +616,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceRootObjectArrayWithBypass() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -646,7 +642,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceNestedValueArray() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -672,7 +668,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceNestedValueArrayDisabled() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -710,7 +706,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testFieldStoredArraySourceNestedValueArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -738,7 +734,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testFieldStoredSourceNestedValue() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -766,7 +762,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testIndexStoredArraySourceNestedObjectArray() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -804,7 +800,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testRootArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -828,7 +824,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNestedArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -902,7 +898,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testConflictingFieldNameAfterArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").startObject("properties");
             {
                 b.startObject("to").startObject("properties");
@@ -933,7 +929,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testArrayWithNestedObjects() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").startObject("properties");
             {
                 b.startObject("to").field("type", "nested").startObject("properties");
@@ -963,7 +959,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayWithinNestedObjects() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").startObject("properties");
             {
                 b.startObject("to").field("type", "nested").startObject("properties");
@@ -1000,7 +996,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayWithinNestedObjectsArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").startObject("properties");
             {
                 b.startObject("to").field("type", "nested").startObject("properties");
@@ -1051,7 +1047,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testArrayWithinArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object").field("synthetic_source_keep", "arrays");
@@ -1104,7 +1100,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayAndValue() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -1146,7 +1142,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDeeplyNestedObjectArrayAndValue() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").startObject("properties").startObject("to").startObject("properties");
             {
                 b.startObject("stored");
@@ -1183,7 +1179,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayAndValueInNestedObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").startObject("properties").startObject("to").startObject("properties");
             {
                 b.startObject("stored");
@@ -1219,7 +1215,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayAndValueDisabledObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").startObject("properties");
             {
                 b.startObject("regular");
@@ -1250,7 +1246,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayAndValueNonDynamicObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").startObject("properties");
             {
                 b.startObject("regular");
@@ -1277,7 +1273,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectArrayAndValueDynamicRuntimeObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").startObject("properties");
             {
                 b.startObject("regular");
@@ -1304,7 +1300,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDisabledObjectWithinHigherLevelArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -1347,7 +1343,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testStoredArrayWithinHigherLevelArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -1400,7 +1396,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testObjectWithKeepAll() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object").field("synthetic_source_keep", "all");
@@ -1436,7 +1432,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testFallbackFieldWithinHigherLevelArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             {
                 b.field("type", "object");
@@ -1466,7 +1462,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testFieldOrdering() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("A").field("type", "integer").endObject();
             b.startObject("B").field("type", "object").field("synthetic_source_keep", "arrays");
             {
@@ -1514,7 +1510,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNestedObjectWithField() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.field("synthetic_source_keep", "all");
@@ -1536,7 +1532,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNestedObjectWithArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.field("synthetic_source_keep", "all");
@@ -1562,7 +1558,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNestedSubobjectWithField() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -1603,7 +1599,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNestedSubobjectWithArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -1652,7 +1648,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNestedObjectIncludeInRoot() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested").field("synthetic_source_keep", "all").field("include_in_root", true);
             {
                 b.startObject("properties");
@@ -1674,7 +1670,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
     public void testNoDynamicObjectSingleField() throws IOException {
         String name = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "false").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -1693,7 +1689,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         int intValue = randomInt();
         String stringValue = randomAlphaOfLength(20);
 
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path").field("type", "object").field("dynamic", "false");
             {
@@ -1737,7 +1733,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNoDynamicObjectSimpleArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "false").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -1753,7 +1749,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNoDynamicObjectSimpleValueArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "false").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(
@@ -1765,7 +1761,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNoDynamicObjectNestedArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "false").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -1781,9 +1777,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testNoDynamicRootObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject().field("dynamic", "false");
-        })).documentMapper();
+        DocumentMapper documentMapper = createSytheticSourceMapperService(topMapping(b -> b.field("dynamic", "false"))).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
             b.field("foo", "bar");
             b.startObject("path").field("X", "Y").endObject();
@@ -1795,7 +1789,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
     public void testRuntimeDynamicObjectSingleField() throws IOException {
         String name = randomAlphaOfLength(20);
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "runtime").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -1814,7 +1808,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         int intValue = randomInt();
         String stringValue = randomAlphaOfLength(20);
 
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path").field("type", "object").field("dynamic", "runtime");
             {
@@ -1858,7 +1852,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testRuntimeDynamicObjectSimpleArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "runtime").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -1874,7 +1868,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testRuntimeDynamicObjectSimpleValueArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "runtime").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(
@@ -1886,7 +1880,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testRuntimeDynamicObjectNestedArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "object").field("dynamic", "runtime").endObject();
         })).documentMapper();
         var syntheticSource = syntheticSource(documentMapper, b -> {
@@ -1902,7 +1896,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDisabledSubObjectWithNameOverlappingParentName() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             b.startObject("properties");
             {
@@ -1923,7 +1917,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testStoredNestedSubObjectWithNameOverlappingParentName() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             b.startObject("properties");
             {
@@ -1944,7 +1938,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testCopyToLogicInsideObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path");
             b.startObject("properties");
             {
@@ -1975,10 +1969,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDynamicIgnoredObjectWithFlatFields() throws IOException {
-        DocumentMapper documentMapper = createMapperService(topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject();
-            b.field("dynamic", false);
-        })).documentMapper();
+        DocumentMapper documentMapper = createSytheticSourceMapperService(topMapping(b -> b.field("dynamic", false))).documentMapper();
 
         CheckedConsumer<XContentBuilder, IOException> document = b -> {
             b.startObject("top");
@@ -2009,10 +2000,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDisabledRootObjectWithFlatFields() throws IOException {
-        DocumentMapper documentMapper = createMapperService(topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject();
-            b.field("enabled", false);
-        })).documentMapper();
+        DocumentMapper documentMapper = createSytheticSourceMapperService(topMapping(b -> b.field("enabled", false))).documentMapper();
 
         CheckedConsumer<XContentBuilder, IOException> document = b -> {
             b.startObject("top");
@@ -2043,7 +2031,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDisabledObjectWithFlatFields() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("top").field("type", "object").field("enabled", false).endObject();
         })).documentMapper();
 
@@ -2076,7 +2064,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testRegularObjectWithFlatFields() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("top").field("type", "object").field("synthetic_source_keep", "all").endObject();
         })).documentMapper();
 
@@ -2109,7 +2097,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testRegularObjectWithFlatFieldsInsideAnArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("top");
             b.startObject("properties");
             {
@@ -2187,7 +2175,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testStoredArrayWithFlatFields() throws IOException {
-        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createMapperServiceWithStoredArraySource(mapping(b -> {
             b.startObject("outer").startObject("properties");
             {
                 b.startObject("inner").field("type", "object").endObject();

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -663,10 +663,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
      * Test that we track the synthetic source if field is neither indexed nor has doc values nor stored
      */
     public void testSyntheticSourceForDisabledField() throws Exception {
-        MapperService mapper = createMapperService(
-            syntheticSourceFieldMapping(
-                b -> b.field("type", "keyword").field("index", false).field("doc_values", false).field("store", false)
-            )
+        MapperService mapper = createSytheticSourceMapperService(
+            fieldMapping(b -> b.field("type", "keyword").field("index", false).field("doc_values", false).field("store", false))
         );
         String value = randomAlphaOfLengthBetween(1, 20);
         assertEquals("{\"field\":\"" + value + "\"}", syntheticSource(mapper.documentMapper(), b -> b.field("field", value)));
@@ -767,8 +765,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     }
 
     public void testDocValuesLoadedFromStoredSynthetic() throws IOException {
-        MapperService mapper = createMapperService(
-            syntheticSourceFieldMapping(b -> b.field("type", "keyword").field("doc_values", false).field("store", true))
+        MapperService mapper = createSytheticSourceMapperService(
+            fieldMapping(b -> b.field("type", "keyword").field("doc_values", false).field("store", true))
         );
         assertScriptDocValues(mapper, "foo", equalTo(List.of("foo")));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -1570,9 +1570,9 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testStoreArraySourceinSyntheticSourceMode() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("o").field("type", "nested").field("synthetic_source_keep", "all").endObject();
-        }));
+        })).documentMapper();
         assertNotNull(mapper.mapping().getRoot().getMapper("o"));
     }
 
@@ -1584,7 +1584,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.startObject("properties");
@@ -1605,7 +1605,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithArray() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.startObject("properties");
@@ -1630,7 +1630,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithSubObjects() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -1670,7 +1670,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithSubArrays() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("boolean_value").field("type", "boolean").endObject();
             b.startObject("path");
             {
@@ -1718,7 +1718,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithIncludeInRoot() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested").field("include_in_root", true);
             {
                 b.startObject("properties");
@@ -1739,7 +1739,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithEmptyObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.startObject("properties");
@@ -1756,7 +1756,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithEmptySubObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.startObject("properties");
@@ -1783,7 +1783,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithArrayContainingEmptyObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.startObject("properties");
@@ -1807,7 +1807,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSyntheticNestedWithArrayContainingOnlyEmptyObject() throws IOException {
-        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+        DocumentMapper documentMapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("path").field("type", "nested");
             {
                 b.startObject("properties");

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -136,7 +136,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testMergeEnabledForIndexTemplates() throws IOException {
-        MapperService mapperService = createMapperService(syntheticSourceMapping(b -> {}));
+        MapperService mapperService = createSytheticSourceMapperService(mapping(b -> {}));
         merge(mapperService, MergeReason.INDEX_TEMPLATE, mapping(b -> {
             b.startObject("object");
             {
@@ -685,9 +685,9 @@ public class ObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testStoreArraySourceinSyntheticSourceMode() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("o").field("type", "object").field("synthetic_source_keep", "arrays").endObject();
-        }));
+        })).documentMapper();
         assertNotNull(mapper.mapping().getRoot().getMapper("o"));
     }
 
@@ -728,7 +728,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
 
     private ObjectMapper createObjectMapperWithAllParametersSet(CheckedConsumer<XContentBuilder, IOException> propertiesBuilder)
         throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("object");
             {
                 b.field("type", "object");
@@ -741,7 +741,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
                 b.endObject();
             }
             b.endObject();
-        }));
+        })).documentMapper();
         return (ObjectMapper) mapper.mapping().getRoot().getMapper("object");
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -387,7 +387,7 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
     }
 
     protected Source getSourceFor(CheckedConsumer<XContentBuilder, IOException> mapping, List<?> inputValues) throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(mapping));
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(mapping)).documentMapper();
 
         CheckedConsumer<XContentBuilder, IOException> input = b -> {
             b.field("field");

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMetricsTests.java
@@ -36,8 +36,8 @@ public class SourceFieldMetricsTests extends MapperServiceTestCase {
     public void testFieldHasValueWithEmptyFieldInfos() {}
 
     public void testSyntheticSourceLoadLatency() throws IOException {
-        var mapping = syntheticSourceMapping(b -> b.startObject("kwd").field("type", "keyword").endObject());
-        var mapper = createDocumentMapper(mapping);
+        var mapping = mapping(b -> b.startObject("kwd").field("type", "keyword").endObject());
+        var mapper = createSytheticSourceMapperService(mapping).documentMapper();
 
         try (Directory directory = newDirectory()) {
             RandomIndexWriter iw = new RandomIndexWriter(random(), directory);

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceLoaderTests.java
@@ -25,25 +25,25 @@ public class SourceLoaderTests extends MapperServiceTestCase {
     }
 
     public void testEmptyObject() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("o").field("type", "object").endObject();
             b.startObject("kwd").field("type", "keyword").endObject();
-        }));
+        })).documentMapper();
         assertTrue(mapper.mappers().newSourceLoader(SourceFieldMetrics.NOOP).reordersFieldValues());
         assertThat(syntheticSource(mapper, b -> b.field("kwd", "foo")), equalTo("""
             {"kwd":"foo"}"""));
     }
 
     public void testDotsInFieldName() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(
-            syntheticSourceMapping(b -> b.startObject("foo.bar.baz").field("type", "keyword").endObject())
-        );
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            mapping(b -> b.startObject("foo.bar.baz").field("type", "keyword").endObject())
+        ).documentMapper();
         assertThat(syntheticSource(mapper, b -> b.field("foo.bar.baz", "aaa")), equalTo("""
             {"foo":{"bar":{"baz":"aaa"}}}"""));
     }
 
     public void testNoSubobjectsIntermediateObject() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("foo");
             {
                 b.field("type", "object").field("subobjects", false);
@@ -54,30 +54,29 @@ public class SourceLoaderTests extends MapperServiceTestCase {
                 b.endObject();
             }
             b.endObject();
-        }));
+        })).documentMapper();
         assertThat(syntheticSource(mapper, b -> b.field("foo.bar.baz", "aaa")), equalTo("""
             {"foo":{"bar.baz":"aaa"}}"""));
     }
 
     public void testNoSubobjectsRootObject() throws IOException {
         XContentBuilder mappings = topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject();
             b.field("subobjects", false);
             b.startObject("properties");
             b.startObject("foo.bar.baz").field("type", "keyword").endObject();
             b.endObject();
         });
-        DocumentMapper mapper = createDocumentMapper(mappings);
+        DocumentMapper mapper = createSytheticSourceMapperService(mappings).documentMapper();
         assertThat(syntheticSource(mapper, b -> b.field("foo.bar.baz", "aaa")), equalTo("""
             {"foo.bar.baz":"aaa"}"""));
     }
 
     public void testSorted() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("foo").field("type", "keyword").endObject();
             b.startObject("bar").field("type", "keyword").endObject();
             b.startObject("baz").field("type", "keyword").endObject();
-        }));
+        })).documentMapper();
         assertThat(
             syntheticSource(mapper, b -> b.field("foo", "over the lazy dog").field("bar", "the quick").field("baz", "brown fox jumped")),
             equalTo("""
@@ -86,12 +85,12 @@ public class SourceLoaderTests extends MapperServiceTestCase {
     }
 
     public void testArraysPushedToLeaves() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("o").startObject("properties");
             b.startObject("foo").field("type", "keyword").endObject();
             b.startObject("bar").field("type", "keyword").endObject();
             b.endObject().endObject();
-        }));
+        })).documentMapper();
         assertThat(syntheticSource(mapper, b -> {
             b.startArray("o");
             b.startObject().field("foo", "a").endObject();
@@ -104,7 +103,7 @@ public class SourceLoaderTests extends MapperServiceTestCase {
     }
 
     public void testHideTheCopyTo() {
-        Exception e = expectThrows(IllegalArgumentException.class, () -> createDocumentMapper(syntheticSourceMapping(b -> {
+        Exception e = expectThrows(IllegalArgumentException.class, () -> createSytheticSourceMapperService(mapping(b -> {
             b.startObject("foo");
             {
                 b.field("type", "keyword");

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1249,7 +1249,7 @@ public class TextFieldMapperTests extends MapperTestCase {
     }
 
     public void testDocValuesLoadedFromStoredSynthetic() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceFieldMapping(b -> b.field("type", "text").field("store", true)));
+        MapperService mapper = createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "text").field("store", true)));
         for (String input : new String[] {
             "foo",       // Won't be tokenized
             "foo bar",   // Will be tokenized. But script doc values still returns the whole field.
@@ -1259,7 +1259,7 @@ public class TextFieldMapperTests extends MapperTestCase {
     }
 
     public void testDocValuesLoadedFromSubKeywordSynthetic() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceFieldMapping(b -> {
+        MapperService mapper = createSytheticSourceMapperService(fieldMapping(b -> {
             b.field("type", "text");
             b.startObject("fields");
             {
@@ -1276,7 +1276,7 @@ public class TextFieldMapperTests extends MapperTestCase {
     }
 
     public void testDocValuesLoadedFromSubStoredKeywordSynthetic() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceFieldMapping(b -> {
+        MapperService mapper = createSytheticSourceMapperService(fieldMapping(b -> {
             b.field("type", "text");
             b.startObject("fields");
             {
@@ -1351,7 +1351,8 @@ public class TextFieldMapperTests extends MapperTestCase {
             }
             b.endObject();
         };
-        MapperService mapper = createMapperService(syntheticSource ? syntheticSourceMapping(buildFields) : mapping(buildFields));
+        XContentBuilder mapping = mapping(buildFields);
+        MapperService mapper = syntheticSource ? createSytheticSourceMapperService(mapping) : createMapperService(mapping);
         BlockReaderSupport blockReaderSupport = getSupportedReaders(mapper, "field.sub");
         var sourceLoader = mapper.mappingLookup().newSourceLoader(SourceFieldMetrics.NOOP);
         testBlockLoader(columnReader, example, blockReaderSupport, sourceLoader);

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
@@ -831,9 +831,9 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
     }
 
     public void testSyntheticSourceWithOnlyIgnoredValues() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field").field("type", "flattened").field("ignore_above", 1).endObject();
-        }));
+        })).documentMapper();
 
         var syntheticSource = syntheticSource(mapper, b -> {
             b.startObject("field");

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -170,7 +170,7 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
     }
 
     protected final DocumentMapper createDocumentMapper(String mappings) throws IOException {
-        MapperService mapperService = createMapperService(mapping(b -> {}));
+        var mapperService = createMapperService(mapping(b -> {}));
         merge(mapperService, mappings);
         return mapperService.documentMapper();
     }
@@ -890,24 +890,6 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
             new FieldMaskingReader(SourceFieldMapper.RECOVERY_SOURCE_NAME, reader),
             new FieldMaskingReader(SourceFieldMapper.RECOVERY_SOURCE_NAME, roundTripReader)
         );
-    }
-
-    protected static XContentBuilder syntheticSourceMapping(CheckedConsumer<XContentBuilder, IOException> buildFields) throws IOException {
-        return topMapping(b -> {
-            b.startObject("_source").field("mode", "synthetic").endObject();
-            b.startObject("properties");
-            buildFields.accept(b);
-            b.endObject();
-        });
-    }
-
-    protected static XContentBuilder syntheticSourceFieldMapping(CheckedConsumer<XContentBuilder, IOException> buildField)
-        throws IOException {
-        return syntheticSourceMapping(b -> {
-            b.startObject("field");
-            buildField.accept(b);
-            b.endObject();
-        });
     }
 
     protected static DirectoryReader wrapInMockESDirectoryReader(DirectoryReader directoryReader) throws IOException {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapperTests.java
@@ -374,9 +374,9 @@ public class HistogramFieldMapperTests extends MapperTestCase {
     }
 
     public void testArrayValueSyntheticSource() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(
-            syntheticSourceFieldMapping(b -> b.field("type", "histogram").field("ignore_malformed", "true"))
-        );
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            fieldMapping(b -> b.field("type", "histogram").field("ignore_malformed", "true"))
+        ).documentMapper();
 
         var randomString = randomAlphaOfLength(10);
         CheckedConsumer<XContentBuilder, IOException> arrayValue = b -> {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -688,8 +688,9 @@ public class FieldSubsetReaderTests extends MapperServiceTestCase {
             Settings.builder()
                 .put("index.mapping.total_fields.limit", 1)
                 .put("index.mapping.total_fields.ignore_dynamic_beyond_limit", true)
+                .put("index.mapping.source.mode", "synthetic")
                 .build(),
-            syntheticSourceMapping(b -> {
+            mapping(b -> {
                 b.startObject("foo").field("type", "keyword").endObject();
             })
         ).documentMapper();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/SyntheticSourceIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/SyntheticSourceIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -76,11 +77,6 @@ public class SyntheticSourceIT extends AbstractEsqlIntegTestCase {
         XContentBuilder mapping = JsonXContent.contentBuilder();
         mapping.startObject();
         {
-            mapping.startObject("_source");
-            mapping.field("mode", "synthetic");
-            mapping.endObject();
-        }
-        {
             mapping.startObject("properties");
             mapping.startObject("id").field("type", "keyword").endObject();
             mapping.startObject("field");
@@ -90,6 +86,8 @@ public class SyntheticSourceIT extends AbstractEsqlIntegTestCase {
         }
         mapping.endObject();
 
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
+        Settings.Builder settings = Settings.builder().put(indexSettings()).put("index.mapping.source.mode", "synthetic");
+
+        assertAcked(client().admin().indices().prepareCreate("test").setSettings(settings).setMapping(mapping));
     }
 }

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapperTests.java
@@ -527,14 +527,14 @@ public class AggregateDoubleMetricFieldMapperTests extends MapperTestCase {
     }
 
     public void testArrayValueSyntheticSource() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(
-            syntheticSourceFieldMapping(
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            fieldMapping(
                 b -> b.field("type", CONTENT_TYPE)
                     .array("metrics", "min", "max")
                     .field("default_metric", "min")
                     .field("ignore_malformed", "true")
             )
-        );
+        ).documentMapper();
 
         var randomString = randomAlphaOfLength(10);
         CheckedConsumer<XContentBuilder, IOException> arrayValue = b -> {

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -230,7 +230,7 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
      * contain the field.
      */
     public void testNullValueBlockLoader() throws IOException {
-        MapperService mapper = createMapperService(syntheticSourceMapping(b -> {
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field");
             b.field("type", "constant_keyword");
             b.endObject();
@@ -325,11 +325,11 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
     }
 
     public void testNullValueSyntheticSource() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
             b.startObject("field");
             b.field("type", "constant_keyword");
             b.endObject();
-        }));
+        })).documentMapper();
         assertThat(syntheticSource(mapper, b -> {}), equalTo("{}"));
     }
 


### PR DESCRIPTION
This change replaces the old synthetic source config in mappings with the newly introduced index setting.

Closes #115859