### PR TITLE
[Spacetime POC] _rank_eval simplifications and improvements [Do not merge]

### DIFF
--- a/modules/rank-eval/src/main/java/module-info.java
+++ b/modules/rank-eval/src/main/java/module-info.java
@@ -12,6 +12,7 @@ module org.elasticsearch.rankeval {
     requires org.elasticsearch.xcontent;
     requires org.elasticsearch.base;
     requires java.naming;
+    requires org.elasticsearch.logging;
 
     exports org.elasticsearch.index.rankeval;
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/HistoricalRankEvalRun.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/HistoricalRankEvalRun.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.rankeval;
+
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @param runId  GUID */
+public record HistoricalRankEvalRun(
+    String runId,
+    String storedCorpus,
+    String templateId,
+    org.elasticsearch.index.rankeval.HistoricalRankEvalRun.Metric metric,
+    double metricScore,
+    List<QueryResult> queryResults
+) implements ToXContentObject {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("run_id", runId);
+        builder.field("stored_corpus", storedCorpus);
+        builder.field("template_id", templateId);
+        builder.startObject("metric");
+        builder.field("name", metric.name());
+        builder.field("k", metric.k());
+        builder.endObject();
+        builder.field("metric_score", metricScore);
+        builder.startArray("queries");
+        for (QueryResult queryResult : queryResults) {
+            builder.startObject();
+            builder.field("query_id", queryResult.queryId());
+            builder.field("metric_score", queryResult.metricScore());
+            builder.endObject();
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+
+    record QueryResult(String queryId, float metricScore) {}
+
+    // This does not return metric-specific details such as relevantRatingThreshold, normalize, ignoreUnlabeled.
+    // We would probably want to keep this in a non-POC.
+    record Metric(String name, int k) {}
+}

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/HistoricalRankEvalRun.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/HistoricalRankEvalRun.java
@@ -49,7 +49,7 @@ public record HistoricalRankEvalRun(
         return builder;
     }
 
-    record QueryResult(String queryId, float metricScore) {}
+    record QueryResult(String queryId, double metricScore) {}
 
     // This does not return metric-specific details such as relevantRatingThreshold, normalize, ignoreUnlabeled.
     // We would probably want to keep this in a non-POC.

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/HistoricalRankEvalRun.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/HistoricalRankEvalRun.java
@@ -19,6 +19,7 @@ import java.util.List;
  * @param runId  GUID */
 public record HistoricalRankEvalRun(
     String runId,
+    long dateRun,
     String storedCorpus,
     String templateId,
     org.elasticsearch.index.rankeval.HistoricalRankEvalRun.Metric metric,
@@ -30,6 +31,7 @@ public record HistoricalRankEvalRun(
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("run_id", runId);
+        builder.field("date_run", dateRun);
         builder.field("stored_corpus", storedCorpus);
         builder.field("template_id", templateId);
         builder.startObject("metric");

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/StoredCorpus.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/StoredCorpus.java
@@ -9,17 +9,19 @@
 
 package org.elasticsearch.index.rankeval;
 
+import java.util.List;
+
 public class StoredCorpus {
     private final String id;
     private final String name;
     private final String description;
-    private final String index;
+    private final List<String> indices;
 
-    public StoredCorpus(String id, String name, String description, String index) {
+    public StoredCorpus(String id, String name, String description, List<String> indices) {
         this.id = id;
         this.name = name;
         this.description = description;
-        this.index = index;
+        this.indices = indices;
     }
 
     public String getId() {
@@ -34,7 +36,7 @@ public class StoredCorpus {
         return description;
     }
 
-    public String getIndex() {
-        return index;
+    public List<String> getIndices() {
+        return indices;
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/StoredCorpus.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/StoredCorpus.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.rankeval;
+
+public class StoredCorpus {
+    private final String id;
+    private final String name;
+    private final String description;
+    private final String index;
+
+    public StoredCorpus(String id, String name, String description, String index) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.index = index;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+}

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/StoredCorpus.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/StoredCorpus.java
@@ -11,32 +11,4 @@ package org.elasticsearch.index.rankeval;
 
 import java.util.List;
 
-public class StoredCorpus {
-    private final String id;
-    private final String name;
-    private final String description;
-    private final List<String> indices;
-
-    public StoredCorpus(String id, String name, String description, List<String> indices) {
-        this.id = id;
-        this.name = name;
-        this.description = description;
-        this.indices = indices;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public List<String> getIndices() {
-        return indices;
-    }
-}
+public record StoredCorpus(String id, String name, String description, List<String> indices) {}

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -55,6 +55,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.createParser;
 import static org.elasticsearch.index.rankeval.RatedRequest.validateEvaluatedQuery;
@@ -310,13 +311,18 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
                 this.rankEvalSpec.getMetric().forcedSearchSize().orElse(10) // Default
             );
 
+            List<HistoricalRankEvalRun.QueryResult> queryResults = responseDetails.entrySet()
+                .stream()
+                .map(query -> new HistoricalRankEvalRun.QueryResult(query.getKey(), query.getValue().metricScore()))
+                .collect(Collectors.toList());
+
             HistoricalRankEvalRun historicalRun = new HistoricalRankEvalRun(
                 runId,
                 this.rankEvalSpec.getStoredCorpus(),
                 this.rankEvalSpec.getTemplates().keySet().iterator().next(),
                 historicalMetric,
                 metricScore,
-                List.of() /* TODO query results */
+                queryResults
             );
 
             try {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -303,7 +303,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
             }
 
             // Record history here
-            String runId = UUID.randomUUID().toString(); // TODO return this in the response too
+            String runId = UUID.randomUUID().toString();
             double metricScore = this.rankEvalSpec.getMetric().combine(responseDetails.values());
 
             HistoricalRankEvalRun.Metric historicalMetric = new HistoricalRankEvalRun.Metric(
@@ -334,7 +334,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
                 LogManager.getLogger(TransportRankEvalAction.class).error("Failed to store historical run", e);
             }
 
-            delegate.onResponse(new RankEvalResponse(metricScore, responseDetails, this.errors));
+            delegate.onResponse(new RankEvalResponse(runId, metricScore, responseDetails, this.errors));
         }
     }
 }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -331,6 +332,7 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
 
             HistoricalRankEvalRun historicalRun = new HistoricalRankEvalRun(
                 runId,
+                Instant.now().toEpochMilli(),
                 this.rankEvalSpec.getStoredCorpus(),
                 this.rankEvalSpec.getTemplates().keySet().iterator().next(),
                 historicalMetric,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -184,6 +184,7 @@ public class TransportVersions {
     public static final TransportVersion INDEX_MODE_LOOKUP = def(8_779_00_0);
     public static final TransportVersion INDEX_REQUEST_REMOVE_METERING = def(8_780_00_0);
     public static final TransportVersion CPU_STAT_STRING_PARSING = def(8_781_00_0);
+    public static final TransportVersion RANK_EVAL_STORED_CORPORA = def(8_782_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
Supports storing queries and judgments in indices and querying these indices along with search templates for a simplified `_rank_eval` API call. Example call: 

```
GET /dbpedia_documents/_rank_eval
{
  "stored_corpus": "dbpedia",
  "templates": [
    {
      "id": "query_string_query_template",
      "template": {
        "id": "query_string_query_template"
      }
    }
  ],
  "metric": {
    "dcg": {
      "k": 20,
      "normalize": true
    }
  }
}
```

Assumes that the following management tables exist and have been populated - tables are regular indices for the POC: 

```
PUT /search_relevance_dataset
{
  "mappings": {
    "properties": {
      "id": { "type": "keyword" },
      "name": { "type": "keyword" },
      "description": { "type": "text" },
      "indices": { "type": "keyword" }
    }
  }
}

# Combined queries + qrels, flattened
PUT /search_relevance_evaluation_corpora
{
  "mappings": {
    "properties": {
      "dataset_id": { "type": "keyword" },
      "index": { "type": "keyword" },
      "query_id": { "type": "keyword" },
      "query_string": { "type": "text" },
      "query_vector": { "type": "sparse_vector" },
      "document_id": { "type": "keyword" },
      "score": { "type": "integer" }
    }
  }
}

PUT /search_relevance_historical_runs
{
  "mappings": {
    "properties": {
      "run_id": {
        "type": "keyword"
      },
      "stored_corpus": {
        "type": "keyword"
      },
      "template_id": {
        "type": "keyword"
      },
      "date_run": {
        "type": "date",
        "format": "strict_date_optional_time||epoch_millis"
      },
      "metric": {
        "properties": {
          "name": {
            "type": "keyword"
          },
          "k": {
            "type": "integer"
          },
          "relevant_rating_threshold": {
            "type": "integer"
          },
          "normalize": {
            "type": "boolean"
          },
          "ignore_unlabeled": {
            "type": "boolean"
          }
        }
      },
      "metric_score": {
        "type": "double"
      },
      "date_run": {
        "type": "date",
        "format": "strict_date_optional_time||epoch_millis"
      },
      "queries": {
        "type": "nested",
        "properties": {
          "query_id": {
            "type": "keyword"
          },
          "metric_score": {
            "type": "double"
          }
        }
      }
    }
  }
}
```