### PR TITLE
[8.x] plugin(apm-data): amend logs-apm component template (#115778)

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm@settings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/logs-apm@settings.yaml
@@ -5,5 +5,6 @@ _meta:
   managed: true
 template:
   settings:
-    codec: best_compression
-    mode: standard
+    index:
+      codec: best_compression
+      mode: standard


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - plugin(apm-data): amend logs-apm component template (#115778) (2b1dc5ad)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)