### PR TITLE
Add stats parameter to count API (#67528)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -103,6 +103,10 @@
       "terminate_after":{
         "type":"number",
         "description":"The maximum count for each shard, upon reaching which the query execution will terminate early"
+      },
+      "stats":{
+        "type":"list",
+        "description":"Specific 'tag' of the request for logging and statistical purposes"
       }
     },
     "body":{

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/count/40_stats.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/count/40_stats.yml
@@ -1,0 +1,36 @@
+setup:
+  - do:
+      indices.create:
+        index:  test
+  - do:
+      index:
+        index:  test
+        id:     "1"
+        body:   { foo: bar }
+  - do:
+      indices.refresh:
+        index: [test]
+
+---
+"count with single stat":
+  - do:
+      count:
+        index: test
+        body:
+          query:
+            match_all: {}
+          stats: ["stat_1"]
+
+  - match: {count : 1}
+
+---
+"count with multiple stats":
+  - do:
+      count:
+        index: test
+        body:
+          query:
+            match_all: {}
+          stats: ["stat_1","stat_2"]
+
+  - match: {count : 1}

--- a/server/src/main/java/org/elasticsearch/rest/action/RestActions.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestActions.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.rest.action;
 
+import java.util.Set;
+
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.ShardOperationFailedException;
@@ -264,6 +266,13 @@ public class RestActions {
      * Parses a top level query including the query element that wraps it
      */
     public static QueryBuilder getQueryContent(XContentParser parser) {
+        return getQueryContent(parser, Set.of());
+    }
+
+    /**
+     * Parses a top level query including the query element that wraps it. Ignoring explicitly supplied ignored tokens when validating.
+     */
+    public static QueryBuilder getQueryContent(XContentParser parser, Set<String> ignoredTokens) {
         try {
             QueryBuilder queryBuilder = null;
             XContentParser.Token first = parser.nextToken();
@@ -281,7 +290,7 @@ public class RestActions {
                     String currentName = parser.currentName();
                     if ("query".equals(currentName)) {
                         queryBuilder = parseTopLevelQuery(parser);
-                    } else {
+                    } else if (ignoredTokens.contains(currentName) == false) {
                         throw new ParsingException(parser.getTokenLocation(), "request does not support [" + parser.currentName() + "]");
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestCountAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestCountAction.java
@@ -27,7 +27,9 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -67,13 +69,17 @@ public class RestCountAction extends BaseRestHandler {
                     searchSourceBuilder.query(queryBuilder);
                 }
             } else {
-                searchSourceBuilder.query(RestActions.getQueryContent(parser));
+                searchSourceBuilder.query(RestActions.getQueryContent(parser, Set.of("stats")));
             }
         });
         countRequest.routing(request.param("routing"));
         float minScore = request.paramAsFloat("min_score", -1f);
         if (minScore != -1f) {
             searchSourceBuilder.minScore(minScore);
+        }
+        String sStats = request.param("stats");
+        if (sStats != null) {
+            searchSourceBuilder.stats(Arrays.asList(Strings.splitStringByCommaToArray(sStats)));
         }
 
         countRequest.preference(request.param("preference"));


### PR DESCRIPTION
Adds `stats` parameter to the count API for the count API. Similar to what already exists in the search API:

>(Optional, string) Specific tag of the request for logging and statistical purposes.

Example request:
```sh
curl -X GET "http://localhost:9200/my_index/_count" -H 'Content-Type: application/json' -d'
{
  "query": {
    "match_all": {}
  },
  "stats": ["stat_1"]
}'
```

Closes #67528