### PR TITLE
Add min/max build versions methods

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/BuildVersion.java
+++ b/server/src/main/java/org/elasticsearch/env/BuildVersion.java
@@ -13,11 +13,13 @@ import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.internal.BuildExtension;
 import org.elasticsearch.plugins.ExtensionLoader;
 import org.elasticsearch.xcontent.ToXContentFragment;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.ServiceLoader;
 
 /**
@@ -111,6 +113,11 @@ public abstract class BuildVersion implements ToXContentFragment, Writeable {
         return CurrentExtensionHolder.BUILD_EXTENSION.fromStream(input);
     }
 
+    public static Tuple<BuildVersion, BuildVersion> calculateMinMaxVersions(Collection<BuildVersion> versions) {
+        if (versions.isEmpty()) return Tuple.tuple(current(), current());
+        return CurrentExtensionHolder.BUILD_EXTENSION.calculateMinMaxVersions(versions);
+    }
+
     /**
      * Get the current build version.
      *
@@ -155,6 +162,11 @@ public abstract class BuildVersion implements ToXContentFragment, Writeable {
         @Override
         public BuildVersion fromStream(StreamInput in) throws IOException {
             return new DefaultBuildVersion(in);
+        }
+
+        @Override
+        public Tuple<BuildVersion, BuildVersion> calculateMinMaxVersions(Collection<BuildVersion> versions) {
+            return null;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
@@ -11,9 +11,11 @@ package org.elasticsearch.internal;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.BuildVersion;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * Allows plugging in current build info.
@@ -58,4 +60,9 @@ public interface BuildExtension {
      * Reads a {@link BuildVersion} from the given stream
      */
     BuildVersion fromStream(StreamInput in) throws IOException;
+
+    /**
+     * Calculates the oldest and youngest build versions from the provided {@code versions}
+     */
+    Tuple<BuildVersion, BuildVersion> calculateMinMaxVersions(Collection<BuildVersion> versions);
 }


### PR DESCRIPTION
Presented for discussion - Rather than using Version, represent min/max cluster versions with BuildVersion