### PR TITLE
[8.x] Adjust analyze limit exception to be a bad_request (#116325)

### DIFF
--- a/docs/changelog/116325.yaml
+++ b/docs/changelog/116325.yaml
@@ -1,0 +1,5 @@
+pr: 116325
+summary: Adjust analyze limit exception to be a `bad_request`
+area: Analysis
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -18,6 +18,7 @@ import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
 import org.elasticsearch.cluster.ClusterState;
@@ -44,6 +45,7 @@ import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -455,11 +457,12 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
         private void increment() {
             tokenCount++;
             if (tokenCount > maxTokenCount) {
-                throw new IllegalStateException(
+                throw new ElasticsearchStatusException(
                     "The number of tokens produced by calling _analyze has exceeded the allowed maximum of ["
                         + maxTokenCount
                         + "]."
-                        + " This limit can be set by changing the [index.analyze.max_token_count] index level setting."
+                        + " This limit can be set by changing the [index.analyze.max_token_count] index level setting.",
+                    RestStatus.BAD_REQUEST
                 );
             }
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.tests.analysis.MockTokenFilter;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.action.admin.indices.analyze.TransportAnalyzeAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -460,8 +461,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         AnalyzeAction.Request request = new AnalyzeAction.Request();
         request.text(text);
         request.analyzer("standard");
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
             () -> TransportAnalyzeAction.analyze(request, registry, null, maxTokenCount)
         );
         assertEquals(
@@ -477,8 +478,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         request2.text(text);
         request2.analyzer("standard");
         request2.explain(true);
-        IllegalStateException e2 = expectThrows(
-            IllegalStateException.class,
+        ElasticsearchStatusException e2 = expectThrows(
+            ElasticsearchStatusException.class,
             () -> TransportAnalyzeAction.analyze(request2, registry, null, maxTokenCount)
         );
         assertEquals(
@@ -506,8 +507,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         AnalyzeAction.Request request = new AnalyzeAction.Request();
         request.text(text);
         request.analyzer("standard");
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
+        ElasticsearchStatusException e = expectThrows(
+            ElasticsearchStatusException.class,
             () -> TransportAnalyzeAction.analyze(request, registry, null, idxMaxTokenCount)
         );
         assertEquals(


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Adjust analyze limit exception to be a bad_request (#116325)