### PR TITLE
[8.x] Ensure class resource stream is closed in ResourceUtils (#116437)

### DIFF
--- a/docs/changelog/116437.yaml
+++ b/docs/changelog/116437.yaml
@@ -1,0 +1,5 @@
+pr: 116437
+summary: Ensure class resource stream is closed in `ResourceUtils`
+area: Indices APIs
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/ResourceUtils.java
@@ -35,11 +35,12 @@ public class ResourceUtils {
     }
 
     public static String loadResource(Class<?> clazz, String name) throws IOException {
-        InputStream is = clazz.getResourceAsStream(name);
-        if (is == null) {
-            throw new IOException("Resource [" + name + "] not found in classpath.");
+        try (InputStream is = clazz.getResourceAsStream(name)) {
+            if (is == null) {
+                throw new IOException("Resource [" + name + "] not found in classpath.");
+            }
+            return new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
         }
-        return new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
     }
 
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Ensure class resource stream is closed in ResourceUtils (#116437)](https://github.com/elastic/elasticsearch/pull/116437)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)