### PR TITLE
ES|QL capitalize commands and functions in doc examples for match and qstr

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-function.csv-spec
@@ -6,11 +6,11 @@ matchWithField
 required_capability: match_function
 
 // tag::match-with-field[]
-from books 
-| where match(author, "Faulkner")
-| keep book_no, author 
-| sort book_no 
-| limit 5;
+FROM books 
+| WHERE MATCH(author, "Faulkner")
+| KEEP book_no, author 
+| SORT book_no 
+| LIMIT 5;
 // end::match-with-field[]
 
 // tag::match-with-field-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -6,11 +6,11 @@ matchWithField
 required_capability: match_operator_colon
 
 // tag::match-with-field[]
-from books 
-| where author:"Faulkner"
-| keep book_no, author 
-| sort book_no 
-| limit 5;
+FROM books 
+| WHERE author:"Faulkner"
+| KEEP book_no, author 
+| SORT book_no 
+| LIMIT 5;
 // end::match-with-field[]
 
 // tag::match-with-field-result[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/qstr-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/qstr-function.csv-spec
@@ -6,11 +6,11 @@ qstrWithField
 required_capability: qstr_function
 
 // tag::qstr-with-field[]
-from books 
-| where qstr("author: Faulkner")
-| keep book_no, author 
-| sort book_no 
-| limit 5;
+FROM books 
+| WHERE QSTR("author: Faulkner")
+| KEEP book_no, author 
+| SORT book_no 
+| LIMIT 5;
 // end::qstr-with-field[]
 
 // tag::qstr-with-field-result[]


### PR DESCRIPTION
ES|QL capitalize commands and functions in doc examples for match and qstr.