### PR TITLE
[8.x] Deduplicate the name of the aggregation when deserializing InternalAggregation (#116307)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.DelayableWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -51,7 +52,12 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
      * Read from a stream.
      */
     protected InternalAggregation(StreamInput in) throws IOException {
-        name = in.readString();
+        final String name = in.readString();
+        if (in instanceof DelayableWriteable.Deduplicator d) {
+            this.name = d.deduplicate(name);
+        } else {
+            this.name = name;
+        }
         metadata = in.readGenericMap();
     }
 


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Deduplicate the name of the aggregation when deserializing InternalAggregation (#116307)