### PR TITLE
ES|QL: Mute test for #116003

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TelemetryIT.java
@@ -128,20 +128,22 @@ public class TelemetryIT extends AbstractEsqlIntegTestCase {
                         : Collections.emptyMap(),
                     Build.current().isSnapshot() ? Map.ofEntries(Map.entry("MAX", 1)) : Collections.emptyMap(),
                     Build.current().isSnapshot()
-                ) },
-            new Object[] {
-                new Test(
-                    """
-                        FROM idx
-                        | EVAL ip = to_ip(host), x = to_string(host), y = to_string(host)
-                        | INLINESTATS max(id)
-                        """,
-                    Build.current().isSnapshot() ? Map.of("FROM", 1, "EVAL", 1, "INLINESTATS", 1, "STATS", 1) : Collections.emptyMap(),
-                    Build.current().isSnapshot()
-                        ? Map.ofEntries(Map.entry("MAX", 1), Map.entry("TO_IP", 1), Map.entry("TO_STRING", 2))
-                        : Collections.emptyMap(),
-                    Build.current().isSnapshot()
                 ) }
+            // awaits fix for https://github.com/elastic/elasticsearch/issues/116003
+            // ,
+            // new Object[] {
+            // new Test(
+            // """
+            // FROM idx
+            // | EVAL ip = to_ip(host), x = to_string(host), y = to_string(host)
+            // | INLINESTATS max(id)
+            // """,
+            // Build.current().isSnapshot() ? Map.of("FROM", 1, "EVAL", 1, "INLINESTATS", 1, "STATS", 1) : Collections.emptyMap(),
+            // Build.current().isSnapshot()
+            // ? Map.ofEntries(Map.entry("MAX", 1), Map.entry("TO_IP", 1), Map.entry("TO_STRING", 2))
+            // : Collections.emptyMap(),
+            // Build.current().isSnapshot()
+            // ) }
         );
     }
 


### PR DESCRIPTION
Muting test for #116003.

Apparently there are planning errors for

```
FROM idx
| EVAL ip = to_ip(host), x = to_string(host), y = to_string(host)
| INLINESTATS max(id)
```

```
java.lang.IllegalStateException: can't find input for [max(id){r}#464]
```