### PR TITLE
[otel-data] Add orchestrator.cluster.name -> k8s.cluster.name alias

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
@@ -95,6 +95,9 @@ template:
               k8s.statefulset.name:
                 type: keyword
                 ignore_above: 1024
+              k8s.cluster.name:
+                type: keyword
+                ignore_above: 1024
       service.node.name:
         type: alias
         path: resource.attributes.service.instance.id
@@ -131,6 +134,10 @@ template:
       host.os.version:
         type: alias
         path: resource.attributes.os.version
+      orchestrator.cluster.name:
+        type: alias
+        path: resource.attributes.k8s.cluster.name
+# Below are non-ECS fields that may be used by Kibana.
       kubernetes.deployment.name:
         type: alias
         path: resource.attributes.k8s.deployment.name
@@ -170,7 +177,6 @@ template:
       kubernetes.node.hostname:
         type: alias
         path: resource.attributes.k8s.node.hostname
-# Below are non-ECS fields that may be used by Kibana.
       service.language.name:
         type: alias
         path: resource.attributes.telemetry.sdk.language

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
@@ -209,12 +209,13 @@ host.name pass-through:
                 k8s.replicaset.name: myReplicasetName
                 k8s.node.uid: myNodeUid
                 k8s.node.hostname: myNodeHostname
+                k8s.cluster.name: myClusterName
   - is_false: errors
   - do:
       search:
         index: logs-generic.otel-default
         body:
-          fields: ["kubernetes.container.name", "kubernetes.cronjob.name", "kubernetes.job.name", "kubernetes.statefulset.name", "kubernetes.daemonset.name", "kubernetes.replicaset.name", "kubernetes.node.uid", "kubernetes.node.hostname" ]
+          fields: ["kubernetes.container.name", "kubernetes.cronjob.name", "kubernetes.job.name", "kubernetes.statefulset.name", "kubernetes.daemonset.name", "kubernetes.replicaset.name", "kubernetes.node.uid", "kubernetes.node.hostname", "orchestrator.cluster.name" ]
   - length: { hits.hits: 1 }
   - match: { hits.hits.0.fields.kubernetes\.container\.name : ["myContainerName"] }
   - match: { hits.hits.0.fields.kubernetes\.cronjob\.name : ["myCronJobName"] }
@@ -224,3 +225,4 @@ host.name pass-through:
   - match: { hits.hits.0.fields.kubernetes\.replicaset\.name : ["myReplicasetName"] }
   - match: { hits.hits.0.fields.kubernetes\.node\.uid : ["myNodeUid"] }
   - match: { hits.hits.0.fields.kubernetes\.node\.hostname : ["myNodeHostname"] }
+  - match: { hits.hits.0.fields.orchestrator\.cluster\.name : ["myClusterName"] }


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36233/files#r1832603045

Context: we already alias lots of `k8s.*` attributes to `kubernetes.*` based on https://github.com/elastic/integrations/blob/main/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml - those are non-ecs fields.

However `k8s.cluster.name` from SemConv was not covered in that file, since that maps to `orchestrator.cluster.name` which is part of ECS and defined in https://github.com/elastic/integrations/blob/main/packages/kubernetes/data_stream/container_logs/fields/ecs.yml, 