### PR TITLE
Fix live version map unsafe flag

### DIFF
--- a/docs/changelog/116053.yaml
+++ b/docs/changelog/116053.yaml
@@ -1,0 +1,5 @@
+pr: 116053
+summary: Fix live version map unsafe flag
+area: Engine
+type: bug
+issues: []


### PR DESCRIPTION
Live version map can unexpectedly go unsafe with single threaded indexing going on. This can cause translog replay to need to transition from unsafe to safe version map.

This draft pull request illustrates the problem through a test-case and a hacky fix to the live version map.