### PR TITLE
Fix release tests for semantic_text

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -370,10 +370,7 @@ public enum DataType {
     }
 
     public static boolean isString(DataType t) {
-        if (EsqlCorePlugin.SEMANTIC_TEXT_FEATURE_FLAG.isEnabled() && t == SEMANTIC_TEXT) {
-            return true;
-        }
-        return t == KEYWORD || t == TEXT;
+        return t == KEYWORD || t == TEXT || t == SEMANTIC_TEXT;
     }
 
     public static boolean isPrimitiveAndSupported(DataType t) {


### PR DESCRIPTION
Alternative to #116177

I initially thought I need this check too in `DataType.isString`, but it is not needed. Having it under `DataType.UNDER_CONSTRUCTION` as we have for `date_nanos` should suffice.
`semantic_text` remains unsupported in non snapshot builds (just to be sure I checked by running Elasticsearch with `-Dbuild.snapshot=false`). The representation of `semantic_text` fields is not returned and `semantic_text` fields cannot be referenced as function/operator arguments for non snapshot builds.
