### PR TITLE
[8.16] Backporting full CompatibilityVersions to NodeInfo

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -247,6 +247,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_ATTACH_TO_EXISTSING_DEPLOYMENT = def(8_771_00_0);
     public static final TransportVersion CONVERT_FAILURE_STORE_OPTIONS_TO_SELECTOR_OPTIONS_INTERNALLY = def(8_772_00_0);
     public static final TransportVersion INFERENCE_DONT_PERSIST_ON_READ_BACKPORT_8_16 = def(8_772_00_1);
+    public static final TransportVersion ADD_COMPATIBILITY_VERSIONS_TO_NODE_INFO_BACKPORT_8_16 = def(8_772_00_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1077,7 +1077,8 @@ class NodeConstruction {
             searchTransportService,
             indexingLimits,
             searchModule.getValuesSourceRegistry().getUsageService(),
-            repositoriesService
+            repositoriesService,
+            compatibilityVersions
         );
 
         final TimeValue metricsInterval = settings.getAsTime("telemetry.agent.metrics_interval", TimeValue.timeValueSeconds(10));

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.node;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.ComponentVersionNumber;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -19,6 +18,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.search.SearchTransportService;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -65,6 +65,7 @@ public class NodeService implements Closeable {
     private final Coordinator coordinator;
     private final RepositoriesService repositoriesService;
     private final Map<String, Integer> componentVersions;
+    private final CompatibilityVersions compatibilityVersions;
 
     NodeService(
         Settings settings,
@@ -84,7 +85,8 @@ public class NodeService implements Closeable {
         SearchTransportService searchTransportService,
         IndexingPressure indexingPressure,
         AggregationUsageService aggregationUsageService,
-        RepositoriesService repositoriesService
+        RepositoriesService repositoriesService,
+        CompatibilityVersions compatibilityVersions
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -104,6 +106,7 @@ public class NodeService implements Closeable {
         this.aggregationUsageService = aggregationUsageService;
         this.repositoriesService = repositoriesService;
         this.componentVersions = findComponentVersions(pluginService);
+        this.compatibilityVersions = compatibilityVersions;
         clusterService.addStateApplier(ingestService);
     }
 
@@ -124,7 +127,7 @@ public class NodeService implements Closeable {
         return new NodeInfo(
             // TODO: revert to Build.current().version() when Kibana is updated
             Version.CURRENT.toString(),
-            TransportVersion.current(),
+            compatibilityVersions,
             IndexVersion.current(),
             componentVersions,
             Build.current(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.action.admin.cluster.node.info;
 import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -40,7 +41,7 @@ public class NodeInfoTests extends ESTestCase {
     public void testGetInfo() {
         NodeInfo nodeInfo = new NodeInfo(
             Build.current().version(),
-            TransportVersion.current(),
+            new CompatibilityVersions(TransportVersion.current(), Map.of()),
             IndexVersion.current(),
             Map.of(),
             Build.current(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.internal.support.AbstractClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -78,7 +79,7 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Build.current().version(),
-                    TransportVersion.current(),
+                    new CompatibilityVersions(TransportVersion.current(), Map.of()),
                     IndexVersion.current(),
                     Map.of(),
                     null,
@@ -156,7 +157,7 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Build.current().version(),
-                    TransportVersion.current(),
+                    new CompatibilityVersions(TransportVersion.current(), Map.of()),
                     IndexVersion.current(),
                     Map.of(),
                     null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
@@ -327,7 +328,7 @@ public class ClusterStatsNodesTests extends ESTestCase {
         }
         return new NodeInfo(
             Build.current().version(),
-            TransportVersion.current(),
+            new CompatibilityVersions(TransportVersion.current(), Map.of()),
             IndexVersion.current(),
             Map.of(),
             Build.current(),

--- a/server/src/test/java/org/elasticsearch/action/ingest/ReservedPipelineActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/ReservedPipelineActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -105,7 +106,7 @@ public class ReservedPipelineActionTests extends ESTestCase {
 
         NodeInfo nodeInfo = new NodeInfo(
             Build.current().version(),
-            TransportVersion.current(),
+            new CompatibilityVersions(TransportVersion.current(), Map.of()),
             IndexVersion.current(),
             Map.of(),
             Build.current(),

--- a/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.mockito.ArgumentCaptor;
@@ -34,11 +35,14 @@ import org.mockito.ArgumentCaptor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
+import static java.util.Map.entry;
 import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.same;
@@ -77,7 +81,7 @@ public class TransportVersionsFixupListenerTests extends ESTestCase {
         return tvs;
     }
 
-    private static NodesInfoResponse getResponse(Map<String, TransportVersion> responseData) {
+    private static NodesInfoResponse getResponse(Map<String, CompatibilityVersions> responseData) {
         return new NodesInfoResponse(
             ClusterName.DEFAULT,
             responseData.entrySet()
@@ -207,10 +211,19 @@ public class TransportVersionsFixupListenerTests extends ESTestCase {
             argThat(transformedMatch(NodesInfoRequest::nodesIds, arrayContainingInAnyOrder("node1", "node2"))),
             action.capture()
         );
-        action.getValue().onResponse(getResponse(Map.of("node1", NEXT_TRANSPORT_VERSION, "node2", NEXT_TRANSPORT_VERSION)));
+        action.getValue()
+            .onResponse(
+                getResponse(
+                    Map.ofEntries(
+                        entry("node1", new CompatibilityVersions(NEXT_TRANSPORT_VERSION, Map.of())),
+                        entry("node2", new CompatibilityVersions(NEXT_TRANSPORT_VERSION, Map.of()))
+                    )
+                )
+            );
         verify(taskQueue).submitTask(anyString(), task.capture(), any());
 
-        assertThat(task.getValue().results(), equalTo(Map.of("node1", NEXT_TRANSPORT_VERSION, "node2", NEXT_TRANSPORT_VERSION)));
+        assertThat(task.getValue().results().keySet(), equalTo(Set.of("node1", "node2")));
+        assertThat(task.getValue().results().values(), everyItem(equalTo(NEXT_TRANSPORT_VERSION)));
     }
 
     public void testConcurrentChangesDoNotOverlap() {
@@ -259,12 +272,17 @@ public class TransportVersionsFixupListenerTests extends ESTestCase {
         Scheduler scheduler = mock(Scheduler.class);
         Executor executor = mock(Executor.class);
 
+        var compatibilityVersions = new CompatibilityVersions(
+            TransportVersion.current(),
+            Map.of(".system-index-1", new SystemIndexDescriptor.MappingsVersion(1, 1234))
+        );
         ClusterState testState1 = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .nodes(node(NEXT_VERSION, NEXT_VERSION, NEXT_VERSION))
+            .nodes(node(Version.CURRENT, Version.CURRENT, Version.CURRENT))
             .nodeIdsToCompatibilityVersions(
-                Maps.transformValues(
-                    versions(NEXT_TRANSPORT_VERSION, TransportVersions.V_8_8_0, TransportVersions.V_8_8_0),
-                    transportVersion -> new CompatibilityVersions(transportVersion, Map.of())
+                Map.ofEntries(
+                    entry("node0", compatibilityVersions),
+                    entry("node1", new CompatibilityVersions(TransportVersions.V_8_8_0, Map.of())),
+                    entry("node2", new CompatibilityVersions(TransportVersions.V_8_8_0, Map.of()))
                 )
             )
             .build();

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -241,7 +242,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
         }
         return new NodeInfo(
             randomAlphaOfLengthBetween(6, 32),
-            TransportVersionUtils.randomVersion(random()),
+            new CompatibilityVersions(TransportVersionUtils.randomVersion(random()), Map.of()),
             IndexVersionUtils.randomVersion(random()),
             componentVersions,
             build,

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.plugins.PluginDescriptor;
@@ -66,7 +67,7 @@ public class RestPluginsActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Build.current().version(),
-                    TransportVersion.current(),
+                    new CompatibilityVersions(TransportVersion.current(), Map.of()),
                     IndexVersion.current(),
                     Map.of(),
                     null,

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -452,7 +453,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         OsInfo osInfo = new OsInfo(randomLong(), processors, Processors.of((double) processors), null, null, null, null);
         return new org.elasticsearch.action.admin.cluster.node.info.NodeInfo(
             Build.current().version(),
-            TransportVersion.current(),
+            new CompatibilityVersions(TransportVersion.current(), Map.of()),
             IndexVersion.current(),
             Map.of(),
             Build.current(),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.SslConfiguration;
@@ -103,7 +104,7 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Build.current().version(),
-                    TransportVersion.current(),
+                    new CompatibilityVersions(TransportVersion.current(), Map.of()),
                     IndexVersion.current(),
                     Map.of(),
                     null,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGeneratorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGeneratorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -236,7 +237,7 @@ public class InternalEnrollmentTokenGeneratorTests extends ESTestCase {
                 List.of(
                     new NodeInfo(
                         Build.current().version(),
-                        TransportVersion.current(),
+                        new CompatibilityVersions(TransportVersion.current(), Map.of()),
                         IndexVersion.current(),
                         Map.of(),
                         null,
@@ -271,7 +272,7 @@ public class InternalEnrollmentTokenGeneratorTests extends ESTestCase {
                 List.of(
                     new NodeInfo(
                         Build.current().version(),
-                        TransportVersion.current(),
+                        new CompatibilityVersions(TransportVersion.current(), Map.of()),
                         IndexVersion.current(),
                         Map.of(),
                         null,


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/116577

Extracting the Transport protocol related changes from https://github.com/elastic/elasticsearch/pull/115771 to make backport easier.