### PR TITLE
[8.x] [DOCS] Fix typo in percentile-aggregation.asciidoc (#116268)

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -77,8 +77,8 @@ percentiles: `[ 1, 5, 25, 50, 75, 95, 99 ]`. The response will look like this:
 
 As you can see, the aggregation will return a calculated value for each percentile
 in the default range. If we assume response times are in milliseconds, it is
-immediately obvious that the webpage normally loads in 10-725ms, but occasionally
-spikes to 945-985ms.
+immediately obvious that the webpage normally loads in 10-720ms, but occasionally
+spikes to 940-980ms.
 
 Often, administrators are only interested in outliers -- the extreme percentiles.
 We can specify just the percents we are interested in (requested percentiles


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Fix typo in percentile-aggregation.asciidoc (#116268)](https://github.com/elastic/elasticsearch/pull/116268)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)