### PR TITLE
Synonyms test fix - number of shards

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -106,8 +106,9 @@
             - synonyms: "hello, salute"
             - synonyms: "ciao => goodbye"
   - match: { result: "updated" }
-  - gte: { reload_analyzers_details._shards.total: 2 } # shard requests are still sent to 2 indices
-  - gte: { reload_analyzers_details._shards.successful: 2 }
+  - set: { reload_analyzers_details._shards.total: total_shards }
+  - gte: { reload_analyzers_details._shards.total: 2 } # Shards for all indices were reloaded. On serverless this may be more as there are more replicas
+  - match: { reload_analyzers_details._shards.successful: $total_shards }
   - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
   - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
   - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -38,7 +38,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
             analysis:
               filter:
                 my_synonym_filter:
@@ -72,7 +71,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
             analysis:
               filter:
                 my_synonym_filter:
@@ -99,7 +97,6 @@
           - '{"index": {"_index": "my_index2", "_id": "2"}}'
           - '{"my_field": "goodbye"}'
 
-
   # An update of synonyms_set1 must trigger auto-reloading of analyzers only for synonyms_set1
   - do:
       synonyms.put_synonym:
@@ -109,8 +106,8 @@
             - synonyms: "hello, salute"
             - synonyms: "ciao => goodbye"
   - match: { result: "updated" }
-  - match: { reload_analyzers_details._shards.total: 2 } # shard requests are still sent to 2 indices
-  - match: { reload_analyzers_details._shards.successful: 2 }
+  - gte: { reload_analyzers_details._shards.total: 2 } # shard requests are still sent to 2 indices
+  - gte: { reload_analyzers_details._shards.successful: 2 }
   - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
   - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
   - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -108,7 +108,7 @@
   - match: { result: "updated" }
   - set: { reload_analyzers_details._shards.total: total_shards }
   - gte: { reload_analyzers_details._shards.total: 2 } # Shards for all indices were reloaded. On serverless this may be more as there are more replicas
-  - match: { reload_analyzers_details._shards.successful: $total_shards }
+  - lt: { reload_analyzers_details._shards.successful: $total_shards } # Only shards for the first index are successful
   - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
   - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
   - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -106,9 +106,9 @@
             - synonyms: "hello, salute"
             - synonyms: "ciao => goodbye"
   - match: { result: "updated" }
-  - set: { reload_analyzers_details._shards.total: total_shards }
-  - gte: { reload_analyzers_details._shards.total: 2 } # Shards for all indices were reloaded. On serverless this may be more as there are more replicas
-  - lt: { reload_analyzers_details._shards.successful: $total_shards } # Only shards for the first index are successful
+  - gt: { reload_analyzers_details._shards.total: 0 }
+  - gt: { reload_analyzers_details._shards.successful: 0 }
+  - match: { reload_analyzers_details._shards.failed: 0 }
   - length: { reload_analyzers_details.reload_details: 1 } # reload details contain only a single index
   - match: { reload_analyzers_details.reload_details.0.index: "my_index1" }
   - match: { reload_analyzers_details.reload_details.0.reloaded_analyzers.0: "my_analyzer1" }


### PR DESCRIPTION
Some synonyms tests were failing on serverless because the number of replicas can't be established there.

Changed tests so replicas are not established, and change checks to not depend on number of replicas directly.