### PR TITLE
ESQL: Fix EsqlNodeSubclassTests

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -174,18 +174,7 @@ public class FieldAttribute extends TypedAttribute {
 
     @Override
     protected NodeInfo<FieldAttribute> info() {
-        return NodeInfo.create(
-            this,
-            FieldAttribute::new,
-            parentName,
-            name(),
-            dataType(),
-            field,
-            (String) null,
-            nullable(),
-            id(),
-            synthetic()
-        );
+        return NodeInfo.create(this, FieldAttribute::new, parentName, name(), field, nullable(), id(), synthetic());
     }
 
     public String parentName() {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
@@ -147,26 +147,7 @@ public class MetadataAttribute extends TypedAttribute {
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(
-            this,
-            (source, name, dataType, qualifier, nullability, id, synthetic, searchable1) -> new MetadataAttribute(
-                source,
-                name,
-                dataType,
-                qualifier,
-                nullability,
-                id,
-                synthetic,
-                searchable1
-            ),
-            name(),
-            dataType(),
-            (String) null,
-            nullable(),
-            id(),
-            synthetic(),
-            searchable
-        );
+        return NodeInfo.create(this, MetadataAttribute::new, name(), dataType(), nullable(), id(), synthetic(), searchable);
     }
 
     public boolean searchable() {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/ReferenceAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/ReferenceAttribute.java
@@ -110,24 +110,7 @@ public class ReferenceAttribute extends TypedAttribute {
 
     @Override
     protected NodeInfo<ReferenceAttribute> info() {
-        return NodeInfo.create(
-            this,
-            (source, name, dataType, qualifier, nullability, id, synthetic) -> new ReferenceAttribute(
-                source,
-                name,
-                dataType,
-                qualifier,
-                nullability,
-                id,
-                synthetic
-            ),
-            name(),
-            dataType(),
-            (String) null,
-            nullable(),
-            id(),
-            synthetic()
-        );
+        return NodeInfo.create(this, ReferenceAttribute::new, name(), dataType(), nullable(), id(), synthetic());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
-import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttributeTests;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedNamedExpression;
@@ -163,15 +162,6 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
          * in the parameters and not included.
          */
         expectedCount -= 1;
-
-        // special exceptions with private constructors
-        if (MetadataAttribute.class.equals(subclass) || ReferenceAttribute.class.equals(subclass)) {
-            expectedCount++;
-        }
-
-        if (FieldAttribute.class.equals(subclass)) {
-            expectedCount += 2;
-        }
 
         assertEquals(expectedCount, info(node).properties().size());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.esql.core.capabilities.UnresolvedException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
-import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttributeTests;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedNamedExpression;
@@ -113,9 +112,13 @@ import static org.mockito.Mockito.mock;
  * </ul>
  */
 public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeSubclassTests {
+    private static final String ESQL_CORE_CLASS_PREFIX = "org.elasticsearch.xpack.esql.core";
+    private static final String ESQL_CORE_JAR_LOCATION_SUBSTRING = "x-pack-esql-core";
+    private static final String ESQL_CLASS_PREFIX = "org.elasticsearch.xpack.esql";
+
     private static final Predicate<String> CLASSNAME_FILTER = className -> {
-        boolean esqlCore = className.startsWith("org.elasticsearch.xpack.esql.core") != false;
-        boolean esqlProper = className.startsWith("org.elasticsearch.xpack.esql") != false;
+        boolean esqlCore = className.startsWith(ESQL_CORE_CLASS_PREFIX) != false;
+        boolean esqlProper = className.startsWith(ESQL_CLASS_PREFIX) != false;
         return (esqlCore || esqlProper);
     };
 
@@ -726,7 +729,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             // NIO FileSystem API is not used since it trips the SecurityManager
             // https://bugs.openjdk.java.net/browse/JDK-8160798
             // so iterate the jar "by hand"
-            if (path.endsWith(".jar") && path.contains("x-pack-ql")) {
+            if (path.endsWith(".jar") && path.contains(ESQL_CORE_JAR_LOCATION_SUBSTRING)) {
                 try (JarInputStream jar = jarStream(root)) {
                     JarEntry je = null;
                     while ((je = jar.getNextJarEntry()) != null) {


### PR DESCRIPTION
- Fix https://github.com/elastic/elasticsearch/issues/114845
- **More importantly!** Fix EsqlNodeSubclassTests _so that they also test the Node subclasses in esql.core._

Due to a subtle mistake when copying the ql project into esql.core, the EsqlNodeSubclassTests did not run on subclasses in esql.core _at all_. This adds a fix to EsqlNodeSubclassTests.subclassesOf.

The classes ReferenceAttribute, FieldAttribute and MetadataAttribute did not respect the contract for Node.info because their info method did not use the longest public constructor - this is https://github.com/elastic/elasticsearch/issues/114845. This is fixed here as well.