### PR TITLE
Remove duplicate 'the the'

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesPlugin.java
@@ -39,7 +39,7 @@ import static org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME;
  *   }
  * }
  * </pre>
- * Will copy the entire core Rest API specifications (assuming the project has tests) and any of the the X-pack specs starting with enrich*.
+ * Will copy the entire core Rest API specifications (assuming the project has tests) and any of the X-pack specs starting with enrich*.
  * It is recommended (but not required) to also explicitly declare which core specs your project depends on to help optimize the caching
  * behavior.
  * <i>For example:</i>
@@ -66,7 +66,7 @@ import static org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME;
  *   }
  * }
  * </pre>
- * Will copy any of the the x-pack tests that start with graph, and will copy the X-pack graph specification, as well as the full core
+ * Will copy any of the x-pack tests that start with graph, and will copy the X-pack graph specification, as well as the full core
  * Rest API specification.
  * <p>
  * Additionally you can specify which sourceSetName resources should be copied to. The default is the yamlRestTest source set.

--- a/docs/reference/connector/docs/connectors-hosted-tutorial-mongo.asciidoc
+++ b/docs/reference/connector/docs/connectors-hosted-tutorial-mongo.asciidoc
@@ -90,7 +90,7 @@ Find this by https://www.mongodb.com/docs/atlas/tutorial/connect-to-your-cluster
 In this example, we'll use the `sample_mflix` database.
 * *Collection*: The name of the collection you want to sync.
 In this example, we'll use the `comments` collection of the `sample_mflix` database.
-* *Username*: The username you created earlier, in the the setup phase.
+* *Username*: The username you created earlier, in the setup phase.
 * *Password*: The password you created earlier.
 
 Keep these details handy!

--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -46,7 +46,7 @@ supports this parameter for CSV responses.
 `drop_null_columns`::
 (Optional, boolean) Should columns that are entirely `null` be removed from
 the `columns` and `values` portion of the results? Defaults to `false`. If
-`true` the the response will include an extra section under the name
+`true` the response will include an extra section under the name
 `all_columns` which has the name of all columns.
 
 `format`::

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -209,7 +209,7 @@ value.
 (string) Reserved for future use, currently set to `anomaly_detector`.
 
 `job_version`::
-(string) The {ml} configuration version number at which the the job was created.
+(string) The {ml} configuration version number at which the job was created.
 
 NOTE: From {es} 8.10.0,  a new version number is used to
 track the configuration and state changes in the {ml} plugin. This new

--- a/docs/reference/reranking/learning-to-rank-model-training.asciidoc
+++ b/docs/reference/reranking/learning-to-rank-model-training.asciidoc
@@ -43,7 +43,7 @@ feature_extractors=[
         feature_name="title_bm25",
         query={"match": {"title": "{{query}}"}}
     ),
-    # We want to use the the number of matched terms in the title field as a feature:
+    # We want to use the number of matched terms in the title field as a feature:
     QueryFeatureExtractor(
         feature_name="title_matched_term_count",
         query={

--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -192,7 +192,7 @@ When the above `dictionary` parameter is specified, the <<search-application-sea
 * It verifies that `query_string` and `default_field` are both strings
 * It accepts `default_field` only if it takes the values `title` or `description`
 
-If the parameters are not valid, the the <<search-application-search, search application search>> API will return an error.
+If the parameters are not valid, the <<search-application-search, search application search>> API will return an error.
 [source,console]
 ----
 POST _application/search_application/my-app/_search

--- a/docs/reference/security/securing-communications/security-minimal-setup.asciidoc
+++ b/docs/reference/security/securing-communications/security-minimal-setup.asciidoc
@@ -78,7 +78,7 @@ This command resets the password to an auto-generated value.
 ./bin/elasticsearch-reset-password -u elastic
 ----
 +
-If you want to set the password to a specific value, run the command with the 
+If you want to set the password to a specific value, run the command with the
 interactive (`-i`) parameter.
 +
 [source,shell]
@@ -93,7 +93,7 @@ interactive (`-i`) parameter.
 ./bin/elasticsearch-reset-password -u kibana_system
 ----
 
-. Save the new passwords. In the next step, you'll add the the password for the
+. Save the new passwords. In the next step, you'll add the password for the
 `kibana_system` user to {kib}.
 
 *Next*: <<add-built-in-users,Configure {kib} to connect to {es} with a password>>

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/support/AbstractXContentParser.java
@@ -370,7 +370,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         }
     }
 
-    // read a list without bounds checks, assuming the the current parser is always on an array start
+    // read a list without bounds checks, assuming the current parser is always on an array start
     private static List<Object> readListUnsafe(XContentParser parser, Supplier<Map<String, Object>> mapFactory) throws IOException {
         assert parser.currentToken() == Token.START_ARRAY;
         ArrayList<Object> list = new ArrayList<>();

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -335,7 +335,7 @@ class S3Service implements Closeable {
      * Customizes {@link com.amazonaws.auth.WebIdentityTokenCredentialsProvider}
      *
      * <ul>
-     * <li>Reads the the location of the web identity token not from AWS_WEB_IDENTITY_TOKEN_FILE, but from a symlink
+     * <li>Reads the location of the web identity token not from AWS_WEB_IDENTITY_TOKEN_FILE, but from a symlink
      * in the plugin directory, so we don't need to create a hardcoded read file permission for the plugin.</li>
      * <li>Supports customization of the STS endpoint via a system property, so we can test it against a test fixture.</li>
      * <li>Supports gracefully shutting down the provider and the STS client.</li>

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -373,7 +373,7 @@ public class FileUtils {
     }
 
     /**
-     * Recursively copy the the source directory to the target directory, preserving permissions.
+     * Recursively copy the source directory to the target directory, preserving permissions.
      */
     public static void copyDirectory(Path source, Path target) throws IOException {
         Files.walkFileTree(source, new SimpleFileVisitor<>() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
@@ -70,7 +70,7 @@ public class SystemIndexMappingUpdateServiceIT extends ESIntegTestCase {
     }
 
     /**
-     * Check that if the the SystemIndexManager finds a managed index with mappings that claim to be newer than
+     * Check that if the SystemIndexManager finds a managed index with mappings that claim to be newer than
      * what it expects, then those mappings are left alone.
      */
     public void testSystemIndexManagerLeavesNewerMappingsAlone() throws Exception {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -2402,7 +2402,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
                 assert previousIndicesLookup.equals(buildIndicesLookup(dataStreamMetadata(), indicesMap));
                 indicesLookup = previousIndicesLookup;
             } else if (skipNameCollisionChecks == false) {
-                // we have changes to the the entity names so we ensure we have no naming collisions
+                // we have changes to the entity names so we ensure we have no naming collisions
                 ensureNoNameCollisions(aliasedIndices.keySet(), indicesMap, dataStreamMetadata());
             }
             assert assertDataStreams(indicesMap, dataStreamMetadata());

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -242,7 +242,7 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
         if (prefix.isEmpty()) {
             return this;
         }
-        // create the the next prefix right after the given prefix, and use it as exclusive upper bound for the sub-map to filter by prefix
+        // create the next prefix right after the given prefix, and use it as exclusive upper bound for the sub-map to filter by prefix
         // below
         char[] toPrefixCharArr = prefix.toCharArray();
         toPrefixCharArr[toPrefixCharArr.length - 1]++;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -954,7 +954,7 @@ public class RecoverySourceHandler {
 
     void createRetentionLease(final long startingSeqNo, ActionListener<RetentionLease> listener) {
         updateRetentionLease(syncListener -> {
-            // Clone the peer recovery retention lease belonging to the source shard. We are retaining history between the the local
+            // Clone the peer recovery retention lease belonging to the source shard. We are retaining history between the local
             // checkpoint of the safe commit we're creating and this lease's retained seqno with the retention lock, and by cloning an
             // existing lease we (approximately) know that all our peers are also retaining history as requested by the cloned lease. If
             // the recovery now fails before copying enough history over then a subsequent attempt will find this lease, determine it is

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -435,7 +435,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     /**
      * Flag that is set to {@code true} if this instance is started with {@link #metadata} that has a higher value for
      * {@link RepositoryMetadata#pendingGeneration()} than for {@link RepositoryMetadata#generation()} indicating a full cluster restart
-     * potentially accounting for the the last {@code index-N} write in the cluster state.
+     * potentially accounting for the last {@code index-N} write in the cluster state.
      * Note: While it is true that this value could also be set to {@code true} for an instance on a node that is just joining the cluster
      * during a new {@code index-N} write, this does not present a problem. The node will still load the correct {@link RepositoryData} in
      * all cases and simply do a redundant listing of the repository contents if it tries to load {@link RepositoryData} and falls back

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChunkedBlobOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChunkedBlobOutputStream.java
@@ -128,7 +128,7 @@ public abstract class ChunkedBlobOutputStream<T> extends OutputStream {
     }
 
     /**
-     * Write the contents of {@link #buffer} to storage. Implementations should call {@link #finishPart} at the end to track the the chunk
+     * Write the contents of {@link #buffer} to storage. Implementations should call {@link #finishPart} at the end to track the chunk
      * of data just written and ready {@link #buffer} for the next write.
      */
     protected abstract void flushBuffer() throws IOException;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterByFilterAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterByFilterAggregator.java
@@ -132,7 +132,7 @@ public class FilterByFilterAggregator extends FiltersAggregator {
         }
 
         /**
-         * Build the the adapter or {@code null} if the this isn't a valid rewrite.
+         * Build the adapter or {@code null} if this isn't a valid rewrite.
          */
         public final T build() throws IOException {
             if (false == valid || aggCtx.enableRewriteToFilterByFilter() == false) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -123,7 +123,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
 
     /**
      * Whether the aggregation will execute. If the main query matches no documents and parent aggregation isn't a global or terms
-     * aggregation with min_doc_count = 0, the the aggregator will not really execute. In those cases it doesn't make sense to load
+     * aggregation with min_doc_count = 0, the aggregator will not really execute. In those cases it doesn't make sense to load
      * global ordinals.
      * <p>
      * Some searches that will never match can still fall through and we endup running query that will produce no results.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -556,7 +556,7 @@ public abstract class AggregationContext implements Releasable {
             // Removing an aggregator is done after calling Aggregator#buildTopLevel which happens on an executor thread.
             // We need to synchronize the removal because he AggregatorContext it is shared between executor threads.
             assert releaseMe.contains(aggregator)
-                : "removing non-existing aggregator [" + aggregator.name() + "] from the the aggregation context";
+                : "removing non-existing aggregator [" + aggregator.name() + "] from the aggregation context";
             releaseMe.remove(aggregator);
         }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/package-info.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/package-info.java
@@ -113,7 +113,7 @@
  *     snapshots, we load the {@link org.elasticsearch.snapshots.SnapshotInfo} for the source snapshot and check for shard snapshot
  *     failures of the relevant indices.</li>
  *     <li>Once all shard counts are known and the health of all source indices data has been verified, we populate the
- *     {@code SnapshotsInProgress.Entry#clones} map for the clone operation with the the relevant shard clone tasks.</li>
+ *     {@code SnapshotsInProgress.Entry#clones} map for the clone operation with the relevant shard clone tasks.</li>
  *     <li>After the clone tasks have been added to the {@code SnapshotsInProgress.Entry}, master executes them on its snapshot thread-pool
  *     by invoking {@link org.elasticsearch.repositories.Repository#cloneShardSnapshot} for each shard that is to be cloned. Each completed
  *     shard snapshot triggers a call to the {@link org.elasticsearch.snapshots.SnapshotsService#masterServiceTaskQueue} which updates the

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class NodeInfoTests extends ESTestCase {
 
     /**
-     * Check that the the {@link NodeInfo#getInfo(Class)} method returns null
+     * Check that the {@link NodeInfo#getInfo(Class)} method returns null
      * for absent info objects, and returns the right thing for present info
      * objects.
      */

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinReasonServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinReasonServiceTests.java
@@ -144,7 +144,7 @@ public class JoinReasonServiceTests extends ESTestCase {
             discoveryNodes[i] = randomDiscoveryNode();
         }
 
-        // we stop tracking the the oldest absent node(s) when only 1/3 of the tracked nodes are present
+        // we stop tracking the oldest absent node(s) when only 1/3 of the tracked nodes are present
         final int cleanupNodeCount = (discoveryNodes.length - 2) / 3;
 
         final DiscoveryNodes.Builder cleanupNodesBuilder = new DiscoveryNodes.Builder().add(masterNode)

--- a/server/src/test/java/org/elasticsearch/common/LocalTimeOffsetTests.java
+++ b/server/src/test/java/org/elasticsearch/common/LocalTimeOffsetTests.java
@@ -275,7 +275,7 @@ public class LocalTimeOffsetTests extends ESTestCase {
     }
 
     /**
-     * The the last "fully defined" transitions in the provided {@linkplain ZoneId}.
+     * The last "fully defined" transitions in the provided {@linkplain ZoneId}.
      */
     private static ZoneOffsetTransition lastTransitionIn(ZoneId zone) {
         List<ZoneOffsetTransition> transitions = zone.getRules().getTransitions();

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -747,7 +747,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
 
             // make sure used bytes is greater than the total circuit breaker limit
             breaker.addWithoutBreaking(200);
-            // make sure that we check on the the following call
+            // make sure that we check on the following call
             for (int i = 0; i < 1023; i++) {
                 multiBucketConsumer.accept(0);
             }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractNXYSignificanceHeuristicTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractNXYSignificanceHeuristicTestCase.java
@@ -27,7 +27,7 @@ public abstract class AbstractNXYSignificanceHeuristicTestCase extends AbstractS
     /**
      * @param includeNegatives value for this test run, should the scores include negative values.
      * @param backgroundIsSuperset value for this test run, indicates in NXY significant terms if the background is indeed
-     *                             a superset of the the subset, or is instead a disjoint set
+     *                             a superset of the subset, or is instead a disjoint set
      * @return  A random instance of an NXY heuristic to test
      */
     protected abstract SignificanceHeuristic getHeuristic(boolean includeNegatives, boolean backgroundIsSuperset);

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -64,7 +64,7 @@ public class BlobCacheMetrics {
             ),
             meterRegistry.registerDoubleHistogram(
                 "es.blob_cache.population.throughput.histogram",
-                "The throughput observed when populating the the cache",
+                "The throughput observed when populating the cache",
                 "MiB/second"
             ),
             meterRegistry.registerLongCounter(

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementServiceTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/async/AsyncTaskManagementServiceTests.java
@@ -313,7 +313,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
             assertThat(task, nullValue());
         });
 
-        logger.trace("Getting the the final response from the index");
+        logger.trace("Getting the final response from the index");
         StoredAsyncResponse<TestResponse> response = getResponse(responseHolder.get().id, TimeValue.ZERO);
         if (success) {
             assertThat(response.getException(), nullValue());

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementServiceTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementServiceTests.java
@@ -313,7 +313,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
             assertThat(task, nullValue());
         });
 
-        logger.trace("Getting the the final response from the index");
+        logger.trace("Getting the final response from the index");
         StoredAsyncResponse<TestResponse> response = getResponse(responseHolder.get().id, TimeValue.ZERO);
         if (success) {
             assertThat(response.getException(), nullValue());

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -396,7 +396,7 @@ public class RollupJobTaskTests extends ESTestCase {
             });
             assertUnblockIn10s(latch2);
 
-            // the the client answer
+            // the client answer
             unblock.countDown();
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SourceGenerator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SourceGenerator.java
@@ -70,7 +70,7 @@ public abstract class SourceGenerator {
         // set page size
         if (size != null) {
             int sz = container.limit() > 0 ? Math.min(container.limit(), size) : size;
-            // now take into account the the minimum page (if set)
+            // now take into account the minimum page (if set)
             // that is, return the multiple of the minimum page size closer to the set size
             int minSize = container.minPageSize();
             sz = minSize > 0 ? (Math.max(sz / minSize, 1) * minSize) : sz;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
@@ -139,7 +139,7 @@ public class MetricAggExtractor implements BucketExtractor {
                 return DateUtils.asDateTimeWithMillis(((Number) object).longValue(), zoneId);
             } else if (dataType.isInteger()) {
                 // MIN and MAX need to return the same type as field's and SUM a long for integral types, but ES returns them always as
-                // floating points -> convert them in the the SELECT pipeline, if needed
+                // floating points -> convert them in the SELECT pipeline, if needed
                 return convert(object, dataType);
             }
         }


### PR DESCRIPTION
After seeing the work in https://github.com/elastic/elasticsearch/pull/115826, I did a search for "the the", and there were many places where `the the` was typed, in comments, docs and messages. All were incorrect and replaces with a single `the`
