### PR TITLE
[8.15] Yet more unsupported locales for Kerb tests (#112555)

### DIFF
--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosTestCase.java
@@ -86,7 +86,8 @@ public abstract class KerberosTestCase extends ESTestCase {
         "sd",
         "mni",
         "sat",
-        "sa"
+        "sa",
+        "bgc"
     );
 
     @BeforeClass


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - Yet more unsupported locales for Kerb tests (#112555) (a2df7e72)

Closes https://github.com/elastic/elasticsearch/issues/116372