### PR TITLE
Revert "[TEST] Replace _source.mode with index.mapping.source.mode in integration tests"

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/top_hits.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/top_hits.yml
@@ -356,10 +356,9 @@ synthetic _source:
       indices.create:
         index: test_synthetic
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               page:
                 type: keyword

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
@@ -180,9 +180,9 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               boolean:
                 type: boolean
@@ -5630,9 +5630,9 @@ version and sequence number synthetic _source:
         body:
           settings:
             number_of_shards: 1
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               keyword:
                 type: keyword

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -285,10 +285,9 @@ synthetic_source:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               foo:
                 type: match_only_text
@@ -363,10 +362,9 @@ synthetic_source with copy_to:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               foo:
                 type: match_only_text

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_feature/30_synthetic_source.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_feature/30_synthetic_source.yml
@@ -7,10 +7,9 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               pagerank:
                 type: rank_feature

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/20_synthetic_source.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/20_synthetic_source.yml
@@ -7,10 +7,9 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               tags:
                 type: rank_features

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/30_synthetic_source.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/30_synthetic_source.yml
@@ -7,10 +7,9 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               a_field:
                 type: search_as_you_type

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/token_count/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/token_count/10_basic.yml
@@ -42,10 +42,9 @@
       indices.create:
         index:  test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               count:
                 type: token_count

--- a/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/60_synthetic_source.yml
+++ b/modules/parent-join/src/yamlRestTest/resources/rest-api-spec/test/60_synthetic_source.yml
@@ -7,10 +7,9 @@ supported:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               join_field:
                 type: join

--- a/modules/percolator/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/percolator/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -137,10 +137,9 @@
       indices.create:
         index: queries_index
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               query:
                 type: percolator

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/110_synthetic_source.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/110_synthetic_source.yml
@@ -3,10 +3,9 @@ setup:
       indices.create:
         index: synthetic
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/100_synthetic_source.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/100_synthetic_source.yml
@@ -3,10 +3,9 @@ update:
       indices.create:
         index: synthetic
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword

--- a/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/270_synthetic_source.yml
+++ b/modules/runtime-fields-common/src/yamlRestTest/resources/rest-api-spec/test/runtime_fields/270_synthetic_source.yml
@@ -8,10 +8,9 @@ keywords:
       indices.create:
         index: index1
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               field1:
                 type: keyword
@@ -77,10 +76,9 @@ doubles:
       indices.create:
         index: index1
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               field1:
                 type: double

--- a/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/20_synthetic_source.yml
+++ b/plugins/mapper-annotated-text/src/yamlRestTest/resources/rest-api-spec/test/mapper_annotatedtext/20_synthetic_source.yml
@@ -10,10 +10,9 @@ stored annotated_text field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text
@@ -41,10 +40,9 @@ annotated_text field with keyword multi-field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text
@@ -74,10 +72,9 @@ multiple values in stored annotated_text field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text
@@ -105,10 +102,9 @@ multiple values in annotated_text field with keyword multi-field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text
@@ -139,10 +135,9 @@ multiple values in annotated_text field with stored keyword multi-field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text
@@ -174,10 +169,9 @@ multiple values in stored annotated_text field with keyword multi-field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text
@@ -208,10 +202,9 @@ fallback synthetic source:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               annotated_text:
                 type: annotated_text

--- a/plugins/mapper-murmur3/src/yamlRestTest/resources/rest-api-spec/test/mapper_murmur3/10_basic.yml
+++ b/plugins/mapper-murmur3/src/yamlRestTest/resources/rest-api-spec/test/mapper_murmur3/10_basic.yml
@@ -134,10 +134,9 @@ setup:
       indices.create:
         index: test_synthetic_source
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               foo:
                 type: keyword

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -7,10 +7,9 @@ keyword:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -49,8 +48,9 @@ fetch without refresh also produces synthetic source:
           settings:
             index:
               refresh_interval: -1
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               obj:
                 properties:
@@ -90,10 +90,9 @@ force_synthetic_source_ok:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: stored
           mappings:
+            _source:
+              mode: stored
             properties:
               obj:
                 properties:
@@ -140,10 +139,9 @@ stored text:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               text:
                 type: text
@@ -214,10 +212,9 @@ stored keyword:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -256,10 +253,9 @@ doc values keyword with ignore_above:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -340,10 +336,9 @@ stored keyword with ignore_above:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -426,10 +421,9 @@ indexed dense vectors:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -471,10 +465,9 @@ non-indexed dense vectors:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -515,10 +508,9 @@ _source filtering:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -558,9 +550,9 @@ _doc_count:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
+          mappings:
+            _source:
+              mode: synthetic
 
   # with _doc_count
   - do:
@@ -687,10 +679,9 @@ fields with ignore_malformed:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               ip:
                 type: ip
@@ -923,10 +914,9 @@ flattened field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               flattened:
                 type: flattened
@@ -1016,10 +1006,9 @@ flattened field with ignore_above:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               field:
                 type: flattened
@@ -1072,10 +1061,9 @@ flattened field with ignore_above and arrays:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               field:
                 type: flattened
@@ -1129,10 +1117,9 @@ completion:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               completion:
                 type: completion

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -11,11 +11,13 @@ object with unmapped fields:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 total_fields:
                   ignore_dynamic_beyond_limit: true
                   limit: 1
+
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -62,12 +64,13 @@ unmapped arrays:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 total_fields:
                   ignore_dynamic_beyond_limit: true
                   limit: 1
 
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -108,12 +111,13 @@ nested object with unmapped fields:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 total_fields:
                   ignore_dynamic_beyond_limit: true
                   limit: 3
 
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -159,12 +163,13 @@ empty object with unmapped fields:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 total_fields:
                   ignore_dynamic_beyond_limit: true
                   limit: 3
 
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -200,10 +205,9 @@ disabled root object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             enabled: false
 
   - do:
@@ -238,10 +242,9 @@ disabled object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 enabled: false
@@ -276,10 +279,9 @@ disabled object contains array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 enabled: false
@@ -317,10 +319,9 @@ disabled subobject:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -356,10 +357,9 @@ disabled subobject with array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -396,10 +396,9 @@ mixed disabled and enabled objects:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -443,10 +442,9 @@ object with dynamic override:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path_no:
                 dynamic: false
@@ -491,10 +489,9 @@ subobject with dynamic override:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -540,10 +537,9 @@ object array in object with dynamic override:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -595,10 +591,9 @@ value array in object with dynamic override:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path_no:
                 dynamic: false
@@ -639,10 +634,9 @@ nested object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               nested_field:
                 type: nested
@@ -685,10 +679,9 @@ nested object next to regular:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               path:
                 properties:
@@ -732,10 +725,9 @@ nested object with disabled:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               obj_field:
                 properties:
@@ -821,10 +813,9 @@ doubly nested object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               obj_field:
                 properties:
@@ -917,10 +908,9 @@ subobjects auto:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             subobjects: auto
             properties:
               id:
@@ -1006,10 +996,9 @@ synthetic_source with copy_to:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               number:
                 type: integer
@@ -1143,10 +1132,9 @@ synthetic_source with disabled doc_values:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               number:
                 type: integer
@@ -1227,10 +1215,9 @@ fallback synthetic_source for text field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               text:
                 type: text
@@ -1262,10 +1249,9 @@ synthetic_source with copy_to and ignored values:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1331,10 +1317,9 @@ synthetic_source with copy_to field having values in source:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1395,10 +1380,9 @@ synthetic_source with ignored source field using copy_to:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1460,10 +1444,9 @@ synthetic_source with copy_to field from dynamic template having values in sourc
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             dynamic_templates:
               - copy_template:
                   match: "k"
@@ -1558,10 +1541,9 @@ synthetic_source with copy_to and invalid values for copy:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1595,10 +1577,9 @@ synthetic_source with copy_to pointing inside object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1700,10 +1681,9 @@ synthetic_source with copy_to pointing to ambiguous field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               k:
                 type: keyword
@@ -1748,10 +1728,9 @@ synthetic_source with copy_to pointing to ambiguous field and subobjects false:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             subobjects: false
             properties:
               k:
@@ -1797,10 +1776,9 @@ synthetic_source with copy_to pointing to ambiguous field and subobjects auto:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             subobjects: auto
             properties:
               k:
@@ -1847,10 +1825,9 @@ synthetic_source with copy_to pointing at dynamic field:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1934,10 +1911,9 @@ synthetic_source with copy_to pointing inside dynamic object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/21_synthetic_source_stored.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/21_synthetic_source_stored.yml
@@ -8,10 +8,9 @@ object param - store complex object:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -73,10 +72,9 @@ object param - object array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -138,10 +136,9 @@ object param - object array within array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               stored:
                 synthetic_source_keep: arrays
@@ -182,10 +179,9 @@ object param - no object array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               stored:
                 synthetic_source_keep: arrays
@@ -225,10 +221,9 @@ object param - field ordering in object array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               a:
                 type: keyword
@@ -275,10 +270,9 @@ object param - nested object array next to other fields:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               a:
                 type: keyword
@@ -332,10 +326,9 @@ object param - nested object with stored array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -385,10 +378,9 @@ index param - nested array within array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -436,9 +428,9 @@ index param - nested array within array - disabled second pass:
             index:
               synthetic_source:
                 enable_second_doc_parsing_pass: false
-              mapping.source.mode: synthetic
-
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -486,8 +478,9 @@ stored field under object with store_array_source:
             index:
               sort.field: "name"
               sort.order: "asc"
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -532,10 +525,9 @@ field param - keep root array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -590,10 +582,9 @@ field param - keep nested array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -659,10 +650,9 @@ field param - keep root singleton fields:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -749,10 +739,9 @@ field param - keep nested singleton fields:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -831,10 +820,9 @@ field param - nested array within array:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -878,9 +866,10 @@ index param - root arrays:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -956,9 +945,10 @@ index param - dynamic root arrays:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               id:
                 type: integer
@@ -1008,9 +998,10 @@ index param - object array within array:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               stored:
                 properties:
@@ -1057,9 +1048,10 @@ index param - no object array:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               stored:
                 properties:
@@ -1101,9 +1093,10 @@ index param - field ordering:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               a:
                 type: keyword
@@ -1151,9 +1144,10 @@ index param - nested arrays:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               a:
                 type: keyword
@@ -1218,9 +1212,10 @@ index param - nested object with stored array:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -1269,9 +1264,10 @@ index param - flattened fields:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 synthetic_source_keep: arrays
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
@@ -146,6 +146,28 @@
   - match: { test_index.mappings.properties.foo.meta.baz: "quux" }
 
 ---
+"disabling synthetic source fails":
+  - requires:
+      cluster_features: ["gte_v8.4.0"]
+      reason:      "Added in 8.4.0"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+
+  - do:
+      catch: /Cannot update parameter \[mode\] from \[synthetic\] to \[stored\]/
+      indices.put_mapping:
+        index: test_index
+        body:
+          _source:
+            mode: stored
+
+---
 "enabling synthetic source from explicit succeeds":
   - requires:
       cluster_features: [ "gte_v8.4.0" ]
@@ -155,9 +177,9 @@
       indices.create:
         index: test_index
         body:
-          settings:
-            index:
-              mapping.source.mode: stored
+          mappings:
+            _source:
+              mode: stored
 
   - do:
       indices.put_mapping:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_source_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_source_mapping.yml
@@ -30,7 +30,9 @@ stored _source mode is supported:
           settings:
             index:
               mode: logsdb
-              mapping.source.mode: stored
+          mappings:
+            _source:
+              mode: stored
   - do:
       indices.get:
         index: test-stored-source
@@ -67,7 +69,9 @@ disabled _source is not supported:
           settings:
             index:
               mode: logsdb
-              mapping.source.mode: disabled
+          mappings:
+            _source:
+              mode: disabled
 
   - match: { error.type: "mapper_parsing_exception" }
   - match: { error.root_cause.0.type: "mapper_parsing_exception" }
@@ -116,9 +120,9 @@ include/exclude is supported with stored _source:
           settings:
             index:
               mode: logsdb
-              mapping.source.mode: stored
           mappings:
             _source:
+              mode: stored
               includes: [a]
 
   - do:
@@ -135,9 +139,9 @@ include/exclude is supported with stored _source:
           settings:
             index:
               mode: logsdb
-              mapping.source.mode: stored
           mappings:
             _source:
+              mode: stored
               excludes: [b]
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -7,10 +7,9 @@ keyword:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -63,9 +62,9 @@ keyword with normalizer:
                   type: custom
                   filter:
                     - lowercase
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               keyword:
                 type: keyword
@@ -145,10 +144,9 @@ stored text:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               text:
                 type: text
@@ -195,10 +193,9 @@ force_synthetic_source_ok:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: stored
           mappings:
+            _source:
+              mode: stored
             properties:
               obj:
                 properties:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/50_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/50_synthetic_source.yml
@@ -9,9 +9,9 @@ setup:
         body:
           settings:
             number_of_shards: 1
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               foo:
                 type: keyword
@@ -21,7 +21,6 @@ setup:
                     index_options: positions
                   vectors:
                     type: text
-                    store: false
                     term_vector: with_positions_offsets
                   positions:
                     type: text

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/90_sparse_vector.yml
@@ -394,10 +394,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               ml.tokens:
                 type: sparse_vector

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_binary_field.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_binary_field.yml
@@ -55,10 +55,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               binary:
                 type: binary

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_synthetic_source.yml
@@ -7,10 +7,9 @@ keyword:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -45,10 +44,9 @@ stored text:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               text:
                 type: text
@@ -85,6 +83,8 @@ stored keyword:
         index: test
         body:
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -120,10 +120,9 @@ stored keyword without sibling fields:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -166,10 +165,9 @@ force_synthetic_source_ok:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: stored
           mappings:
+            _source:
+              mode: stored
             properties:
               obj:
                 properties:
@@ -220,10 +218,9 @@ doc values keyword with ignore_above:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -289,10 +286,9 @@ stored keyword with ignore_above:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -360,10 +356,9 @@ _source filtering:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -402,9 +397,9 @@ _doc_count:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
+          mappings:
+            _source:
+              mode: synthetic
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/540_ignore_above_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/540_ignore_above_synthetic_source.yml
@@ -10,9 +10,10 @@ ignore_above mapping level setting:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 ignore_above: 10
           mappings:
+            _source:
+              mode: synthetic
             properties:
               keyword:
                 type: keyword
@@ -52,9 +53,10 @@ ignore_above mapping level setting on arrays:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 ignore_above: 10
           mappings:
+            _source:
+              mode: synthetic
             properties:
               keyword:
                 type: keyword
@@ -95,9 +97,10 @@ ignore_above mapping overrides setting:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 ignore_above: 10
           mappings:
+            _source:
+              mode: synthetic
             properties:
               keyword:
                 type: keyword
@@ -140,9 +143,10 @@ ignore_above mapping overrides setting on arrays:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 ignore_above: 10
           mappings:
+            _source:
+              mode: synthetic
             properties:
               keyword:
                 type: keyword

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -472,9 +472,9 @@ stored source is supported:
               time_series:
                 start_time: 2021-04-28T00:00:00Z
                 end_time: 2021-04-29T00:00:00Z
-              mapping:
-                source.mode: stored
           mappings:
+            _source:
+              mode: stored
             properties:
               "@timestamp":
                 type: date
@@ -510,9 +510,9 @@ disabled source is not supported:
               time_series:
                 start_time: 2021-04-28T00:00:00Z
                 end_time: 2021-04-29T00:00:00Z
-              mapping:
-                source.mode: disabled
           mappings:
+            _source:
+              mode: disabled
             properties:
               "@timestamp":
                 type: date

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/100_synthetic_source.yml
@@ -7,10 +7,9 @@ keyword:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               kwd:
                 type: keyword
@@ -66,10 +65,9 @@ stored text:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               text:
                 type: text

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/20_ignored_source.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/20_ignored_source.yml
@@ -6,10 +6,9 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               object:
                 enabled: false

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
@@ -7,10 +7,9 @@ constant_keyword:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               const_kwd:
                 type: constant_keyword

--- a/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/80_synthetic_source.yml
+++ b/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/80_synthetic_source.yml
@@ -7,10 +7,9 @@ synthetic source:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -53,10 +52,9 @@ synthetic source with copy_to:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -113,10 +111,9 @@ synthetic source with disabled doc_values:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword

--- a/x-pack/plugin/mapper-version/src/yamlRestTest/resources/rest-api-spec/test/40_synthetic_source.yml
+++ b/x-pack/plugin/mapper-version/src/yamlRestTest/resources/rest-api-spec/test/40_synthetic_source.yml
@@ -7,10 +7,9 @@ setup:
       indices.create:
         index:  test1
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               ver:
                 type: version
@@ -77,10 +76,9 @@ synthetic source with copy_to:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               ver:
                 type: version

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/100_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/100_synthetic_source.yml
@@ -7,10 +7,9 @@ aggregate_metric_double:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               metric:
                 type: aggregate_metric_double
@@ -63,10 +62,9 @@ aggregate_metric_double with ignore_malformed:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               metric:
                 type: aggregate_metric_double

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -182,10 +182,9 @@ histogram with synthetic source:
       indices.create:
         index: histo_synthetic
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               latency:
                 type: histogram
@@ -229,10 +228,9 @@ histogram with synthetic source and zero counts:
       indices.create:
         index: histo_synthetic
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               latency:
                 type: histogram
@@ -319,10 +317,9 @@ histogram with synthetic source and ignore_malformed:
       indices.create:
         index: histo_synthetic
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               latency:
                 type: histogram

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/40_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/40_synthetic_source.yml
@@ -4,10 +4,9 @@ setup:
       indices.create:
         index: source
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               baz:
                 type: keyword

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
@@ -809,10 +809,9 @@ synthetic _source text stored:
       indices.create:
         index:  test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               card:
                 type: text
@@ -841,10 +840,9 @@ synthetic _source text with parent keyword:
       indices.create:
         index:  test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               card:
                 type: keyword

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -481,10 +481,9 @@ setup:
       indices.create:
         index: test2
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               "emp_no":
                 type: long
@@ -527,10 +526,9 @@ setup:
       indices.create:
         index: test2
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               "emp_no":
                 type: long

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/searchable_snapshots/20_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/searchable_snapshots/20_synthetic_source.yml
@@ -11,9 +11,9 @@ setup:
           settings:
             number_of_shards:   1
             number_of_replicas: 0
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               obj:
                 properties:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz_api_keys/30_field_level_security_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz_api_keys/30_field_level_security_synthetic_source.yml
@@ -13,10 +13,9 @@ Filter single field:
       indices.create:
         index: index_fls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -76,10 +75,9 @@ Filter fields in object:
       indices.create:
         index: index_fls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -144,10 +142,9 @@ Fields under a disabled object - uses _ignored_source:
       indices.create:
         index: index_fls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -239,11 +236,12 @@ Dynamic fields beyond limit - uses _ignored_source:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 total_fields:
                   ignore_dynamic_beyond_limit: true
                   limit: 2
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -303,10 +301,9 @@ Field with ignored_malformed:
       indices.create:
         index: index_fls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz_api_keys/40_document_level_security_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz_api_keys/40_document_level_security_synthetic_source.yml
@@ -13,10 +13,9 @@ Filter on single field:
       indices.create:
         index: index_dls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -96,10 +95,9 @@ Filter on nested field:
       indices.create:
         index: index_dls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -180,10 +178,9 @@ Filter on object with stored source:
       indices.create:
         index: index_dls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -261,10 +258,9 @@ Filter on field within a disabled object:
       indices.create:
         index: index_dls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -339,10 +335,9 @@ Filter on field with ignored_malformed:
       indices.create:
         index: index_dls
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -100,11 +100,12 @@ setup:
       indices.create:
         index: test_synthetic
         body:
+          mappings:
+            _source:
+              mode: synthetic
           settings:
             number_of_shards:   1
             number_of_replicas: 0
-            index:
-              mapping.source.mode: synthetic
 
   - do:
       snapshot.create:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/140_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/140_synthetic_source.yml
@@ -8,10 +8,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               shape:
                 type: geo_shape
@@ -75,10 +74,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               shape:
                 type: geo_shape
@@ -159,10 +157,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               shape:
                 type: shape
@@ -226,10 +223,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               shape:
                 type: shape
@@ -310,10 +306,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               point:
                 type: geo_point
@@ -427,10 +422,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               geo_point:
                 type: geo_point
@@ -507,10 +501,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               point:
                 type: point
@@ -604,10 +597,9 @@
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               point:
                 type: point

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms_synthetic_source.yml
@@ -6,10 +6,9 @@ simple:
       indices.create:
         index: airline-data
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               time:
                 type: date

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/wildcard/30_ignore_above_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/wildcard/30_ignore_above_synthetic_source.yml
@@ -10,9 +10,10 @@ wildcard field type ignore_above:
           settings:
             index:
               mapping:
-                source.mode: synthetic
                 ignore_above: 10
           mappings:
+            _source:
+              mode: synthetic
             properties:
               a_wildcard:
                 type: wildcard

--- a/x-pack/plugin/wildcard/src/yamlRestTest/resources/rest-api-spec/test/30_synthetic_source.yml
+++ b/x-pack/plugin/wildcard/src/yamlRestTest/resources/rest-api-spec/test/30_synthetic_source.yml
@@ -7,10 +7,9 @@ synthetic source:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword
@@ -49,10 +48,9 @@ synthetic source with copy_to:
       indices.create:
         index: synthetic_source_test
         body:
-          settings:
-            index:
-              mapping.source.mode: synthetic
           mappings:
+            _source:
+              mode: synthetic
             properties:
               name:
                 type: keyword


### PR DESCRIPTION
Reverts elastic/elasticsearch#115926

The backport pr shows mixedClusterTest failures, it's better to rollback now and roll fwd with feature guarding.