### PR TITLE
[8.15] [Test] Flush response body for progress (#115177)

### DIFF
--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -572,16 +572,16 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                         ),
                         -1
                     );
+                    exchange.getResponseBody().flush();
                 } else if (randomBoolean()) {
                     final var bytesSent = sendIncompleteContent(exchange, bytes);
                     if (bytesSent < meaningfulProgressBytes) {
                         failuresWithoutProgress += 1;
-                    } else {
-                        exchange.getResponseBody().flush();
                     }
                 } else {
                     failuresWithoutProgress += 1;
                 }
+                exchange.getResponseBody().flush();
                 exchange.close();
             }
         }
@@ -626,6 +626,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 failureCount += 1;
                 Streams.readFully(exchange.getRequestBody());
                 sendIncompleteContent(exchange, bytes);
+                exchange.getResponseBody().flush();
                 exchange.close();
             }
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Test] Flush response body for progress (#115177) (8c23fd77)

Closes: #116543