### PR TITLE
Regression: flattened (label) fields when downsampling

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -12,6 +12,7 @@ import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
@@ -88,6 +89,9 @@ class FieldValueFetcher {
                         fetchers.add(new AggregateMetricFieldValueFetcher(metricSubField, aggMetricFieldType, fieldData));
                     }
                 }
+            } if (fieldType instanceof FlattenedFieldMapper.RootFlattenedFieldType rootFlattenedFieldType) {
+                // Can't recreate the flattened field as the value is returned as a literal while the index expect a json object.
+                return Collections.unmodifiableList(fetchers);
             } else {
                 if (context.fieldExistsInIndex(field)) {
                     final IndexFieldData<?> fieldData = context.getForField(fieldType, MappedFieldType.FielddataOperation.SEARCH);


### PR DESCRIPTION
Reproduce in dev-tools:
```
DELETE dummy_downsample
DELETE my-downsampled-time-series-index

PUT dummy_downsample
{
  "mappings": {
    "properties": {
      "@timestamp": {
        "type": "date"
      },
      "flattened": {
        "type": "flattened"
      },
      "keyword": {
        "type": "keyword",
        "time_series_dimension": true
      }
    }
  },
  "settings": {
    "index.mode": "time_series",
    "routing_path": [
      "keyword"
    ],
    "index.time_series.start_time": "2024-09-10T07:00:00.000Z",
    "index.time_series.end_time": "2024-09-10T08:00:00.000Z"
  }
}

POST dummy_downsample/_doc/
{
  "@timestamp": "2024-09-10T07:50:00.000Z",
  "flattened": {
    "key": "value"
  },
  "keyword": "keyword1"
}

POST dummy_downsample/_close
PUT dummy_downsample/_settings
{
  "index.blocks.write": "true"
}
POST dummy_downsample/_open

POST /dummy_downsample/_downsample/my-downsampled-time-series-index
{
  "fixed_interval": "1m"
}
```

last call results in a 500 response code under 8.15. Looking into things, it seems that instead of an object, the value of field of the flattened object is being presented for insertion which fails because the flattened field expects an object.

This however succeeds/silently fails in 8.11
