### PR TITLE
Deduplicate the name of the aggregation when deserializing InternalAgregation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.DelayableWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -51,7 +52,12 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
      * Read from a stream.
      */
     protected InternalAggregation(StreamInput in) throws IOException {
-        name = in.readString();
+        final String name = in.readString();
+        if (in instanceof DelayableWriteable.Deduplicator d) {
+            this.name = d.deduplicate(name);
+        } else {
+            this.name = name;
+        }
         metadata = in.readGenericMap();
     }
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/112707 we added infrastructure to deduplicate objects where deserailizing internal aggregations. Let' use it to deduplicate the names of InternalAgregation objects.