### PR TITLE
ESQL: Wait a bit before .async-search index shard is available

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -153,9 +153,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search/500_date_range/from, to, include_lower, include_upper deprecated}
   issue: https://github.com/elastic/elasticsearch/pull/113286
-- class: org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT
-  method: testLimitedPrivilege
-  issue: https://github.com/elastic/elasticsearch/issues/113419
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {categorize.Categorize}
   issue: https://github.com/elastic/elasticsearch/issues/113428

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
@@ -154,6 +154,14 @@ public class EsqlAsyncSecurityIT extends EsqlSecurityIT {
                     } catch (InterruptedException ex) {
                         throw new RuntimeException(ex);
                     }
+                } else if (statusCode == 503 && message.contains("No shard available for [get [.async-search]")) {
+                    // Workaround for https://github.com/elastic/elasticsearch/issues/113419
+                    logger.warn(".async-search index shards not yet available", e);
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException ex) {
+                        throw new RuntimeException(ex);
+                    }
                 } else {
                     throw e;
                 }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/113419