### PR TITLE
[8.16] Add Default ELSER 2 Capability

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -274,12 +274,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/113655
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDateNanosTests
   issue: https://github.com/elastic/elasticsearch/issues/113661
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/114412
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/114376
 - class: org.elasticsearch.search.retriever.RankDocsRetrieverBuilderTests
   method: testRewrite
   issue: https://github.com/elastic/elasticsearch/issues/114467

--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 restResources {
   restApi {
-    include '_common', 'bulk', 'indices', 'inference', 'index', 'get', 'update', 'reindex', 'search', 'field_caps'
+    include '_common', 'bulk', 'indices', 'inference', 'index', 'get', 'update', 'reindex', 'search', 'field_caps', 'capabilities'
   }
 }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestGetInferenceModelAction.java
@@ -15,8 +15,12 @@ import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
+import org.elasticsearch.xpack.inference.DefaultElserFeatureFlag;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.xpack.inference.rest.Paths.INFERENCE_ID;
@@ -26,6 +30,7 @@ import static org.elasticsearch.xpack.inference.rest.Paths.TASK_TYPE_OR_INFERENC
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetInferenceModelAction extends BaseRestHandler {
+    public static final String DEFAULT_ELSER_2_CAPABILITY = "default_elser_2";
 
     @Override
     public String getName() {
@@ -60,5 +65,15 @@ public class RestGetInferenceModelAction extends BaseRestHandler {
 
         var request = new GetInferenceModelAction.Request(inferenceEntityId, taskType);
         return channel -> client.execute(GetInferenceModelAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        Set<String> capabilities = new HashSet<>();
+        if (DefaultElserFeatureFlag.isEnabled()) {
+            capabilities.add(DEFAULT_ELSER_2_CAPABILITY);
+        }
+
+        return Collections.unmodifiableSet(capabilities);
     }
 }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
@@ -551,8 +551,12 @@ setup:
 ---
 "Calculates embeddings using the default ELSER 2 endpoint":
   - requires:
-      cluster_features: "semantic_text.default_elser_2"
-      reason: semantic_text default ELSER 2 inference ID introduced in 8.16.0
+      reason: "default ELSER 2 inference ID is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: GET
+          path: /_inference
+          capabilities: [default_elser_2]
 
   - do:
       indices.create:

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/40_semantic_text_query.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/40_semantic_text_query.yml
@@ -843,8 +843,12 @@ setup:
 ---
 "Query a field that uses the default ELSER 2 endpoint":
   - requires:
-      cluster_features: "semantic_text.default_elser_2"
-      reason: semantic_text default ELSER 2 inference ID introduced in 8.16.0
+      reason: "default ELSER 2 inference ID is behind a feature flag"
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: GET
+          path: /_inference
+          capabilities: [default_elser_2]
 
   - do:
       indices.create:


### PR DESCRIPTION
Manual backport of #115891.

Addresses https://github.com/elastic/elasticsearch/issues/114376 and https://github.com/elastic/elasticsearch/issues/114412.