### PR TITLE
Enable DEBUG logging for `FileSettingsServiceTests`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -187,9 +187,6 @@ tests:
 - class: org.elasticsearch.search.StressSearchServiceReaperIT
   method: testStressReaper
   issue: https://github.com/elastic/elasticsearch/issues/115816
-- class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
-  method: testProcessFileChanges
-  issue: https://github.com/elastic/elasticsearch/issues/115280
 - class: org.elasticsearch.search.SearchServiceTests
   method: testWaitOnRefreshTimeout
   issue: https://github.com/elastic/elasticsearch/issues/115935

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -130,9 +130,11 @@ public class FileSettingsServiceTests extends ESTestCase {
     public void tearDown() throws Exception {
         try {
             if (fileSettingsService.lifecycleState() == Lifecycle.State.STARTED) {
+                logger.info("Stopping file settings service");
                 fileSettingsService.stop();
             }
             if (fileSettingsService.lifecycleState() == Lifecycle.State.STOPPED) {
+                logger.info("Closing file settings service");
                 fileSettingsService.close();
             }
 
@@ -377,6 +379,10 @@ public class FileSettingsServiceTests extends ESTestCase {
                 logger.info("Moving settings temp file to replace [{}]", tempFile.getFileName());
                 Files.move(tempFile, path, REPLACE_EXISTING, ATOMIC_MOVE);
             } catch (AtomicMoveNotSupportedException e) {
+                logger.info(
+                    "Atomic move was not available. Falling back on non-atomic move for settings temp file to replace [{}]",
+                    tempFile.getFileName()
+                );
                 Files.move(tempFile, path, REPLACE_EXISTING);
             }
         } catch (final IOException e) {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/115280 still mystifies me. It does not reproduce on a buildkite instance either. This PR turns up logging for the file watching service steps (in particular the polled events should be useful) and adds some logging to the test.