### PR TITLE
Simplify AbstractSearchAsyncAction.doPerformPhaseOnShard

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -296,33 +296,23 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     }
 
     private void doPerformPhaseOnShard(int shardIndex, SearchShardIterator shardIt, SearchShardTarget shard, Releasable releasable) {
-        try {
-            executePhaseOnShard(shardIt, shard, new SearchActionListener<>(shard, shardIndex) {
-                @Override
-                public void innerOnResponse(Result result) {
-                    try (releasable) {
-                        onShardResult(result, shardIt);
-                    } catch (Exception exc) {
-                        onShardFailure(shardIndex, shard, shardIt, exc);
-                    }
+        executePhaseOnShard(shardIt, shard, new SearchActionListener<>(shard, shardIndex) {
+            @Override
+            public void innerOnResponse(Result result) {
+                try {
+                    releasable.close();
+                    onShardResult(result, shardIt);
+                } catch (Exception exc) {
+                    onShardFailure(shardIndex, shard, shardIt, exc);
                 }
+            }
 
-                @Override
-                public void onFailure(Exception e) {
-                    try (releasable) {
-                        onShardFailure(shardIndex, shard, shardIt, e);
-                    }
-                }
-            });
-        } catch (final Exception e) {
-            /*
-             * It is possible to run into connection exceptions here because we are getting the connection early and might
-             * run into nodes that are not connected. In this case, on shard failure will move us to the next shard copy.
-             */
-            try (releasable) {
+            @Override
+            public void onFailure(Exception e) {
+                releasable.close();
                 onShardFailure(shardIndex, shard, shardIt, e);
             }
-        }
+        });
     }
 
     private void failOnUnavailable(int shardIndex, SearchShardIterator shardIt) {


### PR DESCRIPTION
1. No need to catch here any longer, we fixed the connection related exceptions separately now, throwing from an method that consumes a listener was smelly to begin with.
2. Not need to try-with-resources that `releasable`, just release it as soon as possible to get the next per-shard request going while we process a result. No need to waste time on an idle data node here.
