### PR TITLE
Reenable compat tests of enrich policy deprecation

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -89,6 +89,5 @@ tasks.named("yamlRestCompatTestTransform").configure({ task ->
   task.skipTest("esql/80_text/reverse text", "The output type changed from TEXT to KEYWORD.")
   task.skipTest("esql/80_text/values function", "The output type changed from TEXT to KEYWORD.")
   task.skipTest("privileges/11_builtin/Test get builtin privileges" ,"unnecessary to test compatibility")
-  task.skipTest("enrich/10_basic/Test using the deprecated elasticsearch_version field results in a warning", "The deprecation message was changed")
 })
 

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -33,7 +33,3 @@ testClusters.configureEach {
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.4.0")
 }
 
-tasks.named("yamlRestCompatTestTransform").configure({ task ->
-  task.skipTest("enrich/10_basic/Test using the deprecated elasticsearch_version field results in a warning", "The deprecation message was changed")
-})
-


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/116504, we changed a deprecation message, and although this didn't break BWC because deprecation messages aren't part of the API contract, it did break the compat tests which asserted on the message. We therefore suppressed the compat tests in question.

In https://github.com/elastic/elasticsearch/pull/116522, we backported that change to the `8.x` branch. So the compat tests on `main` are now asserting the correct message, and so pass, and can be reenabled.