### PR TITLE
Unmute SearchStatesIT::testCanMatch

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,7 +1,4 @@
 tests:
-- class: "org.elasticsearch.upgrades.SearchStatesIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108991"
-  method: "testCanMatch"
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/esql/esql-async-query-api/line_17}
   issue: https://github.com/elastic/elasticsearch/issues/109260


### PR DESCRIPTION
The original failure reported in #108991 seems to be from a temporary connection failure:

java.net.ConnectException: Connection refused

so we umuting the test.

Closes #108991