### PR TITLE
Remove support for legacy OAuth tokens

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -758,13 +758,6 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
         assertAuthenticateWithToken(response.accessToken(), TEST_USER_NAME);
         // Now attempt to authenticate with an invalid access token string
         assertUnauthorizedToken(randomAlphaOfLengthBetween(0, 128));
-        // Now attempt to authenticate with an invalid access token with valid structure (pre 7.2)
-        assertUnauthorizedToken(
-            tokenService.prependVersionAndEncodeAccessToken(
-                TransportVersions.V_7_1_0,
-                tokenService.getRandomTokenBytes(TransportVersions.V_7_1_0, randomBoolean()).v1()
-            )
-        );
         // Now attempt to authenticate with an invalid access token with valid structure (after 7.2 pre 8.10)
         assertUnauthorizedToken(
             tokenService.prependVersionAndEncodeAccessToken(


### PR DESCRIPTION
Dropping legacy token support that were generated in versions before 7.2.

---
TODO

- [ ] Tests
- [ ] Better error handling and messages
- [ ] Cleanup encryption keys from the cluster state