### PR TITLE
[8.x] Unmute SecurityWithBasicLicenseIT (#116300)

### DIFF
--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99169")
     public void testWithBasicLicense() throws Exception {
         checkLicenseType("basic");
         checkSecurityEnabled(false);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Unmute SecurityWithBasicLicenseIT (#116300)](https://github.com/elastic/elasticsearch/pull/116300)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)