### PR TITLE
[8.x] [Inference API] Improve chunked results error message (#115807)

### DIFF
--- a/docs/changelog/115807.yaml
+++ b/docs/changelog/115807.yaml
@@ -1,0 +1,5 @@
+pr: 115807
+summary: "[Inference API] Improve chunked results error message"
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/ResultUtils.java
@@ -14,8 +14,9 @@ public class ResultUtils {
 
     public static ElasticsearchStatusException createInvalidChunkedResultException(String expectedResultName, String receivedResultName) {
         return new ElasticsearchStatusException(
-            "Expected a chunked inference [{}] received [{}]",
-            RestStatus.INTERNAL_SERVER_ERROR,
+            "Received incompatible results. Check that your model_id matches the task_type of this endpoint. "
+                + "Expected chunked output of type [{}] but received [{}].",
+            RestStatus.CONFLICT,
             expectedResultName,
             receivedResultName
         );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Inference API] Improve chunked results error message (#115807) (6742147d)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)