### PR TITLE
drop_null_columns requires json or yaml format

### DIFF
--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -47,7 +47,7 @@ supports this parameter for CSV responses.
 (Optional, boolean) Should columns that are entirely `null` be removed from
 the `columns` and `values` portion of the results? Defaults to `false`. If
 `true` the response will include an extra section under the name
-`all_columns` which has the name of all columns. This parameter requires a `json` or `yaml` format for the response. 
+`all_columns` which has the name of all columns. The API only supports this parameter for CBOR, JSON, SMILE, and YAML responses. 
 
 `format`::
 (Optional, string) Format for the response. For valid values, refer to

--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -47,7 +47,7 @@ supports this parameter for CSV responses.
 (Optional, boolean) Should columns that are entirely `null` be removed from
 the `columns` and `values` portion of the results? Defaults to `false`. If
 `true` the response will include an extra section under the name
-`all_columns` which has the name of all columns.
+`all_columns` which has the name of all columns. This parameter requires a `json` or `yaml` format for the response. 
 
 `format`::
 (Optional, string) Format for the response. For valid values, refer to


### PR DESCRIPTION
This request will add an additional description to the `drop_null_columns` query parameter which notes that the parameter requires the format to be set to `yaml `or `json`. If any other format is being used, null columns will still be shown.