### PR TITLE
Use underlying ByteBuf refCount for ReleasableBytesReference

### DIFF
--- a/docs/changelog/116211.yaml
+++ b/docs/changelog/116211.yaml
@@ -1,0 +1,5 @@
+pr: 116211
+summary: Use underlying `ByteBuf` `refCount` for `ReleasableBytesReference`
+area: Network
+type: bug
+issues: []

--- a/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
@@ -29,10 +29,6 @@ package org.elasticsearch.core;
  */
 public interface RefCounted {
 
-    default int refCnt() {
-        throw new IllegalStateException("not implemented");
-    }
-
     /**
      * Increments the refCount of this instance.
      *

--- a/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
@@ -29,6 +29,10 @@ package org.elasticsearch.core;
  */
 public interface RefCounted {
 
+    default int refCnt() {
+        throw new IllegalStateException("not implemented");
+    }
+
     /**
      * Increments the refCount of this instance.
      *

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageInboundHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageInboundHandler.java
@@ -14,10 +14,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.network.ThreadWatchdog;
-import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.transport.InboundPipeline;
 import org.elasticsearch.transport.Transports;
@@ -52,9 +50,8 @@ public class Netty4MessageInboundHandler extends ChannelInboundHandlerAdapter {
 
         final ByteBuf buffer = (ByteBuf) msg;
         Netty4TcpChannel channel = ctx.channel().attr(Netty4Transport.CHANNEL_KEY).get();
-        final BytesReference wrapped = Netty4Utils.toBytesReference(buffer);
         activityTracker.startActivity();
-        try (ReleasableBytesReference reference = new ReleasableBytesReference(wrapped, new ByteBufRefCounted(buffer))) {
+        try (ReleasableBytesReference reference = Netty4Utils.toReleasableBytesReference(buffer)) {
             pipeline.handleBytes(channel, reference);
         } finally {
             activityTracker.stopActivity();
@@ -81,35 +78,4 @@ public class Netty4MessageInboundHandler extends ChannelInboundHandlerAdapter {
         super.channelInactive(ctx);
     }
 
-    private record ByteBufRefCounted(ByteBuf buffer) implements RefCounted {
-
-        @Override
-        public void incRef() {
-            buffer.retain();
-        }
-
-        @Override
-        public boolean tryIncRef() {
-            if (hasReferences() == false) {
-                return false;
-            }
-            try {
-                buffer.retain();
-            } catch (RuntimeException e) {
-                assert hasReferences() == false;
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public boolean decRef() {
-            return buffer.release();
-        }
-
-        @Override
-        public boolean hasReferences() {
-            return buffer.refCnt() > 0;
-        }
-    }
 }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -145,6 +145,11 @@ public class Netty4Utils {
     private record ByteBufRefCounted(ByteBuf buffer) implements RefCounted {
 
         @Override
+        public int refCnt() {
+            return buffer.refCnt();
+        }
+
+        @Override
         public void incRef() {
             buffer.retain();
         }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -138,13 +138,12 @@ public class Netty4Utils {
         return new ReleasableBytesReference(toBytesReference(buffer), toRefCounted(buffer));
     }
 
-    public static RefCounted toRefCounted(final ByteBuf buf) {
+    static ByteBufRefCounted toRefCounted(final ByteBuf buf) {
         return new ByteBufRefCounted(buf);
     }
 
-    private record ByteBufRefCounted(ByteBuf buffer) implements RefCounted {
+    record ByteBufRefCounted(ByteBuf buffer) implements RefCounted {
 
-        @Override
         public int refCnt() {
             return buffer.refCnt();
         }


### PR DESCRIPTION
When we wrap Netty's ByteBuf in HTTP server we dont track reference counts for underlying buffer and when it's released we must never access these bytes anymore. There are no exceptions or assertions, it happens silently. In this PR I reuse same logic as we do in Transport for ReleasableBytesReference.