### PR TITLE
[8.16] Don't run validate changelogs task during 'check' tasks (#116028)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -409,6 +409,10 @@ gradle.projectsEvaluated {
   }
 }
 
+tasks.named("validateChangelogs") {
+  onlyIf { project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false }
+}
+
 tasks.named("precommit") {
   dependsOn gradle.includedBuild('build-tools').task(':precommit')
   dependsOn gradle.includedBuild('build-tools-internal').task(':precommit')


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Don't run validate changelogs task during 'check' tasks (#116028)