### PR TITLE
Fix `_type` deprecation on simulate pipeline API

### DIFF
--- a/docs/changelog/116259.yaml
+++ b/docs/changelog/116259.yaml
@@ -1,0 +1,11 @@
+pr: 116259
+summary: Fix `_type` deprecation on simulate pipeline API
+area: Ingest Node
+type: deprecation
+issues: []
+deprecation:
+  title: Fix `_type` deprecation on simulate pipeline API
+  area: Ingest Node
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/changelog/116259.yaml
+++ b/docs/changelog/116259.yaml
@@ -4,8 +4,11 @@ area: Ingest Node
 type: deprecation
 issues: []
 deprecation:
-  title: Fix `_type` deprecation on simulate pipeline API
-  area: Ingest Node
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  title: Document `_type` deprecated on simulate pipeline API
+  area: REST API
+  details: >-
+    Passing a document with a `_type` property is deprecated in the `/_ingest/pipeline/{id}/_simulate` and
+    `/_ingest/pipeline/_simulate` APIs.
+  impact: >-
+    Users should already have stopped using mapping types, which were deprecated in {es} 7. This deprecation warning
+    will fire if they specify mapping types on documents pass to the simulate pipeline API.

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
@@ -156,6 +157,7 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
         return new Parsed(pipeline, ingestDocumentList, verbose);
     }
 
+    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Unconditionally deprecate the _type field once V8 BWC support is removed
     private static List<IngestDocument> parseDocs(Map<String, Object> config, RestApiVersion restApiVersion) {
         List<Map<String, Object>> docs = ConfigurationUtils.readList(null, null, config, Fields.DOCS);
         if (docs.isEmpty()) {
@@ -172,7 +174,7 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
             String index = ConfigurationUtils.readStringOrIntProperty(null, null, dataMap, Metadata.INDEX.getFieldName(), "_index");
             String id = ConfigurationUtils.readStringOrIntProperty(null, null, dataMap, Metadata.ID.getFieldName(), "_id");
             String routing = ConfigurationUtils.readOptionalStringOrIntProperty(null, null, dataMap, Metadata.ROUTING.getFieldName());
-            if (restApiVersion == RestApiVersion.V_7 && dataMap.containsKey(Metadata.TYPE.getFieldName())) {
+            if (restApiVersion != RestApiVersion.V_8 && dataMap.containsKey(Metadata.TYPE.getFieldName())) {
                 deprecationLogger.compatibleCritical(
                     "simulate_pipeline_with_types",
                     "[types removal] specifying _type in pipeline simulation requests is deprecated"

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
@@ -47,7 +47,7 @@ public class RestSimulatePipelineAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
-        SimulatePipelineRequest request = new SimulatePipelineRequest(sourceTuple.v2(), sourceTuple.v1());
+        SimulatePipelineRequest request = new SimulatePipelineRequest(sourceTuple.v2(), sourceTuple.v1(), restRequest.getRestApiVersion());
         request.setId(restRequest.param("id"));
         request.setVerbose(restRequest.paramAsBoolean("verbose", false));
         return channel -> client.admin().cluster().simulatePipeline(request, new RestToXContentListener<>(channel));


### PR DESCRIPTION
A change in 8.0.0 was intended to deprecate specifying `_type` in a document passed to the simulate pipeline API, unless it was in BWC mode for v7. There was a logic error which meant that the warning would actually *only* fire in BWC mode... except that the API version was not being correctly passed from the REST request to the transport request, so the warning would never fire.

This change for the 9.0 release fixes both issues, so that the deprecation warning fires unless it is in BWC mode for v8.