### PR TITLE
Adds hands-on learning for Search link to the landing page

### DIFF
--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -80,6 +80,10 @@
 <h3 class="gtk">Get to know Elasticsearch</h3>
 
 <p>
+  <a href="https://www.elastic.co/demo-gallery?solutions=search&features=null&type=hands-on-learning">Hands-on learning for Search</a>
+</p>
+
+<p>
   <em>New webinar:</em>
   <a href="https://www.elastic.co/virtual-events/architecting-search-apps-on-google-cloud">Architect search apps with Google Cloud</a>
 </p>

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -80,6 +80,7 @@
 <h3 class="gtk">Get to know Elasticsearch</h3>
 
 <p>
+<em>Demos:</em>
   <a href="https://www.elastic.co/demo-gallery?solutions=search&features=null&type=hands-on-learning">Hands-on learning for Search</a>
 </p>
 


### PR DESCRIPTION
## Overview

This PR adds a link to the ES guide landing page that points to the Search hands-on learning labs.