### PR TITLE
[8.x] Add missing header in put_data_lifecycle rest-api-spec (#116292)

### DIFF
--- a/docs/changelog/116292.yaml
+++ b/docs/changelog/116292.yaml
@@ -1,0 +1,5 @@
+pr: 116292
+summary: Add missing header in `put_data_lifecycle` rest-api-spec
+area: Data streams
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url": {
       "paths": [


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add missing header in put_data_lifecycle rest-api-spec (#116292)