### PR TITLE
Add mapped fields count to index stats

### DIFF
--- a/docs/changelog/116438.yaml
+++ b/docs/changelog/116438.yaml
@@ -1,0 +1,5 @@
+pr: 116438
+summary: Add mapped fields count to index stats
+area: Stats
+type: enhancement
+issues: []

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamAutoshardingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamAutoshardingIT.java
@@ -494,7 +494,7 @@ public class DataStreamAutoshardingIT extends ESIntegTestCase {
         stats.docs = new DocsStats(100, 0, randomByteSizeValue().getBytes());
         stats.store = new StoreStats();
         stats.indexing = new IndexingStats(new IndexingStats.Stats(1, 1, 1, 1, 1, 1, 1, 1, false, 1, targetWriteLoad, 1));
-        return new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, false, 0);
+        return new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, false, 0, 0);
     }
 
     static void putComposableIndexTemplate(String id, List<String> patterns, @Nullable Settings settings) throws IOException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -547,9 +547,11 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getIndex("test1").getPrimaries().getMerge(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getFlush(), notNullValue());
         assertThat(stats.getIndex("test1").getPrimaries().getRefresh(), notNullValue());
+        assertThat(stats.getIndex("test1").getMappedFieldsCount(), equalTo(2L)); // field + field.keyword
 
         assertThat(stats.getIndex("test2").getPrimaries().getDocs().getCount(), equalTo(1L));
         assertThat(stats.getIndex("test2").getTotal().getDocs().getCount(), equalTo(test2ExpectedWrites));
+        assertThat(stats.getIndex("test2").getMappedFieldsCount(), equalTo(2L)); // field + field.keyword
 
         // make sure that number of requests in progress is 0
         assertThat(stats.getIndex("test1").getTotal().getIndexing().getTotal().getIndexCurrent(), equalTo(0L));

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -188,6 +188,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_CCS_EXEC_INFO_WITH_FAILURES = def(8_783_00_0);
     public static final TransportVersion LOGSDB_TELEMETRY = def(8_784_00_0);
     public static final TransportVersion LOGSDB_TELEMETRY_STATS = def(8_785_00_0);
+    public static final TransportVersion INDEX_STATS_MAPPED_FIELDS = def(8_786_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -276,7 +276,8 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                             seqNoStats,
                             retentionLeaseStats,
                             indexShard.isSearchIdle(),
-                            indexShard.searchIdleTime()
+                            indexShard.searchIdleTime(),
+                            indexShard.mapperService().mappingLookup().getTotalFieldsCount()
                         )
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
@@ -31,6 +31,8 @@ public class IndexStats implements Iterable<IndexShardStats> {
 
     private final ShardStats shards[];
 
+    private Long mappedFieldsCount;
+
     public IndexStats(
         String index,
         String uuid,
@@ -122,6 +124,19 @@ public class IndexStats implements Iterable<IndexShardStats> {
         }
         primary = stats;
         return stats;
+    }
+
+    public Long getMappedFieldsCount() {
+        if (this.mappedFieldsCount != null) {
+            return mappedFieldsCount;
+        }
+        for (ShardStats shard : shards) {
+            if (shard.getShardRouting().primary()) {
+                mappedFieldsCount = shard.getMappedFieldsCount();
+                break;
+            }
+        }
+        return mappedFieldsCount;
     }
 
     public static class IndexStatsBuilder {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -203,6 +203,9 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
                             if (indexStats.getState() != null) {
                                 builder.field("status", indexStats.getState().toString().toLowerCase(Locale.ROOT));
                             }
+                            if (indexStats.getMappedFieldsCount() != null) {
+                                builder.field("mapped_fields_count", indexStats.getMappedFieldsCount());
+                            }
                             builder.startObject("primaries");
                             indexStats.getPrimaries().toXContent(builder, p);
                             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -132,7 +132,8 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
                 seqNoStats,
                 retentionLeaseStats,
                 indexShard.isSearchIdle(),
-                indexShard.searchIdleTime()
+                indexShard.searchIdleTime(),
+                indexShard.mapperService().mappingLookup().getTotalFieldsCount()
             );
         });
     }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -535,7 +535,8 @@ public class IndicesService extends AbstractLifecycleComponent
                     seqNoStats,
                     retentionLeaseStats,
                     indexShard.isSearchIdle(),
-                    indexShard.searchIdleTime()
+                    indexShard.searchIdleTime(),
+                    indexShard.mapperService().mappingLookup().getTotalFieldsCount()
                 ) }
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -671,7 +671,7 @@ public class NodeStatsTests extends ESTestCase {
             .resolve(shardRouting.shardId().getIndex().getUUID())
             .resolve(String.valueOf(shardRouting.shardId().id()));
         ShardPath shardPath = new ShardPath(false, path, path, shardRouting.shardId());
-        return new ShardStats(shardRouting, shardPath, createShardLevelCommonStats(), null, null, null, false, 0);
+        return new ShardStats(shardRouting, shardPath, createShardLevelCommonStats(), null, null, null, false, 0, 0);
     }
 
     public static NodeStats createNodeStats() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -120,6 +120,7 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
             null,
             null,
             false,
+            0,
             0
         );
         ClusterStatsNodeResponse nodeResponse = new ClusterStatsNodeResponse(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -677,7 +677,9 @@ public class TransportRolloverActionTests extends ESTestCase {
                 stats.warmer = new WarmerStats();
                 stats.denseVectorStats = new DenseVectorStats();
                 stats.sparseVectorStats = new SparseVectorStats();
-                shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, false, 0));
+                shardStats.add(
+                    new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, false, 0, 0)
+                );
             }
         }
         return IndicesStatsTests.newIndicesStatsResponse(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
@@ -75,7 +75,7 @@ public class IndicesStatsResponseTests extends ESTestCase {
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(shardId));
                 ShardPath shardPath = new ShardPath(false, path, path, shId);
                 ShardRouting routing = createShardRouting(shId, (shardId == 0));
-                shards.add(new ShardStats(routing, shardPath, null, null, null, null, false, 0));
+                shards.add(new ShardStats(routing, shardPath, null, null, null, null, false, 0, 0));
                 AtomicLong primaryShardsCounter = expectedIndexToPrimaryShardsCount.computeIfAbsent(
                     index.getName(),
                     k -> new AtomicLong(0L)
@@ -124,7 +124,7 @@ public class IndicesStatsResponseTests extends ESTestCase {
             Path path = createTempDir().resolve("indices").resolve(shId.getIndex().getUUID()).resolve(String.valueOf(shId.id()));
             ShardPath shardPath = new ShardPath(false, path, path, shId);
             ShardRouting routing = createShardRouting(shId, (shId.id() == 0));
-            stats.add(new ShardStats(routing, shardPath, new CommonStats(), null, null, null, false, 0));
+            stats.add(new ShardStats(routing, shardPath, new CommonStats(), null, null, null, false, 0, 0));
         }
         final IndicesStatsResponse indicesStatsResponse = new IndicesStatsResponse(
             stats.toArray(new ShardStats[0]),

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -122,8 +122,28 @@ public class DiskUsageTests extends ESTestCase {
         CommonStats commonStats2 = new CommonStats();
         commonStats2.store = new StoreStats(1000, 999, 0L);
         ShardStats[] stats = new ShardStats[] {
-            new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0, null, null, null, false, 0),
-            new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1, null, null, null, false, 0),
+            new ShardStats(
+                test_0,
+                new ShardPath(false, test0Path, test0Path, test_0.shardId()),
+                commonStats0,
+                null,
+                null,
+                null,
+                false,
+                0,
+                0
+            ),
+            new ShardStats(
+                test_1,
+                new ShardPath(false, test1Path, test1Path, test_1.shardId()),
+                commonStats1,
+                null,
+                null,
+                null,
+                false,
+                0,
+                0
+            ),
             new ShardStats(
                 test_1,
                 new ShardPath(false, test1Path, test1Path, test_1.shardId()),
@@ -132,6 +152,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 false,
+                0,
                 0
             ) };
         Map<String, Long> shardSizes = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsTests.java
@@ -115,6 +115,6 @@ public class IndexMetadataStatsTests extends ESTestCase {
             .add(
                 new IndexingStats.Stats(0, 0, 0, 0, 0, 0, 0, 0, false, 0, totalIndexingTimeSinceShardStartedInNanos, totalActiveTimeInNanos)
             );
-        return new ShardStats(shardRouting, commonStats, null, null, null, null, null, false, false, 0);
+        return new ShardStats(shardRouting, commonStats, null, null, null, null, null, false, false, 0, 0);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1622,7 +1622,8 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.seqNoStats(),
             shard.getRetentionLeaseStats(),
             shard.isSearchIdle(),
-            shard.searchIdleTime()
+            shard.searchIdleTime(),
+            0
         );
         assertEquals(shard.shardPath().getRootDataPath().toString(), stats.getDataPath());
         assertEquals(shard.shardPath().getRootStatePath().toString(), stats.getStatePath());

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
@@ -61,6 +61,7 @@ public class RestShardsActionTests extends ESTestCase {
                 null,
                 null,
                 false,
+                0,
                 0
             );
             shardStatsMap.put(shardRouting, shardStats);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -124,7 +124,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 shardStats.getStatePath(),
                 shardStats.isCustomDataPath(),
                 shardStats.isSearchIdle(),
-                shardStats.getSearchIdleTime()
+                shardStats.getSearchIdleTime(),
+                shardStats.getMappedFieldsCount()
             );
         }).toArray(ShardStats[]::new);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datatiers/DataTierUsageFixtures.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datatiers/DataTierUsageFixtures.java
@@ -90,7 +90,7 @@ class DataTierUsageFixtures extends ESTestCase {
         CommonStats commonStats = new CommonStats(CommonStatsFlags.ALL);
         commonStats.getStore().add(storeStats);
         commonStats.getDocs().add(docsStats);
-        return new ShardStats(routing, fakeShardPath, commonStats, null, null, null, false, 0);
+        return new ShardStats(routing, fakeShardPath, commonStats, null, null, null, false, 0, 0);
     }
 
     static IndexMetadata indexMetadata(String indexName, int numberOfShards, int numberOfReplicas, String... dataTierPrefs) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
@@ -184,7 +184,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
             .numberOfReplicas(randomIntBetween(1, 10))
             .build();
 
-        ShardStats sStats = new ShardStats(null, mockShardPath(), null, null, null, null, false, 0);
+        ShardStats sStats = new ShardStats(null, mockShardPath(), null, null, null, null, false, 0, 0);
         ShardStats[] shardStats = new ShardStats[1];
         shardStats[0] = sStats;
 
@@ -293,7 +293,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
     }
 
     private ShardStats randomShardStats(boolean isLeaderIndex) {
-        return new ShardStats(null, mockShardPath(), null, null, null, randomRetentionLeaseStats(isLeaderIndex), false, 0);
+        return new ShardStats(null, mockShardPath(), null, null, null, randomRetentionLeaseStats(isLeaderIndex), false, 0, 0);
     }
 
     private RetentionLeaseStats randomRetentionLeaseStats(boolean isLeaderIndex) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
@@ -55,10 +55,10 @@ public class IndicesStatsMonitoringDocTests extends BaseFilteredMonitoringDocTes
                 null,
                 new ShardStats[] {
                     // Primaries
-                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0),
-                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0),
+                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0, 0),
+                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0, 0),
                     // Replica
-                    new ShardStats(mockShardRouting(false), mockShardPath(), mockCommonStats(), null, null, null, false, 0) }
+                    new ShardStats(mockShardRouting(false), mockShardPath(), mockCommonStats(), null, null, null, false, 0, 0) }
             )
         );
     }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -394,7 +394,7 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(i));
 
                 shardStats.add(
-                    new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, seqNoStats, null, false, 0)
+                    new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, seqNoStats, null, false, 0, 0)
                 );
             }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformsCheckpointServiceTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformsCheckpointServiceTests.java
@@ -283,6 +283,7 @@ public class TransformsCheckpointServiceTests extends ESTestCase {
                                 invalidSeqNoStats,
                                 null,
                                 false,
+                                0,
                                 0
                             )
                         );
@@ -296,6 +297,7 @@ public class TransformsCheckpointServiceTests extends ESTestCase {
                                 validSeqNoStats,
                                 null,
                                 false,
+                                0,
                                 0
                             )
                         );


### PR DESCRIPTION
Returns the number of mapped fields in the index stats response. Useful to debug field explosion issues.