### PR TITLE
Unmute DocsClientYamlTestSuiteIT post-resume-follow/line_84 (#115918)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -161,9 +161,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
   issue: https://github.com/elastic/elasticsearch/issues/113325
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/ccr/apis/follow/post-resume-follow/line_84}
-  issue: https://github.com/elastic/elasticsearch/issues/113343
 - class: org.elasticsearch.xpack.ml.integration.MlJobIT
   method: testDeleteJob_TimingStatsDocumentIsDeleted
   issue: https://github.com/elastic/elasticsearch/issues/113370


### PR DESCRIPTION
Test was fixed by #113673 but wasn't unmuted at the time.

Closes #113343