### PR TITLE
[8.16] char_filter pattern_replace error requires at least java 21 (#116507)

### DIFF
--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -6,7 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
-import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
@@ -28,6 +28,15 @@ dependencies {
   compileOnly project(':modules:lang-painless:spi')
   clusterModules project(':modules:reindex')
   clusterModules project(':modules:mapper-extras')
+}
+
+tasks.named("yamlRestTest").configure { task->
+  if (BuildParams.getRuntimeJavaVersion().majorVersion.toInteger() < 21) {
+    // Requires at least Java 21
+    systemProperty 'tests.rest.blacklist', [
+      "analysis-common/50_char_filters/pattern_replace error handling (too complex pattern)"
+    ].join(',')
+  }
 }
 
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.16`:
 - [char_filter pattern_replace error requires at least java 21 (#116507)](https://github.com/elastic/elasticsearch/pull/116507)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)