### PR TITLE
[8.x] Add num docs and size to logsdb telemetry (#116128)

### DIFF
--- a/docs/changelog/116128.yaml
+++ b/docs/changelog/116128.yaml
@@ -1,0 +1,5 @@
+pr: 116128
+summary: Add num docs and size to logsdb telemetry
+area: Logs
+type: enhancement
+issues: []

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -469,5 +469,6 @@ module org.elasticsearch.server {
             org.elasticsearch.serverless.apifiltering;
     exports org.elasticsearch.lucene.spatial;
     exports org.elasticsearch.inference.configuration;
+    exports org.elasticsearch.monitor.metrics;
 
 }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -187,6 +187,7 @@ public class TransportVersions {
     public static final TransportVersion QUERY_RULES_RETRIEVER = def(8_782_00_0);
     public static final TransportVersion ESQL_CCS_EXEC_INFO_WITH_FAILURES = def(8_783_00_0);
     public static final TransportVersion LOGSDB_TELEMETRY = def(8_784_00_0);
+    public static final TransportVersion LOGSDB_TELEMETRY_STATS = def(8_785_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -243,6 +243,7 @@ import org.elasticsearch.indices.store.TransportNodesListShardStoreMetadata;
 import org.elasticsearch.injection.guice.AbstractModule;
 import org.elasticsearch.injection.guice.TypeLiteral;
 import org.elasticsearch.injection.guice.multibindings.MapBinder;
+import org.elasticsearch.monitor.metrics.IndexModeStatsActionType;
 import org.elasticsearch.persistent.CompletionPersistentTaskAction;
 import org.elasticsearch.persistent.RemovePersistentTaskAction;
 import org.elasticsearch.persistent.StartPersistentTaskAction;
@@ -630,6 +631,7 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportNodesFeaturesAction.TYPE, TransportNodesFeaturesAction.class);
         actions.register(RemoteClusterNodesAction.TYPE, RemoteClusterNodesAction.TransportAction.class);
         actions.register(TransportNodesStatsAction.TYPE, TransportNodesStatsAction.class);
+        actions.register(IndexModeStatsActionType.TYPE, IndexModeStatsActionType.TransportAction.class);
         actions.register(TransportNodesUsageAction.TYPE, TransportNodesUsageAction.class);
         actions.register(TransportNodesHotThreadsAction.TYPE, TransportNodesHotThreadsAction.class);
         actions.register(TransportListTasksAction.TYPE, TransportListTasksAction.class);

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionType.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndexModeStatsActionType.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.monitor.metrics;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public final class IndexModeStatsActionType extends ActionType<IndexModeStatsActionType.StatsResponse> {
+    public static final IndexModeStatsActionType TYPE = new IndexModeStatsActionType();
+
+    private IndexModeStatsActionType() {
+        super("cluster:monitor/nodes/index_mode_stats");
+    }
+
+    public static final class StatsRequest extends BaseNodesRequest<StatsRequest> {
+        public StatsRequest(String[] nodesIds) {
+            super(nodesIds);
+        }
+
+        public StatsRequest(DiscoveryNode... concreteNodes) {
+            super(concreteNodes);
+        }
+    }
+
+    public static final class StatsResponse extends BaseNodesResponse<NodeResponse> {
+        StatsResponse(ClusterName clusterName, List<NodeResponse> nodes, List<FailedNodeException> failures) {
+            super(clusterName, nodes, failures);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            assert false : "must be local";
+            throw new UnsupportedOperationException("must be local");
+        }
+
+        @Override
+        protected List<NodeResponse> readNodesFrom(StreamInput in) throws IOException {
+            assert false : "must be local";
+            throw new UnsupportedOperationException("must be local");
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<NodeResponse> nodes) throws IOException {
+            assert false : "must be local";
+            throw new UnsupportedOperationException("must be local");
+        }
+
+        public Map<IndexMode, IndexStats> stats() {
+            final Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
+            for (IndexMode mode : IndexMode.values()) {
+                stats.put(mode, new IndexStats());
+            }
+            for (NodeResponse node : getNodes()) {
+                for (Map.Entry<IndexMode, IndexStats> e : node.stats.entrySet()) {
+                    stats.get(e.getKey()).add(e.getValue());
+                }
+            }
+            return stats;
+        }
+    }
+
+    public static final class NodeRequest extends TransportRequest {
+        NodeRequest() {
+
+        }
+
+        NodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+
+    public static class NodeResponse extends BaseNodeResponse {
+        private final Map<IndexMode, IndexStats> stats;
+
+        NodeResponse(DiscoveryNode node, Map<IndexMode, IndexStats> stats) {
+            super(node);
+            this.stats = stats;
+        }
+
+        NodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+            super(in, node);
+            stats = in.readMap(IndexMode::readFrom, IndexStats::new);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeMap(stats, (o, m) -> IndexMode.writeTo(m, o), (o, s) -> s.writeTo(o));
+        }
+    }
+
+    public static class TransportAction extends TransportNodesAction<StatsRequest, StatsResponse, NodeRequest, NodeResponse, Void> {
+        private final IndicesService indicesService;
+
+        @Inject
+        public TransportAction(
+            ClusterService clusterService,
+            TransportService transportService,
+            ActionFilters actionFilters,
+            IndicesService indicesService
+        ) {
+            super(
+                TYPE.name(),
+                clusterService,
+                transportService,
+                actionFilters,
+                NodeRequest::new,
+                transportService.getThreadPool().executor(ThreadPool.Names.MANAGEMENT)
+            );
+            this.indicesService = indicesService;
+        }
+
+        @Override
+        protected StatsResponse newResponse(StatsRequest request, List<NodeResponse> nodeResponses, List<FailedNodeException> failures) {
+            return new StatsResponse(ClusterName.DEFAULT, nodeResponses, failures);
+        }
+
+        @Override
+        protected NodeRequest newNodeRequest(StatsRequest request) {
+            return new NodeRequest();
+        }
+
+        @Override
+        protected NodeResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+            return new NodeResponse(in, node);
+        }
+
+        @Override
+        protected NodeResponse nodeOperation(NodeRequest request, Task task) {
+            return new NodeResponse(clusterService.localNode(), IndicesMetrics.getStatsWithoutCache(indicesService));
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndexStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndexStats.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.monitor.metrics;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.search.stats.SearchStats;
+import org.elasticsearch.index.shard.IndexingStats;
+
+import java.io.IOException;
+
+public final class IndexStats implements Writeable {
+    int numIndices = 0;
+    long numDocs = 0;
+    long numBytes = 0;
+    SearchStats.Stats search = new SearchStats().getTotal();
+    IndexingStats.Stats indexing = new IndexingStats().getTotal();
+
+    IndexStats() {
+
+    }
+
+    IndexStats(StreamInput in) throws IOException {
+        this.numIndices = in.readVInt();
+        this.numDocs = in.readVLong();
+        this.numBytes = in.readVLong();
+        this.search = SearchStats.Stats.readStats(in);
+        this.indexing = new IndexingStats.Stats(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(numIndices);
+        out.writeVLong(numDocs);
+        out.writeVLong(numBytes);
+        search.writeTo(out);
+        indexing.writeTo(out);
+    }
+
+    void add(IndexStats other) {
+        this.numIndices += other.numIndices;
+        this.numDocs += other.numDocs;
+        this.numBytes += other.numBytes;
+        this.search.add(other.search);
+        this.indexing.add(other.indexing);
+    }
+
+    public int numIndices() {
+        return numIndices;
+    }
+
+    public long numDocs() {
+        return numDocs;
+    }
+
+    public long numBytes() {
+        return numBytes;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/IndicesMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/IndicesMetrics.java
@@ -18,11 +18,9 @@ import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.telemetry.metric.LongWithAttributes;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
@@ -193,12 +191,36 @@ public class IndicesMetrics extends AbstractLifecycleComponent {
         });
     }
 
-    static class IndexStats {
-        int numIndices = 0;
-        long numDocs = 0;
-        long numBytes = 0;
-        SearchStats.Stats search = new SearchStats().getTotal();
-        IndexingStats.Stats indexing = new IndexingStats().getTotal();
+    static Map<IndexMode, IndexStats> getStatsWithoutCache(IndicesService indicesService) {
+        Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
+        for (IndexMode mode : IndexMode.values()) {
+            stats.put(mode, new IndexStats());
+        }
+        for (IndexService indexService : indicesService) {
+            for (IndexShard indexShard : indexService) {
+                if (indexShard.isSystem()) {
+                    continue; // skip system indices
+                }
+                final ShardRouting shardRouting = indexShard.routingEntry();
+                final IndexMode indexMode = indexShard.indexSettings().getMode();
+                final IndexStats indexStats = stats.get(indexMode);
+                try {
+                    if (shardRouting.primary() && shardRouting.recoverySource() == null) {
+                        if (shardRouting.shardId().id() == 0) {
+                            indexStats.numIndices++;
+                        }
+                        final DocsStats docStats = indexShard.docStats();
+                        indexStats.numDocs += docStats.getCount();
+                        indexStats.numBytes += docStats.getTotalSizeInBytes();
+                        indexStats.indexing.add(indexShard.indexingStats().getTotal());
+                    }
+                    indexStats.search.add(indexShard.searchStats().getTotal());
+                } catch (IllegalIndexShardStateException | AlreadyClosedException ignored) {
+                    // ignored
+                }
+            }
+        }
+        return stats;
     }
 
     private static class IndicesStatsCache extends SingleObjectCache<Map<IndexMode, IndexStats>> {
@@ -219,41 +241,9 @@ public class IndicesMetrics extends AbstractLifecycleComponent {
             this.refresh = true;
         }
 
-        private Map<IndexMode, IndexStats> internalGetIndicesStats() {
-            Map<IndexMode, IndexStats> stats = new EnumMap<>(IndexMode.class);
-            for (IndexMode mode : IndexMode.values()) {
-                stats.put(mode, new IndexStats());
-            }
-            for (IndexService indexService : indicesService) {
-                for (IndexShard indexShard : indexService) {
-                    if (indexShard.isSystem()) {
-                        continue; // skip system indices
-                    }
-                    final ShardRouting shardRouting = indexShard.routingEntry();
-                    final IndexMode indexMode = indexShard.indexSettings().getMode();
-                    final IndexStats indexStats = stats.get(indexMode);
-                    try {
-                        if (shardRouting.primary() && shardRouting.recoverySource() == null) {
-                            if (shardRouting.shardId().id() == 0) {
-                                indexStats.numIndices++;
-                            }
-                            final DocsStats docStats = indexShard.docStats();
-                            indexStats.numDocs += docStats.getCount();
-                            indexStats.numBytes += docStats.getTotalSizeInBytes();
-                            indexStats.indexing.add(indexShard.indexingStats().getTotal());
-                        }
-                        indexStats.search.add(indexShard.searchStats().getTotal());
-                    } catch (IllegalIndexShardStateException | AlreadyClosedException ignored) {
-                        // ignored
-                    }
-                }
-            }
-            return stats;
-        }
-
         @Override
         protected Map<IndexMode, IndexStats> refresh() {
-            return refresh ? internalGetIndicesStats() : getNoRefresh();
+            return refresh ? getStatsWithoutCache(indicesService) : getNoRefresh();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatures.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatures.java
@@ -21,13 +21,15 @@ import java.util.Set;
  */
 public class XPackFeatures implements FeatureSpecification {
     public static final NodeFeature LOGSDB_TELEMETRY = new NodeFeature("logsdb_telemetry");
+    public static final NodeFeature LOGSDB_TELMETRY_STATS = new NodeFeature("logsdb_telemetry_stats");
 
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(
             NodesDataTiersUsageTransportAction.LOCALLY_PRECALCULATED_STATS_FEATURE, // Added in 8.12
             License.INDEPENDENT_TRIAL_VERSION_FEATURE, // 8.14.0
-            LOGSDB_TELEMETRY
+            LOGSDB_TELEMETRY,
+            LOGSDB_TELMETRY_STATS
         );
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_usage.yml
@@ -1,5 +1,8 @@
 ---
 logsdb usage:
+  - requires:
+      cluster_features: ["logsdb_telemetry_stats"]
+      reason: "requires stats"
   - do:
       indices.create:
         index: test1
@@ -7,20 +10,43 @@ logsdb usage:
           settings:
             index:
               mode: logsdb
+  - do:
+      bulk:
+        index: test1
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:30:00Z", "host.name": "foo" }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:31:00Z", "host.name": "bar" }
 
   - do: {xpack.usage: {}}
   - match: { logsdb.available: true }
   - match: { logsdb.indices_count: 1 }
   - match: { logsdb.indices_with_synthetic_source: 1 }
+  - match: { logsdb.num_docs: 2 }
+  - gt:    { logsdb.size_in_bytes: 0}
 
   - do:
       indices.create:
         index: test2
 
+  - do:
+      bulk:
+        index: test2
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:32:00Z", "host.name": "foo" }
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:33:00Z", "host.name": "baz" }
+
   - do: {xpack.usage: {}}
   - match: { logsdb.available: true }
   - match: { logsdb.indices_count: 1 }
   - match: { logsdb.indices_with_synthetic_source: 1 }
+  - match: { logsdb.num_docs: 2 }
+  - gt:    { logsdb.size_in_bytes: 0}
 
   - do:
       indices.create:
@@ -31,7 +57,17 @@ logsdb usage:
               mode: logsdb
               mapping.source.mode: stored
 
+  - do:
+      bulk:
+        index: test3
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2024-02-12T10:32:00Z", "host.name": "foobar"}
+
   - do: {xpack.usage: {}}
   - match: { logsdb.available: true }
   - match: { logsdb.indices_count: 2 }
   - match: { logsdb.indices_with_synthetic_source: 1 }
+  - match: { logsdb.num_docs: 3 }
+  - gt:    { logsdb.size_in_bytes: 0}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add num docs and size to logsdb telemetry (#116128)