### PR TITLE
[ES|QL] Add generated source files to IntelliJ

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'idea'
+}
+
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask;
 import org.elasticsearch.gradle.internal.util.SourceDirectoryCommandLineArgumentProvider;
@@ -52,12 +56,17 @@ dependencies {
   internalClusterTestImplementation project(":modules:mapper-extras")
 }
 
+def generatedPath = "src/main/generated"
 def projectDirectory = project.layout.projectDirectory
-def generatedSourceDir = projectDirectory.dir("src/main/generated")
+def generatedSourceDir = projectDirectory.dir(generatedPath)
 tasks.named("compileJava").configure {
   options.compilerArgumentProviders.add(new SourceDirectoryCommandLineArgumentProvider(generatedSourceDir))
   // IntelliJ sticks generated files here and we can't stop it....
   exclude { normalize(it.file.toString()).contains("src/main/generated-src/generated") }
+}
+
+idea.module {
+  sourceDirs += file(generatedPath)
 }
 
 interface Injected {


### PR DESCRIPTION
Adds the generated classes to IntelliJ source files so it's not shown as red, support go-to-definition, etc.