### PR TITLE
Override default value for `cluster.logsdb.enabled`

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseService.FALLBACK_SETTING;
 
@@ -29,9 +30,10 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
 
     private final Settings settings;
     private final SyntheticSourceLicenseService licenseService;
+    private static final String CLUSTER_LOGSDB_SERVERLESS_ENABLED = "cluster.logsdb.serverless.enabled";
     public static final Setting<Boolean> CLUSTER_LOGSDB_ENABLED = Setting.boolSetting(
         "cluster.logsdb.enabled",
-        false,
+        settings -> String.valueOf(settings.getAsBoolean(CLUSTER_LOGSDB_SERVERLESS_ENABLED, false)),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseService.FALLBACK_SETTING;
 


### PR DESCRIPTION
The default value for `cluster.logsdb.enabled` changes depending on whether the deployment is
Stateful or Stateless. If the deployment is Stateless we need to enable LogsDB by default, which we
do reading the setting `cluster.logsdb.serverless.enabled` defined and configured by the
Stateless LogsDB plugin.