### PR TITLE
[8.x] Aggs: Add real memory CB call when building internal aggregators in buckets (#116329)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -81,12 +81,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
         grow(bucketOrd + 1);
         int docCount = docCountProvider.getDocCount(doc);
         if (docCounts.increment(bucketOrd, docCount) == docCount) {
-            // We call the circuit breaker the time to time in order to give it a chance to check available
-            // memory in the parent breaker and break the execution if we are running out. To achieve that we
-            // are passing 0 as the estimated bytes every 1024 calls
-            if ((++callCount & 0x3FF) == 0) {
-                breaker.addEstimateBytesAndMaybeBreak(0, "allocated_buckets");
-            }
+            updateCircuitBreaker("allocated_buckets");
         }
         subCollector.collect(doc, bucketOrd);
     }
@@ -179,6 +174,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
         prepareSubAggs(bucketOrdsToCollect);
         InternalAggregation[][] aggregations = new InternalAggregation[subAggregators.length][];
         for (int i = 0; i < subAggregators.length; i++) {
+            updateCircuitBreaker("building_sub_aggregation");
             aggregations[i] = subAggregators[i].buildAggregations(bucketOrdsToCollect);
         }
         return subAggsForBucketFunction(aggregations);
@@ -414,5 +410,16 @@ public abstract class BucketsAggregator extends AggregatorBase {
         super.preGetSubLeafCollectors(ctx);
         // Set LeafReaderContext to the doc_count provider
         docCountProvider.setLeafReaderContext(ctx);
+    }
+
+    /**
+     * This method calls the circuit breaker from time to time in order to give it a chance to check available
+     * memory in the parent breaker (Which should be a real memory breaker) and break the execution if we are running out.
+     * To achieve that, we are passing 0 as the estimated bytes every 1024 calls
+     */
+    private void updateCircuitBreaker(String label) {
+        if ((++callCount & 0x3FF) == 0) {
+            breaker.addEstimateBytesAndMaybeBreak(0, label);
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Aggs: Add real memory CB call when building internal aggregators in buckets (#116329)