### PR TITLE
Exclude "aggregations/percentiles_hdr_metric/Negative values test" from mixed cluster tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -264,9 +264,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/filter_crud/Test update filter}
   issue: https://github.com/elastic/elasticsearch/issues/116271
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=aggregations/percentiles_hdr_metric/Negative values test}
-  issue: https://github.com/elastic/elasticsearch/issues/116276
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/get_datafeeds/Test explicit get all datafeeds}
   issue: https://github.com/elastic/elasticsearch/issues/116284

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -61,6 +61,9 @@ excludeList.add('cluster.desired_nodes/20_dry_run/Test validation works for dry 
 // Excluded because they create dot-prefixed indices on older versions
 excludeList.add('indices.resolve_index/20_resolve_system_index/*')
 
+// Excluded because the error has changed
+excludeList.add('aggregations/percentiles_hdr_metric/Negative values test')
+
 BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   if (bwcVersion != VersionProperties.getElasticsearchVersion()) {


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/116174 we change the type of the exception throws which makes this test fail in a mixed cluster environment as we assert the exception. Let's skip it.