### PR TITLE
[8.x] [Test] Use stream.next instead of setAutoRead in test (#115063)

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -176,12 +176,16 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
             var handler = ctx.awaitRestChannelAccepted(opaqueId);
             assertBusy(() -> assertNotNull(handler.stream.buf()));
 
-            // enable auto-read to receive channel close event
-            handler.stream.channel().config().setAutoRead(true);
             assertFalse(handler.streamClosed);
 
-            // terminate connection and wait resources are released
+            // terminate client connection
             ctx.clientChannel.close();
+            // read the first half of the request
+            handler.stream.next();
+            // attempt to read more data and it should notice channel being closed eventually
+            handler.stream.next();
+
+            // wait for resources to be released
             assertBusy(() -> {
                 assertNull(handler.stream.buf());
                 assertTrue(handler.streamClosed);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Test] Use stream.next instead of setAutoRead in test (#115063) (22b4d814)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)