### PR TITLE
Remove code for `?verbose` in `_segments` API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -51,15 +51,6 @@
         ],
         "default":"open",
         "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "verbose":{
-        "type":"boolean",
-        "description":"Includes detailed memory usage by Lucene.",
-        "default":false,
-        "deprecated" : {
-          "version" : "8.0.0",
-          "description" : "lucene no longer keeps track of segment memory overhead as it is largely off-heap"
-        }
       }
     }
   }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesSegmentsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesSegmentsAction.java
@@ -13,8 +13,6 @@ import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -29,8 +27,6 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 @ServerlessScope(Scope.INTERNAL)
 public class RestIndicesSegmentsAction extends BaseRestHandler {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(RestIndicesSegmentsAction.class);
 
     public RestIndicesSegmentsAction() {}
 
@@ -49,13 +45,6 @@ public class RestIndicesSegmentsAction extends BaseRestHandler {
         IndicesSegmentsRequest indicesSegmentsRequest = new IndicesSegmentsRequest(
             Strings.splitStringByCommaToArray(request.param("index"))
         ).withVectorFormatsInfo(request.paramAsBoolean("vector_formats", false));
-        if (request.hasParam("verbose")) {
-            DEPRECATION_LOGGER.warn(
-                DeprecationCategory.INDICES,
-                "indices_segments_action_verbose",
-                "The [verbose] query parameter for [indices_segments_action] has no effect and is deprecated"
-            );
-        }
         indicesSegmentsRequest.indicesOptions(IndicesOptions.fromRequest(request, indicesSegmentsRequest.indicesOptions()));
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
             .indices()


### PR DESCRIPTION
A change made in 8.0 intended to deprecate this parameter. However, because the new code only checked for the presence of the parameter and never consumed it, the effect was actually to remove support for the parameter. This code therefore basically does nothing and can be removed.