### PR TITLE
[8.x] [ML] Wait for all shards to be active when creating the ML stats index (#108202)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1744,7 +1744,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         ensureHealth(restClient, "", requestConsumer);
     }
 
-    protected static void ensureHealth(RestClient restClient, String index, Consumer<Request> requestConsumer) throws IOException {
+    public static void ensureHealth(RestClient restClient, String index, Consumer<Request> requestConsumer) throws IOException {
         Request request = new Request("GET", "/_cluster/health" + (index.isBlank() ? "" : "/" + index));
         requestConsumer.accept(request);
         try {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlStatsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlStatsIndex.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ml;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -66,6 +67,15 @@ public class MlStatsIndex {
         TimeValue masterNodeTimeout,
         ActionListener<Boolean> listener
     ) {
-        MlIndexAndAlias.createIndexAndAliasIfNecessary(client, state, resolver, TEMPLATE_NAME, writeAlias(), masterNodeTimeout, listener);
+        MlIndexAndAlias.createIndexAndAliasIfNecessary(
+            client,
+            state,
+            resolver,
+            TEMPLATE_NAME,
+            writeAlias(),
+            masterNodeTimeout,
+            ActiveShardCount.ALL,
+            listener
+        );
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ml.job.persistence;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -91,6 +92,10 @@ public final class AnomalyDetectorsIndex {
             AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
             AnomalyDetectorsIndex.jobStateIndexWriteAlias(),
             masterNodeTimeout,
+            // TODO: shard count default preserves the existing behaviour when the
+            // parameter was added but it may be that ActiveShardCount.ALL is a
+            // better option
+            ActiveShardCount.DEFAULT,
             finalListener
         );
     }
@@ -123,6 +128,10 @@ public final class AnomalyDetectorsIndex {
             AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
             AnomalyDetectorsIndex.jobStateIndexWriteAlias(),
             masterNodeTimeout,
+            // TODO: shard count default preserves the existing behaviour when the
+            // parameter was added but it may be that ActiveShardCount.ALL is a
+            // better option
+            ActiveShardCount.DEFAULT,
             stateIndexAndAliasCreated
         );
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
@@ -30,6 +30,7 @@ public class MlRestTestStateCleaner {
     }
 
     public void resetFeatures() throws IOException {
+        waitForMlStatsIndexToInitialize();
         deleteAllTrainedModelIngestPipelines();
         // This resets all features, not just ML, but they should have been getting reset between tests anyway so it shouldn't matter
         adminClient.performRequest(new Request("POST", "/_features/_reset"));
@@ -53,5 +54,13 @@ public class MlRestTestStateCleaner {
                 logger.warn(() -> "failed to delete pipeline [" + pipelineId + "]", ex);
             }
         }
+    }
+
+    private void waitForMlStatsIndexToInitialize() throws IOException {
+        ESRestTestCase.ensureHealth(adminClient, ".ml-stats-*", (request) -> {
+            request.addParameter("wait_for_no_initializing_shards", "true");
+            request.addParameter("level", "shards");
+            request.addParameter("timeout", "30s");
+        });
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.internal.AdminClient;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ClusterAdminClient;
@@ -370,7 +371,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
             TestIndexNameExpressionResolver.newInstance(),
             TEST_INDEX_PREFIX,
             TEST_INDEX_ALIAS,
-            TEST_REQUEST_TIMEOUT,
+            TimeValue.timeValueSeconds(30),
+            ActiveShardCount.DEFAULT,
             listener
         );
     }

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceProcessorIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceProcessorIT.java
@@ -40,13 +40,13 @@ public class InferenceProcessorIT extends InferenceTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107777")
     public void testCreateAndDeletePipelineWithInferenceProcessor() throws Exception {
         putRegressionModel(MODEL_ID);
         String pipelineId = "regression-model-pipeline";
         createdPipelines.add(pipelineId);
         putPipeline(MODEL_ID, pipelineId);
 
+        waitForStats();
         Map<String, Object> statsAsMap = getStats(MODEL_ID);
         List<Integer> pipelineCount = (List<Integer>) XContentMapValues.extractValue("trained_model_stats.pipeline_count", statsAsMap);
         assertThat(pipelineCount.get(0), equalTo(1));
@@ -107,6 +107,7 @@ public class InferenceProcessorIT extends InferenceTestCase {
         createdPipelines.add("second_pipeline");
         putPipeline("regression_second", "second_pipeline");
 
+        waitForStats();
         Map<String, Object> statsAsMap = getStats(MODEL_ID);
         List<Integer> pipelineCount = (List<Integer>) XContentMapValues.extractValue("trained_model_stats.pipeline_count", statsAsMap);
         assertThat(pipelineCount.get(0), equalTo(2));

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -563,9 +563,6 @@ setup:
 
 ---
 "Test delete given model referenced by pipeline":
-  - skip:
-      awaits_fix: "https://github.com/elastic/elasticsearch/issues/80703"
-
   - do:
       ingest.put_pipeline:
         id: "pipeline-using-a-classification-model"
@@ -592,9 +589,6 @@ setup:
 
 ---
 "Test force delete given model referenced by pipeline":
-  - skip:
-      awaits_fix: "https://github.com/elastic/elasticsearch/issues/80703"
-
   - do:
       ingest.put_pipeline:
         id: "pipeline-using-a-classification-model"
@@ -622,9 +616,6 @@ setup:
 
 ---
 "Test delete given model with alias referenced by pipeline":
-  - skip:
-      awaits_fix: "https://github.com/elastic/elasticsearch/issues/80703"
-
   - do:
       ml.put_trained_model_alias:
         model_alias: "alias-to-a-classification-model"
@@ -655,8 +646,6 @@ setup:
 
 ---
 "Test force delete given model with alias referenced by pipeline":
-  - skip:
-      awaits_fix: "https://github.com/elastic/elasticsearch/issues/106652"
   - do:
       ml.put_trained_model_alias:
         model_alias: "alias-to-a-classification-model"


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [ML] Wait for all shards to be active when creating the ML stats index (#108202)