### PR TITLE
[8.x] [DOCS] Fix boolean for native connectors (#116394)

### DIFF
--- a/docs/reference/connector/docs/_connectors-create-native.asciidoc
+++ b/docs/reference/connector/docs/_connectors-create-native.asciidoc
@@ -22,7 +22,7 @@ PUT _connector/my-{service-name-stub}-connector
   "index_name": "my-elasticsearch-index",
   "name": "Content synced from {service-name}",
   "service_type": "{service-name-stub}",
-  "is_native": "true"
+  "is_native": true
 }
 ----
 // TEST[skip:can't test in isolation]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Fix boolean for native connectors (#116394)](https://github.com/elastic/elasticsearch/pull/116394)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)