### PR TITLE
Fixing ScheduledEventTest generating same start and end time (#115877)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -267,9 +267,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/42_knn_search_int4_flat/Vector similarity with filter only}
   issue: https://github.com/elastic/elasticsearch/issues/115475
-- class: org.elasticsearch.xpack.core.ml.calendars.ScheduledEventTests
-  method: testBuild_SucceedsWithDefaultSkipResultAndSkipModelUpdatesValues
-  issue: https://github.com/elastic/elasticsearch/issues/115476
 - class: org.elasticsearch.reservedstate.service.FileSettingsServiceTests
   method: testProcessFileChanges
   issue: https://github.com/elastic/elasticsearch/issues/115280

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/calendars/ScheduledEventTests.java
@@ -207,7 +207,7 @@ public class ScheduledEventTests extends AbstractXContentSerializingTestCase<Sch
         String description = randomAlphaOfLength(10);
         String calendarId = randomAlphaOfLength(10);
         Instant startTime = Instant.ofEpochMilli(Instant.now().toEpochMilli());
-        Instant endTime = startTime.plusSeconds(randomInt(3600));
+        Instant endTime = startTime.plusSeconds(randomIntBetween(1, 3600));
 
         ScheduledEvent.Builder builder = new ScheduledEvent.Builder().description(description)
             .calendarId(calendarId)


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/115877