### PR TITLE
[8.x] Fix CCS stats test (#115801)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/30_ccs_stats.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/30_ccs_stats.yml
@@ -70,6 +70,7 @@
           body:
               settings:
                   number_of_replicas: 0
+                  store.stats_refresh_interval: 0ms
 
   - do:
       index:
@@ -78,6 +79,10 @@
         refresh: true
         body:
           foo: bar
+
+  - do:
+      indices.flush:
+        index: test
 
   - do:
       cluster.health:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - Fix CCS stats test (#115801) (5f4e6817)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)