### PR TITLE
Don't run validate changelogs task during 'check' tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -409,6 +409,10 @@ gradle.projectsEvaluated {
   }
 }
 
+tasks.named("validateChangelogs") {
+  onlyIf { project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false }
+}
+
 tasks.named("precommit") {
   dependsOn gradle.includedBuild('build-tools').task(':precommit')
   dependsOn gradle.includedBuild('build-tools-internal').task(':precommit')


### PR DESCRIPTION
We run this check as part of precommit, and in it's own job. We don't want to run this as part of our `checkPart` tasks.