### PR TITLE
Base search queue length on pool size

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/DefaultBuiltInExecutorBuilders.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/DefaultBuiltInExecutorBuilders.java
@@ -68,7 +68,7 @@ public class DefaultBuiltInExecutorBuilders implements BuiltInExecutorBuilders {
                 settings,
                 ThreadPool.Names.SEARCH,
                 searchOrGetThreadPoolSize,
-                1000,
+                searchOrGetThreadPoolSize * 1000,
                 new EsExecutors.TaskTrackingConfig(true, searchAutoscalingEWMA)
             )
         );


### PR DESCRIPTION
Base the queue length on the pool size. The number of tasks enqueued on search is proportional to its size in many cases so linearly increasing the length of the queue makes it so a larger pool does not lead to an increasing chance of rejection under constant search load.

This is a new issue from unifying search and search_worker pool into one.
Previously the queue size hasn't been a big concern for the search pool since the task fan out by shard happened on the unbounded search_worker pool. Unifying the pools means that we can have up to a factor of min(search_thread_count, 10) more tasks for the search pool itself. Using the thread count as a multiplier for the queue length restores the previous effective queue length more or less.
Note that before unifying the pools, we'd still have search threads waiting on work on the search_worker pool because all actual query work would fork there and then block on a future in the search pool so we are not effectively increasing the amount of work queued via this change.
