### PR TITLE
Cleanup IndexActionIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -52,48 +51,9 @@ public class IndexActionIT extends ESIntegTestCase {
             }
             indexRandom(true, builders);
             logger.info("verifying indexed content");
-            int numOfChecks = randomIntBetween(8, 12);
+            int numOfChecks = randomIntBetween(16, 24);
             for (int j = 0; j < numOfChecks; j++) {
-                try {
-                    logger.debug("running search with all types");
-                    assertResponse(prepareSearch("test"), response -> {
-                        if (response.getHits().getTotalHits().value() != numOfDocs) {
-                            final String message = "Count is "
-                                + response.getHits().getTotalHits().value()
-                                + " but "
-                                + numOfDocs
-                                + " was expected. "
-                                + ElasticsearchAssertions.formatShardStatus(response);
-                            logger.error("{}. search response: \n{}", message, response);
-                            fail(message);
-                        }
-                    });
-                } catch (Exception e) {
-                    logger.error("search for all docs types failed", e);
-                    if (firstError == null) {
-                        firstError = e;
-                    }
-                }
-                try {
-                    logger.debug("running search with a specific type");
-                    assertResponse(prepareSearch("test"), response -> {
-                        if (response.getHits().getTotalHits().value() != numOfDocs) {
-                            final String message = "Count is "
-                                + response.getHits().getTotalHits().value()
-                                + " but "
-                                + numOfDocs
-                                + " was expected. "
-                                + ElasticsearchAssertions.formatShardStatus(response);
-                            logger.error("{}. search response: \n{}", message, response);
-                            fail(message);
-                        }
-                    });
-                } catch (Exception e) {
-                    logger.error("search for all docs of a specific type failed", e);
-                    if (firstError == null) {
-                        firstError = e;
-                    }
-                }
+                assertHitCount(prepareSearch("test"), numOfDocs);
             }
             if (firstError != null) {
                 fail(firstError.getMessage());


### PR DESCRIPTION
Followup to the fix for #115716, this test really needs some cleanup now that it's not failing any longer.

We can use the hit count assertion here, no need to be tricky. Also, this can be a single loop nowadays, the two loops are a leftover from when this was testing with types.

finally closes #115716