### PR TITLE
[8.x] Add new multi_dense_vector field for brute-force search (#116275)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/30_multi_dense_vector.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/30_multi_dense_vector.yml
@@ -1,0 +1,141 @@
+setup:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_search
+          capabilities: [ multi_dense_vector_field_mapper ]
+      test_runner_features: capabilities
+      reason: "Support for multi dense vector field mapper capability required"
+---
+"Test create multi-vector field":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector1:
+                type: multi_dense_vector
+                dims: 3
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          vector1: [[2, -1, 1]]
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          vector1: [[2, -1, 1], [3, 4, 5]]
+  - do:
+      index:
+        index: test
+        id: "3"
+        body:
+          vector1: [[2, -1, 1], [3, 4, 5], [6, 7, 8]]
+  - do:
+      indices.refresh: {}
+---
+"Test create dynamic dim multi-vector field":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              name:
+                type: keyword
+              vector1:
+                type: multi_dense_vector
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          vector1: [[2, -1, 1]]
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          vector1: [[2, -1, 1], [3, 4, 5]]
+  - do:
+      index:
+        index: test
+        id: "3"
+        body:
+          vector1: [[2, -1, 1], [3, 4, 5], [6, 7, 8]]
+  - do:
+      cluster.health:
+        wait_for_events: languid
+
+  # verify some other dimension will fail
+  - do:
+      catch: bad_request
+      index:
+        index: test
+        id: "4"
+        body:
+          vector1: [[2, -1, 1], [3, 4, 5], [6, 7, 8, 9]]
+---
+"Test dynamic dim mismatch fails multi-vector field":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector1:
+                type: multi_dense_vector
+  - do:
+      catch: bad_request
+      index:
+        index: test
+        id: "1"
+        body:
+          vector1: [[2, -1, 1], [2]]
+---
+"Test static dim mismatch fails multi-vector field":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector1:
+                type: multi_dense_vector
+                dims: 3
+  - do:
+      catch: bad_request
+      index:
+        index: test
+        id: "1"
+        body:
+          vector1: [[2, -1, 1], [2]]
+---
+"Test poorly formatted multi-vector field":
+  - do:
+      indices.create:
+        index: poorly_formatted_vector
+        body:
+          mappings:
+            properties:
+              vector1:
+                type: multi_dense_vector
+                dims: 3
+  - do:
+      catch: bad_request
+      index:
+        index: poorly_formatted_vector
+        id: "1"
+        body:
+          vector1: [[[2, -1, 1]]]
+  - do:
+      catch: bad_request
+      index:
+        index: poorly_formatted_vector
+        id: "1"
+        body:
+          vector1: [[2, -1, 1], [[2, -1, 1]]]

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -415,13 +415,18 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 return VectorUtil.dotProduct(vectorData.asByteVector(), vectorData.asByteVector());
             }
 
-            private VectorData parseVectorArray(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            private VectorData parseVectorArray(
+                DocumentParserContext context,
+                int dims,
+                IntBooleanConsumer dimChecker,
+                VectorSimilarity similarity
+            ) throws IOException {
                 int index = 0;
-                byte[] vector = new byte[fieldMapper.fieldType().dims];
+                byte[] vector = new byte[dims];
                 float squaredMagnitude = 0;
                 for (XContentParser.Token token = context.parser().nextToken(); token != Token.END_ARRAY; token = context.parser()
                     .nextToken()) {
-                    fieldMapper.checkDimensionExceeded(index, context);
+                    dimChecker.accept(index, false);
                     ensureExpectedToken(Token.VALUE_NUMBER, token, context.parser());
                     final int value;
                     if (context.parser().numberType() != XContentParser.NumberType.INT) {
@@ -459,30 +464,31 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     vector[index++] = (byte) value;
                     squaredMagnitude += value * value;
                 }
-                fieldMapper.checkDimensionMatches(index, context);
-                checkVectorMagnitude(fieldMapper.fieldType().similarity, errorByteElementsAppender(vector), squaredMagnitude);
+                dimChecker.accept(index, true);
+                checkVectorMagnitude(similarity, errorByteElementsAppender(vector), squaredMagnitude);
                 return VectorData.fromBytes(vector);
             }
 
-            private VectorData parseHexEncodedVector(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            private VectorData parseHexEncodedVector(
+                DocumentParserContext context,
+                IntBooleanConsumer dimChecker,
+                VectorSimilarity similarity
+            ) throws IOException {
                 byte[] decodedVector = HexFormat.of().parseHex(context.parser().text());
-                fieldMapper.checkDimensionMatches(decodedVector.length, context);
+                dimChecker.accept(decodedVector.length, true);
                 VectorData vectorData = VectorData.fromBytes(decodedVector);
                 double squaredMagnitude = computeSquaredMagnitude(vectorData);
-                checkVectorMagnitude(
-                    fieldMapper.fieldType().similarity,
-                    errorByteElementsAppender(decodedVector),
-                    (float) squaredMagnitude
-                );
+                checkVectorMagnitude(similarity, errorByteElementsAppender(decodedVector), (float) squaredMagnitude);
                 return vectorData;
             }
 
             @Override
-            VectorData parseKnnVector(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            VectorData parseKnnVector(DocumentParserContext context, int dims, IntBooleanConsumer dimChecker, VectorSimilarity similarity)
+                throws IOException {
                 XContentParser.Token token = context.parser().currentToken();
                 return switch (token) {
-                    case START_ARRAY -> parseVectorArray(context, fieldMapper);
-                    case VALUE_STRING -> parseHexEncodedVector(context, fieldMapper);
+                    case START_ARRAY -> parseVectorArray(context, dims, dimChecker, similarity);
+                    case VALUE_STRING -> parseHexEncodedVector(context, dimChecker, similarity);
                     default -> throw new ParsingException(
                         context.parser().getTokenLocation(),
                         format("Unsupported type [%s] for provided value [%s]", token, context.parser().text())
@@ -492,7 +498,13 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
             @Override
             public void parseKnnVectorAndIndex(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
-                VectorData vectorData = parseKnnVector(context, fieldMapper);
+                VectorData vectorData = parseKnnVector(context, fieldMapper.fieldType().dims, (i, end) -> {
+                    if (end) {
+                        fieldMapper.checkDimensionMatches(i, context);
+                    } else {
+                        fieldMapper.checkDimensionExceeded(i, context);
+                    }
+                }, fieldMapper.fieldType().similarity);
                 Field field = createKnnVectorField(
                     fieldMapper.fieldType().name(),
                     vectorData.asByteVector(),
@@ -676,21 +688,22 @@ public class DenseVectorFieldMapper extends FieldMapper {
             }
 
             @Override
-            VectorData parseKnnVector(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            VectorData parseKnnVector(DocumentParserContext context, int dims, IntBooleanConsumer dimChecker, VectorSimilarity similarity)
+                throws IOException {
                 int index = 0;
                 float squaredMagnitude = 0;
-                float[] vector = new float[fieldMapper.fieldType().dims];
+                float[] vector = new float[dims];
                 for (Token token = context.parser().nextToken(); token != Token.END_ARRAY; token = context.parser().nextToken()) {
-                    fieldMapper.checkDimensionExceeded(index, context);
+                    dimChecker.accept(index, false);
                     ensureExpectedToken(Token.VALUE_NUMBER, token, context.parser());
                     float value = context.parser().floatValue(true);
                     vector[index] = value;
                     squaredMagnitude += value * value;
                     index++;
                 }
-                fieldMapper.checkDimensionMatches(index, context);
+                dimChecker.accept(index, true);
                 checkVectorBounds(vector);
-                checkVectorMagnitude(fieldMapper.fieldType().similarity, errorFloatElementsAppender(vector), squaredMagnitude);
+                checkVectorMagnitude(similarity, errorFloatElementsAppender(vector), squaredMagnitude);
                 return VectorData.fromFloats(vector);
             }
 
@@ -815,12 +828,17 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 return count;
             }
 
-            private VectorData parseVectorArray(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            private VectorData parseVectorArray(
+                DocumentParserContext context,
+                int dims,
+                IntBooleanConsumer dimChecker,
+                VectorSimilarity similarity
+            ) throws IOException {
                 int index = 0;
-                byte[] vector = new byte[fieldMapper.fieldType().dims / Byte.SIZE];
+                byte[] vector = new byte[dims / Byte.SIZE];
                 for (XContentParser.Token token = context.parser().nextToken(); token != Token.END_ARRAY; token = context.parser()
                     .nextToken()) {
-                    fieldMapper.checkDimensionExceeded(index, context);
+                    dimChecker.accept(index * Byte.SIZE, false);
                     ensureExpectedToken(Token.VALUE_NUMBER, token, context.parser());
                     final int value;
                     if (context.parser().numberType() != XContentParser.NumberType.INT) {
@@ -855,35 +873,25 @@ public class DenseVectorFieldMapper extends FieldMapper {
                                 + "];"
                         );
                     }
-                    if (index >= vector.length) {
-                        throw new IllegalArgumentException(
-                            "The number of dimensions for field ["
-                                + fieldMapper.fieldType().name()
-                                + "] should be ["
-                                + fieldMapper.fieldType().dims
-                                + "] but found ["
-                                + (index + 1) * Byte.SIZE
-                                + "]"
-                        );
-                    }
                     vector[index++] = (byte) value;
                 }
-                fieldMapper.checkDimensionMatches(index * Byte.SIZE, context);
+                dimChecker.accept(index * Byte.SIZE, true);
                 return VectorData.fromBytes(vector);
             }
 
-            private VectorData parseHexEncodedVector(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            private VectorData parseHexEncodedVector(DocumentParserContext context, IntBooleanConsumer dimChecker) throws IOException {
                 byte[] decodedVector = HexFormat.of().parseHex(context.parser().text());
-                fieldMapper.checkDimensionMatches(decodedVector.length * Byte.SIZE, context);
+                dimChecker.accept(decodedVector.length * Byte.SIZE, true);
                 return VectorData.fromBytes(decodedVector);
             }
 
             @Override
-            VectorData parseKnnVector(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
+            VectorData parseKnnVector(DocumentParserContext context, int dims, IntBooleanConsumer dimChecker, VectorSimilarity similarity)
+                throws IOException {
                 XContentParser.Token token = context.parser().currentToken();
                 return switch (token) {
-                    case START_ARRAY -> parseVectorArray(context, fieldMapper);
-                    case VALUE_STRING -> parseHexEncodedVector(context, fieldMapper);
+                    case START_ARRAY -> parseVectorArray(context, dims, dimChecker, similarity);
+                    case VALUE_STRING -> parseHexEncodedVector(context, dimChecker);
                     default -> throw new ParsingException(
                         context.parser().getTokenLocation(),
                         format("Unsupported type [%s] for provided value [%s]", token, context.parser().text())
@@ -893,7 +901,13 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
             @Override
             public void parseKnnVectorAndIndex(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException {
-                VectorData vectorData = parseKnnVector(context, fieldMapper);
+                VectorData vectorData = parseKnnVector(context, fieldMapper.fieldType().dims, (i, end) -> {
+                    if (end) {
+                        fieldMapper.checkDimensionMatches(i, context);
+                    } else {
+                        fieldMapper.checkDimensionExceeded(i, context);
+                    }
+                }, fieldMapper.fieldType().similarity);
                 Field field = createKnnVectorField(
                     fieldMapper.fieldType().name(),
                     vectorData.asByteVector(),
@@ -957,7 +971,12 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
         abstract void parseKnnVectorAndIndex(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException;
 
-        abstract VectorData parseKnnVector(DocumentParserContext context, DenseVectorFieldMapper fieldMapper) throws IOException;
+        abstract VectorData parseKnnVector(
+            DocumentParserContext context,
+            int dims,
+            IntBooleanConsumer dimChecker,
+            VectorSimilarity similarity
+        ) throws IOException;
 
         abstract int getNumBytes(int dimensions);
 
@@ -2179,7 +2198,13 @@ public class DenseVectorFieldMapper extends FieldMapper {
             : elementType.getNumBytes(dims);
 
         ByteBuffer byteBuffer = elementType.createByteBuffer(indexCreatedVersion, numBytes);
-        VectorData vectorData = elementType.parseKnnVector(context, this);
+        VectorData vectorData = elementType.parseKnnVector(context, dims, (i, b) -> {
+            if (b) {
+                checkDimensionMatches(i, context);
+            } else {
+                checkDimensionExceeded(i, context);
+            }
+        }, fieldType().similarity);
         vectorData.addToBuffer(byteBuffer);
         if (indexCreatedVersion.onOrAfter(MAGNITUDE_STORED_INDEX_VERSION)) {
             // encode vector magnitude at the end
@@ -2426,5 +2451,12 @@ public class DenseVectorFieldMapper extends FieldMapper {
         public String fieldName() {
             return fullPath();
         }
+    }
+
+    /**
+     * @FunctionalInterface for a function that takes a int and boolean
+     */
+    interface IntBooleanConsumer {
+        void accept(int value, boolean isComplete);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/MultiDenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/MultiDenseVectorFieldMapper.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.FeatureFlag;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.fielddata.FieldDataContext;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.mapper.ArraySourceValueFetcher;
+import org.elasticsearch.index.mapper.DocumentParserContext;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.SimpleMappedFieldType;
+import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.vectors.VectorData;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMS_COUNT;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMS_COUNT_BIT;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.namesToElementType;
+
+public class MultiDenseVectorFieldMapper extends FieldMapper {
+
+    public static final String VECTOR_MAGNITUDES_SUFFIX = "._magnitude";
+    public static final FeatureFlag FEATURE_FLAG = new FeatureFlag("multi_dense_vector");
+    public static final String CONTENT_TYPE = "multi_dense_vector";
+
+    private static MultiDenseVectorFieldMapper toType(FieldMapper in) {
+        return (MultiDenseVectorFieldMapper) in;
+    }
+
+    public static class Builder extends FieldMapper.Builder {
+
+        private final Parameter<DenseVectorFieldMapper.ElementType> elementType = new Parameter<>(
+            "element_type",
+            false,
+            () -> DenseVectorFieldMapper.ElementType.FLOAT,
+            (n, c, o) -> {
+                DenseVectorFieldMapper.ElementType elementType = namesToElementType.get((String) o);
+                if (elementType == null) {
+                    throw new MapperParsingException(
+                        "invalid element_type [" + o + "]; available types are " + namesToElementType.keySet()
+                    );
+                }
+                return elementType;
+            },
+            m -> toType(m).fieldType().elementType,
+            XContentBuilder::field,
+            Objects::toString
+        );
+
+        // This is defined as updatable because it can be updated once, from [null] to a valid dim size,
+        // by a dynamic mapping update. Once it has been set, however, the value cannot be changed.
+        private final Parameter<Integer> dims = new Parameter<>("dims", true, () -> null, (n, c, o) -> {
+            if (o instanceof Integer == false) {
+                throw new MapperParsingException("Property [dims] on field [" + n + "] must be an integer but got [" + o + "]");
+            }
+
+            return XContentMapValues.nodeIntegerValue(o);
+        }, m -> toType(m).fieldType().dims, XContentBuilder::field, Object::toString).setSerializerCheck((id, ic, v) -> v != null)
+            .setMergeValidator((previous, current, c) -> previous == null || Objects.equals(previous, current))
+            .addValidator(dims -> {
+                if (dims == null) {
+                    return;
+                }
+                int maxDims = elementType.getValue() == DenseVectorFieldMapper.ElementType.BIT ? MAX_DIMS_COUNT_BIT : MAX_DIMS_COUNT;
+                int minDims = elementType.getValue() == DenseVectorFieldMapper.ElementType.BIT ? Byte.SIZE : 1;
+                if (dims < minDims || dims > maxDims) {
+                    throw new MapperParsingException(
+                        "The number of dimensions should be in the range [" + minDims + ", " + maxDims + "] but was [" + dims + "]"
+                    );
+                }
+                if (elementType.getValue() == DenseVectorFieldMapper.ElementType.BIT) {
+                    if (dims % Byte.SIZE != 0) {
+                        throw new MapperParsingException("The number of dimensions for should be a multiple of 8 but was [" + dims + "]");
+                    }
+                }
+            });
+        private final Parameter<Map<String, String>> meta = Parameter.metaParam();
+
+        private final IndexVersion indexCreatedVersion;
+
+        public Builder(String name, IndexVersion indexCreatedVersion) {
+            super(name);
+            this.indexCreatedVersion = indexCreatedVersion;
+        }
+
+        @Override
+        protected Parameter<?>[] getParameters() {
+            return new Parameter<?>[] { elementType, dims, meta };
+        }
+
+        public MultiDenseVectorFieldMapper.Builder dimensions(int dimensions) {
+            this.dims.setValue(dimensions);
+            return this;
+        }
+
+        public MultiDenseVectorFieldMapper.Builder elementType(DenseVectorFieldMapper.ElementType elementType) {
+            this.elementType.setValue(elementType);
+            return this;
+        }
+
+        @Override
+        public MultiDenseVectorFieldMapper build(MapperBuilderContext context) {
+            // Validate again here because the dimensions or element type could have been set programmatically,
+            // which affects index option validity
+            validate();
+            return new MultiDenseVectorFieldMapper(
+                leafName(),
+                new MultiDenseVectorFieldType(
+                    context.buildFullName(leafName()),
+                    elementType.getValue(),
+                    dims.getValue(),
+                    indexCreatedVersion,
+                    meta.getValue()
+                ),
+                builderParams(this, context),
+                indexCreatedVersion
+            );
+        }
+    }
+
+    public static final TypeParser PARSER = new TypeParser(
+        (n, c) -> new MultiDenseVectorFieldMapper.Builder(n, c.indexVersionCreated()),
+        notInMultiFields(CONTENT_TYPE)
+    );
+
+    public static final class MultiDenseVectorFieldType extends SimpleMappedFieldType {
+        private final DenseVectorFieldMapper.ElementType elementType;
+        private final Integer dims;
+        private final IndexVersion indexCreatedVersion;
+
+        public MultiDenseVectorFieldType(
+            String name,
+            DenseVectorFieldMapper.ElementType elementType,
+            Integer dims,
+            IndexVersion indexCreatedVersion,
+            Map<String, String> meta
+        ) {
+            super(name, false, false, true, TextSearchInfo.NONE, meta);
+            this.elementType = elementType;
+            this.dims = dims;
+            this.indexCreatedVersion = indexCreatedVersion;
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            if (format != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
+            }
+            return new ArraySourceValueFetcher(name(), context) {
+                @Override
+                protected Object parseSourceValue(Object value) {
+                    return value;
+                }
+            };
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+            throw new IllegalArgumentException(
+                "Field [" + name() + "] of type [" + typeName() + "] doesn't support docvalue_fields or aggregations"
+            );
+        }
+
+        @Override
+        public boolean isAggregatable() {
+            return false;
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
+            return new MultiVectorIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, indexCreatedVersion, dims, elementType);
+        }
+
+        @Override
+        public Query existsQuery(SearchExecutionContext context) {
+            return new FieldExistsQuery(name());
+        }
+
+        @Override
+        public Query termQuery(Object value, SearchExecutionContext context) {
+            throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support term queries");
+        }
+
+        int getVectorDimensions() {
+            return dims;
+        }
+
+        DenseVectorFieldMapper.ElementType getElementType() {
+            return elementType;
+        }
+    }
+
+    private final IndexVersion indexCreatedVersion;
+
+    private MultiDenseVectorFieldMapper(
+        String simpleName,
+        MappedFieldType fieldType,
+        BuilderParams params,
+        IndexVersion indexCreatedVersion
+    ) {
+        super(simpleName, fieldType, params);
+        this.indexCreatedVersion = indexCreatedVersion;
+    }
+
+    @Override
+    public MultiDenseVectorFieldType fieldType() {
+        return (MultiDenseVectorFieldType) super.fieldType();
+    }
+
+    @Override
+    public boolean parsesArrayValue() {
+        return true;
+    }
+
+    @Override
+    public void parse(DocumentParserContext context) throws IOException {
+        if (context.doc().getByKey(fieldType().name()) != null) {
+            throw new IllegalArgumentException(
+                "Field ["
+                    + fullPath()
+                    + "] of type ["
+                    + typeName()
+                    + "] doesn't support indexing multiple values for the same field in the same document"
+            );
+        }
+        if (XContentParser.Token.VALUE_NULL == context.parser().currentToken()) {
+            return;
+        }
+        if (XContentParser.Token.START_ARRAY != context.parser().currentToken()) {
+            throw new IllegalArgumentException(
+                "Field [" + fullPath() + "] of type [" + typeName() + "] cannot be indexed with a single value"
+            );
+        }
+        if (fieldType().dims == null) {
+            int currentDims = -1;
+            while (XContentParser.Token.END_ARRAY != context.parser().nextToken()) {
+                int dims = fieldType().elementType.parseDimensionCount(context);
+                if (currentDims == -1) {
+                    currentDims = dims;
+                } else if (currentDims != dims) {
+                    throw new IllegalArgumentException(
+                        "Field [" + fullPath() + "] of type [" + typeName() + "] cannot be indexed with vectors of different dimensions"
+                    );
+                }
+            }
+            MultiDenseVectorFieldType updatedFieldType = new MultiDenseVectorFieldType(
+                fieldType().name(),
+                fieldType().elementType,
+                currentDims,
+                indexCreatedVersion,
+                fieldType().meta()
+            );
+            Mapper update = new MultiDenseVectorFieldMapper(leafName(), updatedFieldType, builderParams, indexCreatedVersion);
+            context.addDynamicMapper(update);
+            return;
+        }
+        int dims = fieldType().dims;
+        DenseVectorFieldMapper.ElementType elementType = fieldType().elementType;
+        List<VectorData> vectors = new ArrayList<>();
+        while (XContentParser.Token.END_ARRAY != context.parser().nextToken()) {
+            VectorData vector = elementType.parseKnnVector(context, dims, (i, b) -> {
+                if (b) {
+                    checkDimensionMatches(i, context);
+                } else {
+                    checkDimensionExceeded(i, context);
+                }
+            }, null);
+            vectors.add(vector);
+        }
+        int bufferSize = elementType.getNumBytes(dims) * vectors.size();
+        ByteBuffer buffer = ByteBuffer.allocate(bufferSize).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer magnitudeBuffer = ByteBuffer.allocate(vectors.size() * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (VectorData vector : vectors) {
+            vector.addToBuffer(buffer);
+            magnitudeBuffer.putFloat((float) Math.sqrt(elementType.computeSquaredMagnitude(vector)));
+        }
+        String vectorFieldName = fieldType().name();
+        String vectorMagnitudeFieldName = vectorFieldName + VECTOR_MAGNITUDES_SUFFIX;
+        context.doc().addWithKey(vectorFieldName, new BinaryDocValuesField(vectorFieldName, new BytesRef(buffer.array())));
+        context.doc()
+            .addWithKey(
+                vectorMagnitudeFieldName,
+                new BinaryDocValuesField(vectorMagnitudeFieldName, new BytesRef(magnitudeBuffer.array()))
+            );
+    }
+
+    private void checkDimensionExceeded(int index, DocumentParserContext context) {
+        if (index >= fieldType().dims) {
+            throw new IllegalArgumentException(
+                "The ["
+                    + typeName()
+                    + "] field ["
+                    + fullPath()
+                    + "] in doc ["
+                    + context.documentDescription()
+                    + "] has more dimensions "
+                    + "than defined in the mapping ["
+                    + fieldType().dims
+                    + "]"
+            );
+        }
+    }
+
+    private void checkDimensionMatches(int index, DocumentParserContext context) {
+        if (index != fieldType().dims) {
+            throw new IllegalArgumentException(
+                "The ["
+                    + typeName()
+                    + "] field ["
+                    + fullPath()
+                    + "] in doc ["
+                    + context.documentDescription()
+                    + "] has a different number of dimensions "
+                    + "["
+                    + index
+                    + "] than defined in the mapping ["
+                    + fieldType().dims
+                    + "]"
+            );
+        }
+    }
+
+    @Override
+    protected void parseCreateField(DocumentParserContext context) {
+        throw new AssertionError("parse is implemented directly");
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public FieldMapper.Builder getMergeBuilder() {
+        return new MultiDenseVectorFieldMapper.Builder(leafName(), indexCreatedVersion).init(this);
+    }
+
+    @Override
+    protected SyntheticSourceSupport syntheticSourceSupport() {
+        return new SyntheticSourceSupport.Native(new MultiDenseVectorFieldMapper.DocValuesSyntheticFieldLoader());
+    }
+
+    private class DocValuesSyntheticFieldLoader extends SourceLoader.DocValuesBasedSyntheticFieldLoader {
+        private BinaryDocValues values;
+        private boolean hasValue;
+
+        @Override
+        public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
+            values = leafReader.getBinaryDocValues(fullPath());
+            if (values == null) {
+                return null;
+            }
+            return docId -> {
+                hasValue = docId == values.advance(docId);
+                return hasValue;
+            };
+        }
+
+        @Override
+        public boolean hasValue() {
+            return hasValue;
+        }
+
+        @Override
+        public void write(XContentBuilder b) throws IOException {
+            if (false == hasValue) {
+                return;
+            }
+            b.startArray(leafName());
+            BytesRef ref = values.binaryValue();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(ref.bytes, ref.offset, ref.length).order(ByteOrder.LITTLE_ENDIAN);
+            assert ref.length % fieldType().elementType.getNumBytes(fieldType().dims) == 0;
+            int numVecs = ref.length / fieldType().elementType.getNumBytes(fieldType().dims);
+            for (int i = 0; i < numVecs; i++) {
+                b.startArray();
+                int dims = fieldType().elementType == DenseVectorFieldMapper.ElementType.BIT
+                    ? fieldType().dims / Byte.SIZE
+                    : fieldType().dims;
+                for (int dim = 0; dim < dims; dim++) {
+                    fieldType().elementType.readAndWriteValue(byteBuffer, b);
+                }
+                b.endArray();
+            }
+            b.endArray();
+        }
+
+        @Override
+        public String fieldName() {
+            return fullPath();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/MultiVectorDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/MultiVectorDVLeafFieldData.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.fielddata.LeafFieldData;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
+
+final class MultiVectorDVLeafFieldData implements LeafFieldData {
+    private final LeafReader reader;
+    private final String field;
+    private final IndexVersion indexVersion;
+    private final DenseVectorFieldMapper.ElementType elementType;
+    private final int dims;
+
+    MultiVectorDVLeafFieldData(
+        LeafReader reader,
+        String field,
+        IndexVersion indexVersion,
+        DenseVectorFieldMapper.ElementType elementType,
+        int dims
+    ) {
+        this.reader = reader;
+        this.field = field;
+        this.indexVersion = indexVersion;
+        this.elementType = elementType;
+        this.dims = dims;
+    }
+
+    @Override
+    public DocValuesScriptFieldFactory getScriptFieldFactory(String name) {
+        // TODO
+        return null;
+    }
+
+    @Override
+    public SortedBinaryDocValues getBytesValues() {
+        throw new UnsupportedOperationException("String representation of doc values for multi-vector fields is not supported");
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return 0;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/MultiVectorIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/MultiVectorIndexFieldData.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
+public class MultiVectorIndexFieldData implements IndexFieldData<MultiVectorDVLeafFieldData> {
+    protected final String fieldName;
+    protected final ValuesSourceType valuesSourceType;
+    private final int dims;
+    private final IndexVersion indexVersion;
+    private final DenseVectorFieldMapper.ElementType elementType;
+
+    public MultiVectorIndexFieldData(
+        String fieldName,
+        int dims,
+        ValuesSourceType valuesSourceType,
+        IndexVersion indexVersion,
+        DenseVectorFieldMapper.ElementType elementType
+    ) {
+        this.fieldName = fieldName;
+        this.valuesSourceType = valuesSourceType;
+        this.indexVersion = indexVersion;
+        this.elementType = elementType;
+        this.dims = dims;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public ValuesSourceType getValuesSourceType() {
+        return valuesSourceType;
+    }
+
+    @Override
+    public MultiVectorDVLeafFieldData load(LeafReaderContext context) {
+        return new MultiVectorDVLeafFieldData(context.reader(), fieldName, indexVersion, elementType, dims);
+    }
+
+    @Override
+    public MultiVectorDVLeafFieldData loadDirect(LeafReaderContext context) throws Exception {
+        return load(context);
+    }
+
+    @Override
+    public SortField sortField(Object missingValue, MultiValueMode sortMode, XFieldComparatorSource.Nested nested, boolean reverse) {
+        throw new IllegalArgumentException(
+            "Field [" + fieldName + "] of type [" + MultiDenseVectorFieldMapper.CONTENT_TYPE + "] doesn't support sort"
+        );
+    }
+
+    @Override
+    public BucketedSort newBucketedSort(
+        BigArrays bigArrays,
+        Object missingValue,
+        MultiValueMode sortMode,
+        XFieldComparatorSource.Nested nested,
+        SortOrder sortOrder,
+        DocValueFormat format,
+        int bucketSize,
+        BucketedSort.ExtraData extra
+    ) {
+        throw new IllegalArgumentException("only supported on numeric fields");
+    }
+
+    public static class Builder implements IndexFieldData.Builder {
+
+        private final String name;
+        private final ValuesSourceType valuesSourceType;
+        private final IndexVersion indexVersion;
+        private final int dims;
+        private final DenseVectorFieldMapper.ElementType elementType;
+
+        public Builder(
+            String name,
+            ValuesSourceType valuesSourceType,
+            IndexVersion indexVersion,
+            int dims,
+            DenseVectorFieldMapper.ElementType elementType
+        ) {
+            this.name = name;
+            this.valuesSourceType = valuesSourceType;
+            this.indexVersion = indexVersion;
+            this.dims = dims;
+            this.elementType = elementType;
+        }
+
+        @Override
+        public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
+            return new MultiVectorIndexFieldData(name, dims, valuesSourceType, indexVersion, elementType);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -67,6 +67,7 @@ import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.index.mapper.vectors.MultiDenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
 import org.elasticsearch.index.seqno.RetentionLeaseBackgroundSyncAction;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncAction;
@@ -210,6 +211,9 @@ public class IndicesModule extends AbstractModule {
 
         mappers.put(DenseVectorFieldMapper.CONTENT_TYPE, DenseVectorFieldMapper.PARSER);
         mappers.put(SparseVectorFieldMapper.CONTENT_TYPE, SparseVectorFieldMapper.PARSER);
+        if (MultiDenseVectorFieldMapper.FEATURE_FLAG.isEnabled()) {
+            mappers.put(MultiDenseVectorFieldMapper.CONTENT_TYPE, MultiDenseVectorFieldMapper.PARSER);
+        }
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
             for (Map.Entry<String, Mapper.TypeParser> entry : mapperPlugin.getMappers().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -10,9 +10,9 @@
 package org.elasticsearch.rest.action.search;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.mapper.vectors.MultiDenseVectorFieldMapper;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -32,25 +32,22 @@ public final class SearchCapabilities {
     private static final String DENSE_VECTOR_DOCVALUE_FIELDS = "dense_vector_docvalue_fields";
     /** Support kql query. */
     private static final String KQL_QUERY_SUPPORTED = "kql_query";
+    /** Support multi-dense-vector field mapper. */
+    private static final String MULTI_DENSE_VECTOR_FIELD_MAPPER = "multi_dense_vector_field_mapper";
 
-    public static final Set<String> CAPABILITIES = capabilities();
-
-    private static Set<String> capabilities() {
-        Set<String> capabilities = Set.of(
-            RANGE_REGEX_INTERVAL_QUERY_CAPABILITY,
-            BIT_DENSE_VECTOR_SYNTHETIC_SOURCE_CAPABILITY,
-            BYTE_FLOAT_BIT_DOT_PRODUCT_CAPABILITY,
-            DENSE_VECTOR_DOCVALUE_FIELDS
-        );
-
-        if (Build.current().isSnapshot()) {
-            return Collections.unmodifiableSet(Sets.union(capabilities, snapshotBuildCapabilities()));
+    public static final Set<String> CAPABILITIES;
+    static {
+        HashSet<String> capabilities = new HashSet<>();
+        capabilities.add(RANGE_REGEX_INTERVAL_QUERY_CAPABILITY);
+        capabilities.add(BIT_DENSE_VECTOR_SYNTHETIC_SOURCE_CAPABILITY);
+        capabilities.add(BYTE_FLOAT_BIT_DOT_PRODUCT_CAPABILITY);
+        capabilities.add(DENSE_VECTOR_DOCVALUE_FIELDS);
+        if (MultiDenseVectorFieldMapper.FEATURE_FLAG.isEnabled()) {
+            capabilities.add(MULTI_DENSE_VECTOR_FIELD_MAPPER);
         }
-
-        return capabilities;
-    }
-
-    private static Set<String> snapshotBuildCapabilities() {
-        return Set.of(KQL_QUERY_SUPPORTED);
+        if (Build.current().isSnapshot()) {
+            capabilities.add(KQL_QUERY_SUPPORTED);
+        }
+        CAPABILITIES = Set.copyOf(capabilities);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/MultiDenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/MultiDenseVectorFieldMapperTests.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentParsingException;
+import org.elasticsearch.index.mapper.LuceneDocument;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.ElementType;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.lookup.Source;
+import org.elasticsearch.search.lookup.SourceProvider;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.junit.AssumptionViolatedException;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MultiDenseVectorFieldMapperTests extends MapperTestCase {
+
+    @BeforeClass
+    public static void setup() {
+        assumeTrue("Requires multi-dense vector support", MultiDenseVectorFieldMapper.FEATURE_FLAG.isEnabled());
+    }
+
+    private final ElementType elementType;
+    private final int dims;
+
+    public MultiDenseVectorFieldMapperTests() {
+        this.elementType = randomFrom(ElementType.BYTE, ElementType.FLOAT, ElementType.BIT);
+        this.dims = ElementType.BIT == elementType ? 4 * Byte.SIZE : 4;
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        indexMapping(b, IndexVersion.current());
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b, IndexVersion indexVersion) throws IOException {
+        indexMapping(b, indexVersion);
+    }
+
+    private void indexMapping(XContentBuilder b, IndexVersion indexVersion) throws IOException {
+        b.field("type", "multi_dense_vector").field("dims", dims);
+        if (elementType != ElementType.FLOAT) {
+            b.field("element_type", elementType.toString());
+        }
+    }
+
+    @Override
+    protected Object getSampleValueForDocument() {
+        int numVectors = randomIntBetween(1, 16);
+        return Stream.generate(
+            () -> elementType == ElementType.FLOAT ? List.of(0.5, 0.5, 0.5, 0.5) : List.of((byte) 1, (byte) 1, (byte) 1, (byte) 1)
+        ).limit(numVectors).toList();
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker checker) throws IOException {
+        checker.registerConflictCheck(
+            "dims",
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims)),
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims + 8))
+        );
+        checker.registerConflictCheck(
+            "element_type",
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims).field("element_type", "byte")),
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims).field("element_type", "float"))
+        );
+        checker.registerConflictCheck(
+            "element_type",
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims).field("element_type", "float")),
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims * 8).field("element_type", "bit"))
+        );
+        checker.registerConflictCheck(
+            "element_type",
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims).field("element_type", "byte")),
+            fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", dims * 8).field("element_type", "bit"))
+        );
+    }
+
+    @Override
+    protected boolean supportsStoredFields() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsIgnoreMalformed() {
+        return false;
+    }
+
+    @Override
+    protected void assertSearchable(MappedFieldType fieldType) {
+        assertThat(fieldType, instanceOf(MultiDenseVectorFieldMapper.MultiDenseVectorFieldType.class));
+        assertFalse(fieldType.isIndexed());
+        assertFalse(fieldType.isSearchable());
+    }
+
+    protected void assertExistsQuery(MappedFieldType fieldType, Query query, LuceneDocument fields) {
+        assertThat(query, instanceOf(FieldExistsQuery.class));
+        FieldExistsQuery existsQuery = (FieldExistsQuery) query;
+        assertEquals("field", existsQuery.getField());
+        assertNoFieldNamesField(fields);
+    }
+
+    // We override this because dense vectors are the only field type that are not aggregatable but
+    // that do provide fielddata. TODO: resolve this inconsistency!
+    @Override
+    public void testAggregatableConsistency() {}
+
+    public void testDims() {
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                b.field("type", "multi_dense_vector");
+                b.field("dims", 0);
+            })));
+            assertThat(
+                e.getMessage(),
+                equalTo("Failed to parse mapping: " + "The number of dimensions should be in the range [1, 4096] but was [0]")
+            );
+        }
+        // test max limit for non-indexed vectors
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                b.field("type", "multi_dense_vector");
+                b.field("dims", 5000);
+            })));
+            assertThat(
+                e.getMessage(),
+                equalTo("Failed to parse mapping: " + "The number of dimensions should be in the range [1, 4096] but was [5000]")
+            );
+        }
+    }
+
+    public void testMergeDims() throws IOException {
+        XContentBuilder mapping = mapping(b -> {
+            b.startObject("field");
+            b.field("type", "multi_dense_vector");
+            b.endObject();
+        });
+        MapperService mapperService = createMapperService(mapping);
+
+        mapping = mapping(b -> {
+            b.startObject("field");
+            b.field("type", "multi_dense_vector").field("dims", dims);
+            b.endObject();
+        });
+        merge(mapperService, mapping);
+        assertEquals(
+            XContentHelper.convertToMap(BytesReference.bytes(mapping), false, mapping.contentType()).v2(),
+            XContentHelper.convertToMap(mapperService.documentMapper().mappingSource().uncompressed(), false, mapping.contentType()).v2()
+        );
+    }
+
+    public void testLargeDimsBit() throws IOException {
+        createMapperService(fieldMapping(b -> {
+            b.field("type", "multi_dense_vector");
+            b.field("dims", 1024 * Byte.SIZE);
+            b.field("element_type", ElementType.BIT.toString());
+        }));
+    }
+
+    public void testNonIndexedVector() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", 3)));
+
+        float[][] validVectors = { { -12.1f, 100.7f, -4 }, { 42f, .05f, -1f } };
+        double[] dotProduct = new double[2];
+        int vecId = 0;
+        for (float[] vector : validVectors) {
+            for (float value : vector) {
+                dotProduct[vecId] += value * value;
+            }
+            vecId++;
+        }
+        ParsedDocument doc1 = mapper.parse(source(b -> {
+            b.startArray("field");
+            for (float[] vector : validVectors) {
+                b.startArray();
+                for (float value : vector) {
+                    b.value(value);
+                }
+                b.endArray();
+            }
+            b.endArray();
+        }));
+
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(BinaryDocValuesField.class));
+        // assert that after decoding the indexed value is equal to expected
+        BytesRef vectorBR = fields.get(0).binaryValue();
+        assertEquals(ElementType.FLOAT.getNumBytes(validVectors[0].length) * validVectors.length, vectorBR.length);
+        float[][] decodedValues = new float[validVectors.length][];
+        for (int i = 0; i < validVectors.length; i++) {
+            decodedValues[i] = new float[validVectors[i].length];
+            FloatBuffer fb = ByteBuffer.wrap(vectorBR.bytes, i * Float.BYTES * validVectors[i].length, Float.BYTES * validVectors[i].length)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .asFloatBuffer();
+            fb.get(decodedValues[i]);
+        }
+        List<IndexableField> magFields = doc1.rootDoc().getFields("field" + MultiDenseVectorFieldMapper.VECTOR_MAGNITUDES_SUFFIX);
+        assertEquals(1, magFields.size());
+        assertThat(magFields.get(0), instanceOf(BinaryDocValuesField.class));
+        BytesRef magBR = magFields.get(0).binaryValue();
+        assertEquals(Float.BYTES * validVectors.length, magBR.length);
+        FloatBuffer fb = ByteBuffer.wrap(magBR.bytes, magBR.offset, magBR.length).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
+        for (int i = 0; i < validVectors.length; i++) {
+            assertEquals((float) Math.sqrt(dotProduct[i]), fb.get(), 0.001f);
+        }
+        for (int i = 0; i < validVectors.length; i++) {
+            assertArrayEquals("Decoded dense vector values is not equal to the indexed one.", validVectors[i], decodedValues[i], 0.001f);
+        }
+    }
+
+    public void testPoorlyIndexedVector() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", 3)));
+
+        float[][] validVectors = { { -12.1f, 100.7f, -4 }, { 42f, .05f, -1f } };
+        double[] dotProduct = new double[2];
+        int vecId = 0;
+        for (float[] vector : validVectors) {
+            for (float value : vector) {
+                dotProduct[vecId] += value * value;
+            }
+            vecId++;
+        }
+        expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("field");
+            b.startArray(); // double nested array should fail
+            for (float[] vector : validVectors) {
+                b.startArray();
+                for (float value : vector) {
+                    b.value(value);
+                }
+                b.endArray();
+            }
+            b.endArray();
+            b.endArray();
+        })));
+    }
+
+    public void testInvalidParameters() {
+
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> createDocumentMapper(
+                fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", 3).field("element_type", "foo"))
+            )
+        );
+        assertThat(e.getMessage(), containsString("invalid element_type [foo]; available types are "));
+        e = expectThrows(
+            MapperParsingException.class,
+            () -> createDocumentMapper(
+                fieldMapping(b -> b.field("type", "multi_dense_vector").field("dims", 3).startObject("foo").endObject())
+            )
+        );
+        assertThat(
+            e.getMessage(),
+            containsString("Failed to parse mapping: unknown parameter [foo] on mapper [field] of type [multi_dense_vector]")
+        );
+    }
+
+    public void testDocumentsWithIncorrectDims() throws Exception {
+        int dims = 3;
+        XContentBuilder fieldMapping = fieldMapping(b -> {
+            b.field("type", "multi_dense_vector");
+            b.field("dims", dims);
+        });
+
+        DocumentMapper mapper = createDocumentMapper(fieldMapping);
+
+        // test that error is thrown when a document has number of dims more than defined in the mapping
+        float[][] invalidVector = new float[4][dims + 1];
+        DocumentParsingException e = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("field");
+            for (float[] vector : invalidVector) {
+                b.startArray();
+                for (float value : vector) {
+                    b.value(value);
+                }
+                b.endArray();
+            }
+            b.endArray();
+        })));
+        assertThat(e.getCause().getMessage(), containsString("has more dimensions than defined in the mapping [3]"));
+
+        // test that error is thrown when a document has number of dims less than defined in the mapping
+        float[][] invalidVector2 = new float[4][dims - 1];
+        DocumentParsingException e2 = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("field");
+            for (float[] vector : invalidVector2) {
+                b.startArray();
+                for (float value : vector) {
+                    b.value(value);
+                }
+                b.endArray();
+            }
+            b.endArray();
+        })));
+        assertThat(e2.getCause().getMessage(), containsString("has a different number of dimensions [2] than defined in the mapping [3]"));
+        // test that error is thrown when some of the vectors have correct number of dims, but others do not
+        DocumentParsingException e3 = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("field");
+            for (float[] vector : new float[4][dims]) {
+                b.startArray();
+                for (float value : vector) {
+                    b.value(value);
+                }
+                b.endArray();
+            }
+            for (float[] vector : invalidVector2) {
+                b.startArray();
+                for (float value : vector) {
+                    b.value(value);
+                }
+                b.endArray();
+            }
+            b.endArray();
+        })));
+        assertThat(e3.getCause().getMessage(), containsString("has a different number of dimensions [2] than defined in the mapping [3]"));
+    }
+
+    @Override
+    protected void assertFetchMany(MapperService mapperService, String field, Object value, String format, int count) throws IOException {
+        assumeFalse("Dense vectors currently don't support multiple values in the same field", false);
+    }
+
+    /**
+     * Dense vectors don't support doc values or string representation (for doc value parser/fetching).
+     * We may eventually support that, but until then, we only verify that the parsing and fields fetching matches the provided value object
+     */
+    @Override
+    protected void assertFetch(MapperService mapperService, String field, Object value, String format) throws IOException {
+        MappedFieldType ft = mapperService.fieldType(field);
+        MappedFieldType.FielddataOperation fdt = MappedFieldType.FielddataOperation.SEARCH;
+        SourceToParse source = source(b -> b.field(ft.name(), value));
+        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
+        when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
+        when(searchExecutionContext.getForField(ft, fdt)).thenAnswer(inv -> fieldDataLookup(mapperService).apply(ft, () -> {
+            throw new UnsupportedOperationException();
+        }, fdt));
+        ValueFetcher nativeFetcher = ft.valueFetcher(searchExecutionContext, format);
+        ParsedDocument doc = mapperService.documentMapper().parse(source);
+        withLuceneIndex(mapperService, iw -> iw.addDocuments(doc.docs()), ir -> {
+            Source s = SourceProvider.fromStoredFields().getSource(ir.leaves().get(0), 0);
+            nativeFetcher.setNextReader(ir.leaves().get(0));
+            List<Object> fromNative = nativeFetcher.fetchValues(s, 0, new ArrayList<>());
+            MultiDenseVectorFieldMapper.MultiDenseVectorFieldType denseVectorFieldType =
+                (MultiDenseVectorFieldMapper.MultiDenseVectorFieldType) ft;
+            switch (denseVectorFieldType.getElementType()) {
+                case BYTE -> assumeFalse("byte element type testing not currently added", false);
+                case FLOAT -> {
+                    List<float[]> fetchedFloatsList = new ArrayList<>();
+                    for (var f : fromNative) {
+                        float[] fetchedFloats = new float[denseVectorFieldType.getVectorDimensions()];
+                        assert f instanceof List;
+                        List<?> vector = (List<?>) f;
+                        int i = 0;
+                        for (Object v : vector) {
+                            assert v instanceof Number;
+                            fetchedFloats[i++] = ((Number) v).floatValue();
+                        }
+                        fetchedFloatsList.add(fetchedFloats);
+                    }
+                    float[][] fetchedFloats = fetchedFloatsList.toArray(new float[0][]);
+                    assertThat("fetching " + value, fetchedFloats, equalTo(value));
+                }
+            }
+        });
+    }
+
+    @Override
+    protected void randomFetchTestFieldConfig(XContentBuilder b) throws IOException {
+        b.field("type", "multi_dense_vector").field("dims", randomIntBetween(2, 4096)).field("element_type", "float");
+    }
+
+    @Override
+    protected Object generateRandomInputValue(MappedFieldType ft) {
+        MultiDenseVectorFieldMapper.MultiDenseVectorFieldType vectorFieldType = (MultiDenseVectorFieldMapper.MultiDenseVectorFieldType) ft;
+        int numVectors = randomIntBetween(1, 16);
+        return switch (vectorFieldType.getElementType()) {
+            case BYTE -> {
+                byte[][] vectors = new byte[numVectors][vectorFieldType.getVectorDimensions()];
+                for (int i = 0; i < numVectors; i++) {
+                    vectors[i] = randomByteArrayOfLength(vectorFieldType.getVectorDimensions());
+                }
+                yield vectors;
+            }
+            case FLOAT -> {
+                float[][] vectors = new float[numVectors][vectorFieldType.getVectorDimensions()];
+                for (int i = 0; i < numVectors; i++) {
+                    for (int j = 0; j < vectorFieldType.getVectorDimensions(); j++) {
+                        vectors[i][j] = randomFloat();
+                    }
+                }
+                yield vectors;
+            }
+            case BIT -> {
+                byte[][] vectors = new byte[numVectors][vectorFieldType.getVectorDimensions() / 8];
+                for (int i = 0; i < numVectors; i++) {
+                    vectors[i] = randomByteArrayOfLength(vectorFieldType.getVectorDimensions() / 8);
+                }
+                yield vectors;
+            }
+        };
+    }
+
+    public void testCannotBeUsedInMultifields() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+            b.field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("vectors");
+            minimalMapping(b);
+            b.endObject();
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), containsString("Field [vectors] of type [multi_dense_vector] can't be used in multifields"));
+    }
+
+    @Override
+    protected IngestScriptSupport ingestScriptSupport() {
+        throw new AssumptionViolatedException("not supported");
+    }
+
+    @Override
+    protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
+        return new DenseVectorSyntheticSourceSupport();
+    }
+
+    @Override
+    protected boolean supportsEmptyInputArray() {
+        return false;
+    }
+
+    private static class DenseVectorSyntheticSourceSupport implements SyntheticSourceSupport {
+        private final int dims = between(5, 1000);
+        private final int numVecs = between(1, 16);
+        private final ElementType elementType = randomFrom(ElementType.BYTE, ElementType.FLOAT, ElementType.BIT);
+
+        @Override
+        public SyntheticSourceExample example(int maxValues) {
+            Object value = switch (elementType) {
+                case BYTE, BIT:
+                    yield randomList(numVecs, numVecs, () -> randomList(dims, dims, ESTestCase::randomByte));
+                case FLOAT:
+                    yield randomList(numVecs, numVecs, () -> randomList(dims, dims, ESTestCase::randomFloat));
+            };
+            return new SyntheticSourceExample(value, value, this::mapping);
+        }
+
+        private void mapping(XContentBuilder b) throws IOException {
+            b.field("type", "multi_dense_vector");
+            if (elementType == ElementType.BYTE || elementType == ElementType.BIT || randomBoolean()) {
+                b.field("element_type", elementType.toString());
+            }
+            b.field("dims", elementType == ElementType.BIT ? dims * Byte.SIZE : dims);
+        }
+
+        @Override
+        public List<SyntheticSourceInvalidExample> invalidExample() {
+            return List.of();
+        }
+    }
+
+    @Override
+    public void testSyntheticSourceKeepArrays() {
+        // The mapper expects to parse an array of values by default, it's not compatible with array of arrays.
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/MultiDenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/MultiDenseVectorFieldTypeTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.fielddata.FieldDataContext;
+import org.elasticsearch.index.mapper.FieldTypeTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.vectors.MultiDenseVectorFieldMapper.MultiDenseVectorFieldType;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.BBQ_MIN_DIMS;
+
+public class MultiDenseVectorFieldTypeTests extends FieldTypeTestCase {
+
+    @BeforeClass
+    public static void setup() {
+        assumeTrue("Requires multi-dense vector support", MultiDenseVectorFieldMapper.FEATURE_FLAG.isEnabled());
+    }
+
+    private MultiDenseVectorFieldType createFloatFieldType() {
+        return new MultiDenseVectorFieldType(
+            "f",
+            DenseVectorFieldMapper.ElementType.FLOAT,
+            BBQ_MIN_DIMS,
+            IndexVersion.current(),
+            Collections.emptyMap()
+        );
+    }
+
+    private MultiDenseVectorFieldType createByteFieldType() {
+        return new MultiDenseVectorFieldType(
+            "f",
+            DenseVectorFieldMapper.ElementType.BYTE,
+            5,
+            IndexVersion.current(),
+            Collections.emptyMap()
+        );
+    }
+
+    public void testHasDocValues() {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        assertTrue(fft.hasDocValues());
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        assertTrue(bft.hasDocValues());
+    }
+
+    public void testIsIndexed() {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        assertFalse(fft.isIndexed());
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        assertFalse(bft.isIndexed());
+    }
+
+    public void testIsSearchable() {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        assertFalse(fft.isSearchable());
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        assertFalse(bft.isSearchable());
+    }
+
+    public void testIsAggregatable() {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        assertFalse(fft.isAggregatable());
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        assertFalse(bft.isAggregatable());
+    }
+
+    public void testFielddataBuilder() {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        FieldDataContext fdc = new FieldDataContext("test", null, () -> null, Set::of, MappedFieldType.FielddataOperation.SCRIPT);
+        assertNotNull(fft.fielddataBuilder(fdc));
+
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        FieldDataContext bdc = new FieldDataContext("test", null, () -> null, Set::of, MappedFieldType.FielddataOperation.SCRIPT);
+        assertNotNull(bft.fielddataBuilder(bdc));
+    }
+
+    public void testDocValueFormat() {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        expectThrows(IllegalArgumentException.class, () -> fft.docValueFormat(null, null));
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        expectThrows(IllegalArgumentException.class, () -> bft.docValueFormat(null, null));
+    }
+
+    public void testFetchSourceValue() throws IOException {
+        MultiDenseVectorFieldType fft = createFloatFieldType();
+        List<List<Double>> vector = List.of(List.of(0.0, 1.0, 2.0, 3.0, 4.0, 6.0));
+        assertEquals(vector, fetchSourceValue(fft, vector));
+        MultiDenseVectorFieldType bft = createByteFieldType();
+        assertEquals(vector, fetchSourceValue(bft, vector));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -109,6 +109,7 @@ import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.index.mapper.vectors.MultiDenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
@@ -199,6 +200,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
     private static final List<String> TYPE_TEST_BLACKLIST = List.of(
         ObjectMapper.CONTENT_TYPE, // Cannot aggregate objects
         DenseVectorFieldMapper.CONTENT_TYPE, // Cannot aggregate dense vectors
+        MultiDenseVectorFieldMapper.CONTENT_TYPE, // Cannot aggregate dense vectors
         SparseVectorFieldMapper.CONTENT_TYPE, // Sparse vectors are no longer supported
 
         NestedObjectMapper.CONTENT_TYPE, // TODO support for nested


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add new multi_dense_vector field for brute-force search (#116275)](https://github.com/elastic/elasticsearch/pull/116275)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)