### PR TITLE
Record pool name in `EsThread` instances

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -376,9 +376,10 @@ public class EsExecutors {
 
     public static class EsThread extends Thread {
         private final boolean isSystem;
+        @Nullable
         private final String pool;
 
-        EsThread(ThreadGroup group, Runnable target, String name, long stackSize, final String pool, boolean isSystem) {
+        EsThread(ThreadGroup group, Runnable target, String name, long stackSize, @Nullable String pool, boolean isSystem) {
             super(group, target, name, stackSize);
             this.isSystem = isSystem;
             this.pool = pool;


### PR DESCRIPTION
Record the threadpool name in `EsThread` instances and use it for one example optimization as a means of avoiding a fork. Also, this sets up dynamically sizing the search pool in response to blocked threads.
