### PR TITLE
Update allowed error messages in SSL test

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLDriverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SSLDriverTests.java
@@ -172,7 +172,9 @@ public class SSLDriverTests extends ESTestCase {
             serverProtocols = new String[] { "TLSv1.2" };
             clientProtocols = new String[] { "TLSv1.1" };
             expectedMessageMatcher = anyOf(
-                is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences " + "[TLS1.2]"),
+                is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLS12]"),
+                is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLS1.2]"),
+                is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLSv1.2]"),
                 is("org.bouncycastle.tls.TlsFatalAlert: protocol_version(70)"),
                 is("Client requested protocol TLSv1.1 " + "not enabled or not supported")
             );
@@ -185,7 +187,9 @@ public class SSLDriverTests extends ESTestCase {
             serverProtocols = new String[] { "TLSv1.2" };
             clientProtocols = new String[] { "TLSv1.1" };
             expectedMessageMatcher = anyOf(
+                is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLS12]"),
                 is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLS1.2]"),
+                is("The client supported protocol versions [TLSv1.1] are not accepted by server preferences [TLSv1.2]"),
                 is("Client requested protocol TLSv1.1 not enabled or not supported"),
                 is("No appropriate protocol (protocol is disabled or cipher suites are inappropriate)")
             );


### PR DESCRIPTION
Different JRE vendors/version produce slightly different error messages. We don't care which one we receive, just accept any of them.

Resolves: #115016
