### PR TITLE
[8.16] (Doc+) Resolve watermark on Cloud via Autoscaling (#115990)

### DIFF
--- a/docs/reference/troubleshooting/common-issues/disk-usage-exceeded.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/disk-usage-exceeded.asciidoc
@@ -106,6 +106,8 @@ As a long-term solution, we recommend you do one of the following best suited
 to your use case: 
 
 * add nodes to the affected <<data-tiers,data tiers>>
++
+TIP: You should enable <<xpack-autoscaling,autoscaling>> for clusters deployed using our {ess}, {ece}, and {eck} platforms.
 
 * upgrade existing nodes to increase disk space
 +


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [(Doc+) Resolve watermark on Cloud via Autoscaling (#115990)](https://github.com/elastic/elasticsearch/pull/115990)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)