### PR TITLE
[8.x] [DOCS] Use explicit link text in query rules retriever (#116389)

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -554,8 +554,8 @@ It then re-ranks the results based on semantic similarity to the text in the `in
 [[rule-retriever]]
 ==== Query Rules Retriever
 
-The `rule` retriever enables fine-grained control over search results by applying contextual <<query-rules>> to pin or exclude documents for specific queries.
-This retriever has similar functionality to the <<query-dsl-rule-query>>, but works out of the box with other retrievers.
+The `rule` retriever enables fine-grained control over search results by applying contextual <<query-rules,query rules>> to pin or exclude documents for specific queries.
+This retriever has similar functionality to the <<query-dsl-rule-query, rule query>>, but works out of the box with other retrievers.
 
 ===== Prerequisites
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Use explicit link text in query rules retriever (#116389)](https://github.com/elastic/elasticsearch/pull/116389)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)