### PR TITLE
[8.x] ESQL: Move some of ENRICH into compute (#116338)

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -289,34 +289,6 @@ tasks.named('stringTemplates').configure {
   var doubleProperties = prop("Double", "double", "DOUBLE", "Double.BYTES", "DoubleArray")
   var bytesRefProperties = prop("BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF", "")
   var booleanProperties = prop("Boolean", "boolean", "BOOLEAN", "Byte.BYTES", "BitArray")
-  // enrich
-  File enrichResultBuilderInput = file("src/main/java/org/elasticsearch/xpack/esql/enrich/X-EnrichResultBuilder.java.st")
-  template {
-    it.properties = intProperties
-    it.inputFile = enrichResultBuilderInput
-    it.outputFile = "org/elasticsearch/xpack/esql/enrich/EnrichResultBuilderForInt.java"
-  }
-  template {
-    it.properties = longProperties
-    it.inputFile = enrichResultBuilderInput
-    it.outputFile = "org/elasticsearch/xpack/esql/enrich/EnrichResultBuilderForLong.java"
-  }
-  template {
-    it.properties = doubleProperties
-    it.inputFile = enrichResultBuilderInput
-    it.outputFile = "org/elasticsearch/xpack/esql/enrich/EnrichResultBuilderForDouble.java"
-  }
-  template {
-    it.properties = bytesRefProperties
-    it.inputFile = enrichResultBuilderInput
-    it.outputFile = "org/elasticsearch/xpack/esql/enrich/EnrichResultBuilderForBytesRef.java"
-  }
-  template {
-    it.properties = booleanProperties
-    it.inputFile = enrichResultBuilderInput
-    it.outputFile = "org/elasticsearch/xpack/esql/enrich/EnrichResultBuilderForBoolean.java"
-  }
-
 
   File inInputFile = file("src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/X-InEvaluator.java.st")
   template {

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -803,4 +803,32 @@ tasks.named('stringTemplates').configure {
     it.inputFile = bucketedSortInputFile
     it.outputFile = "org/elasticsearch/compute/data/sort/DoubleBucketedSort.java"
   }
+
+  File enrichResultBuilderInput = file("src/main/java/org/elasticsearch/compute/operator/lookup/X-EnrichResultBuilder.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile = enrichResultBuilderInput
+    it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForInt.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile = enrichResultBuilderInput
+    it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForLong.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile = enrichResultBuilderInput
+    it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForDouble.java"
+  }
+  template {
+    it.properties = bytesRefProperties
+    it.inputFile = enrichResultBuilderInput
+    it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForBytesRef.java"
+  }
+  template {
+    it.properties = booleanProperties
+    it.inputFile = enrichResultBuilderInput
+    it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForBoolean.java"
+  }
+
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForDouble.java
@@ -5,35 +5,35 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 
 import java.util.Arrays;
 
 /**
- * {@link EnrichResultBuilder} for Longs.
+ * {@link EnrichResultBuilder} for Doubles.
  * This class is generated. Edit `X-EnrichResultBuilder.java.st` instead.
  */
-final class EnrichResultBuilderForLong extends EnrichResultBuilder {
-    private ObjectArray<long[]> cells;
+final class EnrichResultBuilderForDouble extends EnrichResultBuilder {
+    private ObjectArray<double[]> cells;
 
-    EnrichResultBuilderForLong(BlockFactory blockFactory, int channel) {
+    EnrichResultBuilderForDouble(BlockFactory blockFactory, int channel) {
         super(blockFactory, channel);
         this.cells = blockFactory.bigArrays().newObjectArray(1);
     }
 
     @Override
     void addInputPage(IntVector positions, Page page) {
-        LongBlock block = page.getBlock(channel);
+        DoubleBlock block = page.getBlock(channel);
         for (int i = 0; i < positions.getPositionCount(); i++) {
             int valueCount = block.getValueCount(i);
             if (valueCount == 0) {
@@ -48,53 +48,53 @@ final class EnrichResultBuilderForLong extends EnrichResultBuilder {
             adjustBreaker(RamUsageEstimator.sizeOf(newCell) - (oldCell != null ? RamUsageEstimator.sizeOf(oldCell) : 0));
             int firstValueIndex = block.getFirstValueIndex(i);
             for (int v = 0; v < valueCount; v++) {
-                newCell[dstIndex + v] = block.getLong(firstValueIndex + v);
+                newCell[dstIndex + v] = block.getDouble(firstValueIndex + v);
             }
         }
     }
 
-    private long[] extendCell(long[] oldCell, int newValueCount) {
+    private double[] extendCell(double[] oldCell, int newValueCount) {
         if (oldCell == null) {
-            return new long[newValueCount];
+            return new double[newValueCount];
         } else {
             return Arrays.copyOf(oldCell, oldCell.length + newValueCount);
         }
     }
 
-    private long[] combineCell(long[] first, long[] second) {
+    private double[] combineCell(double[] first, double[] second) {
         if (first == null) {
             return second;
         }
         if (second == null) {
             return first;
         }
-        var result = new long[first.length + second.length];
+        var result = new double[first.length + second.length];
         System.arraycopy(first, 0, result, 0, first.length);
         System.arraycopy(second, 0, result, first.length, second.length);
         return result;
     }
 
-    private void appendGroupToBlockBuilder(LongBlock.Builder builder, long[] group) {
+    private void appendGroupToBlockBuilder(DoubleBlock.Builder builder, double[] group) {
         if (group == null) {
             builder.appendNull();
         } else if (group.length == 1) {
-            builder.appendLong(group[0]);
+            builder.appendDouble(group[0]);
         } else {
             builder.beginPositionEntry();
             // TODO: sort and dedup and set MvOrdering
             for (var v : group) {
-                builder.appendLong(v);
+                builder.appendDouble(v);
             }
             builder.endPositionEntry();
         }
     }
 
-    private long[] getCellOrNull(int position) {
+    private double[] getCellOrNull(int position) {
         return position < cells.size() ? cells.get(position) : null;
     }
 
     private Block buildWithSelected(IntBlock selected) {
-        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())) {
+        try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int selectedCount = selected.getValueCount(i);
                 switch (selectedCount) {
@@ -119,7 +119,7 @@ final class EnrichResultBuilderForLong extends EnrichResultBuilder {
     }
 
     private Block buildWithSelected(IntVector selected) {
-        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(selected.getPositionCount())) {
+        try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 appendGroupToBlockBuilder(builder, getCellOrNull(selected.getInt(i)));
             }

--- a/x-pack/plugin/esql/compute/src/main/java/module-info.java
+++ b/x-pack/plugin/esql/compute/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module org.elasticsearch.compute {
     exports org.elasticsearch.compute.operator.exchange;
     exports org.elasticsearch.compute.aggregation.blockhash;
     exports org.elasticsearch.compute.aggregation.spatial;
+    exports org.elasticsearch.compute.operator.lookup;
     exports org.elasticsearch.compute.operator.topn;
     exports org.elasticsearch.compute.operator.mvdedupe;
     exports org.elasticsearch.compute.aggregation.table;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -31,8 +31,7 @@ import java.io.UncheckedIOException;
  * This operator will emit Pages consisting of a {@link DocVector} and {@link IntBlock} of positions for each query of the input queries.
  * The position block will be used as keys to combine the extracted values by {@link MergePositionsOperator}.
  */
-final class EnrichQuerySourceOperator extends SourceOperator {
-
+public final class EnrichQuerySourceOperator extends SourceOperator {
     private final BlockFactory blockFactory;
     private final QueryList queryList;
     private int queryPosition = -1;
@@ -41,9 +40,9 @@ final class EnrichQuerySourceOperator extends SourceOperator {
     private final int maxPageSize;
 
     // using smaller pages enables quick cancellation and reduces sorting costs
-    static final int DEFAULT_MAX_PAGE_SIZE = 256;
+    public static final int DEFAULT_MAX_PAGE_SIZE = 256;
 
-    EnrichQuerySourceOperator(BlockFactory blockFactory, int maxPageSize, QueryList queryList, IndexReader indexReader) {
+    public EnrichQuerySourceOperator(BlockFactory blockFactory, int maxPageSize, QueryList queryList, IndexReader indexReader) {
         this.blockFactory = blockFactory;
         this.maxPageSize = maxPageSize;
         this.queryList = queryList;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichResultBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichResultBuilder.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/MergePositionsOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/MergePositionsOperator.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -43,7 +43,7 @@ import java.util.Objects;
  * |  null      | null       |
  * |  d         | 2023       |
  */
-final class MergePositionsOperator implements Operator {
+public final class MergePositionsOperator implements Operator {
     private boolean finished = false;
     private final int positionChannel;
     private final EnrichResultBuilder[] builders;
@@ -51,7 +51,7 @@ final class MergePositionsOperator implements Operator {
 
     private Page outputPage;
 
-    MergePositionsOperator(
+    public MergePositionsOperator(
         int positionChannel,
         int[] mergingChannels,
         ElementType[] mergingTypes,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -15,27 +16,23 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
-import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntFunction;
-
-import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
-import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
 
 /**
  * Generates a list of Lucene queries based on the input block.
@@ -61,44 +58,99 @@ public abstract class QueryList {
     abstract Query getQuery(int position);
 
     /**
-     * Returns a list of term queries for the given field and the input block.
+     * Returns a list of term queries for the given field and the input block
+     * using only the {@link ElementType} of the {@link Block} to determine the
+     * query.
      */
-    static QueryList termQueryList(
-        MappedFieldType field,
-        SearchExecutionContext searchExecutionContext,
-        Block block,
-        DataType inputDataType
-    ) {
-        return new TermQueryList(field, searchExecutionContext, block, inputDataType);
+    public static QueryList rawTermQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, Block block) {
+        IntFunction<Object> blockToJavaObject = switch (block.elementType()) {
+            case BOOLEAN -> {
+                BooleanBlock booleanBlock = (BooleanBlock) block;
+                yield booleanBlock::getBoolean;
+            }
+            case BYTES_REF -> offset -> {
+                BytesRefBlock bytesRefBlock = (BytesRefBlock) block;
+                return bytesRefBlock.getBytesRef(offset, new BytesRef());
+            };
+            case DOUBLE -> {
+                DoubleBlock doubleBlock = ((DoubleBlock) block);
+                yield doubleBlock::getDouble;
+            }
+            case FLOAT -> {
+                FloatBlock floatBlock = ((FloatBlock) block);
+                yield floatBlock::getFloat;
+            }
+            case LONG -> {
+                LongBlock intBlock = (LongBlock) block;
+                yield intBlock::getLong;
+            }
+            case INT -> {
+                IntBlock intBlock = (IntBlock) block;
+                yield intBlock::getInt;
+            }
+            case NULL -> offset -> null;
+            case DOC -> throw new IllegalArgumentException("can't read values from [doc] block");
+            case COMPOSITE -> throw new IllegalArgumentException("can't read values from [composite] block");
+            case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
+        };
+        return new TermQueryList(field, searchExecutionContext, block, blockToJavaObject);
+    }
+
+    /**
+     * Returns a list of term queries for the given field and the input block of
+     * {@code ip} field values.
+     */
+    public static QueryList ipTermQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, BytesRefBlock block) {
+        BytesRef scratch = new BytesRef();
+        byte[] ipBytes = new byte[InetAddressPoint.BYTES];
+        return new TermQueryList(field, searchExecutionContext, block, offset -> {
+            final var bytes = block.getBytesRef(offset, scratch);
+            if (ipBytes.length != bytes.length) {
+                // Lucene only support 16-byte IP addresses, even IPv4 is encoded in 16 bytes
+                throw new IllegalStateException("Cannot decode IP field from bytes of length " + bytes.length);
+            }
+            System.arraycopy(bytes.bytes, bytes.offset, ipBytes, 0, bytes.length);
+            return InetAddressPoint.decode(ipBytes);
+        });
+    }
+
+    /**
+     * Returns a list of term queries for the given field and the input block of
+     * {@code date} field values.
+     */
+    public static QueryList dateTermQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, LongBlock block) {
+        return new TermQueryList(
+            field,
+            searchExecutionContext,
+            block,
+            field instanceof RangeFieldMapper.RangeFieldType rangeFieldType
+                ? offset -> rangeFieldType.dateTimeFormatter().formatMillis(block.getLong(offset))
+                : block::getLong
+        );
     }
 
     /**
      * Returns a list of geo_shape queries for the given field and the input block.
      */
-    static QueryList geoShapeQuery(
-        MappedFieldType field,
-        SearchExecutionContext searchExecutionContext,
-        Block block,
-        DataType inputDataType
-    ) {
-        return new GeoShapeQueryList(field, searchExecutionContext, block, inputDataType);
+    public static QueryList geoShapeQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, Block block) {
+        return new GeoShapeQueryList(field, searchExecutionContext, block);
     }
 
     private static class TermQueryList extends QueryList {
-        private final BytesRef scratch = new BytesRef();
-        private final byte[] ipBytes = new byte[InetAddressPoint.BYTES];
         private final MappedFieldType field;
         private final SearchExecutionContext searchExecutionContext;
-        private final DataType inputDataType;
         private final IntFunction<Object> blockValueReader;
 
-        private TermQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, Block block, DataType inputDataType) {
+        private TermQueryList(
+            MappedFieldType field,
+            SearchExecutionContext searchExecutionContext,
+            Block block,
+            IntFunction<Object> blockValueReader
+        ) {
             super(block);
-
             this.field = field;
             this.searchExecutionContext = searchExecutionContext;
-            this.inputDataType = inputDataType;
-            this.blockValueReader = blockToJavaObject();
+            this.blockValueReader = blockValueReader;
         }
 
         @Override
@@ -118,53 +170,6 @@ public abstract class QueryList {
                 }
             };
         }
-
-        private IntFunction<Object> blockToJavaObject() {
-            return switch (block.elementType()) {
-                case BOOLEAN -> {
-                    BooleanBlock booleanBlock = (BooleanBlock) block;
-                    yield booleanBlock::getBoolean;
-                }
-                case BYTES_REF -> {
-                    BytesRefBlock bytesRefBlock = (BytesRefBlock) block;
-                    if (inputDataType == IP) {
-                        yield offset -> {
-                            final var bytes = bytesRefBlock.getBytesRef(offset, scratch);
-                            if (ipBytes.length != bytes.length) {
-                                // Lucene only support 16-byte IP addresses, even IPv4 is encoded in 16 bytes
-                                throw new IllegalStateException("Cannot decode IP field from bytes of length " + bytes.length);
-                            }
-                            System.arraycopy(bytes.bytes, bytes.offset, ipBytes, 0, bytes.length);
-                            return InetAddressPoint.decode(ipBytes);
-                        };
-                    }
-                    yield offset -> bytesRefBlock.getBytesRef(offset, new BytesRef());
-                }
-                case DOUBLE -> {
-                    DoubleBlock doubleBlock = ((DoubleBlock) block);
-                    yield doubleBlock::getDouble;
-                }
-                case FLOAT -> {
-                    FloatBlock floatBlock = ((FloatBlock) block);
-                    yield floatBlock::getFloat;
-                }
-                case INT -> {
-                    IntBlock intBlock = (IntBlock) block;
-                    yield intBlock::getInt;
-                }
-                case LONG -> {
-                    LongBlock longBlock = (LongBlock) block;
-                    if (inputDataType == DATETIME && field instanceof RangeFieldMapper.RangeFieldType rangeFieldType) {
-                        yield offset -> rangeFieldType.dateTimeFormatter().formatMillis(longBlock.getLong(offset));
-                    }
-                    yield longBlock::getLong;
-                }
-                case NULL -> offset -> null;
-                case DOC -> throw new EsqlIllegalArgumentException("can't read values from [doc] block");
-                case COMPOSITE -> throw new EsqlIllegalArgumentException("can't read values from [composite] block");
-                case UNKNOWN -> throw new EsqlIllegalArgumentException("can't read values from [" + block + "]");
-            };
-        }
     }
 
     private static class GeoShapeQueryList extends QueryList {
@@ -172,20 +177,13 @@ public abstract class QueryList {
         private final MappedFieldType field;
         private final SearchExecutionContext searchExecutionContext;
         private final IntFunction<Geometry> blockValueReader;
-        private final DataType inputDataType; // Currently unused, but might be needed for when input is read as doc-values
         private final IntFunction<Query> shapeQuery;
 
-        private GeoShapeQueryList(
-            MappedFieldType field,
-            SearchExecutionContext searchExecutionContext,
-            Block block,
-            DataType inputDataType
-        ) {
+        private GeoShapeQueryList(MappedFieldType field, SearchExecutionContext searchExecutionContext, Block block) {
             super(block);
 
             this.field = field;
             this.searchExecutionContext = searchExecutionContext;
-            this.inputDataType = inputDataType;
             this.blockValueReader = blockToGeometry(block);
             this.shapeQuery = shapeQuery();
         }
@@ -198,7 +196,7 @@ public abstract class QueryList {
                 case 0 -> null;
                 case 1 -> shapeQuery.apply(first);
                 // TODO: support multiple values
-                default -> throw new EsqlIllegalArgumentException("can't read multiple Geometry values from a single position");
+                default -> throw new IllegalArgumentException("can't read multiple Geometry values from a single position");
             };
         }
 
@@ -206,14 +204,17 @@ public abstract class QueryList {
             return switch (block.elementType()) {
                 case LONG -> offset -> {
                     var encoded = ((LongBlock) block).getLong(offset);
-                    return SpatialCoordinateTypes.GEO.longAsPoint(encoded);
+                    return new Point(
+                        GeoEncodingUtils.decodeLongitude((int) encoded),
+                        GeoEncodingUtils.decodeLatitude((int) (encoded >>> 32))
+                    );
                 };
                 case BYTES_REF -> offset -> {
                     var wkb = ((BytesRefBlock) block).getBytesRef(offset, scratch);
                     return WellKnownBinary.fromWKB(GeometryValidator.NOOP, false, wkb.bytes, wkb.offset, wkb.length);
                 };
                 case NULL -> offset -> null;
-                default -> throw new EsqlIllegalArgumentException("can't read Geometry values from [" + block.elementType() + "] block");
+                default -> throw new IllegalArgumentException("can't read Geometry values from [" + block.elementType() + "] block");
             };
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/X-EnrichResultBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/X-EnrichResultBuilder.java.st
@@ -5,35 +5,68 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
+$if(BytesRef)$
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.util.BytesRefArray;
+$else$
+import org.apache.lucene.util.RamUsageEstimator;
+$endif$
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.DoubleBlock;
+$if(long)$
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.$Type$Block;
+$elseif(int)$
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+$else$
+import org.elasticsearch.compute.data.$Type$Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+$endif$
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 
 import java.util.Arrays;
 
 /**
- * {@link EnrichResultBuilder} for Doubles.
+ * {@link EnrichResultBuilder} for $Type$s.
  * This class is generated. Edit `X-EnrichResultBuilder.java.st` instead.
  */
-final class EnrichResultBuilderForDouble extends EnrichResultBuilder {
-    private ObjectArray<double[]> cells;
+final class EnrichResultBuilderFor$Type$ extends EnrichResultBuilder {
+$if(BytesRef)$
+    private final BytesRefArray bytes; // shared between all cells
+    private BytesRef scratch = new BytesRef();
+$endif$
+    private ObjectArray<$if(BytesRef)$int$else$$type$$endif$[]> cells;
 
-    EnrichResultBuilderForDouble(BlockFactory blockFactory, int channel) {
+    EnrichResultBuilderFor$Type$(BlockFactory blockFactory, int channel) {
         super(blockFactory, channel);
         this.cells = blockFactory.bigArrays().newObjectArray(1);
+$if(BytesRef)$
+        BytesRefArray bytes = null;
+        try {
+            bytes = new BytesRefArray(1L, blockFactory.bigArrays());
+            this.bytes = bytes;
+        } finally {
+            if (bytes == null) {
+                this.cells.close();
+            }
+        }
+$endif$
     }
 
     @Override
     void addInputPage(IntVector positions, Page page) {
-        DoubleBlock block = page.getBlock(channel);
+        $Type$Block block = page.getBlock(channel);
+$if(BytesRef)$
+        BytesRef scratch = new BytesRef();
+$endif$
         for (int i = 0; i < positions.getPositionCount(); i++) {
             int valueCount = block.getValueCount(i);
             if (valueCount == 0) {
@@ -47,54 +80,71 @@ final class EnrichResultBuilderForDouble extends EnrichResultBuilder {
             int dstIndex = oldCell != null ? oldCell.length : 0;
             adjustBreaker(RamUsageEstimator.sizeOf(newCell) - (oldCell != null ? RamUsageEstimator.sizeOf(oldCell) : 0));
             int firstValueIndex = block.getFirstValueIndex(i);
+$if(BytesRef)$
+            int bytesOrd = Math.toIntExact(bytes.size());
             for (int v = 0; v < valueCount; v++) {
-                newCell[dstIndex + v] = block.getDouble(firstValueIndex + v);
+                scratch = block.getBytesRef(firstValueIndex + v, scratch);
+                bytes.append(scratch);
+                newCell[dstIndex + v] = bytesOrd + v;
             }
+$else$
+            for (int v = 0; v < valueCount; v++) {
+                newCell[dstIndex + v] = block.get$Type$(firstValueIndex + v);
+            }
+$endif$
         }
     }
 
-    private double[] extendCell(double[] oldCell, int newValueCount) {
+    private $if(BytesRef)$int$else$$type$$endif$[] extendCell($if(BytesRef)$int$else$$type$$endif$[] oldCell, int newValueCount) {
         if (oldCell == null) {
-            return new double[newValueCount];
+            return new $if(BytesRef)$int$else$$type$$endif$[newValueCount];
         } else {
             return Arrays.copyOf(oldCell, oldCell.length + newValueCount);
         }
     }
 
-    private double[] combineCell(double[] first, double[] second) {
+    private $if(BytesRef)$int$else$$type$$endif$[] combineCell($if(BytesRef)$int$else$$type$$endif$[] first, $if(BytesRef)$int$else$$type$$endif$[] second) {
         if (first == null) {
             return second;
         }
         if (second == null) {
             return first;
         }
-        var result = new double[first.length + second.length];
+        var result = new $if(BytesRef)$int$else$$type$$endif$[first.length + second.length];
         System.arraycopy(first, 0, result, 0, first.length);
         System.arraycopy(second, 0, result, first.length, second.length);
         return result;
     }
 
-    private void appendGroupToBlockBuilder(DoubleBlock.Builder builder, double[] group) {
+    private void appendGroupToBlockBuilder($Type$Block.Builder builder, $if(BytesRef)$int$else$$type$$endif$[] group) {
         if (group == null) {
             builder.appendNull();
         } else if (group.length == 1) {
-            builder.appendDouble(group[0]);
+$if(BytesRef)$
+            builder.appendBytesRef(bytes.get(group[0], scratch));
+$else$
+            builder.append$Type$(group[0]);
+$endif$
         } else {
             builder.beginPositionEntry();
             // TODO: sort and dedup and set MvOrdering
             for (var v : group) {
-                builder.appendDouble(v);
+$if(BytesRef)$
+                builder.appendBytesRef(bytes.get(v, scratch));
+$else$
+                builder.append$Type$(v);
+$endif$
             }
             builder.endPositionEntry();
         }
     }
 
-    private double[] getCellOrNull(int position) {
+    private $if(BytesRef)$int$else$$type$$endif$[] getCellOrNull(int position) {
         return position < cells.size() ? cells.get(position) : null;
     }
 
     private Block buildWithSelected(IntBlock selected) {
-        try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
+        try ($Type$Block.Builder builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int selectedCount = selected.getValueCount(i);
                 switch (selectedCount) {
@@ -119,7 +169,7 @@ final class EnrichResultBuilderForDouble extends EnrichResultBuilder {
     }
 
     private Block buildWithSelected(IntVector selected) {
-        try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(selected.getPositionCount())) {
+        try ($Type$Block.Builder builder = blockFactory.new$Type$BlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 appendGroupToBlockBuilder(builder, getCellOrNull(selected.getInt(i)));
             }
@@ -139,6 +189,6 @@ final class EnrichResultBuilderForDouble extends EnrichResultBuilder {
 
     @Override
     public void close() {
-        Releasables.close(cells, super::close);
+        Releasables.close($if(BytesRef)$bytes, $endif$cells, super::close);
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperatorTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Mockito.mock;
@@ -105,7 +104,7 @@ public class EnrichQuerySourceOperatorTests extends ESTestCase {
             inputTerms = termBuilder.build();
         }
         MappedFieldType uidField = new KeywordFieldMapper.KeywordFieldType("uid");
-        QueryList queryList = QueryList.termQueryList(uidField, mock(SearchExecutionContext.class), inputTerms, KEYWORD);
+        QueryList queryList = QueryList.rawTermQueryList(uidField, mock(SearchExecutionContext.class), inputTerms);
         assertThat(queryList.getPositionCount(), equalTo(6));
         assertThat(queryList.getQuery(0), equalTo(new TermQuery(new Term("uid", new BytesRef("b2")))));
         assertThat(queryList.getQuery(1), equalTo(new TermInSetQuery("uid", new BytesRef("c1"), new BytesRef("a2"))));
@@ -186,7 +185,7 @@ public class EnrichQuerySourceOperatorTests extends ESTestCase {
             inputTerms = builder.build();
         }
         MappedFieldType uidField = new KeywordFieldMapper.KeywordFieldType("uid");
-        var queryList = QueryList.termQueryList(uidField, mock(SearchExecutionContext.class), inputTerms, KEYWORD);
+        var queryList = QueryList.rawTermQueryList(uidField, mock(SearchExecutionContext.class), inputTerms);
         int maxPageSize = between(1, 256);
         EnrichQuerySourceOperator queryOperator = new EnrichQuerySourceOperator(blockFactory, maxPageSize, queryList, reader);
         Map<Integer, Set<Integer>> actualPositions = new HashMap<>();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/EnrichResultBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/EnrichResultBuilderTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -29,7 +29,6 @@ import java.util.Map;
 import static org.hamcrest.Matchers.equalTo;
 
 public class EnrichResultBuilderTests extends ESTestCase {
-
     public void testBytesRef() {
         BlockFactory blockFactory = blockFactory();
         Map<Integer, List<BytesRef>> inputValues = new HashMap<>();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/MergePositionsOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/MergePositionsOperatorTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.enrich;
+package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.ValuesSourceReaderOperator;
@@ -40,6 +41,9 @@ import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OutputOperator;
+import org.elasticsearch.compute.operator.lookup.EnrichQuerySourceOperator;
+import org.elasticsearch.compute.operator.lookup.MergePositionsOperator;
+import org.elasticsearch.compute.operator.lookup.QueryList;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
@@ -171,6 +175,19 @@ abstract class AbstractLookupService<R extends AbstractLookupService.Request, T 
      * Build a list of queries to perform inside the actual lookup.
      */
     protected abstract QueryList queryList(T request, SearchExecutionContext context, Block inputBlock, DataType inputDataType);
+
+    protected static QueryList termQueryList(
+        MappedFieldType field,
+        SearchExecutionContext searchExecutionContext,
+        Block block,
+        DataType inputDataType
+    ) {
+        return switch (inputDataType) {
+            case IP -> QueryList.ipTermQueryList(field, searchExecutionContext, (BytesRefBlock) block);
+            case DATETIME -> QueryList.dateTermQueryList(field, searchExecutionContext, (LongBlock) block);
+            default -> QueryList.rawTermQueryList(field, searchExecutionContext, block);
+        };
+    }
 
     /**
      * Perform the actual lookup.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockStreamInput;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.lookup.QueryList;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
@@ -78,8 +79,8 @@ public class EnrichLookupService extends AbstractLookupService<EnrichLookupServi
     protected QueryList queryList(TransportRequest request, SearchExecutionContext context, Block inputBlock, DataType inputDataType) {
         MappedFieldType fieldType = context.getFieldType(request.matchField);
         return switch (request.matchType) {
-            case "match", "range" -> QueryList.termQueryList(fieldType, context, inputBlock, inputDataType);
-            case "geo_match" -> QueryList.geoShapeQuery(fieldType, context, inputBlock, inputDataType);
+            case "match", "range" -> termQueryList(fieldType, context, inputBlock, inputDataType);
+            case "geo_match" -> QueryList.geoShapeQueryList(fieldType, context, inputBlock);
             default -> throw new EsqlIllegalArgumentException("illegal match type " + request.matchType);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockStreamInput;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.lookup.QueryList;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.ShardId;
@@ -74,7 +75,7 @@ public class LookupFromIndexService extends AbstractLookupService<LookupFromInde
     @Override
     protected QueryList queryList(TransportRequest request, SearchExecutionContext context, Block inputBlock, DataType inputDataType) {
         MappedFieldType fieldType = context.getFieldType(request.matchField);
-        return QueryList.termQueryList(fieldType, context, inputBlock, inputDataType);
+        return termQueryList(fieldType, context, inputBlock, inputDataType);
     }
 
     public static class Request extends AbstractLookupService.Request {


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Move some of ENRICH into compute (#116338)