### PR TITLE
[8.16] Fix testSearchConcurrencyDoesNotCreateMoreTasksThanThreads failure

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -1056,8 +1056,9 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
         assertThat(executor.getCompletedTaskCount(), greaterThanOrEqualTo((long) numIters * executorPoolSize));
         // while we parallelize we also limit the number of tasks that each searcher submits
         assertThat(executor.getCompletedTaskCount(), lessThan((long) numIters * numSegmentTasks));
-        // *3 is just a wild guess to account for tasks that get executed while we are still submitting
-        assertThat(executor.getCompletedTaskCount(), lessThan((long) numIters * executorPoolSize * 3));
+        // *10 is just a wild guess to account for tasks that get executed while we are still submitting. The important bit is that it is a
+        // much lower factor than the number of segments
+        assertThat(executor.getCompletedTaskCount(), lessThan((long) numIters * executorPoolSize * 10));
     }
 
     private void doTestSearchConcurrency(ThreadPoolExecutor executor, int numIters, int numSegmentTasks, AtomicInteger completedTasks)


### PR DESCRIPTION
This test was somehow difficult to write in the first place. We had to come up with a threshold of how many tasks max are going to be created, but that is not that easy to calculate as it depends on how quickly such tasks can be created and be executed.

We should have rather used a higher threshold to start with, the important part is anyways that we create a total of tasks that is no longer dependent on the number of segments, given there are much less threads available to execute them.

Closes #116048