### PR TITLE
[8.16] Fix missing remote_cluster docs (#116366)

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-migration.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-migration.asciidoc
@@ -66,10 +66,11 @@ indices that were created from the auto-follow pattern.
 On the local cluster:
 
 . Enhance any roles used by local cluster users with the required
-<<roles-remote-indices-priv,remote indices privileges>> for {ccr} and {ccs}.
+<<roles-remote-indices-priv,remote indices privileges>> or 
+<<roles-remote-cluster-priv, remote cluster privileges>> for {ccr} and {ccs}.
 Refer to <<remote-clusters-privileges-api-key>>. Note:
 
-** You only need to assign additional `remote_indices` privileges to existing
+** You only need to assign additional `remote_indices` or `remote_cluster` privileges to existing
 roles used for cross-cluster operations. You should be able to copy these
 privileges from the original roles on the remote cluster, where they are defined
 under the certification based security model.
@@ -197,7 +198,7 @@ authentication.
 Resume any persistent tasks that you stopped earlier. Tasks should be restarted
 by the same user or API key that created the task before the migration. Ensure
 the roles of this user or API key have been updated with the required
-`remote_indices` privileges. For users, tasks capture the caller's credentials
+`remote_indices` or `remote_cluster` privileges. For users, tasks capture the caller's credentials
 when started and run in that user's security context. For API keys, restarting a
 task will update the task with the updated API key.
 
@@ -246,7 +247,7 @@ If you need to roll back, follow these steps on the local cluster:
 . Remove the remote cluster definition by setting the remote cluster settings to
 `null`.
 
-. Remove the `remote_indices` privileges from any roles that were updated during
+. Remove the `remote_indices` or 'remote_cluster' privileges from any roles that were updated during
 the migration.
 
 . On each node, remove the `remote_cluster_client.ssl.*` settings from

--- a/docs/reference/modules/cluster/remote-clusters-troubleshooting.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-troubleshooting.asciidoc
@@ -399,7 +399,7 @@ This does not show up in any logs.
 
 ====== Resolution
 
-. Check that the local user has the necessary `remote_indices` privileges. Grant sufficient `remote_indices` privileges if necessary.
+. Check that the local user has the necessary `remote_indices` or `remote_cluster` privileges. Grant sufficient `remote_indices` or `remote_cluster` privileges if necessary.
 . If permission is not an issue locally, ask the remote cluster administrator to
 create and distribute a
 <<security-api-create-cross-cluster-api-key,cross-cluster API key>>. Replace the

--- a/docs/reference/rest-api/security/bulk-create-roles.asciidoc
+++ b/docs/reference/rest-api/security/bulk-create-roles.asciidoc
@@ -75,7 +75,7 @@ that begin with `_` are reserved for system usage.
 For more information, see
 <<run-as-privilege>>.
 
-`remote_indices`:: beta:[] (list) A list of remote indices permissions entries.
+`remote_indices`:: (list) A list of remote indices permissions entries.
 +
 --
 NOTE: Remote indices are effective for <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
@@ -93,6 +93,18 @@ have on the specified indices.
 `query`::: A search query that defines the documents the owners of the role have
 read access to. A document within the specified indices must match this query in
 order for it to be accessible by the owners of the role.
+
+`remote_cluster`:: (list) A list of remote cluster permissions entries.
++
+--
+NOTE: Remote cluster permissions are effective for <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
+They have no effect for remote clusters configured with the <<remote-clusters-cert,certificate based model>>.
+--
+`clusters` (required)::: (list) A list of cluster aliases to which the permissions
+in this entry apply.
+`privileges`(required)::: (list) The cluster level privileges that the owners of the role
+have in the specified clusters.
+
 
 For more information, see <<defining-roles>>.
 ====

--- a/docs/reference/rest-api/security/create-roles.asciidoc
+++ b/docs/reference/rest-api/security/create-roles.asciidoc
@@ -96,6 +96,17 @@ have on the specified indices.
 read access to. A document within the specified indices must match this query in
 order for it to be accessible by the owners of the role.
 
+`remote_cluster`:: (list) A list of remote cluster permissions entries.
++
+--
+NOTE: Remote cluster permissions are effective for <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
+They have no effect for remote clusters configured with the <<remote-clusters-cert,certificate based model>>.
+--
+`clusters` (required)::: (list) A list of cluster aliases to which the permissions
+in this entry apply.
+`privileges`(required)::: (list) The cluster level privileges that the owners of the role
+have in the specified clusters.
+
 For more information, see <<defining-roles>>.
 
 [[security-api-put-role-example]]

--- a/docs/reference/security/authentication/remote-clusters-privileges-api-key.asciidoc
+++ b/docs/reference/security/authentication/remote-clusters-privileges-api-key.asciidoc
@@ -2,7 +2,8 @@
 === Configure roles and users
 
 To use a remote cluster for {ccr} or {ccs}, you need to create user roles with
-<<roles-remote-indices-priv,remote indices privileges>> on the local cluster.
+<<roles-remote-indices-priv,remote indices privileges>> or
+<<roles-remote-cluster-priv, remote cluster privileges>> on the local cluster.
 
 You can manage users and roles from Stack Management in {kib} by selecting
 *Security > Roles* from the side navigation. You can also use the
@@ -80,7 +81,7 @@ POST /_security/role/remote-search
       "privileges": [
         "read",
         "read_cross_cluster",
-        "view_index_metadata" 
+        "view_index_metadata"
       ]
     }
   ]


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Fix missing remote_cluster docs (#116366)