### PR TITLE
[8.x] [Inference API] Add API to get configuration of inference services  (#114862)

### DIFF
--- a/docs/changelog/114862.yaml
+++ b/docs/changelog/114862.yaml
@@ -1,0 +1,5 @@
+pr: 114862
+summary: "[Inference API] Add API to get configuration of inference services"
+area: Machine Learning
+type: enhancement
+issues: []

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -468,5 +468,6 @@ module org.elasticsearch.server {
             org.elasticsearch.serverless.shardhealth,
             org.elasticsearch.serverless.apifiltering;
     exports org.elasticsearch.lucene.spatial;
+    exports org.elasticsearch.inference.configuration;
 
 }

--- a/server/src/main/java/org/elasticsearch/inference/EmptySettingsConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/inference/EmptySettingsConfiguration.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class EmptySettingsConfiguration {
+    public static Map<String, SettingsConfiguration> get() {
+        return Collections.emptyMap();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/InferenceService.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 import java.io.Closeable;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +71,14 @@ public interface InferenceService extends Closeable {
      * @return The parsed {@link Model}
      */
     Model parsePersistedConfig(String modelId, TaskType taskType, Map<String, Object> config);
+
+    InferenceServiceConfiguration getConfiguration();
+
+    /**
+     * The task types supported by the service
+     * @return Set of supported.
+     */
+    EnumSet<TaskType> supportedTaskTypes();
 
     /**
      * Perform inference on the model.

--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceConfiguration.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Represents the configuration field settings for an inference provider.
+ */
+public class InferenceServiceConfiguration implements Writeable, ToXContentObject {
+
+    private final String provider;
+    private final List<TaskSettingsConfiguration> taskTypes;
+    private final Map<String, SettingsConfiguration> configuration;
+
+    /**
+     * Constructs a new {@link InferenceServiceConfiguration} instance with specified properties.
+     *
+     * @param provider       The name of the service provider.
+     * @param taskTypes      A list of {@link TaskSettingsConfiguration} supported by the service provider.
+     * @param configuration  The configuration of the service provider, defined by {@link SettingsConfiguration}.
+     */
+    private InferenceServiceConfiguration(
+        String provider,
+        List<TaskSettingsConfiguration> taskTypes,
+        Map<String, SettingsConfiguration> configuration
+    ) {
+        this.provider = provider;
+        this.taskTypes = taskTypes;
+        this.configuration = configuration;
+    }
+
+    public InferenceServiceConfiguration(StreamInput in) throws IOException {
+        this.provider = in.readString();
+        this.taskTypes = in.readCollectionAsList(TaskSettingsConfiguration::new);
+        this.configuration = in.readMap(SettingsConfiguration::new);
+    }
+
+    static final ParseField PROVIDER_FIELD = new ParseField("provider");
+    static final ParseField TASK_TYPES_FIELD = new ParseField("task_types");
+    static final ParseField CONFIGURATION_FIELD = new ParseField("configuration");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<InferenceServiceConfiguration, Void> PARSER = new ConstructingObjectParser<>(
+        "inference_service_configuration",
+        true,
+        args -> {
+            List<String> taskTypes = (ArrayList<String>) args[1];
+            return new InferenceServiceConfiguration.Builder().setProvider((String) args[0])
+                .setTaskTypes((List<TaskSettingsConfiguration>) args[1])
+                .setConfiguration((Map<String, SettingsConfiguration>) args[2])
+                .build();
+        }
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), PROVIDER_FIELD);
+        PARSER.declareObjectArray(constructorArg(), (p, c) -> TaskSettingsConfiguration.fromXContent(p), TASK_TYPES_FIELD);
+        PARSER.declareObject(constructorArg(), (p, c) -> p.map(), CONFIGURATION_FIELD);
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public List<TaskSettingsConfiguration> getTaskTypes() {
+        return taskTypes;
+    }
+
+    public Map<String, SettingsConfiguration> getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(PROVIDER_FIELD.getPreferredName(), provider);
+            builder.field(TASK_TYPES_FIELD.getPreferredName(), taskTypes);
+            builder.field(CONFIGURATION_FIELD.getPreferredName(), configuration);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static InferenceServiceConfiguration fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    public static InferenceServiceConfiguration fromXContentBytes(BytesReference source, XContentType xContentType) {
+        try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
+            return InferenceServiceConfiguration.fromXContent(parser);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("failed to parse inference service configuration", e);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(provider);
+        out.writeCollection(taskTypes);
+        out.writeMapValues(configuration);
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+
+        map.put(PROVIDER_FIELD.getPreferredName(), provider);
+        map.put(TASK_TYPES_FIELD.getPreferredName(), taskTypes);
+        map.put(CONFIGURATION_FIELD.getPreferredName(), configuration);
+
+        return map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InferenceServiceConfiguration that = (InferenceServiceConfiguration) o;
+        return provider.equals(that.provider)
+            && Objects.equals(taskTypes, that.taskTypes)
+            && Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(provider, taskTypes, configuration);
+    }
+
+    public static class Builder {
+
+        private String provider;
+        private List<TaskSettingsConfiguration> taskTypes;
+        private Map<String, SettingsConfiguration> configuration;
+
+        public Builder setProvider(String provider) {
+            this.provider = provider;
+            return this;
+        }
+
+        public Builder setTaskTypes(List<TaskSettingsConfiguration> taskTypes) {
+            this.taskTypes = taskTypes;
+            return this;
+        }
+
+        public Builder setConfiguration(Map<String, SettingsConfiguration> configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public InferenceServiceConfiguration build() {
+            return new InferenceServiceConfiguration(provider, taskTypes, configuration);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/SettingsConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/inference/SettingsConfiguration.java
@@ -1,0 +1,592 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDependency;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
+import org.elasticsearch.inference.configuration.SettingsConfigurationValidation;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * Represents the configuration field settings for an inference provider.
+ */
+public class SettingsConfiguration implements Writeable, ToXContentObject {
+
+    @Nullable
+    private final String category;
+    @Nullable
+    private final Object defaultValue;
+    @Nullable
+    private final List<SettingsConfigurationDependency> dependsOn;
+    @Nullable
+    private final SettingsConfigurationDisplayType display;
+    private final String label;
+    @Nullable
+    private final List<SettingsConfigurationSelectOption> options;
+    @Nullable
+    private final Integer order;
+    @Nullable
+    private final String placeholder;
+    private final boolean required;
+    private final boolean sensitive;
+    @Nullable
+    private final String tooltip;
+    @Nullable
+    private final SettingsConfigurationFieldType type;
+    @Nullable
+    private final List<String> uiRestrictions;
+    @Nullable
+    private final List<SettingsConfigurationValidation> validations;
+    @Nullable
+    private final Object value;
+
+    /**
+     * Constructs a new {@link SettingsConfiguration} instance with specified properties.
+     *
+     * @param category       The category of the configuration field.
+     * @param defaultValue   The default value for the configuration.
+     * @param dependsOn      A list of {@link SettingsConfigurationDependency} indicating dependencies on other configurations.
+     * @param display        The display type, defined by {@link SettingsConfigurationDisplayType}.
+     * @param label          The display label associated with the config field.
+     * @param options        A list of {@link SettingsConfigurationSelectOption} for selectable options.
+     * @param order          The order in which this configuration appears.
+     * @param placeholder    A placeholder text for the configuration field.
+     * @param required       A boolean indicating whether the configuration is required.
+     * @param sensitive      A boolean indicating whether the configuration contains sensitive information.
+     * @param tooltip        A tooltip text providing additional information about the configuration.
+     * @param type           The type of the configuration field, defined by {@link SettingsConfigurationFieldType}.
+     * @param uiRestrictions A list of UI restrictions in string format.
+     * @param validations    A list of {@link SettingsConfigurationValidation} for validating the configuration.
+     * @param value          The current value of the configuration.
+     */
+    private SettingsConfiguration(
+        String category,
+        Object defaultValue,
+        List<SettingsConfigurationDependency> dependsOn,
+        SettingsConfigurationDisplayType display,
+        String label,
+        List<SettingsConfigurationSelectOption> options,
+        Integer order,
+        String placeholder,
+        boolean required,
+        boolean sensitive,
+        String tooltip,
+        SettingsConfigurationFieldType type,
+        List<String> uiRestrictions,
+        List<SettingsConfigurationValidation> validations,
+        Object value
+    ) {
+        this.category = category;
+        this.defaultValue = defaultValue;
+        this.dependsOn = dependsOn;
+        this.display = display;
+        this.label = label;
+        this.options = options;
+        this.order = order;
+        this.placeholder = placeholder;
+        this.required = required;
+        this.sensitive = sensitive;
+        this.tooltip = tooltip;
+        this.type = type;
+        this.uiRestrictions = uiRestrictions;
+        this.validations = validations;
+        this.value = value;
+    }
+
+    public SettingsConfiguration(StreamInput in) throws IOException {
+        this.category = in.readString();
+        this.defaultValue = in.readGenericValue();
+        this.dependsOn = in.readOptionalCollectionAsList(SettingsConfigurationDependency::new);
+        this.display = in.readEnum(SettingsConfigurationDisplayType.class);
+        this.label = in.readString();
+        this.options = in.readOptionalCollectionAsList(SettingsConfigurationSelectOption::new);
+        this.order = in.readOptionalInt();
+        this.placeholder = in.readOptionalString();
+        this.required = in.readBoolean();
+        this.sensitive = in.readBoolean();
+        this.tooltip = in.readOptionalString();
+        this.type = in.readEnum(SettingsConfigurationFieldType.class);
+        this.uiRestrictions = in.readOptionalStringCollectionAsList();
+        this.validations = in.readOptionalCollectionAsList(SettingsConfigurationValidation::new);
+        this.value = in.readGenericValue();
+    }
+
+    static final ParseField CATEGORY_FIELD = new ParseField("category");
+    static final ParseField DEFAULT_VALUE_FIELD = new ParseField("default_value");
+    static final ParseField DEPENDS_ON_FIELD = new ParseField("depends_on");
+    static final ParseField DISPLAY_FIELD = new ParseField("display");
+    static final ParseField LABEL_FIELD = new ParseField("label");
+    static final ParseField OPTIONS_FIELD = new ParseField("options");
+    static final ParseField ORDER_FIELD = new ParseField("order");
+    static final ParseField PLACEHOLDER_FIELD = new ParseField("placeholder");
+    static final ParseField REQUIRED_FIELD = new ParseField("required");
+    static final ParseField SENSITIVE_FIELD = new ParseField("sensitive");
+    static final ParseField TOOLTIP_FIELD = new ParseField("tooltip");
+    static final ParseField TYPE_FIELD = new ParseField("type");
+    static final ParseField UI_RESTRICTIONS_FIELD = new ParseField("ui_restrictions");
+    static final ParseField VALIDATIONS_FIELD = new ParseField("validations");
+    static final ParseField VALUE_FIELD = new ParseField("value");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<SettingsConfiguration, Void> PARSER = new ConstructingObjectParser<>(
+        "service_configuration",
+        true,
+        args -> {
+            int i = 0;
+            return new SettingsConfiguration.Builder().setCategory((String) args[i++])
+                .setDefaultValue(args[i++])
+                .setDependsOn((List<SettingsConfigurationDependency>) args[i++])
+                .setDisplay((SettingsConfigurationDisplayType) args[i++])
+                .setLabel((String) args[i++])
+                .setOptions((List<SettingsConfigurationSelectOption>) args[i++])
+                .setOrder((Integer) args[i++])
+                .setPlaceholder((String) args[i++])
+                .setRequired((Boolean) args[i++])
+                .setSensitive((Boolean) args[i++])
+                .setTooltip((String) args[i++])
+                .setType((SettingsConfigurationFieldType) args[i++])
+                .setUiRestrictions((List<String>) args[i++])
+                .setValidations((List<SettingsConfigurationValidation>) args[i++])
+                .setValue(args[i])
+                .build();
+        }
+    );
+
+    static {
+        PARSER.declareString(optionalConstructorArg(), CATEGORY_FIELD);
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> {
+            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return p.text();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+                return p.numberValue();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
+                return p.booleanValue();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
+                return null;
+            }
+            throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
+        }, DEFAULT_VALUE_FIELD, ObjectParser.ValueType.VALUE);
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> SettingsConfigurationDependency.fromXContent(p), DEPENDS_ON_FIELD);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> SettingsConfigurationDisplayType.displayType(p.text()),
+            DISPLAY_FIELD,
+            ObjectParser.ValueType.STRING_OR_NULL
+        );
+        PARSER.declareString(constructorArg(), LABEL_FIELD);
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> SettingsConfigurationSelectOption.fromXContent(p), OPTIONS_FIELD);
+        PARSER.declareInt(optionalConstructorArg(), ORDER_FIELD);
+        PARSER.declareStringOrNull(optionalConstructorArg(), PLACEHOLDER_FIELD);
+        PARSER.declareBoolean(optionalConstructorArg(), REQUIRED_FIELD);
+        PARSER.declareBoolean(optionalConstructorArg(), SENSITIVE_FIELD);
+        PARSER.declareStringOrNull(optionalConstructorArg(), TOOLTIP_FIELD);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> p.currentToken() == XContentParser.Token.VALUE_NULL ? null : SettingsConfigurationFieldType.fieldType(p.text()),
+            TYPE_FIELD,
+            ObjectParser.ValueType.STRING_OR_NULL
+        );
+        PARSER.declareStringArray(optionalConstructorArg(), UI_RESTRICTIONS_FIELD);
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> SettingsConfigurationValidation.fromXContent(p), VALIDATIONS_FIELD);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> parseConfigurationValue(p),
+            VALUE_FIELD,
+            ObjectParser.ValueType.VALUE_OBJECT_ARRAY
+        );
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public List<SettingsConfigurationDependency> getDependsOn() {
+        return dependsOn;
+    }
+
+    public SettingsConfigurationDisplayType getDisplay() {
+        return display;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public List<SettingsConfigurationSelectOption> getOptions() {
+        return options;
+    }
+
+    public Integer getOrder() {
+        return order;
+    }
+
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public boolean isSensitive() {
+        return sensitive;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public SettingsConfigurationFieldType getType() {
+        return type;
+    }
+
+    public List<String> getUiRestrictions() {
+        return uiRestrictions;
+    }
+
+    public List<SettingsConfigurationValidation> getValidations() {
+        return validations;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    /**
+     * Parses a configuration value from a parser context.
+     * This method can parse strings, numbers, booleans, objects, and null values, matching the types commonly
+     * supported in {@link SettingsConfiguration}.
+     *
+     * @param p the {@link org.elasticsearch.xcontent.XContentParser} instance from which to parse the configuration value.
+     */
+    public static Object parseConfigurationValue(XContentParser p) throws IOException {
+
+        if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+            return p.text();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+            return p.numberValue();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
+            return p.booleanValue();
+        } else if (p.currentToken() == XContentParser.Token.START_OBJECT) {
+            // Crawler expects the value to be an object
+            return p.map();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
+            return null;
+        }
+        throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            if (category != null) {
+                builder.field(CATEGORY_FIELD.getPreferredName(), category);
+            }
+            builder.field(DEFAULT_VALUE_FIELD.getPreferredName(), defaultValue);
+            if (dependsOn != null) {
+                builder.xContentList(DEPENDS_ON_FIELD.getPreferredName(), dependsOn);
+            } else {
+                builder.xContentList(DEPENDS_ON_FIELD.getPreferredName(), new ArrayList<>());
+            }
+            if (display != null) {
+                builder.field(DISPLAY_FIELD.getPreferredName(), display.toString());
+            }
+            builder.field(LABEL_FIELD.getPreferredName(), label);
+            if (options != null) {
+                builder.xContentList(OPTIONS_FIELD.getPreferredName(), options);
+            }
+            if (order != null) {
+                builder.field(ORDER_FIELD.getPreferredName(), order);
+            }
+            if (placeholder != null) {
+                builder.field(PLACEHOLDER_FIELD.getPreferredName(), placeholder);
+            }
+            builder.field(REQUIRED_FIELD.getPreferredName(), required);
+            builder.field(SENSITIVE_FIELD.getPreferredName(), sensitive);
+            if (tooltip != null) {
+                builder.field(TOOLTIP_FIELD.getPreferredName(), tooltip);
+            }
+            if (type != null) {
+                builder.field(TYPE_FIELD.getPreferredName(), type.toString());
+            }
+            if (uiRestrictions != null) {
+                builder.stringListField(UI_RESTRICTIONS_FIELD.getPreferredName(), uiRestrictions);
+            } else {
+                builder.stringListField(UI_RESTRICTIONS_FIELD.getPreferredName(), new ArrayList<>());
+            }
+            if (validations != null) {
+                builder.xContentList(VALIDATIONS_FIELD.getPreferredName(), validations);
+            } else {
+                builder.xContentList(VALIDATIONS_FIELD.getPreferredName(), new ArrayList<>());
+            }
+            builder.field(VALUE_FIELD.getPreferredName(), value);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static SettingsConfiguration fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    public static SettingsConfiguration fromXContentBytes(BytesReference source, XContentType xContentType) {
+        try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
+            return SettingsConfiguration.fromXContent(parser);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse service configuration.", e);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(category);
+        out.writeGenericValue(defaultValue);
+        out.writeOptionalCollection(dependsOn);
+        out.writeEnum(display);
+        out.writeString(label);
+        out.writeOptionalCollection(options);
+        out.writeOptionalInt(order);
+        out.writeOptionalString(placeholder);
+        out.writeBoolean(required);
+        out.writeBoolean(sensitive);
+        out.writeOptionalString(tooltip);
+        out.writeEnum(type);
+        out.writeOptionalStringCollection(uiRestrictions);
+        out.writeOptionalCollection(validations);
+        out.writeGenericValue(value);
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+
+        Optional.ofNullable(category).ifPresent(c -> map.put(CATEGORY_FIELD.getPreferredName(), c));
+        map.put(DEFAULT_VALUE_FIELD.getPreferredName(), defaultValue);
+
+        Optional.ofNullable(dependsOn)
+            .ifPresent(d -> map.put(DEPENDS_ON_FIELD.getPreferredName(), d.stream().map(SettingsConfigurationDependency::toMap).toList()));
+
+        Optional.ofNullable(display).ifPresent(d -> map.put(DISPLAY_FIELD.getPreferredName(), d.toString()));
+
+        map.put(LABEL_FIELD.getPreferredName(), label);
+
+        Optional.ofNullable(options)
+            .ifPresent(o -> map.put(OPTIONS_FIELD.getPreferredName(), o.stream().map(SettingsConfigurationSelectOption::toMap).toList()));
+
+        Optional.ofNullable(order).ifPresent(o -> map.put(ORDER_FIELD.getPreferredName(), o));
+
+        Optional.ofNullable(placeholder).ifPresent(p -> map.put(PLACEHOLDER_FIELD.getPreferredName(), p));
+
+        map.put(REQUIRED_FIELD.getPreferredName(), required);
+        map.put(SENSITIVE_FIELD.getPreferredName(), sensitive);
+
+        Optional.ofNullable(tooltip).ifPresent(t -> map.put(TOOLTIP_FIELD.getPreferredName(), t));
+
+        Optional.ofNullable(type).ifPresent(t -> map.put(TYPE_FIELD.getPreferredName(), t.toString()));
+
+        Optional.ofNullable(uiRestrictions).ifPresent(u -> map.put(UI_RESTRICTIONS_FIELD.getPreferredName(), u));
+
+        Optional.ofNullable(validations)
+            .ifPresent(v -> map.put(VALIDATIONS_FIELD.getPreferredName(), v.stream().map(SettingsConfigurationValidation::toMap).toList()));
+
+        map.put(VALUE_FIELD.getPreferredName(), value);
+
+        return map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SettingsConfiguration that = (SettingsConfiguration) o;
+        return required == that.required
+            && sensitive == that.sensitive
+            && Objects.equals(category, that.category)
+            && Objects.equals(defaultValue, that.defaultValue)
+            && Objects.equals(dependsOn, that.dependsOn)
+            && display == that.display
+            && Objects.equals(label, that.label)
+            && Objects.equals(options, that.options)
+            && Objects.equals(order, that.order)
+            && Objects.equals(placeholder, that.placeholder)
+            && Objects.equals(tooltip, that.tooltip)
+            && type == that.type
+            && Objects.equals(uiRestrictions, that.uiRestrictions)
+            && Objects.equals(validations, that.validations)
+            && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            category,
+            defaultValue,
+            dependsOn,
+            display,
+            label,
+            options,
+            order,
+            placeholder,
+            required,
+            sensitive,
+            tooltip,
+            type,
+            uiRestrictions,
+            validations,
+            value
+        );
+    }
+
+    public static class Builder {
+
+        private String category;
+        private Object defaultValue;
+        private List<SettingsConfigurationDependency> dependsOn;
+        private SettingsConfigurationDisplayType display;
+        private String label;
+        private List<SettingsConfigurationSelectOption> options;
+        private Integer order;
+        private String placeholder;
+        private boolean required;
+        private boolean sensitive;
+        private String tooltip;
+        private SettingsConfigurationFieldType type;
+        private List<String> uiRestrictions;
+        private List<SettingsConfigurationValidation> validations;
+        private Object value;
+
+        public Builder setCategory(String category) {
+            this.category = category;
+            return this;
+        }
+
+        public Builder setDefaultValue(Object defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public Builder setDependsOn(List<SettingsConfigurationDependency> dependsOn) {
+            this.dependsOn = dependsOn;
+            return this;
+        }
+
+        public Builder setDisplay(SettingsConfigurationDisplayType display) {
+            this.display = display;
+            return this;
+        }
+
+        public Builder setLabel(String label) {
+            this.label = label;
+            return this;
+        }
+
+        public Builder setOptions(List<SettingsConfigurationSelectOption> options) {
+            this.options = options;
+            return this;
+        }
+
+        public Builder setOrder(Integer order) {
+            this.order = order;
+            return this;
+        }
+
+        public Builder setPlaceholder(String placeholder) {
+            this.placeholder = placeholder;
+            return this;
+        }
+
+        public Builder setRequired(Boolean required) {
+            this.required = Objects.requireNonNullElse(required, false);
+            return this;
+        }
+
+        public Builder setSensitive(Boolean sensitive) {
+            this.sensitive = Objects.requireNonNullElse(sensitive, false);
+            return this;
+        }
+
+        public Builder setTooltip(String tooltip) {
+            this.tooltip = tooltip;
+            return this;
+        }
+
+        public Builder setType(SettingsConfigurationFieldType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setUiRestrictions(List<String> uiRestrictions) {
+            this.uiRestrictions = uiRestrictions;
+            return this;
+        }
+
+        public Builder setValidations(List<SettingsConfigurationValidation> validations) {
+            this.validations = validations;
+            return this;
+        }
+
+        public Builder setValue(Object value) {
+            this.value = value;
+            return this;
+        }
+
+        public SettingsConfiguration build() {
+            return new SettingsConfiguration(
+                category,
+                defaultValue,
+                dependsOn,
+                display,
+                label,
+                options,
+                order,
+                placeholder,
+                required,
+                sensitive,
+                tooltip,
+                type,
+                uiRestrictions,
+                validations,
+                value
+            );
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/TaskSettingsConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/inference/TaskSettingsConfiguration.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Represents the configuration field settings for a specific task type inference provider.
+ */
+public class TaskSettingsConfiguration implements Writeable, ToXContentObject {
+
+    private final TaskType taskType;
+    private final Map<String, SettingsConfiguration> configuration;
+
+    /**
+     * Constructs a new {@link TaskSettingsConfiguration} instance with specified properties.
+     *
+     * @param taskType       The {@link TaskType} this configuration describes.
+     * @param configuration  The configuration of the task, defined by {@link SettingsConfiguration}.
+     */
+    private TaskSettingsConfiguration(TaskType taskType, Map<String, SettingsConfiguration> configuration) {
+        this.taskType = taskType;
+        this.configuration = configuration;
+    }
+
+    public TaskSettingsConfiguration(StreamInput in) throws IOException {
+        this.taskType = in.readEnum(TaskType.class);
+        this.configuration = in.readMap(SettingsConfiguration::new);
+    }
+
+    static final ParseField TASK_TYPE_FIELD = new ParseField("task_type");
+    static final ParseField CONFIGURATION_FIELD = new ParseField("configuration");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<TaskSettingsConfiguration, Void> PARSER = new ConstructingObjectParser<>(
+        "task_configuration",
+        true,
+        args -> {
+            return new TaskSettingsConfiguration.Builder().setTaskType(TaskType.fromString((String) args[0]))
+                .setConfiguration((Map<String, SettingsConfiguration>) args[1])
+                .build();
+        }
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), TASK_TYPE_FIELD);
+        PARSER.declareObject(constructorArg(), (p, c) -> p.map(), CONFIGURATION_FIELD);
+    }
+
+    public TaskType getTaskType() {
+        return taskType;
+    }
+
+    public Map<String, SettingsConfiguration> getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(TASK_TYPE_FIELD.getPreferredName(), taskType);
+            builder.field(CONFIGURATION_FIELD.getPreferredName(), configuration);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static TaskSettingsConfiguration fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    public static TaskSettingsConfiguration fromXContentBytes(BytesReference source, XContentType xContentType) {
+        try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
+            return TaskSettingsConfiguration.fromXContent(parser);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("failed to parse task configuration", e);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeEnum(taskType);
+        out.writeMapValues(configuration);
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+
+        map.put(TASK_TYPE_FIELD.getPreferredName(), taskType);
+        map.put(CONFIGURATION_FIELD.getPreferredName(), configuration);
+
+        return map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TaskSettingsConfiguration that = (TaskSettingsConfiguration) o;
+        return Objects.equals(taskType, that.taskType) && Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskType, configuration);
+    }
+
+    public static class Builder {
+
+        private TaskType taskType;
+        private Map<String, SettingsConfiguration> configuration;
+
+        public Builder setTaskType(TaskType taskType) {
+            this.taskType = taskType;
+            return this;
+        }
+
+        public Builder setConfiguration(Map<String, SettingsConfiguration> configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public TaskSettingsConfiguration build() {
+            return new TaskSettingsConfiguration(taskType, configuration);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationDependency.java
+++ b/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationDependency.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Represents a dependency within a connector configuration, defining a specific field and its associated value.
+ * This class is used to encapsulate configuration dependencies in a structured format.
+ */
+public class SettingsConfigurationDependency implements Writeable, ToXContentObject {
+
+    private final String field;
+    private final Object value;
+
+    /**
+     * Constructs a new instance of SettingsConfigurationDependency.
+     *
+     * @param field The name of the field in the service dependency.
+     * @param value The value associated with the field.
+     */
+    public SettingsConfigurationDependency(String field, Object value) {
+        this.field = field;
+        this.value = value;
+    }
+
+    public SettingsConfigurationDependency(StreamInput in) throws IOException {
+        this.field = in.readString();
+        this.value = in.readGenericValue();
+    }
+
+    private static final ParseField FIELD_FIELD = new ParseField("field");
+    private static final ParseField VALUE_FIELD = new ParseField("value");
+
+    private static final ConstructingObjectParser<SettingsConfigurationDependency, Void> PARSER = new ConstructingObjectParser<>(
+        "service_configuration_dependency",
+        true,
+        args -> new SettingsConfigurationDependency.Builder().setField((String) args[0]).setValue(args[1]).build()
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), FIELD_FIELD);
+        PARSER.declareField(constructorArg(), (p, c) -> {
+            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return p.text();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+                return p.numberValue();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
+                return p.booleanValue();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
+                return null;
+            }
+            throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
+        }, VALUE_FIELD, ObjectParser.ValueType.VALUE);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(FIELD_FIELD.getPreferredName(), field);
+            builder.field(VALUE_FIELD.getPreferredName(), value);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(FIELD_FIELD.getPreferredName(), field);
+        map.put(VALUE_FIELD.getPreferredName(), value);
+        return map;
+    }
+
+    public static SettingsConfigurationDependency fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(field);
+        out.writeGenericValue(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SettingsConfigurationDependency that = (SettingsConfigurationDependency) o;
+        return Objects.equals(field, that.field) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, value);
+    }
+
+    public static class Builder {
+
+        private String field;
+        private Object value;
+
+        public Builder setField(String field) {
+            this.field = field;
+            return this;
+        }
+
+        public Builder setValue(Object value) {
+            this.value = value;
+            return this;
+        }
+
+        public SettingsConfigurationDependency build() {
+            return new SettingsConfigurationDependency(field, value);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationDisplayType.java
+++ b/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationDisplayType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import java.util.Locale;
+
+public enum SettingsConfigurationDisplayType {
+    TEXT,
+    TEXTBOX,
+    TEXTAREA,
+    NUMERIC,
+    TOGGLE,
+    DROPDOWN;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    public static SettingsConfigurationDisplayType displayType(String type) {
+        for (SettingsConfigurationDisplayType displayType : SettingsConfigurationDisplayType.values()) {
+            if (displayType.name().equalsIgnoreCase(type)) {
+                return displayType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown " + SettingsConfigurationDisplayType.class.getSimpleName() + " [" + type + "].");
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationFieldType.java
+++ b/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationFieldType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+public enum SettingsConfigurationFieldType {
+    STRING("str"),
+    INTEGER("int"),
+    LIST("list"),
+    BOOLEAN("bool");
+
+    private final String value;
+
+    SettingsConfigurationFieldType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+
+    public static SettingsConfigurationFieldType fieldType(String type) {
+        for (SettingsConfigurationFieldType fieldType : SettingsConfigurationFieldType.values()) {
+            if (fieldType.value.equals(type)) {
+                return fieldType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown " + SettingsConfigurationFieldType.class.getSimpleName() + " [" + type + "].");
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationSelectOption.java
+++ b/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationSelectOption.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+public class SettingsConfigurationSelectOption implements Writeable, ToXContentObject {
+    private final String label;
+    private final Object value;
+
+    private SettingsConfigurationSelectOption(String label, Object value) {
+        this.label = label;
+        this.value = value;
+    }
+
+    public SettingsConfigurationSelectOption(StreamInput in) throws IOException {
+        this.label = in.readString();
+        this.value = in.readGenericValue();
+    }
+
+    private static final ParseField LABEL_FIELD = new ParseField("label");
+    private static final ParseField VALUE_FIELD = new ParseField("value");
+
+    private static final ConstructingObjectParser<SettingsConfigurationSelectOption, Void> PARSER = new ConstructingObjectParser<>(
+        "service_configuration_select_option",
+        true,
+        args -> new SettingsConfigurationSelectOption.Builder().setLabel((String) args[0]).setValue(args[1]).build()
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), LABEL_FIELD);
+        PARSER.declareField(constructorArg(), (p, c) -> {
+            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return p.text();
+            } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+                return p.numberValue();
+            }
+            throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
+        }, VALUE_FIELD, ObjectParser.ValueType.VALUE);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(LABEL_FIELD.getPreferredName(), label);
+            builder.field(VALUE_FIELD.getPreferredName(), value);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(LABEL_FIELD.getPreferredName(), label);
+        map.put(VALUE_FIELD.getPreferredName(), value);
+        return map;
+    }
+
+    public static SettingsConfigurationSelectOption fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(label);
+        out.writeGenericValue(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SettingsConfigurationSelectOption that = (SettingsConfigurationSelectOption) o;
+        return Objects.equals(label, that.label) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(label, value);
+    }
+
+    public static class Builder {
+
+        private String label;
+        private Object value;
+
+        public Builder setLabel(String label) {
+            this.label = label;
+            return this;
+        }
+
+        public Builder setValue(Object value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder setLabelAndValue(String labelAndValue) {
+            this.label = labelAndValue;
+            this.value = labelAndValue;
+            return this;
+        }
+
+        public SettingsConfigurationSelectOption build() {
+            return new SettingsConfigurationSelectOption(label, value);
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationValidation.java
+++ b/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationValidation.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParseException;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * Represents a configuration validation entity, encapsulating a validation constraint and its corresponding type.
+ * This class is used to define and handle specific validation rules or requirements within a configuration context.
+ */
+public class SettingsConfigurationValidation implements Writeable, ToXContentObject {
+
+    private final Object constraint;
+    private final SettingsConfigurationValidationType type;
+
+    /**
+     * Constructs a new SettingsConfigurationValidation instance with specified constraint and type.
+     * This constructor initializes the object with a given validation constraint and its associated validation type.
+     *
+     * @param constraint The validation constraint (string, number or list), represented as generic Object type.
+     * @param type       The type of configuration validation, specified as an instance of {@link SettingsConfigurationValidationType}.
+     */
+    private SettingsConfigurationValidation(Object constraint, SettingsConfigurationValidationType type) {
+        this.constraint = constraint;
+        this.type = type;
+    }
+
+    public SettingsConfigurationValidation(StreamInput in) throws IOException {
+        this.constraint = in.readGenericValue();
+        this.type = in.readEnum(SettingsConfigurationValidationType.class);
+    }
+
+    private static final ParseField CONSTRAINT_FIELD = new ParseField("constraint");
+    private static final ParseField TYPE_FIELD = new ParseField("type");
+
+    private static final ConstructingObjectParser<SettingsConfigurationValidation, Void> PARSER = new ConstructingObjectParser<>(
+        "service_configuration_validation",
+        true,
+        args -> new SettingsConfigurationValidation.Builder().setConstraint(args[0])
+            .setType((SettingsConfigurationValidationType) args[1])
+            .build()
+    );
+
+    static {
+        PARSER.declareField(
+            constructorArg(),
+            (p, c) -> parseConstraintValue(p),
+            CONSTRAINT_FIELD,
+            ObjectParser.ValueType.VALUE_OBJECT_ARRAY
+        );
+        PARSER.declareField(
+            constructorArg(),
+            (p, c) -> SettingsConfigurationValidationType.validationType(p.text()),
+            TYPE_FIELD,
+            ObjectParser.ValueType.STRING
+        );
+    }
+
+    /**
+     * Parses the value of a constraint from the XContentParser stream.
+     * This method is designed to handle various types of constraint values as per the connector's protocol original specification.
+     * The constraints can be of type string, number, or list of values.
+     */
+    private static Object parseConstraintValue(XContentParser p) throws IOException {
+        if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+            return p.text();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+            return p.numberValue();
+        } else if (p.currentToken() == XContentParser.Token.START_ARRAY) {
+            return p.list();
+        }
+        throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(CONSTRAINT_FIELD.getPreferredName(), constraint);
+            builder.field(TYPE_FIELD.getPreferredName(), type.toString());
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public Map<String, Object> toMap() {
+        return Map.of(CONSTRAINT_FIELD.getPreferredName(), constraint, TYPE_FIELD.getPreferredName(), type.toString());
+    }
+
+    public static SettingsConfigurationValidation fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeGenericValue(constraint);
+        out.writeEnum(type);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SettingsConfigurationValidation that = (SettingsConfigurationValidation) o;
+        return Objects.equals(constraint, that.constraint) && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(constraint, type);
+    }
+
+    public static class Builder {
+
+        private Object constraint;
+        private SettingsConfigurationValidationType type;
+
+        public Builder setConstraint(Object constraint) {
+            this.constraint = constraint;
+            return this;
+        }
+
+        public Builder setType(SettingsConfigurationValidationType type) {
+            this.type = type;
+            return this;
+        }
+
+        public SettingsConfigurationValidation build() {
+            return new SettingsConfigurationValidation(constraint, type);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationValidationType.java
+++ b/server/src/main/java/org/elasticsearch/inference/configuration/SettingsConfigurationValidationType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import java.util.Locale;
+
+public enum SettingsConfigurationValidationType {
+    LESS_THAN,
+    GREATER_THAN,
+    LIST_TYPE,
+    INCLUDED_IN,
+    REGEX;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    public static SettingsConfigurationValidationType validationType(String type) {
+        for (SettingsConfigurationValidationType displayType : SettingsConfigurationValidationType.values()) {
+            if (displayType.name().equalsIgnoreCase(type)) {
+                return displayType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown " + SettingsConfigurationValidationType.class.getSimpleName() + " [" + type + "].");
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/InferenceServiceConfigurationTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/inference/InferenceServiceConfigurationTestUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomInt;
+
+public class InferenceServiceConfigurationTestUtils {
+
+    public static InferenceServiceConfiguration getRandomServiceConfigurationField() {
+        return new InferenceServiceConfiguration.Builder().setProvider(randomAlphaOfLength(10))
+            .setTaskTypes(getRandomTaskTypeConfiguration())
+            .setConfiguration(getRandomServiceConfiguration(10))
+            .build();
+    }
+
+    private static List<TaskSettingsConfiguration> getRandomTaskTypeConfiguration() {
+        return List.of(TaskSettingsConfigurationTestUtils.getRandomTaskSettingsConfigurationField());
+    }
+
+    private static Map<String, SettingsConfiguration> getRandomServiceConfiguration(int numFields) {
+        var numConfigFields = randomInt(numFields);
+        Map<String, SettingsConfiguration> configuration = new HashMap<>();
+        for (int i = 0; i < numConfigFields; i++) {
+            configuration.put(randomAlphaOfLength(10), SettingsConfigurationTestUtils.getRandomSettingsConfigurationField());
+        }
+
+        return configuration;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/InferenceServiceConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/InferenceServiceConfigurationTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class InferenceServiceConfigurationTests extends ESTestCase {
+    public void testToXContent() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "provider": "some_provider",
+               "task_types": [
+                  {
+               "task_type": "text_embedding",
+               "configuration": {
+                    "text_field_configuration": {
+                        "default_value": null,
+                        "depends_on": [
+                            {
+                                "field": "some_field",
+                                "value": true
+                            }
+                        ],
+                        "display": "textbox",
+                        "label": "Very important field",
+                        "options": [],
+                        "order": 4,
+                        "required": true,
+                        "sensitive": true,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "str",
+                        "ui_restrictions": [],
+                        "validations": null,
+                        "value": ""
+                    },
+                    "numeric_field_configuration": {
+                        "default_value": 3,
+                        "depends_on": null,
+                        "display": "numeric",
+                        "label": "Very important numeric field",
+                        "options": [],
+                        "order": 2,
+                        "required": true,
+                        "sensitive": false,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "int",
+                        "ui_restrictions": [],
+                        "validations": [
+                            {
+                                "constraint": 0,
+                                "type": "greater_than"
+                            }
+                        ],
+                        "value": ""
+                    }
+               }
+            },
+            {
+               "task_type": "completion",
+               "configuration": {
+                    "text_field_configuration": {
+                        "default_value": null,
+                        "depends_on": [
+                            {
+                                "field": "some_field",
+                                "value": true
+                            }
+                        ],
+                        "display": "textbox",
+                        "label": "Very important field",
+                        "options": [],
+                        "order": 4,
+                        "required": true,
+                        "sensitive": true,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "str",
+                        "ui_restrictions": [],
+                        "validations": null,
+                        "value": ""
+                    },
+                    "numeric_field_configuration": {
+                        "default_value": 3,
+                        "depends_on": null,
+                        "display": "numeric",
+                        "label": "Very important numeric field",
+                        "options": [],
+                        "order": 2,
+                        "required": true,
+                        "sensitive": false,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "int",
+                        "ui_restrictions": [],
+                        "validations": [
+                            {
+                                "constraint": 0,
+                                "type": "greater_than"
+                            }
+                        ],
+                        "value": ""
+                    }
+               }
+            }
+               ],
+               "configuration": {
+                    "text_field_configuration": {
+                        "default_value": null,
+                        "depends_on": [
+                            {
+                                "field": "some_field",
+                                "value": true
+                            }
+                        ],
+                        "display": "textbox",
+                        "label": "Very important field",
+                        "options": [],
+                        "order": 4,
+                        "required": true,
+                        "sensitive": true,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "str",
+                        "ui_restrictions": [],
+                        "validations": null,
+                        "value": ""
+                    },
+                    "numeric_field_configuration": {
+                        "default_value": 3,
+                        "depends_on": null,
+                        "display": "numeric",
+                        "label": "Very important numeric field",
+                        "options": [],
+                        "order": 2,
+                        "required": true,
+                        "sensitive": false,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "int",
+                        "ui_restrictions": [],
+                        "validations": [
+                            {
+                                "constraint": 0,
+                                "type": "greater_than"
+                            }
+                        ],
+                        "value": ""
+                    }
+               }
+            }
+            """);
+
+        InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+            new BytesArray(content),
+            XContentType.JSON
+        );
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        InferenceServiceConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = InferenceServiceConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToMap() {
+        InferenceServiceConfiguration configField = InferenceServiceConfigurationTestUtils.getRandomServiceConfigurationField();
+        Map<String, Object> configFieldAsMap = configField.toMap();
+
+        assertThat(configFieldAsMap.get("provider"), equalTo(configField.getProvider()));
+        assertThat(configFieldAsMap.get("task_types"), equalTo(configField.getTaskTypes()));
+        assertThat(configFieldAsMap.get("configuration"), equalTo(configField.getConfiguration()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTestUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.inference.configuration.SettingsConfigurationDependency;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
+import org.elasticsearch.inference.configuration.SettingsConfigurationValidation;
+import org.elasticsearch.inference.configuration.SettingsConfigurationValidationType;
+
+import java.util.List;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ESTestCase.randomInt;
+
+public class SettingsConfigurationTestUtils {
+
+    public static SettingsConfiguration getRandomSettingsConfigurationField() {
+        return new SettingsConfiguration.Builder().setCategory(randomAlphaOfLength(10))
+            .setDefaultValue(randomAlphaOfLength(10))
+            .setDependsOn(List.of(getRandomSettingsConfigurationDependency()))
+            .setDisplay(getRandomSettingsConfigurationDisplayType())
+            .setLabel(randomAlphaOfLength(10))
+            .setOptions(List.of(getRandomSettingsConfigurationSelectOption(), getRandomSettingsConfigurationSelectOption()))
+            .setOrder(randomInt())
+            .setPlaceholder(randomAlphaOfLength(10))
+            .setRequired(randomBoolean())
+            .setSensitive(randomBoolean())
+            .setTooltip(randomAlphaOfLength(10))
+            .setType(getRandomConfigurationFieldType())
+            .setUiRestrictions(List.of(randomAlphaOfLength(10), randomAlphaOfLength(10)))
+            .setValidations(List.of(getRandomSettingsConfigurationValidation()))
+            .setValue(randomAlphaOfLength(10))
+            .build();
+    }
+
+    private static SettingsConfigurationDependency getRandomSettingsConfigurationDependency() {
+        return new SettingsConfigurationDependency.Builder().setField(randomAlphaOfLength(10)).setValue(randomAlphaOfLength(10)).build();
+    }
+
+    private static SettingsConfigurationSelectOption getRandomSettingsConfigurationSelectOption() {
+        return new SettingsConfigurationSelectOption.Builder().setLabel(randomAlphaOfLength(10)).setValue(randomAlphaOfLength(10)).build();
+    }
+
+    private static SettingsConfigurationValidation getRandomSettingsConfigurationValidation() {
+        return new SettingsConfigurationValidation.Builder().setConstraint(randomAlphaOfLength(10))
+            .setType(getRandomConfigurationValidationType())
+            .build();
+    }
+
+    public static SettingsConfigurationDisplayType getRandomSettingsConfigurationDisplayType() {
+        SettingsConfigurationDisplayType[] values = SettingsConfigurationDisplayType.values();
+        return values[randomInt(values.length - 1)];
+    }
+
+    public static SettingsConfigurationFieldType getRandomConfigurationFieldType() {
+        SettingsConfigurationFieldType[] values = SettingsConfigurationFieldType.values();
+        return values[randomInt(values.length - 1)];
+    }
+
+    public static SettingsConfigurationValidationType getRandomConfigurationValidationType() {
+        SettingsConfigurationValidationType[] values = SettingsConfigurationValidationType.values();
+        return values[randomInt(values.length - 1)];
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/SettingsConfigurationTests.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDependency;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
+import org.elasticsearch.inference.configuration.SettingsConfigurationValidation;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class SettingsConfigurationTests extends ESTestCase {
+
+    public void testToXContent() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "default_value": null,
+               "depends_on": [
+                 {
+                   "field": "some_field",
+                   "value": true
+                 }
+               ],
+               "display": "textbox",
+               "label": "Very important field",
+               "options": [],
+               "order": 4,
+               "required": true,
+               "sensitive": false,
+               "tooltip": "Wow, this tooltip is useful.",
+               "type": "str",
+               "ui_restrictions": [],
+               "validations": [
+                  {
+                     "constraint": 0,
+                     "type": "greater_than"
+                  }
+               ],
+               "value": ""
+            }
+            """);
+
+        SettingsConfiguration configuration = SettingsConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        SettingsConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = SettingsConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToXContent_WithNumericSelectOptions() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "default_value": null,
+               "depends_on": [
+                 {
+                   "field": "some_field",
+                   "value": true
+                 }
+               ],
+               "display": "textbox",
+               "label": "Very important field",
+               "options": [
+                 {
+                   "label": "five",
+                   "value": 5
+                 },
+                 {
+                   "label": "ten",
+                   "value": 10
+                 }
+               ],
+               "order": 4,
+               "required": true,
+               "sensitive": false,
+               "tooltip": "Wow, this tooltip is useful.",
+               "type": "str",
+               "ui_restrictions": [],
+               "validations": [
+                  {
+                     "constraint": 0,
+                     "type": "greater_than"
+                  }
+               ],
+               "value": ""
+            }
+            """);
+
+        SettingsConfiguration configuration = SettingsConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        SettingsConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = SettingsConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToXContentCrawlerConfig_WithNullValue() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "label": "nextSyncConfig",
+               "value": null
+            }
+            """);
+
+        SettingsConfiguration configuration = SettingsConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        SettingsConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = SettingsConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToXContentWithMultipleConstraintTypes() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "default_value": null,
+               "depends_on": [
+                 {
+                   "field": "some_field",
+                   "value": true
+                 }
+               ],
+               "display": "textbox",
+               "label": "Very important field",
+               "options": [],
+               "order": 4,
+               "required": true,
+               "sensitive": false,
+               "tooltip": "Wow, this tooltip is useful.",
+               "type": "str",
+               "ui_restrictions": [],
+               "validations": [
+                   {
+                       "constraint": 32,
+                       "type": "less_than"
+                   },
+                   {
+                       "constraint": "^\\\\\\\\d{4}-\\\\\\\\d{2}-\\\\\\\\d{2}$",
+                       "type": "regex"
+                   },
+                   {
+                       "constraint": "int",
+                       "type": "list_type"
+                   },
+                   {
+                       "constraint": [
+                           1,
+                           2,
+                           3
+                       ],
+                       "type": "included_in"
+                   },
+                   {
+                       "constraint": [
+                           "string_1",
+                           "string_2",
+                           "string_3"
+                       ],
+                       "type": "included_in"
+                   }
+               ],
+               "value": ""
+            }
+            """);
+
+        SettingsConfiguration configuration = SettingsConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        SettingsConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = SettingsConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToMap() {
+        SettingsConfiguration configField = SettingsConfigurationTestUtils.getRandomSettingsConfigurationField();
+        Map<String, Object> configFieldAsMap = configField.toMap();
+
+        if (configField.getCategory() != null) {
+            assertThat(configFieldAsMap.get("category"), equalTo(configField.getCategory()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("category"));
+        }
+
+        assertThat(configFieldAsMap.get("default_value"), equalTo(configField.getDefaultValue()));
+
+        if (configField.getDependsOn() != null) {
+            List<Map<String, Object>> dependsOnAsList = configField.getDependsOn()
+                .stream()
+                .map(SettingsConfigurationDependency::toMap)
+                .toList();
+            assertThat(configFieldAsMap.get("depends_on"), equalTo(dependsOnAsList));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("depends_on"));
+        }
+
+        if (configField.getDisplay() != null) {
+            assertThat(configFieldAsMap.get("display"), equalTo(configField.getDisplay().toString()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("display"));
+        }
+
+        assertThat(configFieldAsMap.get("label"), equalTo(configField.getLabel()));
+
+        if (configField.getOptions() != null) {
+            List<Map<String, Object>> optionsAsList = configField.getOptions()
+                .stream()
+                .map(SettingsConfigurationSelectOption::toMap)
+                .toList();
+            assertThat(configFieldAsMap.get("options"), equalTo(optionsAsList));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("options"));
+        }
+
+        if (configField.getOrder() != null) {
+            assertThat(configFieldAsMap.get("order"), equalTo(configField.getOrder()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("order"));
+        }
+
+        if (configField.getPlaceholder() != null) {
+            assertThat(configFieldAsMap.get("placeholder"), equalTo(configField.getPlaceholder()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("placeholder"));
+        }
+
+        assertThat(configFieldAsMap.get("required"), equalTo(configField.isRequired()));
+        assertThat(configFieldAsMap.get("sensitive"), equalTo(configField.isSensitive()));
+
+        if (configField.getTooltip() != null) {
+            assertThat(configFieldAsMap.get("tooltip"), equalTo(configField.getTooltip()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("tooltip"));
+        }
+
+        if (configField.getType() != null) {
+            assertThat(configFieldAsMap.get("type"), equalTo(configField.getType().toString()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("type"));
+        }
+
+        if (configField.getUiRestrictions() != null) {
+            assertThat(configFieldAsMap.get("ui_restrictions"), equalTo(configField.getUiRestrictions()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("ui_restrictions"));
+        }
+
+        if (configField.getValidations() != null) {
+            List<Map<String, Object>> validationsAsList = configField.getValidations()
+                .stream()
+                .map(SettingsConfigurationValidation::toMap)
+                .toList();
+            assertThat(configFieldAsMap.get("validations"), equalTo(validationsAsList));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("validations"));
+        }
+
+        assertThat(configFieldAsMap.get("value"), equalTo(configField.getValue()));
+
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/TaskSettingsConfigurationTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/inference/TaskSettingsConfigurationTestUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomInt;
+
+public class TaskSettingsConfigurationTestUtils {
+
+    public static TaskSettingsConfiguration getRandomTaskSettingsConfigurationField() {
+        return new TaskSettingsConfiguration.Builder().setTaskType(getRandomTaskType())
+            .setConfiguration(getRandomServiceConfiguration(10))
+            .build();
+    }
+
+    private static TaskType getRandomTaskType() {
+        TaskType[] values = TaskType.values();
+        return values[randomInt(values.length - 1)];
+    }
+
+    private static Map<String, SettingsConfiguration> getRandomServiceConfiguration(int numFields) {
+        var numConfigFields = randomInt(numFields);
+        Map<String, SettingsConfiguration> configuration = new HashMap<>();
+        for (int i = 0; i < numConfigFields; i++) {
+            configuration.put(randomAlphaOfLength(10), SettingsConfigurationTestUtils.getRandomSettingsConfigurationField());
+        }
+
+        return configuration;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/TaskSettingsConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/TaskSettingsConfigurationTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class TaskSettingsConfigurationTests extends ESTestCase {
+    public void testToXContent() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "task_type": "text_embedding",
+               "configuration": {
+                    "text_field_configuration": {
+                        "default_value": null,
+                        "depends_on": [
+                            {
+                                "field": "some_field",
+                                "value": true
+                            }
+                        ],
+                        "display": "textbox",
+                        "label": "Very important field",
+                        "options": [],
+                        "order": 4,
+                        "required": true,
+                        "sensitive": true,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "str",
+                        "ui_restrictions": [],
+                        "validations": null,
+                        "value": ""
+                    },
+                    "numeric_field_configuration": {
+                        "default_value": 3,
+                        "depends_on": null,
+                        "display": "numeric",
+                        "label": "Very important numeric field",
+                        "options": [],
+                        "order": 2,
+                        "required": true,
+                        "sensitive": false,
+                        "tooltip": "Wow, this tooltip is useful.",
+                        "type": "int",
+                        "ui_restrictions": [],
+                        "validations": [
+                            {
+                                "constraint": 0,
+                                "type": "greater_than"
+                            }
+                        ],
+                        "value": ""
+                    }
+               }
+            }
+            """);
+
+        TaskSettingsConfiguration configuration = TaskSettingsConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        TaskSettingsConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = TaskSettingsConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToMap() {
+        TaskSettingsConfiguration configField = TaskSettingsConfigurationTestUtils.getRandomTaskSettingsConfigurationField();
+        Map<String, Object> configFieldAsMap = configField.toMap();
+
+        assertThat(configFieldAsMap.get("task_type"), equalTo(configField.getTaskType()));
+        assertThat(configFieldAsMap.get("configuration"), equalTo(configField.getConfiguration()));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/configuration/SettingsConfigurationDisplayTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/configuration/SettingsConfigurationDisplayTypeTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import org.elasticsearch.inference.SettingsConfigurationTestUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class SettingsConfigurationDisplayTypeTests extends ESTestCase {
+
+    public void testDisplayType_WithValidConfigurationDisplayTypeString() {
+        SettingsConfigurationDisplayType displayType = SettingsConfigurationTestUtils.getRandomSettingsConfigurationDisplayType();
+        assertThat(SettingsConfigurationDisplayType.displayType(displayType.toString()), equalTo(displayType));
+    }
+
+    public void testDisplayType_WithInvalidConfigurationDisplayTypeString_ExpectIllegalArgumentException() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> SettingsConfigurationDisplayType.displayType("invalid configuration display type")
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/inference/configuration/SettingsConfigurationFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/configuration/SettingsConfigurationFieldTypeTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import org.elasticsearch.inference.SettingsConfigurationTestUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class SettingsConfigurationFieldTypeTests extends ESTestCase {
+
+    public void testFieldType_WithValidConfigurationFieldTypeString() {
+        SettingsConfigurationFieldType fieldType = SettingsConfigurationTestUtils.getRandomConfigurationFieldType();
+        assertThat(SettingsConfigurationFieldType.fieldType(fieldType.toString()), equalTo(fieldType));
+    }
+
+    public void testFieldType_WithInvalidConfigurationFieldTypeString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> SettingsConfigurationFieldType.fieldType("invalid field type"));
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/inference/configuration/SettingsConfigurationValidationTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/inference/configuration/SettingsConfigurationValidationTypeTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.inference.configuration;
+
+import org.elasticsearch.inference.SettingsConfigurationTestUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class SettingsConfigurationValidationTypeTests extends ESTestCase {
+
+    public void testValidationType_WithValidConfigurationValidationTypeString() {
+        SettingsConfigurationValidationType validationType = SettingsConfigurationTestUtils.getRandomConfigurationValidationType();
+
+        assertThat(SettingsConfigurationValidationType.validationType(validationType.toString()), equalTo(validationType));
+    }
+
+    public void testValidationType_WithInvalidConfigurationValidationTypeString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> SettingsConfigurationValidationType.validationType("invalid validation type"));
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/GetInferenceServicesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/GetInferenceServicesAction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.action;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class GetInferenceServicesAction extends ActionType<GetInferenceServicesAction.Response> {
+
+    public static final GetInferenceServicesAction INSTANCE = new GetInferenceServicesAction();
+    public static final String NAME = "cluster:monitor/xpack/inference/services/get";
+
+    public GetInferenceServicesAction() {
+        super(NAME);
+    }
+
+    public static class Request extends AcknowledgedRequest<GetInferenceServicesAction.Request> {
+
+        private final TaskType taskType;
+
+        public Request(TaskType taskType) {
+            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, DEFAULT_ACK_TIMEOUT);
+            this.taskType = Objects.requireNonNull(taskType);
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.taskType = TaskType.fromStream(in);
+        }
+
+        public TaskType getTaskType() {
+            return taskType;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            taskType.writeTo(out);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return taskType == request.taskType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(taskType);
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private final List<InferenceServiceConfiguration> configurations;
+
+        public Response(List<InferenceServiceConfiguration> configurations) {
+            this.configurations = configurations;
+        }
+
+        public List<InferenceServiceConfiguration> getConfigurations() {
+            return configurations;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeCollection(configurations);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startArray();
+            for (var configuration : configurations) {
+                if (configuration != null) {
+                    configuration.toXContent(builder, params);
+                }
+            }
+            builder.endArray();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GetInferenceServicesAction.Response response = (GetInferenceServicesAction.Response) o;
+            return Objects.equals(configurations, response.configurations);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(configurations);
+        }
+    }
+}

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -291,26 +291,44 @@ public class InferenceBaseRestTest extends ESRestTestCase {
     @SuppressWarnings("unchecked")
     protected Map<String, Object> getModel(String modelId) throws IOException {
         var endpoint = Strings.format("_inference/%s?error_trace", modelId);
-        return ((List<Map<String, Object>>) getInternal(endpoint).get("endpoints")).get(0);
+        return ((List<Map<String, Object>>) getInternalAsMap(endpoint).get("endpoints")).get(0);
     }
 
     @SuppressWarnings("unchecked")
     protected List<Map<String, Object>> getModels(String modelId, TaskType taskType) throws IOException {
         var endpoint = Strings.format("_inference/%s/%s", taskType, modelId);
-        return (List<Map<String, Object>>) getInternal(endpoint).get("endpoints");
+        return (List<Map<String, Object>>) getInternalAsMap(endpoint).get("endpoints");
     }
 
     @SuppressWarnings("unchecked")
     protected List<Map<String, Object>> getAllModels() throws IOException {
         var endpoint = Strings.format("_inference/_all");
-        return (List<Map<String, Object>>) getInternal("_inference/_all").get("endpoints");
+        return (List<Map<String, Object>>) getInternalAsMap("_inference/_all").get("endpoints");
     }
 
-    private Map<String, Object> getInternal(String endpoint) throws IOException {
+    protected List<Object> getAllServices() throws IOException {
+        var endpoint = Strings.format("_inference/_services");
+        return getInternalAsList(endpoint);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected List<Object> getServices(TaskType taskType) throws IOException {
+        var endpoint = Strings.format("_inference/_services/%s", taskType);
+        return getInternalAsList(endpoint);
+    }
+
+    private Map<String, Object> getInternalAsMap(String endpoint) throws IOException {
         var request = new Request("GET", endpoint);
         var response = client().performRequest(request);
         assertOkOrCreated(response);
         return entityAsMap(response);
+    }
+
+    private List<Object> getInternalAsList(String endpoint) throws IOException {
+        var request = new Request("GET", endpoint);
+        var response = client().performRequest(request);
+        assertOkOrCreated(response);
+        return entityAsList(response);
     }
 
     protected Map<String, Object> infer(String modelId, List<String> input) throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.inference.TaskType;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -126,6 +127,140 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         var inference = infer(modelId, List.of(randomAlphaOfLength(10)));
         assertNonEmptyInferenceResults(inference, 1, TaskType.SPARSE_EMBEDDING);
         deleteModel(modelId);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetServicesWithoutTaskType() throws IOException {
+        List<Object> services = getAllServices();
+        assertThat(services.size(), equalTo(19));
+
+        String[] providers = new String[services.size()];
+        for (int i = 0; i < services.size(); i++) {
+            Map<String, Object> serviceConfig = (Map<String, Object>) services.get(i);
+            providers[i] = (String) serviceConfig.get("provider");
+        }
+
+        Arrays.sort(providers);
+        assertArrayEquals(
+            providers,
+            List.of(
+                "alibabacloud-ai-search",
+                "amazonbedrock",
+                "anthropic",
+                "azureaistudio",
+                "azureopenai",
+                "cohere",
+                "elastic",
+                "elasticsearch",
+                "googleaistudio",
+                "googlevertexai",
+                "hugging_face",
+                "hugging_face_elser",
+                "mistral",
+                "openai",
+                "streaming_completion_test_service",
+                "test_reranking_service",
+                "test_service",
+                "text_embedding_test_service",
+                "watsonxai"
+            ).toArray()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetServicesWithTextEmbeddingTaskType() throws IOException {
+        List<Object> services = getServices(TaskType.TEXT_EMBEDDING);
+        assertThat(services.size(), equalTo(13));
+
+        String[] providers = new String[services.size()];
+        for (int i = 0; i < services.size(); i++) {
+            Map<String, Object> serviceConfig = (Map<String, Object>) services.get(i);
+            providers[i] = (String) serviceConfig.get("provider");
+        }
+
+        Arrays.sort(providers);
+        assertArrayEquals(
+            providers,
+            List.of(
+                "alibabacloud-ai-search",
+                "amazonbedrock",
+                "azureaistudio",
+                "azureopenai",
+                "cohere",
+                "elasticsearch",
+                "googleaistudio",
+                "googlevertexai",
+                "hugging_face",
+                "mistral",
+                "openai",
+                "text_embedding_test_service",
+                "watsonxai"
+            ).toArray()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetServicesWithRerankTaskType() throws IOException {
+        List<Object> services = getServices(TaskType.RERANK);
+        assertThat(services.size(), equalTo(5));
+
+        String[] providers = new String[services.size()];
+        for (int i = 0; i < services.size(); i++) {
+            Map<String, Object> serviceConfig = (Map<String, Object>) services.get(i);
+            providers[i] = (String) serviceConfig.get("provider");
+        }
+
+        Arrays.sort(providers);
+        assertArrayEquals(
+            providers,
+            List.of("alibabacloud-ai-search", "cohere", "elasticsearch", "googlevertexai", "test_reranking_service").toArray()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetServicesWithCompletionTaskType() throws IOException {
+        List<Object> services = getServices(TaskType.COMPLETION);
+        assertThat(services.size(), equalTo(9));
+
+        String[] providers = new String[services.size()];
+        for (int i = 0; i < services.size(); i++) {
+            Map<String, Object> serviceConfig = (Map<String, Object>) services.get(i);
+            providers[i] = (String) serviceConfig.get("provider");
+        }
+
+        Arrays.sort(providers);
+        assertArrayEquals(
+            providers,
+            List.of(
+                "alibabacloud-ai-search",
+                "amazonbedrock",
+                "anthropic",
+                "azureaistudio",
+                "azureopenai",
+                "cohere",
+                "googleaistudio",
+                "openai",
+                "streaming_completion_test_service"
+            ).toArray()
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetServicesWithSparseEmbeddingTaskType() throws IOException {
+        List<Object> services = getServices(TaskType.SPARSE_EMBEDDING);
+        assertThat(services.size(), equalTo(6));
+
+        String[] providers = new String[services.size()];
+        for (int i = 0; i < services.size(); i++) {
+            Map<String, Object> serviceConfig = (Map<String, Object>) services.get(i);
+            providers[i] = (String) serviceConfig.get("provider");
+        }
+
+        Arrays.sort(providers);
+        assertArrayEquals(
+            providers,
+            List.of("alibabacloud-ai-search", "elastic", "elasticsearch", "hugging_face", "hugging_face_elser", "test_service").toArray()
+        );
     }
 
     public void testSkipValidationAndStart() throws IOException {

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestRerankingServiceExtension.java
@@ -13,10 +13,13 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
@@ -24,7 +27,11 @@ import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -32,6 +39,8 @@ import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +61,8 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
 
     public static class TestInferenceService extends AbstractTestInferenceService {
         public static final String NAME = "test_reranking_service";
+
+        private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.RERANK);
 
         public TestInferenceService(InferenceServiceFactoryContext context) {}
 
@@ -76,6 +87,16 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
             var taskSettings = TestTaskSettings.fromMap(taskSettingsMap);
 
             parsedModelListener.onResponse(new TestServiceModel(modelId, taskType, name(), serviceSettings, taskSettings, secretSettings));
+        }
+
+        @Override
+        public InferenceServiceConfiguration getConfiguration() {
+            return Configuration.get();
+        }
+
+        @Override
+        public EnumSet<TaskType> supportedTaskTypes() {
+            return supportedTaskTypes;
         }
 
         @Override
@@ -131,6 +152,38 @@ public class TestRerankingServiceExtension implements InferenceServiceExtension 
 
         protected ServiceSettings getServiceSettingsFromMap(Map<String, Object> serviceSettingsMap) {
             return TestServiceSettings.fromMap(serviceSettingsMap);
+        }
+
+        public static class Configuration {
+            public static InferenceServiceConfiguration get() {
+                return configuration.getOrCompute();
+            }
+
+            private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+                () -> {
+                    var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                    configurationMap.put(
+                        "model",
+                        new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                            .setLabel("Model")
+                            .setOrder(1)
+                            .setRequired(true)
+                            .setSensitive(true)
+                            .setTooltip("")
+                            .setType(SettingsConfigurationFieldType.STRING)
+                            .build()
+                    );
+
+                    return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                        Map<String, SettingsConfiguration> taskSettingsConfig;
+                        switch (t) {
+                            default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                        }
+                        return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                    }).toList()).setConfiguration(configurationMap).build();
+                }
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -45,12 +45,14 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.inference.action.DeleteInferenceEndpointAction;
 import org.elasticsearch.xpack.core.inference.action.GetInferenceDiagnosticsAction;
 import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceServicesAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.action.PutInferenceModelAction;
 import org.elasticsearch.xpack.core.inference.action.UpdateInferenceModelAction;
 import org.elasticsearch.xpack.inference.action.TransportDeleteInferenceEndpointAction;
 import org.elasticsearch.xpack.inference.action.TransportGetInferenceDiagnosticsAction;
 import org.elasticsearch.xpack.inference.action.TransportGetInferenceModelAction;
+import org.elasticsearch.xpack.inference.action.TransportGetInferenceServicesAction;
 import org.elasticsearch.xpack.inference.action.TransportInferenceAction;
 import org.elasticsearch.xpack.inference.action.TransportInferenceUsageAction;
 import org.elasticsearch.xpack.inference.action.TransportPutInferenceModelAction;
@@ -75,6 +77,7 @@ import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.elasticsearch.xpack.inference.rest.RestDeleteInferenceEndpointAction;
 import org.elasticsearch.xpack.inference.rest.RestGetInferenceDiagnosticsAction;
 import org.elasticsearch.xpack.inference.rest.RestGetInferenceModelAction;
+import org.elasticsearch.xpack.inference.rest.RestGetInferenceServicesAction;
 import org.elasticsearch.xpack.inference.rest.RestInferenceAction;
 import org.elasticsearch.xpack.inference.rest.RestPutInferenceModelAction;
 import org.elasticsearch.xpack.inference.rest.RestStreamInferenceAction;
@@ -155,7 +158,8 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
             new ActionHandler<>(UpdateInferenceModelAction.INSTANCE, TransportUpdateInferenceModelAction.class),
             new ActionHandler<>(DeleteInferenceEndpointAction.INSTANCE, TransportDeleteInferenceEndpointAction.class),
             new ActionHandler<>(XPackUsageFeatureAction.INFERENCE, TransportInferenceUsageAction.class),
-            new ActionHandler<>(GetInferenceDiagnosticsAction.INSTANCE, TransportGetInferenceDiagnosticsAction.class)
+            new ActionHandler<>(GetInferenceDiagnosticsAction.INSTANCE, TransportGetInferenceDiagnosticsAction.class),
+            new ActionHandler<>(GetInferenceServicesAction.INSTANCE, TransportGetInferenceServicesAction.class)
         );
     }
 
@@ -178,7 +182,8 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
             new RestPutInferenceModelAction(),
             new RestUpdateInferenceModelAction(),
             new RestDeleteInferenceEndpointAction(),
-            new RestGetInferenceDiagnosticsAction()
+            new RestGetInferenceDiagnosticsAction(),
+            new RestGetInferenceServicesAction()
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceServicesAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceServicesAction.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.inference.InferenceService;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceServicesAction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TransportGetInferenceServicesAction extends HandledTransportAction<
+    GetInferenceServicesAction.Request,
+    GetInferenceServicesAction.Response> {
+
+    private final InferenceServiceRegistry serviceRegistry;
+
+    @Inject
+    public TransportGetInferenceServicesAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        InferenceServiceRegistry serviceRegistry
+    ) {
+        super(
+            GetInferenceServicesAction.NAME,
+            transportService,
+            actionFilters,
+            GetInferenceServicesAction.Request::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        GetInferenceServicesAction.Request request,
+        ActionListener<GetInferenceServicesAction.Response> listener
+    ) {
+        if (request.getTaskType() == TaskType.ANY) {
+            getAllServiceConfigurations(listener);
+        } else {
+            getServiceConfigurationsForTaskType(request.getTaskType(), listener);
+        }
+    }
+
+    private void getServiceConfigurationsForTaskType(
+        TaskType requestedTaskType,
+        ActionListener<GetInferenceServicesAction.Response> listener
+    ) {
+        var filteredServices = serviceRegistry.getServices()
+            .entrySet()
+            .stream()
+            .filter(service -> service.getValue().supportedTaskTypes().contains(requestedTaskType))
+            .collect(Collectors.toSet());
+
+        getServiceConfigurationsForServices(filteredServices, listener.delegateFailureAndWrap((delegate, configurations) -> {
+            delegate.onResponse(new GetInferenceServicesAction.Response(configurations));
+        }));
+    }
+
+    private void getAllServiceConfigurations(ActionListener<GetInferenceServicesAction.Response> listener) {
+        getServiceConfigurationsForServices(
+            serviceRegistry.getServices().entrySet(),
+            listener.delegateFailureAndWrap((delegate, configurations) -> {
+                delegate.onResponse(new GetInferenceServicesAction.Response(configurations));
+            })
+        );
+    }
+
+    private void getServiceConfigurationsForServices(
+        Set<Map.Entry<String, InferenceService>> services,
+        ActionListener<List<InferenceServiceConfiguration>> listener
+    ) {
+        try {
+            var serviceConfigurations = new ArrayList<InferenceServiceConfiguration>();
+            for (var service : services) {
+                serviceConfigurations.add(service.getValue().getConfiguration());
+            }
+            listener.onResponse(serviceConfigurations.stream().toList());
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/alibabacloudsearch/AlibabaCloudSearchEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/alibabacloudsearch/AlibabaCloudSearchEmbeddingsRequestEntity.java
@@ -27,7 +27,7 @@ public record AlibabaCloudSearchEmbeddingsRequestEntity(List<String> input, Alib
 
     private static final String TEXTS_FIELD = "input";
 
-    static final String INPUT_TYPE_FIELD = "input_type";
+    public static final String INPUT_TYPE_FIELD = "input_type";
 
     public AlibabaCloudSearchEmbeddingsRequestEntity {
         Objects.requireNonNull(input);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/alibabacloudsearch/AlibabaCloudSearchSparseRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/alibabacloudsearch/AlibabaCloudSearchSparseRequestEntity.java
@@ -21,9 +21,9 @@ public record AlibabaCloudSearchSparseRequestEntity(List<String> input, AlibabaC
 
     private static final String TEXTS_FIELD = "input";
 
-    static final String INPUT_TYPE_FIELD = "input_type";
+    public static final String INPUT_TYPE_FIELD = "input_type";
 
-    static final String RETURN_TOKEN_FIELD = "return_token";
+    public static final String RETURN_TOKEN_FIELD = "return_token";
 
     public AlibabaCloudSearchSparseRequestEntity {
         Objects.requireNonNull(input);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntity.java
@@ -34,7 +34,7 @@ public record CohereEmbeddingsRequestEntity(
     private static final String CLUSTERING = "clustering";
     private static final String CLASSIFICATION = "classification";
     private static final String TEXTS_FIELD = "texts";
-    static final String INPUT_TYPE_FIELD = "input_type";
+    public static final String INPUT_TYPE_FIELD = "input_type";
     static final String EMBEDDING_TYPES_FIELD = "embedding_types";
 
     public CohereEmbeddingsRequestEntity {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/Paths.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/Paths.java
@@ -11,6 +11,7 @@ public final class Paths {
 
     static final String INFERENCE_ID = "inference_id";
     static final String TASK_TYPE_OR_INFERENCE_ID = "task_type_or_id";
+    static final String TASK_TYPE = "task_type";
     static final String INFERENCE_ID_PATH = "_inference/{" + TASK_TYPE_OR_INFERENCE_ID + "}";
     static final String TASK_TYPE_INFERENCE_ID_PATH = "_inference/{" + TASK_TYPE_OR_INFERENCE_ID + "}/{" + INFERENCE_ID + "}";
     static final String INFERENCE_DIAGNOSTICS_PATH = "_inference/.diagnostics";
@@ -20,6 +21,8 @@ public final class Paths {
         + INFERENCE_ID
         + "}/_update";
     static final String INFERENCE_ID_UPDATE_PATH = "_inference/{" + TASK_TYPE_OR_INFERENCE_ID + "}/_update";
+    static final String INFERENCE_SERVICES_PATH = "_inference/_services";
+    static final String TASK_TYPE_INFERENCE_SERVICES_PATH = "_inference/_services/{" + TASK_TYPE + "}";
 
     static final String STREAM_INFERENCE_ID_PATH = "_inference/{" + TASK_TYPE_OR_INFERENCE_ID + "}/_stream";
     static final String STREAM_TASK_TYPE_INFERENCE_ID_PATH = "_inference/{"

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestGetInferenceServicesAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestGetInferenceServicesAction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.rest;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.inference.action.GetInferenceServicesAction;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.inference.rest.Paths.INFERENCE_SERVICES_PATH;
+import static org.elasticsearch.xpack.inference.rest.Paths.TASK_TYPE;
+import static org.elasticsearch.xpack.inference.rest.Paths.TASK_TYPE_INFERENCE_SERVICES_PATH;
+
+@ServerlessScope(Scope.INTERNAL)
+public class RestGetInferenceServicesAction extends BaseRestHandler {
+    @Override
+    public String getName() {
+        return "get_inference_services_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, INFERENCE_SERVICES_PATH), new Route(GET, TASK_TYPE_INFERENCE_SERVICES_PATH));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        TaskType taskType;
+        if (restRequest.hasParam(TASK_TYPE)) {
+            taskType = TaskType.fromStringOrStatusException(restRequest.param(TASK_TYPE));
+        } else {
+            taskType = TaskType.ANY;
+        }
+
+        var request = new GetInferenceServicesAction.Request(taskType);
+        return channel -> client.execute(GetInferenceServicesAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/embeddings/AlibabaCloudSearchEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/embeddings/AlibabaCloudSearchEmbeddingsModel.java
@@ -7,19 +7,28 @@
 
 package org.elasticsearch.xpack.inference.services.alibabacloudsearch.embeddings;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.alibabacloudsearch.AlibabaCloudSearchActionVisitor;
+import org.elasticsearch.xpack.inference.external.request.alibabacloudsearch.AlibabaCloudSearchEmbeddingsRequestEntity;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class AlibabaCloudSearchEmbeddingsModel extends AlibabaCloudSearchModel {
     public static AlibabaCloudSearchEmbeddingsModel of(
@@ -104,5 +113,36 @@ public class AlibabaCloudSearchEmbeddingsModel extends AlibabaCloudSearchModel {
     @Override
     public ExecutableAction accept(AlibabaCloudSearchActionVisitor visitor, Map<String, Object> taskSettings, InputType inputType) {
         return visitor.create(this, taskSettings, inputType);
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    AlibabaCloudSearchEmbeddingsRequestEntity.INPUT_TYPE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Input Type")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the type of input passed to the model.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("ingest", "search")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/sparse/AlibabaCloudSearchSparseModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/sparse/AlibabaCloudSearchSparseModel.java
@@ -7,19 +7,28 @@
 
 package org.elasticsearch.xpack.inference.services.alibabacloudsearch.sparse;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.alibabacloudsearch.AlibabaCloudSearchActionVisitor;
+import org.elasticsearch.xpack.inference.external.request.alibabacloudsearch.AlibabaCloudSearchSparseRequestEntity;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class AlibabaCloudSearchSparseModel extends AlibabaCloudSearchModel {
     public static AlibabaCloudSearchSparseModel of(
@@ -98,5 +107,51 @@ public class AlibabaCloudSearchSparseModel extends AlibabaCloudSearchModel {
     @Override
     public ExecutableAction accept(AlibabaCloudSearchActionVisitor visitor, Map<String, Object> taskSettings, InputType inputType) {
         return visitor.create(this, taskSettings, inputType);
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    AlibabaCloudSearchSparseRequestEntity.INPUT_TYPE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Input Type")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the type of input passed to the model.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("ingest", "search")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .setValue("")
+                        .build()
+                );
+                configurationMap.put(
+                    AlibabaCloudSearchSparseRequestEntity.RETURN_TOKEN_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TOGGLE)
+                        .setLabel("Return Token")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip(
+                            "If `true`, the token name will be returned in the response. Defaults to `false` which means only the "
+                                + "token ID will be returned in the response."
+                        )
+                        .setType(SettingsConfigurationFieldType.BOOLEAN)
+                        .setValue(true)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockSecretSettings.java
@@ -13,12 +13,17 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -112,5 +117,39 @@ public class AmazonBedrockSecretSettings implements SecretSettings {
     @Override
     public SecretSettings newSecretSettings(Map<String, Object> newSecrets) {
         return fromMap(new HashMap<>(newSecrets));
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+                configurationMap.put(
+                    ACCESS_KEY_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Access Key")
+                        .setOrder(1)
+                        .setRequired(true)
+                        .setSensitive(true)
+                        .setTooltip("A valid AWS access key that has permissions to use Amazon Bedrock.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+                configurationMap.put(
+                    SECRET_KEY_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Secret Key")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(true)
+                        .setTooltip("A valid AWS secret key that is paired with the access_key.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockService.java
@@ -12,18 +12,26 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -40,11 +48,15 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.completion.AmazonBedrockChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings.AmazonBedrockEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings.AmazonBedrockEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
@@ -52,6 +64,9 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MODEL_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.PROVIDER_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.REGION_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.TOP_K_FIELD;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProviderCapabilities.chatCompletionProviderHasTopKParameter;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProviderCapabilities.getEmbeddingsMaxBatchSize;
@@ -62,6 +77,8 @@ public class AmazonBedrockService extends SenderService {
     public static final String NAME = "amazonbedrock";
 
     private final Sender amazonBedrockSender;
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION);
 
     public AmazonBedrockService(
         HttpRequestSender.Factory httpSenderFactory,
@@ -214,6 +231,16 @@ public class AmazonBedrockService extends SenderService {
         );
     }
 
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
     private static AmazonBedrockModel createModel(
         String inferenceEntityId,
         TaskType taskType,
@@ -346,5 +373,75 @@ public class AmazonBedrockService extends SenderService {
     public void close() throws IOException {
         super.close();
         IOUtils.closeWhileHandlingException(amazonBedrockSender);
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    PROVIDER_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Provider")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The model provider for your deployment.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("amazontitan", "anthropic", "ai21labs", "cohere", "meta", "mistral")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .build()
+                );
+
+                configurationMap.put(
+                    MODEL_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model")
+                        .setOrder(4)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The base model ID or an ARN to a custom model based on a foundational model.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    REGION_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Region")
+                        .setOrder(5)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The region that your model or ARN is deployed in.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.putAll(AmazonBedrockSecretSettings.Configuration.get());
+                configurationMap.putAll(
+                    RateLimitSettings.toSettingsConfigurationWithTooltip(
+                        "By default, the amazonbedrock service sets the number of requests allowed per minute to 240."
+                    )
+                );
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case COMPLETION -> taskSettingsConfig = AmazonBedrockChatCompletionModel.Configuration.get();
+                        // TEXT_EMBEDDING task type has no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/completion/AmazonBedrockChatCompletionModel.java
@@ -7,18 +7,29 @@
 
 package org.elasticsearch.xpack.inference.services.amazonbedrock.completion;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.amazonbedrock.AmazonBedrockActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockModel;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockSecretSettings;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.MAX_NEW_TOKENS_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.TEMPERATURE_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.TOP_K_FIELD;
+import static org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockConstants.TOP_P_FIELD;
 
 public class AmazonBedrockChatCompletionModel extends AmazonBedrockModel {
 
@@ -79,5 +90,63 @@ public class AmazonBedrockChatCompletionModel extends AmazonBedrockModel {
     @Override
     public AmazonBedrockChatCompletionTaskSettings getTaskSettings() {
         return (AmazonBedrockChatCompletionTaskSettings) super.getTaskSettings();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MAX_NEW_TOKENS_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Max New Tokens")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Sets the maximum number for the output tokens to be generated.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TEMPERATURE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Temperature")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("A number between 0.0 and 1.0 that controls the apparent creativity of the results.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TOP_P_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Top P")
+                        .setOrder(3)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Alternative to temperature. A number in the range of 0.0 to 1.0, to eliminate low-probability tokens.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TOP_K_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Top K")
+                        .setOrder(4)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Only available for anthropic, cohere, and mistral providers. Alternative to temperature.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicService.java
@@ -11,16 +11,23 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.external.action.anthropic.AnthropicActionCreator;
 import org.elasticsearch.xpack.inference.external.http.sender.DocumentsOnlyInput;
@@ -30,11 +37,16 @@ import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.SenderService;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.anthropic.completion.AnthropicChatCompletionModel;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
@@ -43,6 +55,8 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNot
 
 public class AnthropicService extends SenderService {
     public static final String NAME = "anthropic";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.COMPLETION);
 
     public AnthropicService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -163,6 +177,16 @@ public class AnthropicService extends SenderService {
     }
 
     @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
+    @Override
     public void doInfer(
         Model model,
         InferenceInputs inputs,
@@ -204,5 +228,45 @@ public class AnthropicService extends SenderService {
     @Override
     public Set<TaskType> supportedStreamingTasks() {
         return COMPLETION_ONLY;
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model ID")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The name of the model to use for the inference task.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(
+                    RateLimitSettings.toSettingsConfigurationWithTooltip(
+                        "By default, the anthropic service sets the number of requests allowed per minute to 50."
+                    )
+                );
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case COMPLETION -> taskSettingsConfig = AnthropicChatCompletionModel.Configuration.get();
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/completion/AnthropicChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/completion/AnthropicChatCompletionModel.java
@@ -8,10 +8,14 @@
 package org.elasticsearch.xpack.inference.services.anthropic.completion;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.anthropic.AnthropicActionVisitor;
 import org.elasticsearch.xpack.inference.external.request.anthropic.AnthropicRequestUtils;
@@ -22,7 +26,14 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.anthropic.AnthropicServiceFields.MAX_TOKENS;
+import static org.elasticsearch.xpack.inference.services.anthropic.AnthropicServiceFields.TEMPERATURE_FIELD;
+import static org.elasticsearch.xpack.inference.services.anthropic.AnthropicServiceFields.TOP_K_FIELD;
+import static org.elasticsearch.xpack.inference.services.anthropic.AnthropicServiceFields.TOP_P_FIELD;
 
 public class AnthropicChatCompletionModel extends AnthropicModel {
 
@@ -122,5 +133,63 @@ public class AnthropicChatCompletionModel extends AnthropicModel {
             .setHost(AnthropicRequestUtils.HOST)
             .setPathSegments(AnthropicRequestUtils.API_VERSION_1, AnthropicRequestUtils.MESSAGES_PATH)
             .build();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MAX_TOKENS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Max Tokens")
+                        .setOrder(1)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The maximum number of tokens to generate before stopping.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TEMPERATURE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Temperature")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("The amount of randomness injected into the response.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+                configurationMap.put(
+                    TOP_K_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Top K")
+                        .setOrder(3)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies to only sample from the top K options for each subsequent token.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TOP_P_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Top P")
+                        .setOrder(4)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies to use Anthropic’s nucleus sampling.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioService.java
@@ -12,18 +12,26 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -39,10 +47,15 @@ import org.elasticsearch.xpack.inference.services.azureaistudio.completion.Azure
 import org.elasticsearch.xpack.inference.services.azureaistudio.completion.AzureAiStudioChatCompletionTaskSettings;
 import org.elasticsearch.xpack.inference.services.azureaistudio.embeddings.AzureAiStudioEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.azureaistudio.embeddings.AzureAiStudioEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
@@ -50,6 +63,9 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.ENDPOINT_TYPE_FIELD;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.PROVIDER_FIELD;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.TARGET_FIELD;
 import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioProviderCapabilities.providerAllowsEndpointTypeForTask;
 import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioProviderCapabilities.providerAllowsTaskType;
 import static org.elasticsearch.xpack.inference.services.azureaistudio.completion.AzureAiStudioChatCompletionTaskSettings.DEFAULT_MAX_NEW_TOKENS;
@@ -58,6 +74,8 @@ import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFie
 public class AzureAiStudioService extends SenderService {
 
     static final String NAME = "azureaistudio";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION);
 
     public AzureAiStudioService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -196,6 +214,16 @@ public class AzureAiStudioService extends SenderService {
             null,
             parsePersistedConfigErrorMsg(inferenceEntityId, NAME)
         );
+    }
+
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
     }
 
     @Override
@@ -368,5 +396,76 @@ public class AzureAiStudioService extends SenderService {
                 RestStatus.BAD_REQUEST
             );
         }
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    TARGET_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Target")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The target URL of your Azure AI Studio model deployment.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    ENDPOINT_TYPE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Endpoint Type")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the type of endpoint that is used in your model deployment.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("token", "realtime")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .build()
+                );
+
+                configurationMap.put(
+                    PROVIDER_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Provider")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The model provider for your deployment.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("cohere", "meta", "microsoft_phi", "mistral", "openai", "databricks")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .build()
+                );
+
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case TEXT_EMBEDDING -> taskSettingsConfig = AzureAiStudioEmbeddingsModel.Configuration.get();
+                        case COMPLETION -> taskSettingsConfig = AzureAiStudioChatCompletionModel.Configuration.get();
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionModel.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.inference.services.azureaistudio.completion;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.azureaistudio.AzureAiStudioActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -21,9 +25,12 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.COMPLETIONS_URI_PATH;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.USER_FIELD;
 
 public class AzureAiStudioChatCompletionModel extends AzureAiStudioModel {
 
@@ -101,5 +108,31 @@ public class AzureAiStudioChatCompletionModel extends AzureAiStudioModel {
     @Override
     public ExecutableAction accept(AzureAiStudioActionVisitor creator, Map<String, Object> taskSettings) {
         return creator.create(this, taskSettings);
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    USER_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("User")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the user issuing the request.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/embeddings/AzureAiStudioEmbeddingsModel.java
@@ -7,11 +7,15 @@
 
 package org.elasticsearch.xpack.inference.services.azureaistudio.embeddings;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.azureaistudio.AzureAiStudioActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -22,9 +26,15 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.DO_SAMPLE_FIELD;
 import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.EMBEDDINGS_URI_PATH;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.MAX_NEW_TOKENS_FIELD;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.TEMPERATURE_FIELD;
+import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.TOP_P_FIELD;
 
 public class AzureAiStudioEmbeddingsModel extends AzureAiStudioModel {
 
@@ -105,5 +115,66 @@ public class AzureAiStudioEmbeddingsModel extends AzureAiStudioModel {
     @Override
     public ExecutableAction accept(AzureAiStudioActionVisitor creator, Map<String, Object> taskSettings) {
         return creator.create(this, taskSettings);
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    DO_SAMPLE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Do Sample")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Instructs the inference process to perform sampling or not.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    MAX_NEW_TOKENS_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Max New Tokens")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Provides a hint for the maximum number of output tokens to be generated.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TEMPERATURE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Temperature")
+                        .setOrder(3)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("A number in the range of 0.0 to 2.0 that specifies the sampling temperature.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+                configurationMap.put(
+                    TOP_P_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Top P")
+                        .setOrder(4)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip(
+                            "A number in the range of 0.0 to 2.0 that is an alternative value to temperature. Should not be used "
+                                + "if temperature is specified."
+                        )
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiSecretSettings.java
@@ -13,12 +13,17 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -130,5 +135,39 @@ public class AzureOpenAiSecretSettings implements SecretSettings {
     @Override
     public SecretSettings newSecretSettings(Map<String, Object> newSecrets) {
         return AzureOpenAiSecretSettings.fromMap(new HashMap<>(newSecrets));
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+                configurationMap.put(
+                    API_KEY,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("API Key")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(true)
+                        .setTooltip("You must provide either an API key or an Entra ID.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+                configurationMap.put(
+                    ENTRA_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Entra ID")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(true)
+                        .setTooltip("You must provide either an API key or an Entra ID.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiService.java
@@ -12,18 +12,25 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -38,7 +45,10 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.azureopenai.completion.AzureOpenAiCompletionModel;
 import org.elasticsearch.xpack.inference.services.azureopenai.embeddings.AzureOpenAiEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.azureopenai.embeddings.AzureOpenAiEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,10 +59,15 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
+import static org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiServiceFields.API_VERSION;
+import static org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiServiceFields.DEPLOYMENT_ID;
+import static org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiServiceFields.RESOURCE_NAME;
 import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.EMBEDDING_MAX_BATCH_SIZE;
 
 public class AzureOpenAiService extends SenderService {
     public static final String NAME = "azureopenai";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION);
 
     public AzureOpenAiService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -210,6 +225,16 @@ public class AzureOpenAiService extends SenderService {
     }
 
     @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
+    @Override
     protected void doInfer(
         Model model,
         InferenceInputs inputs,
@@ -264,7 +289,7 @@ public class AzureOpenAiService extends SenderService {
      * For text embedding models get the embedding size and
      * update the service settings.
      *
-     * @param model The new model
+     * @param model    The new model
      * @param listener The listener
      */
     @Override
@@ -321,5 +346,70 @@ public class AzureOpenAiService extends SenderService {
     @Override
     public Set<TaskType> supportedStreamingTasks() {
         return COMPLETION_ONLY;
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    RESOURCE_NAME,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Resource Name")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The name of your Azure OpenAI resource.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    API_VERSION,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("API Version")
+                        .setOrder(4)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The Azure API version ID to use.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    DEPLOYMENT_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Deployment ID")
+                        .setOrder(5)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The deployment name of your deployed models.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.putAll(AzureOpenAiSecretSettings.Configuration.get());
+                configurationMap.putAll(
+                    RateLimitSettings.toSettingsConfigurationWithTooltip(
+                        "The azureopenai service sets a default number of requests allowed per minute depending on the task type."
+                    )
+                );
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case TEXT_EMBEDDING -> taskSettingsConfig = AzureOpenAiEmbeddingsModel.Configuration.get();
+                        case COMPLETION -> taskSettingsConfig = AzureOpenAiCompletionModel.Configuration.get();
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/completion/AzureOpenAiCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/completion/AzureOpenAiCompletionModel.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.inference.services.azureopenai.completion;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.azureopenai.AzureOpenAiActionVisitor;
 import org.elasticsearch.xpack.inference.external.request.azureopenai.AzureOpenAiUtils;
@@ -19,7 +23,11 @@ import org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiModel;
 import org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiSecretSettings;
 
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiServiceFields.USER;
 
 public class AzureOpenAiCompletionModel extends AzureOpenAiModel {
 
@@ -120,4 +128,29 @@ public class AzureOpenAiCompletionModel extends AzureOpenAiModel {
         return new String[] { AzureOpenAiUtils.CHAT_PATH, AzureOpenAiUtils.COMPLETIONS_PATH };
     }
 
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    USER,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("User")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the user issuing the request.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/embeddings/AzureOpenAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/embeddings/AzureOpenAiEmbeddingsModel.java
@@ -7,11 +7,15 @@
 
 package org.elasticsearch.xpack.inference.services.azureopenai.embeddings;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.azureopenai.AzureOpenAiActionVisitor;
 import org.elasticsearch.xpack.inference.external.request.azureopenai.AzureOpenAiUtils;
@@ -20,7 +24,11 @@ import org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiModel;
 import org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiSecretSettings;
 
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiServiceFields.USER;
 
 public class AzureOpenAiEmbeddingsModel extends AzureOpenAiModel {
 
@@ -124,4 +132,29 @@ public class AzureOpenAiEmbeddingsModel extends AzureOpenAiModel {
         return new String[] { AzureOpenAiUtils.EMBEDDINGS_PATH };
     }
 
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    USER,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("User")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the user issuing the request.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -11,17 +11,22 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
@@ -38,7 +43,11 @@ import org.elasticsearch.xpack.inference.services.cohere.completion.CohereComple
 import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.cohere.rerank.CohereRerankModel;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,6 +62,8 @@ import static org.elasticsearch.xpack.inference.services.cohere.CohereServiceFie
 
 public class CohereService extends SenderService {
     public static final String NAME = "cohere";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION, TaskType.RERANK);
 
     // TODO Batching - We'll instantiate a batching class within the services that want to support it and pass it through to
     // the Cohere*RequestManager via the CohereActionCreator class
@@ -212,6 +223,16 @@ public class CohereService extends SenderService {
     }
 
     @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
+    @Override
     public void doInfer(
         Model model,
         InferenceInputs inputs,
@@ -322,5 +343,31 @@ public class CohereService extends SenderService {
     @Override
     public Set<TaskType> supportedStreamingTasks() {
         return COMPLETION_ONLY;
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case TEXT_EMBEDDING -> taskSettingsConfig = CohereEmbeddingsModel.Configuration.get();
+                        case RERANK -> taskSettingsConfig = CohereRerankModel.Configuration.get();
+                        // COMPLETION task type has no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsModel.java
@@ -7,12 +7,17 @@
 
 package org.elasticsearch.xpack.inference.services.cohere.embeddings;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.cohere.CohereActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -20,7 +25,13 @@ import org.elasticsearch.xpack.inference.services.cohere.CohereModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.inference.external.request.cohere.CohereEmbeddingsRequestEntity.INPUT_TYPE_FIELD;
+import static org.elasticsearch.xpack.inference.services.cohere.CohereServiceFields.TRUNCATE;
 
 public class CohereEmbeddingsModel extends CohereModel {
     public static CohereEmbeddingsModel of(CohereEmbeddingsModel model, Map<String, Object> taskSettings, InputType inputType) {
@@ -98,5 +109,53 @@ public class CohereEmbeddingsModel extends CohereModel {
     @Override
     public URI uri() {
         return getServiceSettings().getCommonSettings().uri();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    INPUT_TYPE_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Input Type")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the type of input passed to the model.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("classification", "clusterning", "ingest", "search")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .setValue("")
+                        .build()
+                );
+                configurationMap.put(
+                    TRUNCATE,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Truncate")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies how the API handles inputs longer than the maximum token length.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of("NONE", "START", "END")
+                                .map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build())
+                                .toList()
+                        )
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/rerank/CohereRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/rerank/CohereRerankModel.java
@@ -7,11 +7,15 @@
 
 package org.elasticsearch.xpack.inference.services.cohere.rerank;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.cohere.CohereActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
@@ -19,7 +23,12 @@ import org.elasticsearch.xpack.inference.services.cohere.CohereModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.cohere.rerank.CohereRerankTaskSettings.RETURN_DOCUMENTS;
+import static org.elasticsearch.xpack.inference.services.cohere.rerank.CohereRerankTaskSettings.TOP_N_DOCS_ONLY;
 
 public class CohereRerankModel extends CohereModel {
     public static CohereRerankModel of(CohereRerankModel model, Map<String, Object> taskSettings) {
@@ -101,5 +110,42 @@ public class CohereRerankModel extends CohereModel {
     @Override
     public URI uri() {
         return getServiceSettings().uri();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    RETURN_DOCUMENTS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TOGGLE)
+                        .setLabel("Return Documents")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specify whether to return doc text within the results.")
+                        .setType(SettingsConfigurationFieldType.BOOLEAN)
+                        .setValue(false)
+                        .build()
+                );
+                configurationMap.put(
+                    TOP_N_DOCS_ONLY,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Top N")
+                        .setOrder(2)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("The number of most relevant documents to return, defaults to the number of the documents.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -12,16 +12,23 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.inference.results.ErrorChunkedInferenceResults;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedSparseEmbeddingResults;
@@ -34,11 +41,16 @@ import org.elasticsearch.xpack.inference.external.http.sender.InferenceInputs;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.SenderService;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.inference.results.ResultUtils.createInvalidChunkedResultException;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
@@ -50,6 +62,8 @@ public class ElasticInferenceService extends SenderService {
     public static final String NAME = "elastic";
 
     private final ElasticInferenceServiceComponents elasticInferenceServiceComponents;
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.SPARSE_EMBEDDING);
 
     public ElasticInferenceService(
         HttpRequestSender.Factory factory,
@@ -134,6 +148,16 @@ public class ElasticInferenceService extends SenderService {
         } catch (Exception e) {
             parsedModelListener.onFailure(e);
         }
+    }
+
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
     }
 
     private static ElasticInferenceServiceModel createModel(
@@ -255,5 +279,52 @@ public class ElasticInferenceService extends SenderService {
         );
 
         return new ElasticInferenceServiceSparseEmbeddingsModel(model, serviceSettings);
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model ID")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The name of the model to use for the inference task.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    MAX_INPUT_TOKENS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Maximum Input Tokens")
+                        .setOrder(3)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Allows you to specify the maximum number of tokens per input.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        // SPARSE_EMBEDDING task type has no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/BaseElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/BaseElasticsearchInternalService.java
@@ -39,7 +39,6 @@ import org.elasticsearch.xpack.inference.DefaultElserFeatureFlag;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 
 import java.io.IOException;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -82,12 +81,6 @@ public abstract class BaseElasticsearchInternalService implements InferenceServi
         this.preferredModelVariantFn = preferredModelVariantFn;
         this.clusterService = context.clusterService();
     }
-
-    /**
-     * The task types supported by the service
-     * @return Set of supported.
-     */
-    protected abstract EnumSet<TaskType> supportedTaskTypes();
 
     @Override
     public void start(Model model, ActionListener<Boolean> finalListener) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandRerankModel.java
@@ -7,7 +7,17 @@
 
 package org.elasticsearch.xpack.inference.services.elasticsearch;
 
+import org.elasticsearch.common.util.LazyInitializable;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandRerankTaskSettings.RETURN_DOCUMENTS;
 
 public class CustomElandRerankModel extends CustomElandModel {
 
@@ -24,5 +34,31 @@ public class CustomElandRerankModel extends CustomElandModel {
     @Override
     public CustomElandInternalServiceSettings getServiceSettings() {
         return (CustomElandInternalServiceSettings) super.getServiceSettings();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    RETURN_DOCUMENTS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TOGGLE)
+                        .setLabel("Return Documents")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Returns the document instead of only the index.")
+                        .setType(SettingsConfigurationFieldType.BOOLEAN)
+                        .setValue(true)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -15,18 +15,26 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
 import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationSelectOption;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.inference.results.InferenceTextEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
@@ -62,12 +70,17 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.inference.results.ResultUtils.createInvalidChunkedResultException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings.NUM_THREADS;
+import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V1_MODEL;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL_LINUX_X86;
 
@@ -87,6 +100,12 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
     public static final String DEFAULT_ELSER_ID = ".elser-2-elasticsearch";
     public static final String DEFAULT_E5_ID = ".multilingual-e5-small-elasticsearch";
 
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(
+        TaskType.RERANK,
+        TaskType.TEXT_EMBEDDING,
+        TaskType.SPARSE_EMBEDDING
+    );
+
     private static final Logger logger = LogManager.getLogger(ElasticsearchInternalService.class);
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(ElasticsearchInternalService.class);
 
@@ -103,8 +122,8 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
     }
 
     @Override
-    protected EnumSet<TaskType> supportedTaskTypes() {
-        return EnumSet.of(TaskType.RERANK, TaskType.TEXT_EMBEDDING, TaskType.SPARSE_EMBEDDING);
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
     }
 
     @Override
@@ -141,7 +160,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
 
             throwIfNotEmptyMap(config, name());
 
-            String modelId = (String) serviceSettingsMap.get(ElasticsearchInternalServiceSettings.MODEL_ID);
+            String modelId = (String) serviceSettingsMap.get(MODEL_ID);
             String deploymentId = (String) serviceSettingsMap.get(ElasticsearchInternalServiceSettings.DEPLOYMENT_ID);
             if (deploymentId != null) {
                 validateAgainstDeployment(modelId, deploymentId, taskType, modelListener.delegateFailureAndWrap((l, settings) -> {
@@ -211,6 +230,11 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         }
     }
 
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
     private void customElandCase(
         String inferenceEntityId,
         TaskType taskType,
@@ -219,7 +243,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         ChunkingSettings chunkingSettings,
         ActionListener<Model> modelListener
     ) {
-        String modelId = (String) serviceSettingsMap.get(ElasticsearchInternalServiceSettings.MODEL_ID);
+        String modelId = (String) serviceSettingsMap.get(MODEL_ID);
         var request = new GetTrainedModelsAction.Request(modelId);
 
         var getModelsListener = modelListener.<GetTrainedModelsAction.Response>delegateFailureAndWrap((delegate, response) -> {
@@ -437,7 +461,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
             chunkingSettings = ChunkingSettingsBuilder.fromMap(removeFromMap(config, ModelConfigurations.CHUNKING_SETTINGS));
         }
 
-        String modelId = (String) serviceSettingsMap.get(ElasticsearchInternalServiceSettings.MODEL_ID);
+        String modelId = (String) serviceSettingsMap.get(MODEL_ID);
         if (modelId == null) {
             throw new IllegalArgumentException("Error parsing request config, model id is missing");
         }
@@ -991,5 +1015,75 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         } else {
             return null;
         }
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.DROPDOWN)
+                        .setLabel("Model ID")
+                        .setOrder(1)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The name of the model to use for the inference task.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setOptions(
+                            Stream.of(
+                                ELSER_V1_MODEL,
+                                ELSER_V2_MODEL,
+                                ELSER_V2_MODEL_LINUX_X86,
+                                MULTILINGUAL_E5_SMALL_MODEL_ID,
+                                MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86
+                            ).map(v -> new SettingsConfigurationSelectOption.Builder().setLabelAndValue(v).build()).toList()
+                        )
+                        .setDefaultValue(MULTILINGUAL_E5_SMALL_MODEL_ID)
+                        .build()
+                );
+
+                configurationMap.put(
+                    NUM_ALLOCATIONS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Number Allocations")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The total number of allocations this model is assigned across machine learning nodes.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .setDefaultValue(1)
+                        .build()
+                );
+
+                configurationMap.put(
+                    NUM_THREADS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Number Threads")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("Sets the number of threads used by each model allocation during inference.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .setDefaultValue(2)
+                        .build()
+                );
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case RERANK -> taskSettingsConfig = CustomElandRerankModel.Configuration.get();
+                        // SPARSE_EMBEDDING, TEXT_EMBEDDING task types have no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioService.java
@@ -11,18 +11,25 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -40,13 +47,18 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.googleaistudio.completion.GoogleAiStudioCompletionModel;
 import org.elasticsearch.xpack.inference.services.googleaistudio.embeddings.GoogleAiStudioEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.googleaistudio.embeddings.GoogleAiStudioEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.validation.ModelValidatorBuilder;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -58,6 +70,8 @@ import static org.elasticsearch.xpack.inference.services.googleaistudio.GoogleAi
 public class GoogleAiStudioService extends SenderService {
 
     public static final String NAME = "googleaistudio";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION);
 
     public GoogleAiStudioService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -212,6 +226,16 @@ public class GoogleAiStudioService extends SenderService {
     }
 
     @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
+    @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.V_8_15_0;
     }
@@ -307,5 +331,41 @@ public class GoogleAiStudioService extends SenderService {
         for (var request : batchedRequests) {
             doInfer(model, new DocumentsOnlyInput(request.batch().inputs()), taskSettings, inputType, timeout, request.listener());
         }
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model ID")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("ID of the LLM you're using.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        // COMPLETION, TEXT_EMBEDDING task types have no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiSecretSettings.java
@@ -13,12 +13,17 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -106,5 +111,28 @@ public class GoogleVertexAiSecretSettings implements SecretSettings {
     @Override
     public SecretSettings newSecretSettings(Map<String, Object> newSecrets) {
         return GoogleVertexAiSecretSettings.fromMap(new HashMap<>(newSecrets));
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+                configurationMap.put(
+                    SERVICE_ACCOUNT_JSON,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Credentials JSON")
+                        .setOrder(1)
+                        .setRequired(true)
+                        .setSensitive(true)
+                        .setTooltip("API Key for the provider you're connecting to.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
@@ -12,17 +12,24 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -37,10 +44,14 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankModel;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -48,10 +59,14 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
 import static org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiServiceFields.EMBEDDING_MAX_BATCH_SIZE;
+import static org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiServiceFields.LOCATION;
+import static org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiServiceFields.PROJECT_ID;
 
 public class GoogleVertexAiService extends SenderService {
 
     public static final String NAME = "googlevertexai";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.RERANK);
 
     public GoogleVertexAiService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -147,6 +162,16 @@ public class GoogleVertexAiService extends SenderService {
             null,
             parsePersistedConfigErrorMsg(inferenceEntityId, NAME)
         );
+    }
+
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
     }
 
     @Override
@@ -298,5 +323,72 @@ public class GoogleVertexAiService extends SenderService {
             );
             default -> throw new ElasticsearchStatusException(failureMessage, RestStatus.BAD_REQUEST);
         };
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model ID")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("ID of the LLM you're using.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    LOCATION,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("GCP Region")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip(
+                            "Please provide the GCP region where the Vertex AI API(s) is enabled. "
+                                + "For more information, refer to the {geminiVertexAIDocs}."
+                        )
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    PROJECT_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("GCP Project")
+                        .setOrder(4)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip(
+                            "The GCP Project ID which has Vertex AI API(s) enabled. For more information "
+                                + "on the URL, refer to the {geminiVertexAIDocs}."
+                        )
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.putAll(GoogleVertexAiSecretSettings.Configuration.get());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case TEXT_EMBEDDING -> taskSettingsConfig = GoogleVertexAiEmbeddingsModel.Configuration.get();
+                        case RERANK -> taskSettingsConfig = GoogleVertexAiRerankModel.Configuration.get();
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModel.java
@@ -8,11 +8,15 @@
 package org.elasticsearch.xpack.inference.services.googlevertexai.embeddings;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.googlevertexai.GoogleVertexAiActionVisitor;
 import org.elasticsearch.xpack.inference.external.request.googlevertexai.GoogleVertexAiUtils;
@@ -22,9 +26,12 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiS
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsTaskSettings.AUTO_TRUNCATE;
 
 public class GoogleVertexAiEmbeddingsModel extends GoogleVertexAiModel {
 
@@ -143,5 +150,31 @@ public class GoogleVertexAiEmbeddingsModel extends GoogleVertexAiModel {
                 format("%s:%s", modelId, GoogleVertexAiUtils.PREDICT)
             )
             .build();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    AUTO_TRUNCATE,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TOGGLE)
+                        .setLabel("Auto Truncate")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies if the API truncates inputs longer than the maximum token length automatically.")
+                        .setType(SettingsConfigurationFieldType.BOOLEAN)
+                        .setValue(false)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankModel.java
@@ -8,10 +8,14 @@
 package org.elasticsearch.xpack.inference.services.googlevertexai.rerank;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.googlevertexai.GoogleVertexAiActionVisitor;
 import org.elasticsearch.xpack.inference.external.request.googlevertexai.GoogleVertexAiUtils;
@@ -21,9 +25,12 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiS
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankTaskSettings.TOP_N;
 
 public class GoogleVertexAiRerankModel extends GoogleVertexAiModel {
 
@@ -137,5 +144,31 @@ public class GoogleVertexAiRerankModel extends GoogleVertexAiModel {
                 format("%s:%s", GoogleVertexAiUtils.DEFAULT_RANKING_CONFIG, GoogleVertexAiUtils.RANK)
             )
             .build();
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    TOP_N,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TOGGLE)
+                        .setLabel("Top N")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the number of the top n documents, which should be returned.")
+                        .setType(SettingsConfigurationFieldType.BOOLEAN)
+                        .setValue(false)
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
@@ -12,15 +12,22 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.inference.results.ErrorChunkedInferenceResults;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedSparseEmbeddingResults;
@@ -34,14 +41,21 @@ import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceBaseService;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceModel;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.inference.results.ResultUtils.createInvalidChunkedResultException;
+import static org.elasticsearch.xpack.inference.services.huggingface.elser.HuggingFaceElserServiceSettings.URL;
 
 public class HuggingFaceElserService extends HuggingFaceBaseService {
     public static final String NAME = "hugging_face_elser";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.SPARSE_EMBEDDING);
 
     public HuggingFaceElserService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -107,7 +121,53 @@ public class HuggingFaceElserService extends HuggingFaceBaseService {
     }
 
     @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
+    @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.V_8_12_0;
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    URL,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("URL")
+                        .setOrder(1)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The URL endpoint to use for the requests.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        // SPARSE_EMBEDDING task type has no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserServiceSettings.java
@@ -36,7 +36,7 @@ public class HuggingFaceElserServiceSettings extends FilteredXContentObject
         HuggingFaceRateLimitServiceSettings {
 
     public static final String NAME = "hugging_face_elser_service_settings";
-    static final String URL = "url";
+    public static final String URL = "url";
     private static final int ELSER_TOKEN_LIMIT = 512;
     // At the time of writing HuggingFace hasn't posted the default rate limit for inference endpoints so the value his is only a guess
     // 3000 requests per minute

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
@@ -11,17 +11,24 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
 import org.elasticsearch.xpack.inference.external.action.ibmwatsonx.IbmWatsonxActionCreator;
@@ -36,19 +43,28 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsServiceSettings;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
+import static org.elasticsearch.xpack.inference.services.huggingface.elser.HuggingFaceElserServiceSettings.URL;
+import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxServiceFields.API_VERSION;
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxServiceFields.EMBEDDING_MAX_BATCH_SIZE;
+import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxServiceFields.PROJECT_ID;
 
 public class IbmWatsonxService extends SenderService {
 
     public static final String NAME = "watsonxai";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING);
 
     public IbmWatsonxService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -133,6 +149,16 @@ public class IbmWatsonxService extends SenderService {
             secretSettingsMap,
             parsePersistedConfigErrorMsg(inferenceEntityId, NAME)
         );
+    }
+
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
     }
 
     private static IbmWatsonxModel createModelFromPersistent(
@@ -250,5 +276,86 @@ public class IbmWatsonxService extends SenderService {
 
     protected IbmWatsonxActionCreator getActionCreator(Sender sender, ServiceComponents serviceComponents) {
         return new IbmWatsonxActionCreator(getSender(), getServiceComponents());
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    API_VERSION,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("API Version")
+                        .setOrder(1)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The IBM Watsonx API version ID to use.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    PROJECT_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Project ID")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model ID")
+                        .setOrder(3)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The name of the model to use for the inference task.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    URL,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("URL")
+                        .setOrder(4)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    MAX_INPUT_TOKENS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Maximum Input Tokens")
+                        .setOrder(5)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Allows you to specify the maximum number of tokens per input.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        // TEXT_EMBEDDING task type has no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/MistralService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/MistralService.java
@@ -11,18 +11,25 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -36,20 +43,28 @@ import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.mistral.embeddings.MistralEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.mistral.embeddings.MistralEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.validation.ModelValidatorBuilder;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
+import static org.elasticsearch.xpack.inference.services.mistral.MistralConstants.MODEL_FIELD;
 
 public class MistralService extends SenderService {
     public static final String NAME = "mistral";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING);
 
     public MistralService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -101,6 +116,16 @@ public class MistralService extends SenderService {
         } else {
             listener.onFailure(createInvalidModelException(model));
         }
+    }
+
+    @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
     }
 
     @Override
@@ -272,5 +297,53 @@ public class MistralService extends SenderService {
         } else {
             throw ServiceUtils.invalidModelTypeForUpdateModelWithEmbeddingDetails(model.getClass());
         }
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_FIELD,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("Refer to the Mistral models documentation for the list of available text embedding models.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    MAX_INPUT_TOKENS,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                        .setLabel("Maximum Input Tokens")
+                        .setOrder(3)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Allows you to specify the maximum number of tokens per input.")
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
+                configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration());
+                configurationMap.putAll(RateLimitSettings.toSettingsConfiguration());
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        // TEXT_EMBEDDING task type has no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -11,18 +11,25 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.EmbeddingRequestChunker;
@@ -37,13 +44,18 @@ import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.openai.completion.OpenAiChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsServiceSettings;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.services.validation.ModelValidatorBuilder;
 
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMap;
@@ -51,9 +63,12 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
 import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.EMBEDDING_MAX_BATCH_SIZE;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.ORGANIZATION;
 
 public class OpenAiService extends SenderService {
     public static final String NAME = "openai";
+
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.COMPLETION);
 
     public OpenAiService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);
@@ -213,6 +228,16 @@ public class OpenAiService extends SenderService {
     }
 
     @Override
+    public InferenceServiceConfiguration getConfiguration() {
+        return Configuration.get();
+    }
+
+    @Override
+    public EnumSet<TaskType> supportedTaskTypes() {
+        return supportedTaskTypes;
+    }
+
+    @Override
     public void doInfer(
         Model model,
         InferenceInputs inputs,
@@ -334,5 +359,79 @@ public class OpenAiService extends SenderService {
             var modelId = taskSettings.remove(MODEL_ID);
             serviceSettings.put(MODEL_ID, modelId);
         }
+    }
+
+    public static class Configuration {
+        public static InferenceServiceConfiguration get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<InferenceServiceConfiguration, RuntimeException> configuration = new LazyInitializable<>(
+            () -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    MODEL_ID,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Model ID")
+                        .setOrder(2)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip("The name of the model to use for the inference task.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    ORGANIZATION,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("Organization ID")
+                        .setOrder(3)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("The unique identifier of your organization.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .build()
+                );
+
+                configurationMap.put(
+                    URL,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("URL")
+                        .setOrder(4)
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setTooltip(
+                            "The OpenAI API endpoint URL. For more information on the URL, refer to the "
+                                + "https://platform.openai.com/docs/api-reference."
+                        )
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setDefaultValue("https://api.openai.com/v1/chat/completions")
+                        .build()
+                );
+
+                configurationMap.putAll(
+                    DefaultSecretSettings.toSettingsConfigurationWithTooltip(
+                        "The OpenAI API authentication key. For more details about generating OpenAI API keys, "
+                            + "refer to the https://platform.openai.com/account/api-keys."
+                    )
+                );
+                configurationMap.putAll(
+                    RateLimitSettings.toSettingsConfigurationWithTooltip(
+                        "Default number of requests allowed per minute. For text_embedding is 3000. For completion is 500."
+                    )
+                );
+
+                return new InferenceServiceConfiguration.Builder().setProvider(NAME).setTaskTypes(supportedTaskTypes.stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        case TEXT_EMBEDDING -> taskSettingsConfig = OpenAiEmbeddingsModel.Configuration.get();
+                        case COMPLETION -> taskSettingsConfig = OpenAiChatCompletionModel.Configuration.get();
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList()).setConfiguration(configurationMap).build();
+            }
+        );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionModel.java
@@ -7,17 +7,25 @@
 
 package org.elasticsearch.xpack.inference.services.openai.completion;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.openai.OpenAiActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.USER;
 
 public class OpenAiChatCompletionModel extends OpenAiModel {
 
@@ -87,5 +95,31 @@ public class OpenAiChatCompletionModel extends OpenAiModel {
     @Override
     public ExecutableAction accept(OpenAiActionVisitor creator, Map<String, Object> taskSettings) {
         return creator.create(this, taskSettings);
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    USER,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("User")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the user issuing the request.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModel.java
@@ -7,18 +7,26 @@
 
 package org.elasticsearch.xpack.inference.services.openai.embeddings;
 
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.openai.OpenAiActionVisitor;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.USER;
 
 public class OpenAiEmbeddingsModel extends OpenAiModel {
 
@@ -96,5 +104,31 @@ public class OpenAiEmbeddingsModel extends OpenAiModel {
     @Override
     public ExecutableAction accept(OpenAiActionVisitor creator, Map<String, Object> taskSettings) {
         return creator.create(this, taskSettings);
+    }
+
+    public static class Configuration {
+        public static Map<String, SettingsConfiguration> get() {
+            return configuration.getOrCompute();
+        }
+
+        private static final LazyInitializable<Map<String, SettingsConfiguration>, RuntimeException> configuration =
+            new LazyInitializable<>(() -> {
+                var configurationMap = new HashMap<String, SettingsConfiguration>();
+
+                configurationMap.put(
+                    USER,
+                    new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                        .setLabel("User")
+                        .setOrder(1)
+                        .setRequired(false)
+                        .setSensitive(false)
+                        .setTooltip("Specifies the user issuing the request.")
+                        .setType(SettingsConfigurationFieldType.STRING)
+                        .setValue("")
+                        .build()
+                );
+
+                return Collections.unmodifiableMap(configurationMap);
+            });
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/DefaultSecretSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/DefaultSecretSettings.java
@@ -16,6 +16,9 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.SecretSettings;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -47,6 +50,26 @@ public record DefaultSecretSettings(SecureString apiKey) implements SecretSettin
         }
 
         return new DefaultSecretSettings(secureApiToken);
+    }
+
+    public static Map<String, SettingsConfiguration> toSettingsConfigurationWithTooltip(String tooltip) {
+        var configurationMap = new HashMap<String, SettingsConfiguration>();
+        configurationMap.put(
+            API_KEY,
+            new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.TEXTBOX)
+                .setLabel("API Key")
+                .setOrder(1)
+                .setRequired(true)
+                .setSensitive(true)
+                .setTooltip(tooltip)
+                .setType(SettingsConfigurationFieldType.STRING)
+                .build()
+        );
+        return configurationMap;
+    }
+
+    public static Map<String, SettingsConfiguration> toSettingsConfiguration() {
+        return DefaultSecretSettings.toSettingsConfigurationWithTooltip("API Key for the provider you're connecting to.");
     }
 
     public DefaultSecretSettings {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/RateLimitSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/settings/RateLimitSettings.java
@@ -11,11 +11,15 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.configuration.SettingsConfigurationDisplayType;
+import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +50,26 @@ public class RateLimitSettings implements Writeable, ToXContentFragment {
         }
 
         return requestsPerMinute == null ? defaultValue : new RateLimitSettings(requestsPerMinute);
+    }
+
+    public static Map<String, SettingsConfiguration> toSettingsConfigurationWithTooltip(String tooltip) {
+        var configurationMap = new HashMap<String, SettingsConfiguration>();
+        configurationMap.put(
+            FIELD_NAME + "." + REQUESTS_PER_MINUTE_FIELD,
+            new SettingsConfiguration.Builder().setDisplay(SettingsConfigurationDisplayType.NUMERIC)
+                .setLabel("Rate Limit")
+                .setOrder(6)
+                .setRequired(false)
+                .setSensitive(false)
+                .setTooltip(tooltip)
+                .setType(SettingsConfigurationFieldType.INTEGER)
+                .build()
+        );
+        return configurationMap;
+    }
+
+    public static Map<String, SettingsConfiguration> toSettingsConfiguration() {
+        return RateLimitSettings.toSettingsConfigurationWithTooltip("Minimize the number of rate limit errors.");
     }
 
     /**

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
@@ -13,9 +13,13 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.EmptySettingsConfiguration;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.SettingsConfiguration;
+import org.elasticsearch.inference.TaskSettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -27,6 +31,8 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -160,6 +166,26 @@ public class SenderServiceTests extends ESTestCase {
         @Override
         public TransportVersion getMinimalSupportedVersion() {
             return TransportVersion.current();
+        }
+
+        @Override
+        public InferenceServiceConfiguration getConfiguration() {
+            return new InferenceServiceConfiguration.Builder().setProvider("test service")
+                .setTaskTypes(supportedTaskTypes().stream().map(t -> {
+                    Map<String, SettingsConfiguration> taskSettingsConfig;
+                    switch (t) {
+                        // no task settings
+                        default -> taskSettingsConfig = EmptySettingsConfiguration.get();
+                    }
+                    return new TaskSettingsConfiguration.Builder().setTaskType(t).setConfiguration(taskSettingsConfig).build();
+                }).toList())
+                .setConfiguration(new HashMap<>())
+                .build();
+        }
+
+        @Override
+        public EnumSet<TaskType> supportedTaskTypes() {
+            return EnumSet.of(TaskType.TEXT_EMBEDDING);
         }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
@@ -9,11 +9,15 @@ package org.elasticsearch.xpack.inference.services.alibabacloudsearch;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -21,6 +25,8 @@ import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedSparseEmbeddingResults;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -54,6 +60,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
@@ -392,6 +400,235 @@ public class AlibabaCloudSearchServiceTests extends ESTestCase {
             } else if (TaskType.SPARSE_EMBEDDING.equals(taskType)) {
                 assertThat(firstResult, instanceOf(InferenceChunkedSparseEmbeddingResults.class));
             }
+        }
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = new AlibabaCloudSearchService(mock(HttpRequestSender.Factory.class), createWithEmptySettings(threadPool))) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                       "provider": "alibabacloud-ai-search",
+                       "task_types": [
+                             {
+                                 "task_type": "text_embedding",
+                                 "configuration": {
+                                     "input_type": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "dropdown",
+                                         "label": "Input Type",
+                                         "options": [
+                                             {
+                                                 "label": "ingest",
+                                                 "value": "ingest"
+                                             },
+                                             {
+                                                 "label": "search",
+                                                 "value": "search"
+                                             }
+                                         ],
+                                         "order": 1,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "Specifies the type of input passed to the model.",
+                                         "type": "str",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": ""
+                                     }
+                                 }
+                             },
+                             {
+                                 "task_type": "sparse_embedding",
+                                 "configuration": {
+                                     "return_token": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "toggle",
+                                         "label": "Return Token",
+                                         "order": 2,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "If `true`, the token name will be returned in the response. Defaults to `false` which means only the token ID will be returned in the response.",
+                                         "type": "bool",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": true
+                                     },
+                                     "input_type": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "dropdown",
+                                         "label": "Input Type",
+                                         "options": [
+                                             {
+                                                 "label": "ingest",
+                                                 "value": "ingest"
+                                             },
+                                             {
+                                                 "label": "search",
+                                                 "value": "search"
+                                             }
+                                         ],
+                                         "order": 1,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "Specifies the type of input passed to the model.",
+                                         "type": "str",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": ""
+                                     }
+                                 }
+                             },
+                             {
+                                 "task_type": "rerank",
+                                 "configuration": {}
+                             },
+                             {
+                                 "task_type": "completion",
+                                 "configuration": {}
+                             }
+                       ],
+                       "configuration": {
+                         "workspace": {
+                           "default_value": null,
+                           "depends_on": [],
+                           "display": "textbox",
+                           "label": "Workspace",
+                           "order": 5,
+                           "required": true,
+                           "sensitive": false,
+                           "tooltip": "The name of the workspace used for the {infer} task.",
+                           "type": "str",
+                           "ui_restrictions": [],
+                           "validations": [],
+                           "value": null
+                         },
+                         "api_key": {
+                           "default_value": null,
+                           "depends_on": [],
+                           "display": "textbox",
+                           "label": "API Key",
+                           "order": 1,
+                           "required": true,
+                           "sensitive": true,
+                           "tooltip": "A valid API key for the AlibabaCloud AI Search API.",
+                           "type": "str",
+                           "ui_restrictions": [],
+                           "validations": [],
+                           "value": null
+                         },
+                         "service_id": {
+                           "default_value": null,
+                           "depends_on": [],
+                           "display": "dropdown",
+                           "label": "Project ID",
+                           "options": [
+                             {
+                               "label": "ops-text-embedding-001",
+                               "value": "ops-text-embedding-001"
+                             },
+                             {
+                               "label": "ops-text-embedding-zh-001",
+                               "value": "ops-text-embedding-zh-001"
+                             },
+                             {
+                               "label": "ops-text-embedding-en-001",
+                               "value": "ops-text-embedding-en-001"
+                             },
+                             {
+                               "label": "ops-text-embedding-002",
+                               "value": "ops-text-embedding-002"
+                             },
+                             {
+                               "label": "ops-text-sparse-embedding-001",
+                               "value": "ops-text-sparse-embedding-001"
+                             },
+                             {
+                               "label": "ops-bge-reranker-larger",
+                               "value": "ops-bge-reranker-larger"
+                             }
+                           ],
+                           "order": 2,
+                           "required": true,
+                           "sensitive": false,
+                           "tooltip": "The name of the model service to use for the {infer} task.",
+                           "type": "str",
+                           "ui_restrictions": [],
+                           "validations": [],
+                           "value": null
+                         },
+                         "host": {
+                           "default_value": null,
+                           "depends_on": [],
+                           "display": "textbox",
+                           "label": "Host",
+                           "order": 3,
+                           "required": true,
+                           "sensitive": false,
+                           "tooltip": "The name of the host address used for the {infer} task. You can find the host address at https://opensearch.console.aliyun.com/cn-shanghai/rag/api-key[ the API keys section] of the documentation.",
+                           "type": "str",
+                           "ui_restrictions": [],
+                           "validations": [],
+                           "value": null
+                         },
+                         "rate_limit.requests_per_minute": {
+                           "default_value": null,
+                           "depends_on": [],
+                           "display": "numeric",
+                           "label": "Rate Limit",
+                           "order": 6,
+                           "required": false,
+                           "sensitive": false,
+                           "tooltip": "Minimize the number of rate limit errors.",
+                           "type": "int",
+                           "ui_restrictions": [],
+                           "validations": [],
+                           "value": null
+                         },
+                         "http_schema": {
+                           "default_value": null,
+                           "depends_on": [],
+                           "display": "dropdown",
+                           "label": "HTTP Schema",
+                           "options": [
+                             {
+                               "label": "https",
+                               "value": "https"
+                             },
+                             {
+                               "label": "http",
+                               "value": "http"
+                             }
+                           ],
+                           "order": 4,
+                           "required": true,
+                           "sensitive": false,
+                           "tooltip": "",
+                           "type": "str",
+                           "ui_restrictions": [],
+                           "validations": [],
+                           "value": null
+                         }
+                       }
+                    }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -14,11 +14,15 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -28,6 +32,8 @@ import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -56,6 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
@@ -138,6 +146,210 @@ public class AmazonBedrockServiceTests extends ESTestCase {
                     getAmazonBedrockSecretSettingsMap("access", "secret")
                 ),
                 modelVerificationListener
+            );
+        }
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = createAmazonBedrockService()) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                         "provider": "amazonbedrock",
+                         "task_types": [
+                               {
+                                   "task_type": "text_embedding",
+                                   "configuration": {}
+                               },
+                               {
+                                   "task_type": "completion",
+                                   "configuration": {
+                                       "top_p": {
+                                           "default_value": null,
+                                           "depends_on": [],
+                                           "display": "numeric",
+                                           "label": "Top P",
+                                           "order": 3,
+                                           "required": false,
+                                           "sensitive": false,
+                                           "tooltip": "Alternative to temperature. A number in the range of 0.0 to 1.0, to eliminate low-probability tokens.",
+                                           "type": "int",
+                                           "ui_restrictions": [],
+                                           "validations": [],
+                                           "value": null
+                                       },
+                                       "max_new_tokens": {
+                                           "default_value": null,
+                                           "depends_on": [],
+                                           "display": "numeric",
+                                           "label": "Max New Tokens",
+                                           "order": 1,
+                                           "required": false,
+                                           "sensitive": false,
+                                           "tooltip": "Sets the maximum number for the output tokens to be generated.",
+                                           "type": "int",
+                                           "ui_restrictions": [],
+                                           "validations": [],
+                                           "value": null
+                                       },
+                                       "top_k": {
+                                           "default_value": null,
+                                           "depends_on": [],
+                                           "display": "numeric",
+                                           "label": "Top K",
+                                           "order": 4,
+                                           "required": false,
+                                           "sensitive": false,
+                                           "tooltip": "Only available for anthropic, cohere, and mistral providers. Alternative to temperature.",
+                                           "type": "int",
+                                           "ui_restrictions": [],
+                                           "validations": [],
+                                           "value": null
+                                       },
+                                       "temperature": {
+                                           "default_value": null,
+                                           "depends_on": [],
+                                           "display": "numeric",
+                                           "label": "Temperature",
+                                           "order": 2,
+                                           "required": false,
+                                           "sensitive": false,
+                                           "tooltip": "A number between 0.0 and 1.0 that controls the apparent creativity of the results.",
+                                           "type": "int",
+                                           "ui_restrictions": [],
+                                           "validations": [],
+                                           "value": null
+                                       }
+                                   }
+                               }
+                         ],
+                         "configuration": {
+                             "secret_key": {
+                                 "default_value": null,
+                                 "depends_on": [],
+                                 "display": "textbox",
+                                 "label": "Secret Key",
+                                 "order": 2,
+                                 "required": true,
+                                 "sensitive": true,
+                                 "tooltip": "A valid AWS secret key that is paired with the access_key.",
+                                 "type": "str",
+                                 "ui_restrictions": [],
+                                 "validations": [],
+                                 "value": null
+                             },
+                             "provider": {
+                                 "default_value": null,
+                                 "depends_on": [],
+                                 "display": "dropdown",
+                                 "label": "Provider",
+                                 "options": [
+                                     {
+                                         "label": "amazontitan",
+                                         "value": "amazontitan"
+                                     },
+                                     {
+                                         "label": "anthropic",
+                                         "value": "anthropic"
+                                     },
+                                     {
+                                         "label": "ai21labs",
+                                         "value": "ai21labs"
+                                     },
+                                     {
+                                         "label": "cohere",
+                                         "value": "cohere"
+                                     },
+                                     {
+                                         "label": "meta",
+                                         "value": "meta"
+                                     },
+                                     {
+                                         "label": "mistral",
+                                         "value": "mistral"
+                                     }
+                                 ],
+                                 "order": 3,
+                                 "required": true,
+                                 "sensitive": false,
+                                 "tooltip": "The model provider for your deployment.",
+                                 "type": "str",
+                                 "ui_restrictions": [],
+                                 "validations": [],
+                                 "value": null
+                             },
+                             "access_key": {
+                                 "default_value": null,
+                                 "depends_on": [],
+                                 "display": "textbox",
+                                 "label": "Access Key",
+                                 "order": 1,
+                                 "required": true,
+                                 "sensitive": true,
+                                 "tooltip": "A valid AWS access key that has permissions to use Amazon Bedrock.",
+                                 "type": "str",
+                                 "ui_restrictions": [],
+                                 "validations": [],
+                                 "value": null
+                             },
+                             "model": {
+                                 "default_value": null,
+                                 "depends_on": [],
+                                 "display": "textbox",
+                                 "label": "Model",
+                                 "order": 4,
+                                 "required": true,
+                                 "sensitive": false,
+                                 "tooltip": "The base model ID or an ARN to a custom model based on a foundational model.",
+                                 "type": "str",
+                                 "ui_restrictions": [],
+                                 "validations": [],
+                                 "value": null
+                             },
+                             "rate_limit.requests_per_minute": {
+                                 "default_value": null,
+                                 "depends_on": [],
+                                 "display": "numeric",
+                                 "label": "Rate Limit",
+                                 "order": 6,
+                                 "required": false,
+                                 "sensitive": false,
+                                 "tooltip": "By default, the amazonbedrock service sets the number of requests allowed per minute to 240.",
+                                 "type": "int",
+                                 "ui_restrictions": [],
+                                 "validations": [],
+                                 "value": null
+                             },
+                             "region": {
+                                 "default_value": null,
+                                 "depends_on": [],
+                                 "display": "textbox",
+                                 "label": "Region",
+                                 "order": 5,
+                                 "required": true,
+                                 "sensitive": false,
+                                 "tooltip": "The region that your model or ARN is deployed in.",
+                                 "type": "str",
+                                 "ui_restrictions": [],
+                                 "validations": [],
+                                 "value": null
+                             }
+                         }
+                     }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
             );
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
@@ -11,8 +11,12 @@ import org.apache.http.HttpHeaders;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -22,6 +26,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -47,6 +52,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.buildExpectationCompletions;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getModelListenerForException;
@@ -591,6 +598,135 @@ public class AnthropicServiceTests extends ESTestCase {
             .hasNoEvents()
             .hasErrorWithStatusCode(RestStatus.REQUEST_ENTITY_TOO_LARGE.getStatus())
             .hasErrorContaining("blah");
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createServiceWithMockSender()) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                      "provider": "anthropic",
+                      "task_types": [
+                           {
+                               "task_type": "completion",
+                               "configuration": {
+                                   "top_p": {
+                                       "default_value": null,
+                                       "depends_on": [],
+                                       "display": "numeric",
+                                       "label": "Top P",
+                                       "order": 4,
+                                       "required": false,
+                                       "sensitive": false,
+                                       "tooltip": "Specifies to use Anthropic’s nucleus sampling.",
+                                       "type": "int",
+                                       "ui_restrictions": [],
+                                       "validations": [],
+                                       "value": null
+                                   },
+                                   "max_tokens": {
+                                       "default_value": null,
+                                       "depends_on": [],
+                                       "display": "numeric",
+                                       "label": "Max Tokens",
+                                       "order": 1,
+                                       "required": true,
+                                       "sensitive": false,
+                                       "tooltip": "The maximum number of tokens to generate before stopping.",
+                                       "type": "int",
+                                       "ui_restrictions": [],
+                                       "validations": [],
+                                       "value": null
+                                   },
+                                   "top_k": {
+                                       "default_value": null,
+                                       "depends_on": [],
+                                       "display": "numeric",
+                                       "label": "Top K",
+                                       "order": 3,
+                                       "required": false,
+                                       "sensitive": false,
+                                       "tooltip": "Specifies to only sample from the top K options for each subsequent token.",
+                                       "type": "int",
+                                       "ui_restrictions": [],
+                                       "validations": [],
+                                       "value": null
+                                   },
+                                   "temperature": {
+                                       "default_value": null,
+                                       "depends_on": [],
+                                       "display": "textbox",
+                                       "label": "Temperature",
+                                       "order": 2,
+                                       "required": false,
+                                       "sensitive": false,
+                                       "tooltip": "The amount of randomness injected into the response.",
+                                       "type": "str",
+                                       "ui_restrictions": [],
+                                       "validations": [],
+                                       "value": null
+                                   }
+                               }
+                           }
+                      ],
+                      "configuration": {
+                          "api_key": {
+                              "default_value": null,
+                              "depends_on": [],
+                              "display": "textbox",
+                              "label": "API Key",
+                              "order": 1,
+                              "required": true,
+                              "sensitive": true,
+                              "tooltip": "API Key for the provider you're connecting to.",
+                              "type": "str",
+                              "ui_restrictions": [],
+                              "validations": [],
+                              "value": null
+                          },
+                          "rate_limit.requests_per_minute": {
+                              "default_value": null,
+                              "depends_on": [],
+                              "display": "numeric",
+                              "label": "Rate Limit",
+                              "order": 6,
+                              "required": false,
+                              "sensitive": false,
+                              "tooltip": "By default, the anthropic service sets the number of requests allowed per minute to 50.",
+                              "type": "int",
+                              "ui_restrictions": [],
+                              "validations": [],
+                              "value": null
+                          },
+                          "model_id": {
+                              "default_value": null,
+                              "depends_on": [],
+                              "display": "textbox",
+                              "label": "Model ID",
+                              "order": 2,
+                              "required": true,
+                              "sensitive": false,
+                              "tooltip": "The name of the model to use for the inference task.",
+                              "type": "str",
+                              "ui_restrictions": [],
+                              "validations": [],
+                              "value": null
+                          }
+                      }
+                  }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
+        }
     }
 
     public void testSupportsStreaming() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
@@ -13,12 +13,16 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -29,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
@@ -61,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -1271,6 +1278,221 @@ public class AzureAiStudioServiceTests extends ESTestCase {
             .hasNoEvents()
             .hasErrorWithStatusCode(401)
             .hasErrorContaining("You didn't provide an API key...");
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = createService()) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                        "provider": "azureaistudio",
+                        "task_types": [
+                             {
+                                 "task_type": "text_embedding",
+                                 "configuration": {
+                                     "top_p": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "numeric",
+                                         "label": "Top P",
+                                         "order": 4,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "A number in the range of 0.0 to 2.0 that is an alternative value to temperature. Should not be used if temperature is specified.",
+                                         "type": "int",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": null
+                                     },
+                                     "max_new_tokens": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "numeric",
+                                         "label": "Max New Tokens",
+                                         "order": 2,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "Provides a hint for the maximum number of output tokens to be generated.",
+                                         "type": "int",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": null
+                                     },
+                                     "temperature": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "numeric",
+                                         "label": "Temperature",
+                                         "order": 3,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "A number in the range of 0.0 to 2.0 that specifies the sampling temperature.",
+                                         "type": "int",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": null
+                                     },
+                                     "do_sample": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "numeric",
+                                         "label": "Do Sample",
+                                         "order": 1,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "Instructs the inference process to perform sampling or not.",
+                                         "type": "int",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": null
+                                     }
+                                 }
+                             },
+                             {
+                                 "task_type": "completion",
+                                 "configuration": {
+                                     "user": {
+                                         "default_value": null,
+                                         "depends_on": [],
+                                         "display": "textbox",
+                                         "label": "User",
+                                         "order": 1,
+                                         "required": false,
+                                         "sensitive": false,
+                                         "tooltip": "Specifies the user issuing the request.",
+                                         "type": "str",
+                                         "ui_restrictions": [],
+                                         "validations": [],
+                                         "value": ""
+                                     }
+                                 }
+                             }
+                        ],
+                        "configuration": {
+                            "endpoint_type": {
+                                "default_value": null,
+                                "depends_on": [],
+                                "display": "dropdown",
+                                "label": "Endpoint Type",
+                                "options": [
+                                    {
+                                        "label": "token",
+                                        "value": "token"
+                                    },
+                                    {
+                                        "label": "realtime",
+                                        "value": "realtime"
+                                    }
+                                ],
+                                "order": 3,
+                                "required": true,
+                                "sensitive": false,
+                                "tooltip": "Specifies the type of endpoint that is used in your model deployment.",
+                                "type": "str",
+                                "ui_restrictions": [],
+                                "validations": [],
+                                "value": null
+                            },
+                            "provider": {
+                                "default_value": null,
+                                "depends_on": [],
+                                "display": "dropdown",
+                                "label": "Provider",
+                                "options": [
+                                    {
+                                        "label": "cohere",
+                                        "value": "cohere"
+                                    },
+                                    {
+                                        "label": "meta",
+                                        "value": "meta"
+                                    },
+                                    {
+                                        "label": "microsoft_phi",
+                                        "value": "microsoft_phi"
+                                    },
+                                    {
+                                        "label": "mistral",
+                                        "value": "mistral"
+                                    },
+                                    {
+                                        "label": "openai",
+                                        "value": "openai"
+                                    },
+                                    {
+                                        "label": "databricks",
+                                        "value": "databricks"
+                                    }
+                                ],
+                                "order": 3,
+                                "required": true,
+                                "sensitive": false,
+                                "tooltip": "The model provider for your deployment.",
+                                "type": "str",
+                                "ui_restrictions": [],
+                                "validations": [],
+                                "value": null
+                            },
+                            "api_key": {
+                                "default_value": null,
+                                "depends_on": [],
+                                "display": "textbox",
+                                "label": "API Key",
+                                "order": 1,
+                                "required": true,
+                                "sensitive": true,
+                                "tooltip": "API Key for the provider you're connecting to.",
+                                "type": "str",
+                                "ui_restrictions": [],
+                                "validations": [],
+                                "value": null
+                            },
+                            "rate_limit.requests_per_minute": {
+                                "default_value": null,
+                                "depends_on": [],
+                                "display": "numeric",
+                                "label": "Rate Limit",
+                                "order": 6,
+                                "required": false,
+                                "sensitive": false,
+                                "tooltip": "Minimize the number of rate limit errors.",
+                                "type": "int",
+                                "ui_restrictions": [],
+                                "validations": [],
+                                "value": null
+                            },
+                            "target": {
+                                "default_value": null,
+                                "depends_on": [],
+                                "display": "textbox",
+                                "label": "Target",
+                                "order": 2,
+                                "required": true,
+                                "sensitive": false,
+                                "tooltip": "The target URL of your Azure AI Studio model deployment.",
+                                "type": "str",
+                                "ui_restrictions": [],
+                                "validations": [],
+                                "value": null
+                            }
+                        }
+                    }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
+        }
     }
 
     public void testSupportsStreaming() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
@@ -14,11 +14,15 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -29,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -55,6 +60,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -1399,6 +1406,157 @@ public class AzureOpenAiServiceTests extends ESTestCase {
             .hasNoEvents()
             .hasErrorWithStatusCode(401)
             .hasErrorContaining("You didn't provide an API key...");
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = createAzureOpenAiService()) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                            "provider": "azureopenai",
+                            "task_types": [
+                                 {
+                                     "task_type": "text_embedding",
+                                     "configuration": {
+                                         "user": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "textbox",
+                                             "label": "User",
+                                             "order": 1,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specifies the user issuing the request.",
+                                             "type": "str",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": ""
+                                         }
+                                     }
+                                 },
+                                 {
+                                     "task_type": "completion",
+                                     "configuration": {
+                                         "user": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "textbox",
+                                             "label": "User",
+                                             "order": 1,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specifies the user issuing the request.",
+                                             "type": "str",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": ""
+                                         }
+                                     }
+                                 }
+                            ],
+                            "configuration": {
+                                "api_key": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "API Key",
+                                    "order": 1,
+                                    "required": false,
+                                    "sensitive": true,
+                                    "tooltip": "You must provide either an API key or an Entra ID.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "entra_id": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "Entra ID",
+                                    "order": 2,
+                                    "required": false,
+                                    "sensitive": true,
+                                    "tooltip": "You must provide either an API key or an Entra ID.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "rate_limit.requests_per_minute": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "numeric",
+                                    "label": "Rate Limit",
+                                    "order": 6,
+                                    "required": false,
+                                    "sensitive": false,
+                                    "tooltip": "The azureopenai service sets a default number of requests allowed per minute depending on the task type.",
+                                    "type": "int",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "deployment_id": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "Deployment ID",
+                                    "order": 5,
+                                    "required": true,
+                                    "sensitive": false,
+                                    "tooltip": "The deployment name of your deployed models.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "resource_name": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "Resource Name",
+                                    "order": 3,
+                                    "required": true,
+                                    "sensitive": false,
+                                    "tooltip": "The name of your Azure OpenAI resource.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "api_version": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "API Version",
+                                    "order": 4,
+                                    "required": true,
+                                    "sensitive": false,
+                                    "tooltip": "The Azure API version ID to use.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                }
+                            }
+                        }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
+        }
     }
 
     public void testSupportsStreaming() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -14,12 +14,16 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -30,6 +34,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingByteResults;
@@ -59,6 +64,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -1578,6 +1585,165 @@ public class CohereServiceTests extends ESTestCase {
             .hasNoEvents()
             .hasErrorWithStatusCode(500)
             .hasErrorContaining("how dare you");
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = createCohereService()) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                            "provider": "cohere",
+                            "task_types": [
+                                 {
+                                     "task_type": "text_embedding",
+                                     "configuration": {
+                                         "truncate": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "dropdown",
+                                             "label": "Truncate",
+                                             "options": [
+                                                 {
+                                                     "label": "NONE",
+                                                     "value": "NONE"
+                                                 },
+                                                 {
+                                                     "label": "START",
+                                                     "value": "START"
+                                                 },
+                                                 {
+                                                     "label": "END",
+                                                     "value": "END"
+                                                 }
+                                             ],
+                                             "order": 2,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specifies how the API handles inputs longer than the maximum token length.",
+                                             "type": "str",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": ""
+                                         },
+                                         "input_type": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "dropdown",
+                                             "label": "Input Type",
+                                             "options": [
+                                                 {
+                                                     "label": "classification",
+                                                     "value": "classification"
+                                                 },
+                                                 {
+                                                     "label": "clusterning",
+                                                     "value": "clusterning"
+                                                 },
+                                                 {
+                                                     "label": "ingest",
+                                                     "value": "ingest"
+                                                 },
+                                                 {
+                                                     "label": "search",
+                                                     "value": "search"
+                                                 }
+                                             ],
+                                             "order": 1,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specifies the type of input passed to the model.",
+                                             "type": "str",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": ""
+                                         }
+                                     }
+                                 },
+                                 {
+                                     "task_type": "rerank",
+                                     "configuration": {
+                                         "top_n": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "numeric",
+                                             "label": "Top N",
+                                             "order": 2,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "The number of most relevant documents to return, defaults to the number of the documents.",
+                                             "type": "int",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": null
+                                         },
+                                         "return_documents": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "toggle",
+                                             "label": "Return Documents",
+                                             "order": 1,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specify whether to return doc text within the results.",
+                                             "type": "bool",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": false
+                                         }
+                                     }
+                                 },
+                                 {
+                                     "task_type": "completion",
+                                     "configuration": {}
+                                 }
+                            ],
+                            "configuration": {
+                                "api_key": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "API Key",
+                                    "order": 1,
+                                    "required": true,
+                                    "sensitive": true,
+                                    "tooltip": "API Key for the provider you're connecting to.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "rate_limit.requests_per_minute": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "numeric",
+                                    "label": "Rate Limit",
+                                    "order": 6,
+                                    "required": false,
+                                    "sensitive": false,
+                                    "tooltip": "Minimize the number of rate limit errors.",
+                                    "type": "int",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                }
+                            }
+                        }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
+        }
     }
 
     public void testSupportsStreaming() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -11,12 +11,16 @@ import org.apache.http.HttpHeaders;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.EmptySecretSettings;
 import org.elasticsearch.inference.EmptyTaskSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -25,6 +29,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedSparseEmbeddingResults;
@@ -48,6 +53,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getModelListenerForException;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
@@ -484,6 +491,78 @@ public class ElasticInferenceServiceTests extends ESTestCase {
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             assertThat(requestMap, is(Map.of("input", List.of("input text"))));
+        }
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createServiceWithMockSender()) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "elastic",
+                       "task_types": [
+                            {
+                                "task_type": "sparse_embedding",
+                                "configuration": {}
+                            }
+                       ],
+                       "configuration": {
+                           "rate_limit.requests_per_minute": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Rate Limit",
+                               "order": 6,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Minimize the number of rate limit errors.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "model_id": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "Model ID",
+                               "order": 2,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The name of the model to use for the inference task.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "max_input_tokens": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Maximum Input Tokens",
+                               "order": 3,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Allows you to specify the maximum number of tokens per input.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -15,9 +15,12 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
@@ -25,6 +28,7 @@ import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.EmptyTaskSettings;
 import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -34,6 +38,8 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ErrorChunkedInferenceResults;
@@ -76,6 +82,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86;
@@ -1449,6 +1457,123 @@ public class ElasticsearchInternalServiceTests extends ESTestCase {
         assertTrue(service.isDefaultId(".elser-2-elasticsearch"));
         assertTrue(service.isDefaultId(".multilingual-e5-small-elasticsearch"));
         assertFalse(service.isDefaultId("foo"));
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createService(mock(Client.class))) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "elasticsearch",
+                       "task_types": [
+                            {
+                                "task_type": "text_embedding",
+                                "configuration": {}
+                            },
+                            {
+                                "task_type": "sparse_embedding",
+                                "configuration": {}
+                            },
+                            {
+                                "task_type": "rerank",
+                                "configuration": {
+                                    "return_documents": {
+                                        "default_value": null,
+                                        "depends_on": [],
+                                        "display": "toggle",
+                                        "label": "Return Documents",
+                                        "order": 1,
+                                        "required": false,
+                                        "sensitive": false,
+                                        "tooltip": "Returns the document instead of only the index.",
+                                        "type": "bool",
+                                        "ui_restrictions": [],
+                                        "validations": [],
+                                        "value": true
+                                    }
+                                }
+                            }
+                       ],
+                       "configuration": {
+                           "num_allocations": {
+                               "default_value": 1,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Number Allocations",
+                               "order": 2,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The total number of allocations this model is assigned across machine learning nodes.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "num_threads": {
+                               "default_value": 2,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Number Threads",
+                               "order": 3,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "Sets the number of threads used by each model allocation during inference.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "model_id": {
+                               "default_value": ".multilingual-e5-small",
+                               "depends_on": [],
+                               "display": "dropdown",
+                               "label": "Model ID",
+                               "options": [
+                                   {
+                                       "label": ".elser_model_1",
+                                       "value": ".elser_model_1"
+                                   },
+                                   {
+                                       "label": ".elser_model_2",
+                                       "value": ".elser_model_2"
+                                   },
+                                   {
+                                       "label": ".elser_model_2_linux-x86_64",
+                                       "value": ".elser_model_2_linux-x86_64"
+                                   },
+                                   {
+                                       "label": ".multilingual-e5-small",
+                                       "value": ".multilingual-e5-small"
+                                   },
+                                   {
+                                       "label": ".multilingual-e5-small_linux-x86_64",
+                                       "value": ".multilingual-e5-small_linux-x86_64"
+                                   }
+                               ],
+                               "order": 1,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The name of the model to use for the inference task.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
+        }
     }
 
     private ElasticsearchInternalService createService(Client client) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
@@ -12,13 +12,17 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
 import org.elasticsearch.inference.EmptyTaskSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -29,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
@@ -56,6 +61,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -1118,6 +1125,82 @@ public class GoogleAiStudioServiceTests extends ESTestCase {
             SimilarityMeasure expectedSimilarityMeasure = similarityMeasure == null ? SimilarityMeasure.DOT_PRODUCT : similarityMeasure;
             assertEquals(expectedSimilarityMeasure, updatedModel.getServiceSettings().similarity());
             assertEquals(embeddingSize, updatedModel.getServiceSettings().dimensions().intValue());
+        }
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createGoogleAiStudioService()) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "googleaistudio",
+                       "task_types": [
+                            {
+                                "task_type": "text_embedding",
+                                "configuration": {}
+                            },
+                            {
+                                "task_type": "completion",
+                                "configuration": {}
+                            }
+                       ],
+                       "configuration": {
+                           "api_key": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "API Key",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": true,
+                               "tooltip": "API Key for the provider you're connecting to.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "rate_limit.requests_per_minute": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Rate Limit",
+                               "order": 6,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Minimize the number of rate limit errors.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "model_id": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "Model ID",
+                               "order": 2,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "ID of the LLM you're using.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
@@ -9,14 +9,20 @@ package org.elasticsearch.xpack.inference.services.googlevertexai;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
@@ -35,6 +41,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
@@ -818,6 +826,143 @@ public class GoogleVertexAiServiceTests extends ESTestCase {
     }
 
     // testInfer tested via end-to-end notebook tests in AppEx repo
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = createGoogleVertexAiService()) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                           "provider": "googlevertexai",
+                           "task_types": [
+                                {
+                                    "task_type": "text_embedding",
+                                    "configuration": {
+                                        "auto_truncate": {
+                                            "default_value": null,
+                                            "depends_on": [],
+                                            "display": "toggle",
+                                            "label": "Auto Truncate",
+                                            "order": 1,
+                                            "required": false,
+                                            "sensitive": false,
+                                            "tooltip": "Specifies if the API truncates inputs longer than the maximum token length automatically.",
+                                            "type": "bool",
+                                            "ui_restrictions": [],
+                                            "validations": [],
+                                            "value": false
+                                        }
+                                    }
+                                },
+                                {
+                                    "task_type": "rerank",
+                                    "configuration": {
+                                        "top_n": {
+                                            "default_value": null,
+                                            "depends_on": [],
+                                            "display": "toggle",
+                                            "label": "Top N",
+                                            "order": 1,
+                                            "required": false,
+                                            "sensitive": false,
+                                            "tooltip": "Specifies the number of the top n documents, which should be returned.",
+                                            "type": "bool",
+                                            "ui_restrictions": [],
+                                            "validations": [],
+                                            "value": false
+                                        }
+                                    }
+                                }
+                           ],
+                           "configuration": {
+                               "service_account_json": {
+                                   "default_value": null,
+                                   "depends_on": [],
+                                   "display": "textbox",
+                                   "label": "Credentials JSON",
+                                   "order": 1,
+                                   "required": true,
+                                   "sensitive": true,
+                                   "tooltip": "API Key for the provider you're connecting to.",
+                                   "type": "str",
+                                   "ui_restrictions": [],
+                                   "validations": [],
+                                   "value": null
+                               },
+                               "project_id": {
+                                   "default_value": null,
+                                   "depends_on": [],
+                                   "display": "textbox",
+                                   "label": "GCP Project",
+                                   "order": 4,
+                                   "required": true,
+                                   "sensitive": false,
+                                   "tooltip": "The GCP Project ID which has Vertex AI API(s) enabled. For more information on the URL, refer to the {geminiVertexAIDocs}.",
+                                   "type": "str",
+                                   "ui_restrictions": [],
+                                   "validations": [],
+                                   "value": null
+                               },
+                               "location": {
+                                   "default_value": null,
+                                   "depends_on": [],
+                                   "display": "textbox",
+                                   "label": "GCP Region",
+                                   "order": 3,
+                                   "required": true,
+                                   "sensitive": false,
+                                   "tooltip": "Please provide the GCP region where the Vertex AI API(s) is enabled. For more information, refer to the {geminiVertexAIDocs}.",
+                                   "type": "str",
+                                   "ui_restrictions": [],
+                                   "validations": [],
+                                   "value": null
+                               },
+                               "rate_limit.requests_per_minute": {
+                                   "default_value": null,
+                                   "depends_on": [],
+                                   "display": "numeric",
+                                   "label": "Rate Limit",
+                                   "order": 6,
+                                   "required": false,
+                                   "sensitive": false,
+                                   "tooltip": "Minimize the number of rate limit errors.",
+                                   "type": "int",
+                                   "ui_restrictions": [],
+                                   "validations": [],
+                                   "value": null
+                               },
+                               "model_id": {
+                                   "default_value": null,
+                                   "depends_on": [],
+                                   "display": "textbox",
+                                   "label": "Model ID",
+                                   "order": 2,
+                                   "required": true,
+                                   "sensitive": false,
+                                   "tooltip": "ID of the LLM you're using.",
+                                   "type": "str",
+                                   "ui_restrictions": [],
+                                   "validations": [],
+                                   "value": null
+                               }
+                           }
+                       }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
+        }
+    }
 
     private GoogleVertexAiService createGoogleVertexAiService() {
         return new GoogleVertexAiService(mock(HttpRequestSender.Factory.class), createWithEmptySettings(threadPool));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceElserServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceElserServiceTests.java
@@ -9,15 +9,20 @@ package org.elasticsearch.xpack.inference.services.huggingface;
 
 import org.apache.http.HttpHeaders;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedSparseEmbeddingResults;
@@ -38,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
@@ -120,6 +127,83 @@ public class HuggingFaceElserServiceTests extends ESTestCase {
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             assertThat(requestMap.size(), Matchers.is(1));
             assertThat(requestMap.get("inputs"), Matchers.is(List.of("abc")));
+        }
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (
+            var service = new HuggingFaceElserService(
+                HttpRequestSenderTests.createSenderFactory(threadPool, clientManager),
+                createWithEmptySettings(threadPool)
+            )
+        ) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "hugging_face_elser",
+                       "task_types": [
+                            {
+                                "task_type": "sparse_embedding",
+                                "configuration": {}
+                            }
+                       ],
+                       "configuration": {
+                           "api_key": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "API Key",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": true,
+                               "tooltip": "API Key for the provider you're connecting to.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "rate_limit.requests_per_minute": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Rate Limit",
+                               "order": 6,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Minimize the number of rate limit errors.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "url": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "URL",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The URL endpoint to use for the requests.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -13,11 +13,15 @@ import org.apache.http.HttpHeaders;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -28,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -53,6 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResultsTests.asMapWithListsInsteadOfArrays;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -855,6 +862,82 @@ public class HuggingFaceServiceTests extends ESTestCase {
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             assertThat(requestMap.size(), Matchers.is(1));
             assertThat(requestMap.get("inputs"), Matchers.is(List.of("abc")));
+        }
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createHuggingFaceService()) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "hugging_face",
+                       "task_types": [
+                            {
+                                "task_type": "text_embedding",
+                                "configuration": {}
+                            },
+                            {
+                                "task_type": "sparse_embedding",
+                                "configuration": {}
+                            }
+                       ],
+                       "configuration": {
+                           "api_key": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "API Key",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": true,
+                               "tooltip": "API Key for the provider you're connecting to.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "rate_limit.requests_per_minute": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Rate Limit",
+                               "order": 6,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Minimize the number of rate limit errors.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "url": {
+                               "default_value": "https://api.openai.com/v1/embeddings",
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "URL",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The URL endpoint to use for the requests.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": "https://api.openai.com/v1/embeddings"
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -13,11 +13,15 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.EmptyTaskSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -28,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -58,6 +63,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -760,6 +767,106 @@ public class IbmWatsonxServiceTests extends ESTestCase {
                         SimilarityMeasure.COSINE
                     )
                 )
+            );
+        }
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createIbmWatsonxService()) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "watsonxai",
+                       "task_types": [
+                            {
+                                "task_type": "text_embedding",
+                                "configuration": {}
+                            }
+                       ],
+                       "configuration": {
+                           "project_id": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "Project ID",
+                               "order": 2,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "model_id": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "Model ID",
+                               "order": 3,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The name of the model to use for the inference task.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "api_version": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "API Version",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "The IBM Watsonx API version ID to use.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "max_input_tokens": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Maximum Input Tokens",
+                               "order": 5,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Allows you to specify the maximum number of tokens per input.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "url": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "URL",
+                               "order": 4,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
             );
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
@@ -12,12 +12,16 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -28,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -54,6 +59,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
@@ -735,6 +742,92 @@ public class MistralServiceTests extends ESTestCase {
             assertThat(error.getMessage(), containsString("Received an authentication error status code for request"));
             assertThat(error.getMessage(), containsString("Error message: [Incorrect API key provided:]"));
             assertThat(webServer.requests(), hasSize(1));
+        }
+    }
+
+    public void testGetConfiguration() throws Exception {
+        try (var service = createService()) {
+            String content = XContentHelper.stripWhitespace("""
+                {
+                       "provider": "mistral",
+                       "task_types": [
+                            {
+                                "task_type": "text_embedding",
+                                "configuration": {}
+                            }
+                       ],
+                       "configuration": {
+                           "api_key": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "API Key",
+                               "order": 1,
+                               "required": true,
+                               "sensitive": true,
+                               "tooltip": "API Key for the provider you're connecting to.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "model": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "textbox",
+                               "label": "Model",
+                               "order": 2,
+                               "required": true,
+                               "sensitive": false,
+                               "tooltip": "Refer to the Mistral models documentation for the list of available text embedding models.",
+                               "type": "str",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "rate_limit.requests_per_minute": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Rate Limit",
+                               "order": 6,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Minimize the number of rate limit errors.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           },
+                           "max_input_tokens": {
+                               "default_value": null,
+                               "depends_on": [],
+                               "display": "numeric",
+                               "label": "Maximum Input Tokens",
+                               "order": 3,
+                               "required": false,
+                               "sensitive": false,
+                               "tooltip": "Allows you to specify the maximum number of tokens per input.",
+                               "type": "int",
+                               "ui_restrictions": [],
+                               "validations": [],
+                               "value": null
+                           }
+                       }
+                   }
+                """);
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -14,11 +14,15 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
@@ -28,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.InferenceChunkedTextEmbeddingFloatResults;
@@ -56,6 +61,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.getRequestConfigMap;
@@ -1583,6 +1590,143 @@ public class OpenAiServiceTests extends ESTestCase {
             assertThat(requestMap.get("input"), Matchers.is(List.of("foo", "bar")));
             assertThat(requestMap.get("model"), Matchers.is("model"));
             assertThat(requestMap.get("user"), Matchers.is("user"));
+        }
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    public void testGetConfiguration() throws Exception {
+        try (var service = createOpenAiService()) {
+            String content = XContentHelper.stripWhitespace(
+                """
+                    {
+                            "provider": "openai",
+                            "task_types": [
+                                 {
+                                     "task_type": "text_embedding",
+                                     "configuration": {
+                                         "user": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "textbox",
+                                             "label": "User",
+                                             "order": 1,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specifies the user issuing the request.",
+                                             "type": "str",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": ""
+                                         }
+                                     }
+                                 },
+                                 {
+                                     "task_type": "completion",
+                                     "configuration": {
+                                         "user": {
+                                             "default_value": null,
+                                             "depends_on": [],
+                                             "display": "textbox",
+                                             "label": "User",
+                                             "order": 1,
+                                             "required": false,
+                                             "sensitive": false,
+                                             "tooltip": "Specifies the user issuing the request.",
+                                             "type": "str",
+                                             "ui_restrictions": [],
+                                             "validations": [],
+                                             "value": ""
+                                         }
+                                     }
+                                 }
+                            ],
+                            "configuration": {
+                                "api_key": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "API Key",
+                                    "order": 1,
+                                    "required": true,
+                                    "sensitive": true,
+                                    "tooltip": "The OpenAI API authentication key. For more details about generating OpenAI API keys, refer to the https://platform.openai.com/account/api-keys.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "organization_id": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "Organization ID",
+                                    "order": 3,
+                                    "required": false,
+                                    "sensitive": false,
+                                    "tooltip": "The unique identifier of your organization.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "rate_limit.requests_per_minute": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "numeric",
+                                    "label": "Rate Limit",
+                                    "order": 6,
+                                    "required": false,
+                                    "sensitive": false,
+                                    "tooltip": "Default number of requests allowed per minute. For text_embedding is 3000. For completion is 500.",
+                                    "type": "int",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "model_id": {
+                                    "default_value": null,
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "Model ID",
+                                    "order": 2,
+                                    "required": true,
+                                    "sensitive": false,
+                                    "tooltip": "The name of the model to use for the inference task.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                },
+                                "url": {
+                                    "default_value": "https://api.openai.com/v1/chat/completions",
+                                    "depends_on": [],
+                                    "display": "textbox",
+                                    "label": "URL",
+                                    "order": 4,
+                                    "required": true,
+                                    "sensitive": false,
+                                    "tooltip": "The OpenAI API endpoint URL. For more information on the URL, refer to the https://platform.openai.com/docs/api-reference.",
+                                    "type": "str",
+                                    "ui_restrictions": [],
+                                    "validations": [],
+                                    "value": null
+                                }
+                            }
+                        }
+                    """
+            );
+            InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
+                new BytesArray(content),
+                XContentType.JSON
+            );
+            boolean humanReadable = true;
+            BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+            InferenceServiceConfiguration serviceConfiguration = service.getConfiguration();
+            assertToXContentEquivalent(
+                originalBytes,
+                toXContent(serviceConfiguration, XContentType.JSON, humanReadable),
+                XContentType.JSON
+            );
         }
     }
 

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -384,6 +384,7 @@ public class Constants {
         "cluster:monitor/xpack/inference",
         "cluster:monitor/xpack/inference/get",
         "cluster:monitor/xpack/inference/diagnostics/get",
+        "cluster:monitor/xpack/inference/services/get",
         "cluster:monitor/xpack/info",
         "cluster:monitor/xpack/info/aggregate_metric",
         "cluster:monitor/xpack/info/analytics",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Inference API] Add API to get configuration of inference services  (#114862)](https://github.com/elastic/elasticsearch/pull/114862)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)