### PR TITLE
Adding alias for k8s events field

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
@@ -170,6 +170,10 @@ template:
       kubernetes.node.hostname:
         type: alias
         path: resource.attributes.k8s.node.hostname
+      # Below is needed for the k8s events filtering per namespace
+      resource.attributes.k8s.namespace.name:
+        type: alias
+        path: body.structured.object.regarding.namespace
 # Below are non-ECS fields that may be used by Kibana.
       service.language.name:
         type: alias


### PR DESCRIPTION
Adding a new alias for the `resource.attributes.k8s.namespace.name` field that is used as a filter in Otel kubernetes Dashboard

For more information check https://github.com/elastic/integrations/pull/11591

