### PR TITLE
[TEST] Unmute entire integration test suits

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -261,18 +261,6 @@ tests:
 - class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
   method: testEveryActionIsEitherOperatorOnlyOrNonOperator
   issue: https://github.com/elastic/elasticsearch/issues/102992
-- class: org.elasticsearch.datastreams.DataStreamsClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/116291
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/114723
-- class: org.elasticsearch.xpack.search.AsyncSearchSecurityIT
-  issue: https://github.com/elastic/elasticsearch/issues/116293
-- class: org.elasticsearch.xpack.downsample.DownsampleRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/116326
-- class: org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/116327
-- class: org.elasticsearch.validation.DotPrefixClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/116328
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testBottomFieldSort
   issue: https://github.com/elastic/elasticsearch/issues/116249


### PR DESCRIPTION
These tests where successively muted, without evidence that they were to blame for test failures. Unmuting to see if failures persist.

Fixes #116291, #114723, #116293, #116326, #116327, #116328