### PR TITLE
Move the lucene_snapshot branch to target branch_10x

### DIFF
--- a/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
+++ b/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
@@ -1,10 +1,10 @@
 steps:
   - trigger: apache-lucene-build-snapshot
-    label: Trigger pipeline to build lucene 10 snapshot
+    label: Trigger pipeline to build lucene snapshot
     key: lucene-build
     if: (build.env("LUCENE_BUILD_ID") == null || build.env("LUCENE_BUILD_ID") == "")
     build:
-      branch: branch_10_0
+      branch: branch_10x
   - wait
   - label: Upload and update lucene snapshot
     command: .buildkite/scripts/lucene-snapshot/upload-snapshot.sh


### PR DESCRIPTION
We have been tracking branch_10_0 for a bit following the Lucene 10.0 release. With this commit we move to tracking 10x, so that we get ready to upgrade to Lucene 10.1 when needed.
