### PR TITLE
Mute test42AutoconfigurationNotTriggeredWhenNodeCannotBecomeMaster

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -279,6 +279,9 @@ tests:
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test40AutoconfigurationNotTriggeredWhenNodeIsMeantToJoinExistingCluster
   issue: https://github.com/elastic/elasticsearch/issues/116289
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test42AutoconfigurationNotTriggeredWhenNodeCannotBecomeMaster
+  issue: https://github.com/elastic/elasticsearch/issues/116299
 - class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/116291
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/116299