### PR TITLE
[7.17] Add SLES 15.6 to docker linux exclusions list (#116506)

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -18,3 +18,4 @@ sles-15.2
 sles-15.3
 sles-15.4
 sles-15.5
+sles-15.6


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Add SLES 15.6 to docker linux exclusions list (#116506)