### PR TITLE
Test fixes for semantic_text

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -80,10 +81,11 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
     public Set<DataType> supportedTypes() {
         Set<DataType> supportedTypes = new HashSet<>();
         for (DataType dataType : factories().keySet()) {
-            if (DataType.UNDER_CONSTRUCTION.containsKey(dataType) == false
-                || DataType.UNDER_CONSTRUCTION.get(dataType).isEnabled() == true) {
-                supportedTypes.add(dataType);
+            // TODO: this should use DataType.UNDER_CONSTRUCTION but we would need to fix the failures for date_nanos
+            if (dataType == DataType.SEMANTIC_TEXT && EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled() == false) {
+                continue;
             }
+            supportedTypes.add(dataType);
         }
         return supportedTypes;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java
@@ -78,7 +78,14 @@ public abstract class AbstractConvertFunction extends UnaryScalarFunction {
     }
 
     public Set<DataType> supportedTypes() {
-        return factories().keySet();
+        Set<DataType> supportedTypes = new HashSet<>();
+        for (DataType dataType : factories().keySet()) {
+            if (DataType.UNDER_CONSTRUCTION.containsKey(dataType) == false
+                || DataType.UNDER_CONSTRUCTION.get(dataType).isEnabled() == true) {
+                supportedTypes.add(dataType);
+            }
+        }
+        return supportedTypes;
     }
 
     private static String supportedTypesNames(Set<DataType> types) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ConcatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ConcatTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.esql.EsqlClientException;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -23,6 +24,7 @@ import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -48,7 +50,7 @@ public class ConcatTests extends AbstractScalarFunctionTestCase {
         for (int length = 4; length < 100; length++) {
             suppliers(suppliers, length);
         }
-        Set<DataType> supported = Set.of(DataType.NULL, DataType.KEYWORD, DataType.TEXT, DataType.SEMANTIC_TEXT);
+        Set<DataType> supported = new HashSet<>(DataType.stringTypes());
         List<Set<DataType>> supportedPerPosition = List.of(supported, supported);
         for (DataType lhs : DataType.types()) {
             if (lhs == DataType.NULL || DataType.isRepresentable(lhs) == false) {
@@ -72,7 +74,9 @@ public class ConcatTests extends AbstractScalarFunctionTestCase {
         if (length > 3) {
             suppliers.add(supplier("ascii", DataType.KEYWORD, length, () -> randomAlphaOfLengthBetween(1, 10)));
             suppliers.add(supplier("unicode", DataType.TEXT, length, () -> randomRealisticUnicodeOfLengthBetween(1, 10)));
-            suppliers.add(supplier("unicode", DataType.SEMANTIC_TEXT, length, () -> randomRealisticUnicodeOfLengthBetween(1, 10)));
+            if (EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
+                suppliers.add(supplier("unicode", DataType.SEMANTIC_TEXT, length, () -> randomRealisticUnicodeOfLengthBetween(1, 10)));
+            }
         } else {
             add(suppliers, "ascii", length, () -> randomAlphaOfLengthBetween(1, 10));
             add(suppliers, "unicode", length, () -> randomRealisticUnicodeOfLengthBetween(1, 10));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LengthTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LengthTests.java
@@ -53,38 +53,22 @@ public class LengthTests extends AbstractScalarFunctionTestCase {
     }
 
     private static List<TestCaseSupplier> makeTestCases(String title, Supplier<String> text, int expectedLength) {
-        return List.of(
-            new TestCaseSupplier(
-                title + " with keyword",
-                List.of(DataType.KEYWORD),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(new TestCaseSupplier.TypedData(new BytesRef(text.get()), DataType.KEYWORD, "f")),
-                    "LengthEvaluator[val=Attribute[channel=0]]",
-                    DataType.INTEGER,
-                    equalTo(expectedLength)
+        List<TestCaseSupplier> testCases = new ArrayList<>();
+        for (DataType dataType : DataType.stringTypes()) {
+            testCases.add(
+                new TestCaseSupplier(
+                    title + " with " + dataType.typeName(),
+                    List.of(dataType),
+                    () -> new TestCaseSupplier.TestCase(
+                        List.of(new TestCaseSupplier.TypedData(new BytesRef(text.get()), dataType, "f")),
+                        "LengthEvaluator[val=Attribute[channel=0]]",
+                        DataType.INTEGER,
+                        equalTo(expectedLength)
+                    )
                 )
-            ),
-            new TestCaseSupplier(
-                title + " with text",
-                List.of(DataType.TEXT),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(new TestCaseSupplier.TypedData(new BytesRef(text.get()), DataType.TEXT, "f")),
-                    "LengthEvaluator[val=Attribute[channel=0]]",
-                    DataType.INTEGER,
-                    equalTo(expectedLength)
-                )
-            ),
-            new TestCaseSupplier(
-                title + " with semantic_text",
-                List.of(DataType.SEMANTIC_TEXT),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(new TestCaseSupplier.TypedData(new BytesRef(text.get()), DataType.SEMANTIC_TEXT, "f")),
-                    "LengthEvaluator[val=Attribute[channel=0]]",
-                    DataType.INTEGER,
-                    equalTo(expectedLength)
-                )
-            )
-        );
+            );
+        }
+        return testCases;
     }
 
     private Matcher<Object> resultsMatcher(List<TestCaseSupplier.TypedData> typedData) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -62,21 +63,27 @@ public class RepeatTests extends AbstractScalarFunctionTestCase {
             );
         }));
 
-        cases.add(
-            new TestCaseSupplier("Repeat basic test with semantic_text input", List.of(DataType.SEMANTIC_TEXT, DataType.INTEGER), () -> {
-                String text = randomAlphaOfLength(10);
-                int number = between(0, 10);
-                return new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(new BytesRef(text), DataType.SEMANTIC_TEXT, "str"),
-                        new TestCaseSupplier.TypedData(number, DataType.INTEGER, "number")
-                    ),
-                    "RepeatEvaluator[str=Attribute[channel=0], number=Attribute[channel=1]]",
-                    DataType.KEYWORD,
-                    equalTo(new BytesRef(text.repeat(number)))
-                );
-            })
-        );
+        if (EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
+            cases.add(
+                new TestCaseSupplier(
+                    "Repeat basic test with semantic_text input",
+                    List.of(DataType.SEMANTIC_TEXT, DataType.INTEGER),
+                    () -> {
+                        String text = randomAlphaOfLength(10);
+                        int number = between(0, 10);
+                        return new TestCaseSupplier.TestCase(
+                            List.of(
+                                new TestCaseSupplier.TypedData(new BytesRef(text), DataType.SEMANTIC_TEXT, "str"),
+                                new TestCaseSupplier.TypedData(number, DataType.INTEGER, "number")
+                            ),
+                            "RepeatEvaluator[str=Attribute[channel=0], number=Attribute[channel=1]]",
+                            DataType.KEYWORD,
+                            equalTo(new BytesRef(text.repeat(number)))
+                        );
+                    }
+                )
+            );
+        }
 
         cases.add(new TestCaseSupplier("Repeat with number zero", List.of(DataType.KEYWORD, DataType.INTEGER), () -> {
             String text = randomAlphaOfLength(10);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RightTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RightTests.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -166,19 +167,21 @@ public class RightTests extends AbstractScalarFunctionTestCase {
                 equalTo(new BytesRef(unicodeRightSubstring(text, length)))
             );
         }));
-        suppliers.add(new TestCaseSupplier("ascii as semantic_text", List.of(DataType.SEMANTIC_TEXT, DataType.INTEGER), () -> {
-            String text = randomAlphaOfLengthBetween(1, 64);
-            int length = between(1, text.length());
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(new BytesRef(text), DataType.SEMANTIC_TEXT, "str"),
-                    new TestCaseSupplier.TypedData(length, DataType.INTEGER, "length")
-                ),
-                "RightEvaluator[str=Attribute[channel=0], length=Attribute[channel=1]]",
-                DataType.KEYWORD,
-                equalTo(new BytesRef(unicodeRightSubstring(text, length)))
-            );
-        }));
+        if (EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
+            suppliers.add(new TestCaseSupplier("ascii as semantic_text", List.of(DataType.SEMANTIC_TEXT, DataType.INTEGER), () -> {
+                String text = randomAlphaOfLengthBetween(1, 64);
+                int length = between(1, text.length());
+                return new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(new BytesRef(text), DataType.SEMANTIC_TEXT, "str"),
+                        new TestCaseSupplier.TypedData(length, DataType.INTEGER, "length")
+                    ),
+                    "RightEvaluator[str=Attribute[channel=0], length=Attribute[channel=1]]",
+                    DataType.KEYWORD,
+                    equalTo(new BytesRef(unicodeRightSubstring(text, length)))
+                );
+            }));
+        }
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers, (v, p) -> switch (p) {
             case 0 -> "string";
             case 1 -> "integer";

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToLowerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToLowerTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -45,9 +46,10 @@ public class ToLowerTests extends AbstractConfigurationFunctionTestCase {
         suppliers.add(supplier("keyword unicode", DataType.KEYWORD, () -> randomUnicodeOfLengthBetween(1, 10)));
         suppliers.add(supplier("text ascii", DataType.TEXT, () -> randomAlphaOfLengthBetween(1, 10)));
         suppliers.add(supplier("text unicode", DataType.TEXT, () -> randomUnicodeOfLengthBetween(1, 10)));
-        suppliers.add(supplier("semantic_text ascii", DataType.SEMANTIC_TEXT, () -> randomAlphaOfLengthBetween(1, 10)));
-        suppliers.add(supplier("semantic_text unicode", DataType.SEMANTIC_TEXT, () -> randomUnicodeOfLengthBetween(1, 10)));
-
+        if (EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
+            suppliers.add(supplier("semantic_text ascii", DataType.SEMANTIC_TEXT, () -> randomAlphaOfLengthBetween(1, 10)));
+            suppliers.add(supplier("semantic_text unicode", DataType.SEMANTIC_TEXT, () -> randomUnicodeOfLengthBetween(1, 10)));
+        }
         // add null as parameter
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers, (v, p) -> "string");
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToUpperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ToUpperTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -45,8 +46,10 @@ public class ToUpperTests extends AbstractConfigurationFunctionTestCase {
         suppliers.add(supplier("keyword unicode", DataType.KEYWORD, () -> randomUnicodeOfLengthBetween(1, 10)));
         suppliers.add(supplier("text ascii", DataType.TEXT, () -> randomAlphaOfLengthBetween(1, 10)));
         suppliers.add(supplier("text unicode", DataType.TEXT, () -> randomUnicodeOfLengthBetween(1, 10)));
-        suppliers.add(supplier("semantic_text ascii", DataType.SEMANTIC_TEXT, () -> randomAlphaOfLengthBetween(1, 10)));
-        suppliers.add(supplier("semantic_text unicode", DataType.SEMANTIC_TEXT, () -> randomUnicodeOfLengthBetween(1, 10)));
+        if (EsqlCapabilities.Cap.SEMANTIC_TEXT_TYPE.isEnabled()) {
+            suppliers.add(supplier("semantic_text ascii", DataType.SEMANTIC_TEXT, () -> randomAlphaOfLengthBetween(1, 10)));
+            suppliers.add(supplier("semantic_text unicode", DataType.SEMANTIC_TEXT, () -> randomUnicodeOfLengthBetween(1, 10)));
+        }
 
         // add null as parameter
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers, (v, p) -> "string");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeTests.java
@@ -53,7 +53,7 @@ public class WildcardLikeTests extends AbstractScalarFunctionTestCase {
     }
 
     private static void addCases(List<TestCaseSupplier> suppliers) {
-        for (DataType type : new DataType[] { DataType.KEYWORD, DataType.TEXT, DataType.SEMANTIC_TEXT }) {
+        for (DataType type : DataType.stringTypes()) {
             suppliers.add(new TestCaseSupplier(" with " + type.esType(), List.of(type, type), () -> {
                 BytesRef str = new BytesRef(randomAlphaOfLength(5));
                 String patternString = randomAlphaOfLength(2);


### PR DESCRIPTION
Because `semantic_text` is available only in snapshots some of the tests fail when running with `-Dbuild.snapshot=false` since I did not add explicit checks for `EsqlCapabilities.Cap.SEMANTIC_TEXT`.
I assumed that adding `semantic_text` in `UNDER_CONSTRUCTION` would take care of that.

Examples of release test failing on a different PR: https://github.com/elastic/elasticsearch/pull/114831

To check I have run:

```
./gradlew ":x-pack:plugin:esql:test" -Dbuild.snapshot=false  -Dbuild.snapshot=false -Dlicense.key=x-pack/license-tools/src/test/resources/public.key
```
