### PR TITLE
[8.16] Remove trailing semicolon in REPEAT function example (#116218)

### DIFF
--- a/docs/reference/esql/functions/kibana/definition/repeat.json
+++ b/docs/reference/esql/functions/kibana/definition/repeat.json
@@ -42,7 +42,7 @@
     }
   ],
   "examples" : [
-    "ROW a = \"Hello!\"\n| EVAL triple_a = REPEAT(a, 3);"
+    "ROW a = \"Hello!\"\n| EVAL triple_a = REPEAT(a, 3)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/esql/functions/kibana/docs/repeat.md
+++ b/docs/reference/esql/functions/kibana/docs/repeat.md
@@ -7,5 +7,5 @@ Returns a string constructed by concatenating `string` with itself the specified
 
 ```
 ROW a = "Hello!"
-| EVAL triple_a = REPEAT(a, 3);
+| EVAL triple_a = REPEAT(a, 3)
 ```

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1604,8 +1604,9 @@ repeat
 required_capability: repeat 
 // tag::repeat[]
 ROW a = "Hello!"
-| EVAL triple_a = REPEAT(a, 3);
+| EVAL triple_a = REPEAT(a, 3)
 // end::repeat[]
+;
 
 // tag::repeat-result[]
 a:keyword | triple_a:keyword


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Remove trailing semicolon in REPEAT function example (#116218)