### PR TITLE
[8.x] Fix new logsdb tests (#116108)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -705,6 +705,7 @@ logsdb with default ignore dynamic beyond limit and default sorting:
         body:
           query:
             match_all: {}
+          sort: "@timestamp"
 
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._source.name: "bar" }
@@ -766,15 +767,16 @@ logsdb with default ignore dynamic beyond limit and non-default sorting:
         body:
           query:
             match_all: {}
+          sort: "@timestamp"
 
   - match: { hits.total.value: 2 }
-  - match: { hits.hits.0._source.name: "foo" }
-  - match: { hits.hits.0._source.value: 10 }
-  - match: { hits.hits.0._source.message: "the quick brown fox" }
+  - match: { hits.hits.0._source.name: "bar" }
+  - match: { hits.hits.0._source.value: 20 }
+  - match: { hits.hits.0._source.message: "jumps over the lazy dog" }
   - match: { hits.hits.0._ignored: [ "host", "message", "pid", "region", "value" ] }
-  - match: { hits.hits.1._source.name: "bar" }
-  - match: { hits.hits.1._source.value: 20 }
-  - match: { hits.hits.1._source.message: "jumps over the lazy dog" }
+  - match: { hits.hits.1._source.name: "foo" }
+  - match: { hits.hits.1._source.value: 10 }
+  - match: { hits.hits.1._source.message: "the quick brown fox" }
   - match: { hits.hits.1._ignored: [ "host", "message", "pid", "region", "value" ] }
 
 ---
@@ -871,6 +873,7 @@ logsdb with default ignore dynamic beyond limit and subobjects false:
         body:
           query:
             match_all: {}
+          sort: "@timestamp"
 
   - match: { hits.total.value: 2 }
   - match: { hits.hits.0._source.name: "bar" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix new logsdb tests (#116108)](https://github.com/elastic/elasticsearch/pull/116108)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)