### PR TITLE
[Inference API Docs] Update service-elser.asciidoc

### DIFF
--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -7,6 +7,12 @@ You can also deploy ELSER by using the <<infer-service-elasticsearch>>.
 NOTE: The API request will automatically download and deploy the ELSER model if
 it isn't already downloaded.
 
+[WARNING]
+.Deprecated in 8.16
+====
+The elser service is deprecated and will be removed in a future release. 
+Use the <<infer-service-elasticsearch>> instead, with model_id included in the service_settings.
+====
 
 [discrete]
 [[infer-service-elser-api-request]]


### PR DESCRIPTION
Adds deprecation warning to elser service. 

Related to https://github.com/elastic/search-docs-team/issues/216

