### PR TITLE
Add SLES 15.6 to docker linux exclusions list

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -15,6 +15,7 @@ sles-15.2
 sles-15.3
 sles-15.4
 sles-15.5
+sles-15.6
 
 # These OSes are deprecated and filtered starting with 8.0.0, but need to be excluded
 # for PR checks


### PR DESCRIPTION
New version of SLES is out so we need to added it to the exclusions list as there are issues with our Docker tests fixtures.

Closes https://github.com/elastic/elasticsearch/issues/116461