### PR TITLE
[DOCS] Use explicit link text in query rules retriever

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -554,7 +554,7 @@ It then re-ranks the results based on semantic similarity to the text in the `in
 [[rule-retriever]]
 ==== Query Rules Retriever
 
-The `rule` retriever enables fine-grained control over search results by applying contextual <<query-rules>> to pin or exclude documents for specific queries.
+The `rule` retriever enables fine-grained control over search results by applying contextual <<query-rules,query rules>> to pin or exclude documents for specific queries.
 This retriever has similar functionality to the <<query-dsl-rule-query>>, but works out of the box with other retrievers.
 
 ===== Prerequisites

--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -555,7 +555,7 @@ It then re-ranks the results based on semantic similarity to the text in the `in
 ==== Query Rules Retriever
 
 The `rule` retriever enables fine-grained control over search results by applying contextual <<query-rules,query rules>> to pin or exclude documents for specific queries.
-This retriever has similar functionality to the <<query-dsl-rule-query>>, but works out of the box with other retrievers.
+This retriever has similar functionality to the <<query-dsl-rule-query, rule query>>, but works out of the box with other retrievers.
 
 ===== Prerequisites
 


### PR DESCRIPTION
Missed this previously 🔍 

Was rendering the titles which didn't fit in sentence context 👇 

<img width="879" alt="Screenshot 2024-11-07 at 10 56 10" src="https://github.com/user-attachments/assets/ece357ed-f993-4136-9614-eb8e1a30fad0">
