### PR TITLE
[Inference API] Deleting inference endpoint if start model action returns license error

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAction.java
@@ -32,6 +32,7 @@ public class PutTrainedModelAction extends ActionType<PutTrainedModelAction.Resp
     public static final String NAME = "cluster:admin/xpack/ml/inference/put";
     public static final String MODEL_ALREADY_EXISTS_ERROR_MESSAGE_FRAGMENT =
         "the model id is the same as the deployment id of a current model deployment";
+    public static final String LICENSE_NON_COMPLIANT_ERROR_MESSAGE_FRAGMENT = "current license is non-compliant";
 
     private PutTrainedModelAction() {
         super(NAME);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InsufficientLicenseIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InsufficientLicenseIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class InsufficientLicenseIT extends ESRestTestCase {
+
+    private static final String PASSWORD = "secret-test-password";
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.license.self_generated.type", "basic")
+        .setting("xpack.security.enabled", "true")
+        .plugin("inference-service-test")
+        .user("x_pack_rest_user", "x-pack-test-password")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        // use the privileged users here but not in the tests
+        String token = basicAuthHeaderValue("x_pack_rest_user", new SecureString("x-pack-test-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    public void testInsufficientLicense() throws IOException {
+        var putRequest = new Request("PUT", "_inference/sparse_embedding/license_test");
+        putRequest.setJsonEntity("""
+            {
+              "service": "elser",
+              "service_settings": {
+                "num_allocations": 1,
+                "num_threads": 1
+              }
+            }
+            """);
+        var getRequest = new Request("GET", "_inference/sparse_embedding/license_test");
+
+        try (RestClient client = buildClient(restClientSettings(), getClusterHosts().toArray(new HttpHost[0]))) {
+            // Creating inference endpoint will return a license error
+            ResponseException putException = expectThrows(ResponseException.class, () -> client.performRequest(putRequest));
+            assertThat(putException.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
+            assertThat(putException.getMessage(), containsString("current license is non-compliant for [ml]"));
+
+            // Assert no inference endpoint created
+            ResponseException getException = expectThrows(ResponseException.class, () -> client.performRequest(getRequest));
+            assertThat(getException.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.NOT_FOUND.getStatus()));
+            assertThat(getException.getMessage(), containsString("Inference endpoint not found [license_test]"));
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/elastic/ml-team/issues/1377

## Summary

When creating an inference endpoint for a built in model, the endpoint is created first and then the model is started. Because the license is not checked until the model is started, we are left with orphan inference endpoints. This updates the logic to catch license errors returned by the `PutTrainedModelAction` and delete the inference endpoint that was created.

## To Verify

Create an inference endpoint using

```
PUT _inference/sparse_embedding/my-inference-endpoint
{
  "service": "elser",
  "service_settings": {
    "num_allocations": 1,
    "num_threads": 1
  }
}
```

You should see a 403 license error response. Verify that the inference endpoint does not exist with 

```
GET _inference/sparse_embedding/my-inference-endpoint
```
which should now return a 404