### PR TITLE
Unmute a lot of fixed tests from search race condition

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -127,18 +127,9 @@ tests:
 - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
   method: testStalledShardMigrationProperlyDetected
   issue: https://github.com/elastic/elasticsearch/issues/115697
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoHash
-  issue: https://github.com/elastic/elasticsearch/issues/115664
 - class: org.elasticsearch.xpack.inference.InferenceCrudIT
   method: testSupportedStream
   issue: https://github.com/elastic/elasticsearch/issues/113430
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoTile
-  issue: https://github.com/elastic/elasticsearch/issues/115717
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoShapeGeoHex
-  issue: https://github.com/elastic/elasticsearch/issues/115705
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
   issue: https://github.com/elastic/elasticsearch/issues/115808
@@ -157,32 +148,14 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/inference_crud/Test delete given model referenced by pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/115970
-- class: org.elasticsearch.search.slice.SearchSliceIT
-  method: testPointInTime
-  issue: https://github.com/elastic/elasticsearch/issues/115988
-- class: org.elasticsearch.action.search.PointInTimeIT
-  method: testPITTiebreak
-  issue: https://github.com/elastic/elasticsearch/issues/115810
 - class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
   method: testReindexWithShutdown
   issue: https://github.com/elastic/elasticsearch/issues/115996
 - class: org.elasticsearch.search.query.SearchQueryIT
   method: testAllDocsQueryString
   issue: https://github.com/elastic/elasticsearch/issues/115728
-- class: org.elasticsearch.search.basic.SearchWithRandomExceptionsIT
-  method: testRandomExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/116027
-- class: org.elasticsearch.action.admin.HotThreadsIT
-  method: testHotThreadsDontFail
-  issue: https://github.com/elastic/elasticsearch/issues/115754
-- class: org.elasticsearch.search.functionscore.QueryRescorerIT
-  method: testScoring
-  issue: https://github.com/elastic/elasticsearch/issues/116050
 - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
   issue: https://github.com/elastic/elasticsearch/issues/116087
-- class: org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilderIT
-  method: testPinnedPromotions
-  issue: https://github.com/elastic/elasticsearch/issues/116097
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=cat.shards/10_basic/Help}
   issue: https://github.com/elastic/elasticsearch/issues/116110
@@ -195,9 +168,6 @@ tests:
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testSnapshotRestore {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/111777
-- class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
-  method: testGeoPointGeoTile
-  issue: https://github.com/elastic/elasticsearch/issues/115818
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsRestIT
   method: testLookbackWithIndicesOptions
   issue: https://github.com/elastic/elasticsearch/issues/116127
@@ -261,9 +231,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {categorize.Categorize ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/116373
-- class: org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsIntegTests
-  method: testCreateAndRestoreSearchableSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/116377
 - class: org.elasticsearch.threadpool.SimpleThreadPoolIT
   method: testThreadPoolMetrics
   issue: https://github.com/elastic/elasticsearch/issues/108320
@@ -302,9 +269,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/inference_crud/Test force delete given model referenced by pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/116555
-- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-  method: testRandomDirectoryIOExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/114824
 
 # Examples:
 #


### PR DESCRIPTION
These are all fixed by #116264 

closes #115664 #113430 #115717 #115705 #115970 #115988 #115810 #116027
 #115754 #116097 #115818 #116377 #114824
