### PR TITLE
fix testMaybeConvertToBytesRefStringCorrectSize

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/AbstractQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/AbstractQueryBuilderTests.java
@@ -100,10 +100,10 @@ public class AbstractQueryBuilderTests extends ESTestCase {
         int correctSize = 0;
         for (int i = 0; i < capacity; i++) {
             if (i < capacity / 3) {
-                termBuilder.append((char) randomIntBetween(0, 128));
+                termBuilder.append((char) randomIntBetween(0, 127));
                 ++correctSize; // use only one byte for char < 128
             } else if (i < 2 * capacity / 3) {
-                termBuilder.append((char) randomIntBetween(128, 2048));
+                termBuilder.append((char) randomIntBetween(128, 2047));
                 correctSize += 2; // use two bytes for char < 2048
             } else {
                 termBuilder.append((char) randomIntBetween(2048, 4092));


### PR DESCRIPTION
randomIntBetween is inclusive while we want max to be exclusive.
Relates to: https://github.com/elastic/elasticsearch/pull/115655
Fix already in backport PR https://github.com/elastic/elasticsearch/pull/116381 