### PR TITLE
[8.15] Don't run validate changelogs task during 'check' tasks (#116028)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,6 +408,10 @@ gradle.projectsEvaluated {
   }
 }
 
+tasks.named("validateChangelogs") {
+  onlyIf { project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false }
+}
+
 tasks.named("precommit") {
   dependsOn gradle.includedBuild('build-tools').task(':precommit')
   dependsOn gradle.includedBuild('build-tools-internal').task(':precommit')


### PR DESCRIPTION
Backports the following commits to 8.15:
 - Don't run validate changelogs task during 'check' tasks (#116028)