### PR TITLE
[8.x] muting RemoteClusterPermissionsTests.testCollapseAndRemoveUnsupportedPrivileges

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -328,6 +328,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/60_enrich/Enrich on keyword with fields}
   issue: https://github.com/elastic/elasticsearch/issues/116593
+- class: org.elasticsearch.xpack.core.security.authz.permission.RemoteClusterPermissionsTests
+  method: testCollapseAndRemoveUnsupportedPrivileges
+  issue: https://github.com/elastic/elasticsearch/issues/116520
 
 # Examples:
 #


### PR DESCRIPTION
Muting for the failure in https://github.com/elastic/elasticsearch/issues/116520 (backport)