### PR TITLE
KQL update tests 

### DIFF
--- a/x-pack/plugin/kql/src/test/resources/supported-queries
+++ b/x-pack/plugin/kql/src/test/resources/supported-queries
@@ -23,54 +23,54 @@ f*oo
  *:"foo bar"
 
 // Querying a field
-foo_field:200
-foo_field:foo
-foo_field:foo bar
-foo_field:(foo bar)
-foo_field:foo*
-foo_field: f*oo
-foo_field: *foo
-foo_field:"foo bar"
-foo_field.subfield:foo
-foo_*_field:foo
-foo_field:*
-foo_*:*
+mapped_int:200
+mapped_string_2:foo
+mapped_string:foo bar
+mapped_string:(foo bar)
+mapped_string:foo*
+mapped_string_2: f*oo
+mapped_string: *foo
+mapped_string:"foo bar"
+mapped_object.subfield:foo
+mapped_str*:foo
+mapped_string:*
+mapped_str_*:*
 
 // Range queries
-foo_field<200
-foo_field<foo
-foo_field<"foo bar"
-foo_field>=200
-foo_field>=foo
-foo_field>"foo bar"
-foo_field<=foo
-foo_field>=foo
+mapped_int<200
+mapped_string_2<foo
+mapped_string<"foo bar"
+mapped_double>=200
+mapped_string_alias>=foo
+mapped_string>"foo bar"
+mapped_string<=foo
+mapped_string_2>=foo
 
 // Boolean queries
 NOT foo
 NOT foo bar
-NOT foo_field:foo
-NOT foo_field<foo
-foo_field:foo AND foo_field:foo bar
-foo_field<foo AND foo_field>bar
-(foo_field:foo) AND (foo_field:foo bar)
-foo_field:foo OR foo_field:foo bar
-NOT(foo_field:foo OR foo_field:foo bar)
-NOT(foo_field:foo AND foo_field:foo bar)
-NOT foo_field:foo AND NOT foo_field:foo bar
-(NOT foo_field:foo) AND (NOT foo_field:foo bar)
-NOT(foo_field:foo) AND NOT(foo_field:foo bar)
-foo_field:foo AND foo_field:foo bar AND foo bar
-foo_field:foo AND foo_field:foo bar OR foo bar
-foo_field:foo OR foo_field:foo bar OR foo bar
-foo_field:foo OR foo_field:foo bar AND foo bar
-foo_field:foo AND (foo_field:foo bar OR foo bar)
-foo_field:foo AND (foo_field:foo bar OR foo bar)
-foo_field:foo OR (foo_field:foo bar OR foo bar)
+NOT mapped_string:foo
+NOT mapped_string_2<foo
+mapped_string:foo AND mapped_string_2:foo bar
+mapped_string<foo AND mapped_string>bar
+(mapped_string:foo) AND (mapped_string:foo bar)
+mapped_string:foo OR mapped_string_2:foo bar
+NOT(mapped_string:foo OR mapped_string:foo bar)
+NOT(mapped_string:foo AND mapped_string:foo bar)
+NOT mapped_string:foo AND NOT mapped_string_2:foo bar
+(NOT mapped_string_alias:foo) AND (NOT mapped_string:foo bar)
+NOT(mapped_string:foo) AND NOT(mapped_string:foo bar)
+mapped_string:foo AND mapped_string_2:foo bar AND foo bar
+mapped_string:foo AND mapped_string_2:foo bar OR foo bar
+mapped_string:foo OR mapped_string_2:foo bar OR foo bar
+mapped_string:foo OR mapped_string:foo bar AND foo bar
+mapped_string:foo AND (mapped_string_2:foo bar OR foo bar)
+mapped_string:foo AND (mapped_string_2:foo bar OR foo bar)
+mapped_string:foo OR (mapped_string_2:foo bar OR foo bar)
 
-foo:AND
-foo:OR
-foo:NOT
+mapped_string:AND
+mapped_string:OR
+mapped_string:NOT
 foo AND
 foo OR
 foo NOT
@@ -79,43 +79,51 @@ OR foo
 NOT
 
 // Nested queries
-nested_field: { NOT foo }
-nested_field: { NOT foo bar }
-nested_field: { NOT foo_field:foo }
-nested_field: { foo_field:foo AND foo_field:foo bar }
-nested_field: { foo_field<foo AND foo_field>bar }
-nested_field: { (foo_field:foo) AND (foo_field:foo bar) }
-nested_field: { foo_field:foo OR foo_field:foo bar }
-nested_field: { NOT(foo_field:foo OR foo_field:foo bar) }
-nested_field: { NOT(foo_field:foo AND foo_field:foo bar) }
-nested_field: { NOT foo_field:foo AND NOT foo_field:foo bar }
-nested_field: { (NOT foo_field:foo) AND (NOT foo_field:foo bar) }
-nested_field: { NOT(foo_field:foo) AND NOT(foo_field:foo bar) }
-nested_field: { foo_field:foo AND foo_field:foo bar AND foo bar }
-nested_field: { foo_field:foo AND foo_field:foo bar OR foo bar }
-nested_field: { foo_field:foo OR foo_field:foo bar OR foo bar }
-nested_field: { foo_field:foo OR foo_field:foo bar AND foo bar }
-nested_field: { foo_field:foo AND (foo_field:foo bar OR foo bar) }
-nested_field: { foo_field:foo AND (foo_field:foo bar OR foo bar) }
-nested_field: { foo_field:foo OR (foo_field:foo bar OR foo bar) }
-nested_field: { sub_nested_field : { foo_field:foo } AND foo_field:foo bar }
+mapped_nested: { NOT foo }
+mapped_nested: { NOT foo bar }
+mapped_nested: { NOT mapped_string:foo }
+mapped_nested: { mapped_string:foo AND mapped_string_2:foo bar }
+mapped_nested: { mapped_string<foo AND mapped_int>2 }
+mapped_nested: { (mapped_string:foo) AND (mapped_string_2:foo bar) }
+mapped_nested: { mapped_string:foo OR mapped_string_2:foo bar }
+mapped_nested: { NOT(mapped_string:foo OR mapped_string_2:foo bar) }
+mapped_nested: { NOT(mapped_string:foo AND mapped_string_2:foo bar) }
+mapped_nested: { NOT mapped_string:foo AND NOT mapped_string_2:foo bar }
+mapped_nested: { (NOT mapped_string:foo) AND (NOT mapped_string_2:foo bar) }
+mapped_nested: { NOT(mapped_string:foo) AND NOT(mapped_string_2:foo bar) }
+mapped_nested: { mapped_string:foo AND mapped_string_2:foo bar AND foo bar }
+mapped_nested: { mapped_string:foo AND mapped_string_2:foo bar OR foo bar }
+mapped_nested: { mapped_string:foo OR mapped_string_2:foo bar OR foo bar }
+mapped_nested: { mapped_string:foo OR mapped_string_2:foo bar AND foo bar }
+mapped_nested: { mapped_string:foo AND (mapped_string_2:foo bar OR foo bar) }
+mapped_nested: { mapped_string:foo AND (mapped_string_2:foo bar OR foo bar) }
+mapped_nested: { mapped_string:foo OR (mapped_string_2:foo bar OR foo bar) }
+mapped_nested: { mapped_str*:foo }
+mapped_nested: { mapped_nested : { mapped_string:foo AND mapped_int < 3 } AND mapped_string_2:foo bar }
+mapped_nested: { mapped_nested.mapped_string:foo AND mapped_string_2:foo bar }
+
+// Inline nested queries
+mapped_nested.mapped_string:foo AND mapped_nested.mapped_int < 2
+mapped_nested.mapped_nested.mapped_string:foo AND mapped_nested.mapped_int < 2
+mapped_nested.mapped_str*: foo
+
 
 // Queries with escape sequences
-foo_field : (foo\(bar\))
-foo_field : foo\:bar
-foo_field : (foo \\and bar)
-foo_field : (foo \\or bar)
-foo_field : foo \\not bar
-foo_field : foo \{bar\}
-foo_field : foo \(bar\)
-foo_field : foo \\ bar
-foo_field : foo \"bar\"
+mapped_string:(foo\(bar\))
+mapped_string:foo\:bar
+mapped_string:(foo \\and bar)
+mapped_string:(foo \\or bar)
+mapped_string:foo \\not bar
+mapped_string:foo \{bar\}
+mapped_string:foo \(bar\)
+mapped_string:foo \\ bar
+mapped_string:foo \"bar\"
 
-foo_field : "foo and bar"
-foo_field : "foo not bar"
-foo_field : "foo or bar"
-foo_field : "foo : bar"
-foo_field : "foo { bar }"
-foo_field : "foo (bar)"
-foo_field : "foo \\ bar"
-foo_field : "foo \"bar\""
+mapped_string:"foo and bar"
+mapped_string:"foo not bar"
+mapped_string:"foo or bar"
+mapped_string:"foo : bar"
+mapped_string:"foo { bar }"
+mapped_string:"foo (bar)"
+mapped_string:"foo \\ bar"
+mapped_string:"foo \"bar\""

--- a/x-pack/plugin/kql/src/test/resources/unsupported-queries
+++ b/x-pack/plugin/kql/src/test/resources/unsupported-queries
@@ -1,36 +1,36 @@
 
 // Incomplete expressions
-foo_field :
-foo_field <
-foo_field >
-foo_field >=
-foo_field <=
+mapped_string :
+mapped_string <
+mapped_string >
+mapped_string >=
+mapped_string <=
 >= foo
 : "foo"
 : foo
 
 // Parentheses mismatch
-foo_field: (foo bar
-foo_field: foo bar)
-NOT foo_field:foo OR foo_field:foo bar)
-NOT (foo_field:foo AND) foo_field:foo bar
+mapped_string: (foo bar
+mapped_string: foo bar)
+NOT mapped_string:foo OR mapped_string_2:foo bar)
+NOT (mapped_string:foo AND) mapped_string_2:foo bar
 
 // Quotes mismatch
-foo_field: "foo bar
-foo_field: foo bar"
+mapped_string: "foo bar
+mapped_string: foo bar"
 
 // Can't nest grouping terms parentheses
-foo_field:(foo (bar))
+mapped_string:(foo (bar))
 
 // Bad syntax for nested fields:
-nested_field { foo: bar }
+mapped_nested { mapped_string: bar }
 
 // Missing escape sequences:
-foo_field: foo:bar
-foo_field: (foo and bar)
-foo_field: (foo or bar)
-foo_field: foo not bar
-foo_field: foo { bar }
-foo_field: foo (bar)
-foo_field: foo "bar"
-foo_field: "foo "bar""
+mapped_string: foo:bar
+mapped_string: (foo and bar)
+mapped_string: (foo or bar)
+mapped_string: foo not bar
+mapped_string: foo { bar }
+mapped_string: foo (bar)
+mapped_string: foo "bar"
+mapped_string: "foo "bar""


### PR DESCRIPTION
This PR updates the KQL tests to prepare the implementation of nested field support.

More specifically it does:
- use field name that are mapped in the tests instead of random field names in `supported-queries` and `unsupported-queries`
- Add nested field and subfields to the mapping used in tests
