### PR TITLE
Mute UpgradeClusterClientYamlTestSuiteIT#indices.create/20_synthetic_source tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -364,6 +364,7 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=indices.create/20_synthetic_source/nested object with unmapped fields}
   issue: https://github.com/elastic/elasticsearch/issues/115912
+
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -355,6 +355,15 @@ tests:
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=indices.create/20_synthetic_source/object with unmapped fields}
+  issue: https://github.com/elastic/elasticsearch/issues/115910
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=indices.create/20_synthetic_source/empty object with unmapped fields}
+  issue: https://github.com/elastic/elasticsearch/issues/115911
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=indices.create/20_synthetic_source/nested object with unmapped fields}
+  issue: https://github.com/elastic/elasticsearch/issues/115912
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -364,7 +364,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=indices.create/20_synthetic_source/nested object with unmapped fields}
   issue: https://github.com/elastic/elasticsearch/issues/115912
-
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:


### PR DESCRIPTION
Manual mute for: https://github.com/elastic/elasticsearch/issues/115910, https://github.com/elastic/elasticsearch/issues/115911, https://github.com/elastic/elasticsearch/issues/115912

These are also failing on 8.16.