### PR TITLE
[8.16] Backporting doc changes for retrievers 

### DIFF
--- a/docs/reference/search/search-your-data/retrievers-examples.asciidoc
+++ b/docs/reference/search/search-your-data/retrievers-examples.asciidoc
@@ -1,0 +1,428 @@
+[[retrievers-examples]]
+=== Retrievers examples
+
+Learn how to combine different retrievers in these hands-on examples.
+To demonstrate the full functionality of retrievers, these examples require access to a <<semantic-reranking-models,semantic reranking model>> set up using the <<inference-apis,Elastic inference APIs>>.
+
+[discrete]
+[[retrievers-examples-setup]]
+==== Add example data
+
+To begin with, we'll set up the necessary services and have them in place for later use.
+
+[source,js]
+----
+// Setup rerank task stored as `my-rerank-model`
+PUT _inference/rerank/my-rerank-model
+{
+ "service": "cohere",
+ "service_settings": {
+   "model_id": "rerank-english-v3.0",
+   "api_key": "{{COHERE_API_KEY}}"
+ }
+}
+----
+//NOTCONSOLE
+
+Now that we have our reranking service in place, lets create the `retrievers_example` index, and add some documents to it.
+[source,js]
+----
+PUT retrievers_example
+{
+   "mappings": {
+       "properties": {
+           "vector": {
+               "type": "dense_vector",
+               "dims": 3,
+               "similarity": "l2_norm",
+               "index": true
+           },
+           "text": {
+               "type": "text"
+           },
+           "year": {
+               "type": "integer"
+           },
+           "topic": {
+               "type": "keyword"
+           }
+       }
+   }
+}
+----
+//NOTCONSOLE
+
+[source,js]
+----
+POST /retrievers_example/_doc/1
+{
+ "vector": [0.23, 0.67, 0.89],
+ "text": "Large language models are revolutionizing information retrieval by boosting search precision, deepening contextual understanding, and reshaping user experiences in data-rich environments.",
+ "year": 2024,
+ "topic": ["llm", "ai", "information_retrieval"]
+}
+
+POST /retrievers_example/_doc/2
+{
+ "vector": [0.12, 0.56, 0.78],
+ "text": "Artificial intelligence is transforming medicine, from advancing diagnostics and tailoring treatment plans to empowering predictive patient care for improved health outcomes.",
+ "year": 2023,
+ "topic": ["ai", "medicine"]
+}
+
+POST /retrievers_example/_doc/3
+{
+ "vector": [0.45, 0.32, 0.91],
+  "text": "AI is redefining security by enabling advanced threat detection, proactive risk analysis, and dynamic defenses against increasingly sophisticated cyber threats.",
+ "year": 2024,
+ "topic": ["ai", "security"]
+}
+
+POST /retrievers_example/_doc/4
+{
+ "vector": [0.34, 0.21, 0.98],
+ "text": "Elastic introduces Elastic AI Assistant, the open, generative AI sidekick powered by ESRE to democratize cybersecurity and enable users of every skill level.",
+ "year": 2023,
+ "topic": ["ai", "elastic", "assistant"]
+}
+
+POST /retrievers_example/_doc/5
+{
+ "vector": [0.11, 0.65, 0.47],
+ "text": "Learn how to spin up a deployment of our hosted Elasticsearch Service and use Elastic Observability to gain deeper insight into the behavior of your applications and systems.",
+ "year": 2024,
+ "topic": ["documentation", "observability", "elastic"]
+}
+
+----
+//NOTCONSOLE
+
+Now that we also have our documents in place, let's try to run some queries using retrievers.
+
+[discrete]
+[[retrievers-examples-combining-standard-knn-retrievers-with-rrf]]
+==== Example: Combining query and kNN with RRF
+
+First, let's examine how to combine two different types of queries: a `kNN` query and a
+`query_string` query. While these queries may produce scores in different ranges, we can use
+Reciprocal Rank Fusion (`rrf`) to combine the results and generate a merged final result
+list.
+
+To implement this in the retriever framework, we start with the top-level element: our `rrf`
+retriever. This retriever operates on top of two other retrievers: a `knn` retriever and a
+`standard` retriever. Our query structure would look like this:
+
+[source,js]
+----
+GET /retrievers_example/_search
+{
+   "retriever":{
+       "rrf": {
+           "retrievers":[
+               {
+                   "standard":{
+                       "query":{
+                           "query_string":{
+                              "query": "(information retrieval) OR (artificial intelligence)",
+                              "default_field": "text"
+                           }
+                       }
+                   }
+               },
+               {
+                   "knn": {
+                       "field": "vector",
+                       "query_vector": [
+                           0.23,
+                           0.67,
+                           0.89
+                       ],
+                       "k": 3,
+                       "num_candidates": 5
+                   }
+               }
+           ],
+           "rank_window_size": 10,
+           "rank_constant": 1
+       }
+   },
+   "_source": ["text", "topic"]
+}
+----
+//NOTCONSOLE
+
+[discrete]
+[[retrievers-examples-collapsing-retriever-results]]
+==== Example: Grouping results by year with `collapse`
+
+In our result set, we have many documents with the same `year` value. We can clean this
+up using the `collapse` parameter with our retriever. This enables grouping results by
+any field and returns only the highest-scoring document from each group. In this example
+we'll collapse our results based on the `year` field.
+
+[source,js]
+----
+GET /retrievers_example/_search
+{
+   "retriever":{
+       "rrf": {
+           "retrievers":[
+               {
+                   "standard":{
+                       "query":{
+                           "query_string":{
+                              "query": "(information retrieval) OR (artificial intelligence)",
+                              "default_field": "text"
+                           }
+                       }
+                   }
+               },
+               {
+                   "knn": {
+                       "field": "vector",
+                       "query_vector": [
+                           0.23,
+                           0.67,
+                           0.89
+                       ],
+                       "k": 3,
+                       "num_candidates": 5
+                   }
+               }
+           ],
+           "rank_window_size": 10,
+           "rank_constant": 1
+       }
+   },
+   "collapse": {
+       "field": "year",
+       "inner_hits": {
+           "name": "topic related documents",
+           "_source": ["text", "year"]
+       }
+   },
+   "_source": ["text", "topic"]
+}
+----
+//NOTCONSOLE
+
+[discrete]
+[[retrievers-examples-text-similarity-reranker-on-top-of-rrf]]
+==== Example: Rerank results of an RRF retriever
+
+Previously, we used a `text_similarity_reranker` retriever within an `rrf` retriever.
+Because retrievers support full composability, we can also rerank the results of an
+`rrf` retriever. Let's apply this to our first example.
+
+[source,js]
+----
+GET retrievers_example/_search
+{
+   "retriever": {
+       "text_similarity_reranker": {
+           "retriever": {
+               "rrf": {
+                   "retrievers": [
+                       {
+                           "standard":{
+                               "query":{
+                                   "query_string":{
+                                      "query": "(information retrieval) OR (artificial intelligence)",
+                                      "default_field": "text"
+                                   }
+                               }
+                           }
+                       },
+                       {
+                           "knn": {
+                               "field": "vector",
+                               "query_vector": [
+                                   0.23,
+                                   0.67,
+                                   0.89
+                               ],
+                               "k": 3,
+                               "num_candidates": 5
+                           }
+                       }
+                   ],
+                   "rank_window_size": 10,
+                   "rank_constant": 1
+               }
+           },
+           "field": "text",
+           "inference_id": "my-rerank-model",
+           "inference_text": "What are the state of the art applications of AI in information retrieval?"
+       }
+   },
+   "_source": ["text", "topic"]
+}
+
+----
+//NOTCONSOLE
+
+[discrete]
+[[retrievers-examples-rrf-ranking-on-text-similarity-reranker-results]]
+==== Example: RRF with semantic reranker
+
+For this example, we'll replace our semantic query with the `my-rerank-model`
+reranker we previously configured. Since this is a reranker, it needs an initial pool of
+documents to work with. In this case, we'll filter for documents about `ai` topics.
+
+[source,js]
+----
+GET /retrievers_example/_search
+{
+    "retriever": {
+        "rrf": {
+            "retrievers": [
+                {
+                    "knn": {
+                        "field": "vector",
+                        "query_vector": [
+                            0.23,
+                            0.67,
+                            0.89
+                        ],
+                        "k": 3,
+                        "num_candidates": 5
+                    }
+                },
+                {
+                    "text_similarity_reranker": {
+                        "retriever": {
+                            "standard": {
+                                "query": {
+                                    "term": {
+                                        "topic": "ai"
+                                    }
+                                }
+                            }
+                        },
+                        "field": "text",
+                        "inference_id": "my-rerank-model",
+                        "inference_text": "Can I use generative AI to identify user intent and improve search relevance?"
+                    }
+                }
+            ],
+            "rank_window_size": 10,
+            "rank_constant": 1
+        }
+    },
+    "_source": [
+        "text",
+        "topic"
+    ]
+}
+----
+//NOTCONSOLE
+
+[discrete]
+[[retrievers-examples-chaining-text-similarity-reranker-retrievers]]
+==== Example: Chaining multiple semantic rerankers
+
+Full composability means we can chain together multiple retrievers of the same type. For instance, imagine we have a computationally expensive reranker that's specialized for AI content. We can rerank the results of a `text_similarity_reranker` using another `text_similarity_reranker` retriever. Each reranker can operate on different fields and/or use different inference services.
+
+[source,js]
+----
+GET retrievers_example/_search
+{
+   "retriever": {
+       "text_similarity_reranker": {
+           "retriever": {
+               "text_similarity_reranker": {
+                   "retriever": {
+                       "knn": {
+                           "field": "vector",
+                           "query_vector": [
+                               0.23,
+                               0.67,
+                               0.89
+                           ],
+                           "k": 3,
+                           "num_candidates": 5
+                       }
+                   },
+                   "rank_window_size": 100,
+                   "field": "text",
+                   "inference_id": "my-rerank-model",
+                   "inference_text": "What are the state of the art applications of AI in information retrieval?"
+               }
+           },
+           "rank_window_size": 10,
+           "field": "text",
+           "inference_id": "my-other-more-expensive-rerank-model",
+           "inference_text": "Applications of Large Language Models in technology and their impact on user satisfaction"
+       }
+   },
+   "_source": [
+       "text",
+       "topic"
+   ]
+}
+----
+//NOTCONSOLE
+
+
+Note that our example applies two reranking steps. First, we rerank the top 100
+documents from the `knn` search using the `my-rerank-model` reranker. Then we
+pick the top 10 results and rerank them using the more fine-grained
+`my-other-more-expensive-rerank-model`.
+
+[discrete]
+[[retrievers-examples-rrf-and-aggregations]]
+==== Example: Combine RRF with aggregations
+
+Retrievers support both composability and most of the standard `_search` functionality. For instance,
+we can compute aggregations with the `rrf` retriever. When using a compound retriever,
+the aggregations are computed based on its nested retrievers. In the following example,
+the `terms` aggregation for the `topic` field will include all results, not just the top `rank_window_size`,
+from the 2 nested retrievers, i.e. all documents whose `year` field is greater than 2023, and whose `topic` field
+matches the term `elastic`.
+
+[source,js]
+----
+GET retrievers_example/_search
+{
+    "retriever": {
+        "rrf": {
+            "retrievers": [
+                {
+                    "standard": {
+                        "query": {
+                            "range": {
+                                "year": {
+                                    "gt": 2023
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "standard": {
+                        "query": {
+                            "term": {
+                                "topic": "elastic"
+                            }
+                        }
+                    }
+                }
+            ],
+            "rank_window_size": 10,
+            "rank_constant": 1
+        }
+    },
+    "_source": [
+        "text",
+        "topic"
+    ],
+    "aggs": {
+        "topics": {
+            "terms": {
+                "field": "topic"
+            }
+        }
+    }
+}
+----
+//NOTCONSOLE

--- a/docs/reference/search/search-your-data/retrievers-overview.asciidoc
+++ b/docs/reference/search/search-your-data/retrievers-overview.asciidoc
@@ -1,5 +1,5 @@
 [[retrievers-overview]]
-=== Retrievers
+== Retrievers
 
 A retriever is an abstraction that was added to the Search API in *8.14.0* and was made generally available in *8.16.0*.
 This abstraction enables the configuration of multi-stage retrieval pipelines within a single `_search` call.
@@ -11,31 +11,31 @@ For implementation details, including notable restrictions, check out the
 
 [discrete]
 [[retrievers-overview-types]]
-==== Retriever types
+=== Retriever types
 
 Retrievers come in various types, each tailored for different search operations.
 The following retrievers are currently available:
 
-* <<standard-retriever,*Standard Retriever*>>. Returns top documents from a
-traditional https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html[query].
-Mimics a traditional query but in the context of a retriever framework. This
-ensures backward compatibility as existing `_search` requests remain supported.
-That way you can transition to the new abstraction at your own pace without
-mixing syntaxes.
-* <<knn-retriever,*kNN Retriever*>>. Returns top documents from a <<search-api-knn,knn search>>,
-in the context of a retriever framework.
-* <<rrf-retriever,*RRF Retriever*>>. Combines and ranks multiple first-stage retrievers using
-the reciprocal rank fusion (RRF) algorithm. Allows you to combine multiple result sets
-with different relevance indicators into a single result set.
-An RRF retriever is a *compound retriever*, where its `filter` element is
-propagated to its sub retrievers.
-+
-
-* <<text-similarity-reranker-retriever,*Text Similarity Re-ranker Retriever*>>. Used for <<semantic-reranking,semantic reranking>>.
+* <<standard-retriever,*Standard Retriever*>>.
+Returns top documents from a traditional https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html[query].
+Mimics a traditional query but in the context of a retriever framework.
+This ensures backward compatibility as existing `_search` requests remain supported.
+That way you can transition to the new abstraction at your own pace without mixing syntaxes.
+* <<knn-retriever,*kNN Retriever*>>.
+Returns top documents from a <<search-api-knn,knn search>>, in the context of a retriever framework.
+* <<rrf-retriever,*RRF Retriever*>>.
+Combines and ranks multiple first-stage retrievers using the reciprocal rank fusion (RRF) algorithm.
+Allows you to combine multiple result sets with different relevance indicators into a single result set.
+An RRF retriever is a *compound retriever*, where its `filter` element is propagated to its sub retrievers.
+* <<rule-retriever,*Rule Retriever*>>.
+Applies <<query-rules,query rules>> to the query before returning results.
+* <<text-similarity-reranker-retriever,*Text Similarity Re-ranker Retriever*>>.
+Used for <<semantic-reranking,semantic reranking>>.
 Requires first creating a `rerank` task using the <<put-inference-api,{es} Inference API>>.
 
 [discrete]
-==== What makes retrievers useful?
+[[retrievers-overview-why-are-they-useful]]
+=== What makes retrievers useful?
 
 Here's an overview of what makes retrievers useful and how they differ from regular queries.
 
@@ -67,78 +67,109 @@ When using compound retrievers, only the query element is allowed, which enforce
 
 [discrete]
 [[retrievers-overview-example]]
-==== Example
+=== Example
 
-The following example demonstrates the powerful queries that we can now compose, and how retrievers simplify this process. We can use any combination of retrievers we want, propagating the
-results of a nested retriever to its parent. In this scenario, we'll make use of all 4 (currently) available retrievers, i.e. `standard`, `knn`, `text_similarity_reranker` and `rrf`.
-We'll first combine the results of a `semantic` query using the `standard` retriever, and that of a `knn` search on a dense vector field, using `rrf` to get the top 100 results.
-Finally, we'll then rerank the top-50 results of `rrf` using the `text_similarity_reranker`
+The following example demonstrates how using retrievers simplify the composability of queries for RRF ranking.
 
 [source,js]
 ----
 GET example-index/_search
 {
   "retriever": {
-    "text_similarity_reranker": {
-      "retriever": {
-        "rrf": {
-          "retrievers": [
-            {
-                "standard": {
-                  "query": {
-                    "semantic": {
-                      "field": "inference_field",
-                      "query": "state of the art vector database"
-                    }
-                  }
-                }
-            },
-            {
-              "knn": {
-                "query_vector": [
-                  0.54,
-                  ...,
-                  0.245
-                ],
-                "field": "embedding",
-                "k": 10,
-                "num_candidates": 15
+    "rrf": {
+      "retrievers": [
+        {
+          "standard": {
+            "query": {
+              "sparse_vector": {
+                "field": "vector.tokens",
+                "inference_id": "my-elser-endpoint",
+                "query": "What blue shoes are on sale?"
               }
             }
-          ],
-          "rank_window_size": 100,
-          "rank_constant": 10
+          }
+        },
+        {
+          "standard": {
+            "query": {
+              "match": {
+                "text": "blue shoes sale"
+              }
+            }
+          }
         }
-      },
-      "rank_window_size": 50,
-      "field": "description",
-      "inference_text": "what's the best way to create complex pipelines and retrieve documents?",
-      "inference_id": "my-awesome-rerank-model"
+      ]
     }
   }
 }
 ----
 //NOTCONSOLE
 
+This example demonstrates how you can combine different retrieval strategies into a single `retriever` pipeline.
+
+Compare to `RRF` with `sub_searches` approach (which is deprecated as of 8.16.0):
+
+.*Expand* for example
+[%collapsible]
+==============
+
+[source,js]
+----
+GET example-index/_search
+{
+  "sub_searches":[
+    {
+      "query":{
+        "match":{
+          "text":"blue shoes sale"
+        }
+      }
+    },
+    {
+      "query":{
+        "sparse_vector": {
+            "field": "vector.tokens",
+            "inference_id": "my-elser-endoint",
+            "query": "What blue shoes are on sale?"
+          }
+        }
+      }
+  ],
+  "rank":{
+    "rrf":{
+      "rank_window_size":50,
+      "rank_constant":20
+    }
+  }
+}
+----
+//NOTCONSOLE
+==============
+
+For more examples on how to use retrievers, please refer to <<retrievers-examples,retriever examples>>.
+
 [discrete]
 [[retrievers-overview-glossary]]
-==== Glossary
+=== Glossary
 
 Here are some important terms:
 
-* *Retrieval Pipeline*. Defines the entire retrieval and ranking logic to
-produce top hits.
-* *Retriever Tree*. A hierarchical structure that defines how retrievers interact.
-* *First-stage Retriever*. Returns an initial set of candidate documents.
-* *Compound Retriever*. Builds on one or more retrievers,
-enhancing document retrieval and ranking logic.
-* *Combiners*. Compound retrievers that merge top hits
-from multiple sub-retrievers.
-* *Rerankers*. Special compound retrievers that reorder hits and may adjust the number of hits, with distinctions between first-stage and second-stage rerankers.
+* *Retrieval Pipeline*.
+Defines the entire retrieval and ranking logic to produce top hits.
+* *Retriever Tree*.
+A hierarchical structure that defines how retrievers interact.
+* *First-stage Retriever*.
+Returns an initial set of candidate documents.
+* *Compound Retriever*.
+Builds on one or more retrievers, enhancing document retrieval and ranking logic.
+* *Combiners*.
+Compound retrievers that merge top hits from multiple sub-retrievers.
+* *Rerankers*.
+Special compound retrievers that reorder hits and may adjust the number of hits, with distinctions between first-stage and second-stage rerankers.
 
 [discrete]
 [[retrievers-overview-play-in-search]]
-==== Retrievers in action
+=== Retrievers in action
 
 The Search Playground builds Elasticsearch queries using the retriever abstraction.
 It automatically detects the fields and types in your index and builds a retriever tree based on your selections.
@@ -149,6 +180,9 @@ Refer to the {kibana-ref}/playground.html[Playground documentation] for more inf
 
 [discrete]
 [[retrievers-overview-api-reference]]
-==== API reference
+=== API reference
 
 For implementation details, including notable restrictions, check out the <<retriever,reference documentation>> in the Search API docs.
+
+
+include::retrievers-examples.asciidoc[]

--- a/docs/reference/search/search-your-data/retrievers-overview.asciidoc
+++ b/docs/reference/search/search-your-data/retrievers-overview.asciidoc
@@ -27,8 +27,6 @@ Returns top documents from a <<search-api-knn,knn search>>, in the context of a 
 Combines and ranks multiple first-stage retrievers using the reciprocal rank fusion (RRF) algorithm.
 Allows you to combine multiple result sets with different relevance indicators into a single result set.
 An RRF retriever is a *compound retriever*, where its `filter` element is propagated to its sub retrievers.
-* <<rule-retriever,*Rule Retriever*>>.
-Applies <<query-rules,query rules>> to the query before returning results.
 * <<text-similarity-reranker-retriever,*Text Similarity Re-ranker Retriever*>>.
 Used for <<semantic-reranking,semantic reranking>>.
 Requires first creating a `rerank` task using the <<put-inference-api,{es} Inference API>>.

--- a/docs/reference/search/search-your-data/search-api.asciidoc
+++ b/docs/reference/search/search-your-data/search-api.asciidoc
@@ -530,5 +530,4 @@ include::retrieve-inner-hits.asciidoc[]
 include::search-shard-routing.asciidoc[]
 include::search-using-query-rules.asciidoc[]
 include::search-template.asciidoc[]
-include::retrievers-overview.asciidoc[]
 

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -43,6 +43,7 @@ DSL, with a simplified user experience. Create search applications based on your
 results directly in the Kibana Search UI.
 
 include::search-api.asciidoc[]
+include::retrievers-overview.asciidoc[]
 include::knn-search.asciidoc[]
 include::semantic-search.asciidoc[]
 include::search-across-clusters.asciidoc[]


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/116196 to `8.16`.

cc @leemthompo 