### PR TITLE
[CI] Remove test support for windows 2016 and 2019

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -40,8 +40,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
-              - windows-2019
               - windows-2022
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -345,8 +345,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
-              - windows-2019
               - windows-2022
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -38,8 +38,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
-              - windows-2019
               - windows-2022
             GRADLE_TASK:
               - checkPart1

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -12,7 +12,7 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2019
+              - windows-2022
             PACKAGING_TASK:
               - default-windows-archive
         agents:

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -10,8 +10,6 @@ steps:
         matrix:
           setup:
             image:
-              - windows-2016
-              - windows-2019
               - windows-2022
             PACKAGING_TASK:
               - default-windows-archive

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -48,7 +48,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-@PackagingTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/116299")
 public class ArchiveTests extends PackagingTestCase {
 
     @BeforeClass


### PR DESCRIPTION
This removes test coverage for elasticsearch against windows 2016 and 2019.

With ml only supporting windows 2022 tests against older platforms started failing. 

closes #116299 #116317 #116290 #116289 #116286