### PR TITLE
[8.16][DOCS] Updates Connectors section page references

### DIFF
--- a/docs/reference/connector/docs/_connectors-create-client.asciidoc
+++ b/docs/reference/connector/docs/_connectors-create-client.asciidoc
@@ -3,7 +3,7 @@
 
 To create a new {service-name} connector:
 
-. Navigate to the *Search -> Connectors* page in the Kibana UI.
+. In the Kibana UI, navigate to the *Search -> Content -> Connectors* page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 . Follow the instructions to create a new  *{service-name}* self-managed connector.
 
 [discrete#es-connectors-{service-name-stub}-client-create-use-the-api]

--- a/docs/reference/connector/docs/_connectors-create-native.asciidoc
+++ b/docs/reference/connector/docs/_connectors-create-native.asciidoc
@@ -3,7 +3,7 @@
 
 To create a new {service-name} connector:
 
-. Navigate to the *Search -> Connectors* page in the Kibana UI.
+. In the Kibana UI, navigate to the *Search -> Content -> Connectors* page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 . Follow the instructions to create a new native  *{service-name}* connector.
 
 For additional operations, see <<es-connectors-usage>>.

--- a/docs/reference/connector/docs/connectors-hosted-tutorial-mongo.asciidoc
+++ b/docs/reference/connector/docs/connectors-hosted-tutorial-mongo.asciidoc
@@ -123,7 +123,7 @@ Once you're deployment is created, navigate to *Search*.
 The Elastic connector will sync your MongoDB data into a search-optimized Elasticsearch index.
 The first step is to create your index in the Kibana UI.
 
-In the main menu navigate to *Search > Content > Indices*.
+In the main menu, navigate to *Search > Content > Indices*, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Follow these steps to create your index:
 
@@ -178,7 +178,7 @@ If all the configuration details are correct, the sync will begin and documents 
 
 As soon as your first documents are synced, you can view the documents and inspect the mapping for the index:
 
-* In Kibana, navigate to *Search* > *Content* > *Indices*.
+* In Kibana, navigate to *Search* > *Content* > *Indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 * Select your index, for example `search-mongo-sample`.
 * Choose the *Documents* tab to view the synced documents.
 Expand a document to view its fields.

--- a/docs/reference/connector/docs/connectors-managed-service.asciidoc
+++ b/docs/reference/connector/docs/connectors-managed-service.asciidoc
@@ -80,7 +80,7 @@ Create a new index to be managed by the connector.
 
 Continue from above, or navigate to the following location within the {kib} UI:
 
-*Search > Content > Elasticsearch indices*
+*Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Choose the index to configure, and then choose the *Configuration* tab.
 

--- a/docs/reference/connector/docs/connectors-usage.asciidoc
+++ b/docs/reference/connector/docs/connectors-usage.asciidoc
@@ -3,7 +3,7 @@
 
 This document describes operations available to <<es-native-connectors,managed connectors>> and <<es-build-connector,self-managed connectors>>, using the UI.
 
-In the Kibana UI, go to *Search > Content > Connectors* to view a summary of all your connectors and sync jobs, and to create new connectors.
+In the Kibana UI, navigate to *Search > Content > Connectors* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field]. Here, you can view a summary of all your connectors and sync jobs, and to create new connectors.
 
 [TIP]
 ====
@@ -24,7 +24,7 @@ Once you've chosen the data source type you'd like to sync, you'll be prompted t
 
 View and manage all Elasticsearch indices managed by connectors.
 
-In the {kib} UI, navigate to *Search > Content > Connectors* to view a list of connector indices and their attributes, including connector type health and ingestion status.
+In the {kib} UI, navigate to *Search > Content > Connectors* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field]. Here, you can view a list of connector indices and their attributes, including connector type health and ingestion status.
 
 Within this interface, you can choose to view the details for each existing index or delete an index.
 Or, you can <<es-connectors-usage-index-create,create a new connector index>>.
@@ -82,7 +82,7 @@ The workflow for these updates is as follows:
 
 After creating an index to be managed by a connector, you can configure automatic, recurring syncs.
 
-In the {kib} UI, navigate to *Search > Content > Connectors*.
+In the {kib} UI, navigate to *Search > Content > Connectors* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Choose the index to configure, and then choose the *Scheduling* tab.
 
@@ -107,7 +107,7 @@ You may want to <<es-connectors-usage-index-view,view the index details>> to see
 
 After creating the index to be managed by a connector, you can request a single sync at any time.
 
-In the {kib} UI, navigate to *Search > Content > Elasticsearch indices*.
+In the {kib} UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Then choose the index to sync.
 
@@ -128,7 +128,7 @@ This operation requires access to Kibana and the `write` {ref}/security-privileg
 
 After a sync has started, you can cancel the sync before it completes.
 
-In the {kib} UI, navigate to *Search > Content > Elasticsearch indices*.
+In the {kib} UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Then choose the index with the running sync.
 
@@ -144,7 +144,7 @@ This operation requires access to Kibana and the `write` {ref}/security-privileg
 
 View the index details to see a variety of information that communicate the status of the index and connector.
 
-In the {kib} UI, navigate to *Search > Content > Elasticsearch indices*.
+In the {kib} UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Then choose the index to view.
 
@@ -192,7 +192,7 @@ This operation requires access to Kibana and the `read` {ref}/security-privilege
 View the documents the connector has synced from the data.
 Additionally view the index mappings to determine the current document schema.
 
-In the {kib} UI, navigate to *Search > Content > Elasticsearch indices*.
+In the {kib} UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Then choose the index to view.
 
@@ -211,7 +211,7 @@ See <<es-connectors-security>> for security details.
 
 Use <<es-sync-rules,sync rules>> to limit which documents are fetched from the data source, or limit which fetched documents are stored in Elastic.
 
-In the {kib} UI, navigate to *Search > Content > Elasticsearch indices*.
+In the {kib} UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Then choose the index to manage and choose the *Sync rules* tab.
 
@@ -220,6 +220,6 @@ Then choose the index to manage and choose the *Sync rules* tab.
 
 Use {ref}/ingest-pipeline-search.html[ingest pipelines] to transform fetched data before it is stored in Elastic.
 
-In the {kib} UI, navigate to *Search > Content > Elasticsearch indices*.
+In the {kib} UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Then choose the index to manage and choose the *Pipelines* tab.

--- a/docs/reference/connector/docs/dls-e2e-guide.asciidoc
+++ b/docs/reference/connector/docs/dls-e2e-guide.asciidoc
@@ -54,7 +54,7 @@ To build our search experience for our SharePoint Online data, we need to create
 
 Follow these steps to create a Search Application in the Kibana UI:
 
-. Navigate to *Search > Search Applications*.
+. Navigate to *Search > Search Applications* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 . Select *Create*.
 . *Name* the Search Application.
 . Select the *index* used by the SharePoint Online connector.

--- a/docs/reference/connector/docs/postgresql-connector-client-tutorial.asciidoc
+++ b/docs/reference/connector/docs/postgresql-connector-client-tutorial.asciidoc
@@ -70,7 +70,7 @@ To complete this tutorial, you'll need to complete the following steps:
 Elastic connectors enable you to create searchable, read-only replicas of your data sources in Elasticsearch.
 The first step in setting up your self-managed connector is to create an index.
 
-In the {kibana-ref}[Kibana^] UI go to *Search > Content > Elasticsearch indices*.
+In the {kibana-ref}[Kibana^] UI, navigate to *Search > Content > Elasticsearch indices* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Create a new connector index:
 


### PR DESCRIPTION
### Overview

This PR backports the following changes to the 8.16 branch:
[Expands semantic_text tutorial with hybrid search #114398
](https://github.com/elastic/elasticsearch/pull/116239)