### PR TITLE
Update index.max_result_window error to point to search_after not scroll

### DIFF
--- a/docs/changelog/116541.yaml
+++ b/docs/changelog/116541.yaml
@@ -1,0 +1,5 @@
+pr: 116541
+summary: Update `index.max_result_window` error to point to `search_after` not scroll
+area: Search
+type: enhancement
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/30_limits.yml
@@ -19,7 +19,7 @@ setup:
 ---
 "Request window limits without scroll":
   - do:
-      catch:      /Result window is too large, from \+ size must be less than or equal to[:] \[10000\] but was \[10010\]\. See the scroll api for a more efficient way to request large data sets\./
+      catch:      /Result window is too large, from \+ size must be less than or equal to[:] \[10000\] but was \[10010\]\. See search after for a more efficient way to request large data sets\./
       search:
         rest_total_hits_as_int: true
         index: test_1

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -571,7 +571,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
                     + IndexSettings.MAX_RESULT_WINDOW_SETTING.get(Settings.EMPTY)
             )
         );
-        assertThat(e.toString(), containsString("See the scroll api for a more efficient way to request large data sets"));
+        assertThat(e.toString(), containsString("See search after for a more efficient way to request large data sets"));
     }
 
     private void assertRescoreWindowFails(int windowSize) {

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -360,7 +360,7 @@ final class DefaultSearchContext extends SearchContext {
                         + maxResultWindow
                         + "] but was ["
                         + resultWindow
-                        + "]. See the scroll api for a more efficient way to request large data sets. "
+                        + "]. See the search_after parameter for a more efficient way to request large data sets. "
                         + "This limit can be set by changing the ["
                         + IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey()
                         + "] index level setting."

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -360,7 +360,7 @@ final class DefaultSearchContext extends SearchContext {
                         + maxResultWindow
                         + "] but was ["
                         + resultWindow
-                        + "]. See the search_after parameter for a more efficient way to request large data sets. "
+                        + "]. See search after for a more efficient way to request large data sets. "
                         + "This limit can be set by changing the ["
                         + IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey()
                         + "] index level setting."

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -196,7 +196,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     "Result window is too large, from + size must be less than or equal to:"
                         + " ["
                         + maxResultWindow
-                        + "] but was [310]. See the scroll api for a more efficient way to request large data sets. "
+                        + "] but was [310]. See the search_after parameter for a more efficient way to request large data sets. "
                         + "This limit can be set by changing the ["
                         + IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey()
                         + "] index level setting."

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -196,7 +196,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     "Result window is too large, from + size must be less than or equal to:"
                         + " ["
                         + maxResultWindow
-                        + "] but was [310]. See the search_after parameter for a more efficient way to request large data sets. "
+                        + "] but was [310]. See search after for a more efficient way to request large data sets. "
                         + "This limit can be set by changing the ["
                         + IndexSettings.MAX_RESULT_WINDOW_SETTING.getKey()
                         + "] index level setting."


### PR DESCRIPTION
👋 howdy, team! We now recommend search_after but no longer recommend scroll for searching `size:>10K` per [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#size)
> By default, you cannot page through more than 10,000 hits using the from and size parameters. To page through more hits, use the [search_after](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after) parameter. 

Therefore, this updates the historical error message to therefore point to `search_after` not `scroll`.