### PR TITLE
Fix and unmute org.elasticsearch.script.StatsSummaryTests:testEqualsAndHashCode

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -103,9 +103,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
   method: test {case-functions.testUcaseInline3}
   issue: https://github.com/elastic/elasticsearch/issues/112643
-- class: org.elasticsearch.script.StatsSummaryTests
-  method: testEqualsAndHashCode
-  issue: https://github.com/elastic/elasticsearch/issues/112439
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.HdfsRepositoryAnalysisRestIT
   issue: https://github.com/elastic/elasticsearch/issues/112889
 - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT

--- a/server/src/test/java/org/elasticsearch/script/StatsSummaryTests.java
+++ b/server/src/test/java/org/elasticsearch/script/StatsSummaryTests.java
@@ -76,8 +76,8 @@ public class StatsSummaryTests extends ESTestCase {
         assertThat(stats1.hashCode(), equalTo(stats2.hashCode()));
 
         // Accumulators with different values are not equals
-        randomDoubles(randomIntBetween(0, 20)).forEach(stats1);
-        randomDoubles(randomIntBetween(0, 20)).forEach(stats2);
+        randomDoubles(randomIntBetween(1, 10)).forEach(stats1);
+        randomDoubles(randomIntBetween(11, 20)).forEach(stats2);
         assertThat(stats1, not(equalTo(stats2)));
         assertThat(stats1.hashCode(), not(equalTo(stats2.hashCode())));
     }

--- a/server/src/test/java/org/elasticsearch/script/StatsSummaryTests.java
+++ b/server/src/test/java/org/elasticsearch/script/StatsSummaryTests.java
@@ -75,9 +75,21 @@ public class StatsSummaryTests extends ESTestCase {
         assertThat(stats1, equalTo(stats2));
         assertThat(stats1.hashCode(), equalTo(stats2.hashCode()));
 
+        // Accumulators with same sum, but different counts are not equals
+        stats1.accept(1);
+        stats1.accept(1);
+        stats2.accept(2);
+        assertThat(stats1.getSum(), equalTo(stats2.getSum()));
+        assertThat(stats1.getCount(), not(equalTo(stats2.getCount())));
+        assertThat(stats1, not(equalTo(stats2)));
+        assertThat(stats1.hashCode(), not(equalTo(stats2.hashCode())));
+
         // Accumulators with different values are not equals
-        randomDoubles(randomIntBetween(1, 10)).forEach(stats1);
-        randomDoubles(randomIntBetween(11, 20)).forEach(stats2);
+        stats1.reset();
+        stats2.reset();
+        randomDoubles(randomIntBetween(1, 20)).forEach(stats1.andThen(v -> stats2.accept(v + randomDoubleBetween(0.0, 1.0, false))));
+        assertThat(stats1.getCount(), equalTo(stats2.getCount()));
+        assertThat(stats1.getSum(), not(equalTo(stats2.getSum())));
         assertThat(stats1, not(equalTo(stats2)));
         assertThat(stats1.hashCode(), not(equalTo(stats2.hashCode())));
     }


### PR DESCRIPTION
This commit fixes and unmutes org.elasticsearch.script.StatsSummaryTests:testEqualsAndHashCode.

Previously, there was no guarantee that the doubles added to `stats1` and `stats2` will be different. In fact, the count may even be zero - which we seen in one particular failure. The simplest thing here, to avoid this potential situation, is to ensure that there is at least one value, and that the values added to each stats instance are different.

closes #112511
closes #112439