### PR TITLE
[8.16] Document using xpack.ml.use_auto_machine_memory_percent setting in docker getting started (#114009)

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -86,6 +86,15 @@ docker run --name es01 --net elastic -p 9200:9200 -it -m 1GB {docker-image}
 TIP: Use the `-m` flag to set a memory limit for the container. This removes the
 need to <<docker-set-heap-size,manually set the JVM size>>.
 +
+
+{ml-cap} features such as <<semantic-search-elser, semantic search with ELSER>>
+require a larger container with more than 1GB of memory.
+If you intend to use the {ml} capabilities, then start the container with this command:
++
+[source,sh,subs="attributes"]
+----
+docker run --name es01 --net elastic -p 9200:9200 -it -m 6GB -e "xpack.ml.use_auto_machine_memory_percent=true" {docker-image}
+----
 The command prints the `elastic` user password and an enrollment token for {kib}.
 
 . Copy the generated `elastic` password and enrollment token. These credentials

--- a/docs/reference/setup/install/docker/docker-compose.yml
+++ b/docs/reference/setup/install/docker/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
       - xpack.security.transport.ssl.verification_mode=certificate
       - xpack.license.self_generated.type=${LICENSE}
+      - xpack.ml.use_auto_machine_memory_percent=true
     mem_limit: ${MEM_LIMIT}
     ulimits:
       memlock:
@@ -130,6 +131,7 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
       - xpack.security.transport.ssl.verification_mode=certificate
       - xpack.license.self_generated.type=${LICENSE}
+      - xpack.ml.use_auto_machine_memory_percent=true
     mem_limit: ${MEM_LIMIT}
     ulimits:
       memlock:
@@ -170,6 +172,7 @@ services:
       - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
       - xpack.security.transport.ssl.verification_mode=certificate
       - xpack.license.self_generated.type=${LICENSE}
+      - xpack.ml.use_auto_machine_memory_percent=true
     mem_limit: ${MEM_LIMIT}
     ulimits:
       memlock:


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Document using xpack.ml.use_auto_machine_memory_percent setting in docker getting started (#114009)