### PR TITLE
[8.16] [ML] Handle empty percentile results (#116015)

### DIFF
--- a/docs/changelog/116015.yaml
+++ b/docs/changelog/116015.yaml
@@ -1,0 +1,6 @@
+pr: 116015
+summary: Empty percentile results no longer throw no_such_element_exception in Anomaly Detection jobs
+area: Machine Learning
+type: bug
+issues:
+ - 116013

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.metrics.GeoCentroid;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -408,8 +407,8 @@ class AggregationToJsonProcessor {
     }
 
     private boolean processPercentiles(Percentiles percentiles) {
-        Iterator<Percentile> percentileIterator = percentiles.iterator();
-        boolean aggregationAdded = addMetricIfFinite(percentiles.getName(), percentileIterator.next().value());
+        var percentileIterator = percentiles.iterator();
+        var aggregationAdded = percentileIterator.hasNext() && addMetricIfFinite(percentiles.getName(), percentileIterator.next().value());
         if (percentileIterator.hasNext()) {
             throw new IllegalArgumentException("Multi-percentile aggregation [" + percentiles.getName() + "] is not supported");
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessorTests.java
@@ -505,6 +505,15 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
             {"time":4400,"my_value":4.0,"doc_count":7}"""));
     }
 
+    public void testProcessGivenEmptyPercentiles() throws IOException {
+        var histogramBuckets = List.of(createHistogramBucket(1000L, 4, List.of(createMax("time", 1000), createPercentiles("my_field"))));
+
+        var json = aggToString(Sets.newHashSet("my_field"), histogramBuckets);
+
+        assertThat(json, equalTo("""
+            {"time":1000,"doc_count":4}"""));
+    }
+
     public void testProcessGivenSinglePercentilesPerHistogram() throws IOException {
         List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 4, Arrays.asList(createMax("time", 1000), createPercentiles("my_field", 1.0))),


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [ML] Handle empty percentile results (#116015)