### PR TITLE
[8.16] Document new ip geolocation fields (#116603)

### DIFF
--- a/docs/changelog/114193.yaml
+++ b/docs/changelog/114193.yaml
@@ -1,0 +1,5 @@
+pr: 114193
+summary: Add postal_code support to the City and Enterprise databases
+area: Ingest Node
+type: enhancement
+issues: []

--- a/docs/changelog/114268.yaml
+++ b/docs/changelog/114268.yaml
@@ -1,0 +1,5 @@
+pr: 114268
+summary: Support more maxmind fields in the geoip processor
+area: Ingest Node
+type: enhancement
+issues: []

--- a/docs/changelog/114521.yaml
+++ b/docs/changelog/114521.yaml
@@ -1,0 +1,5 @@
+pr: 114521
+summary: Add support for registered country fields for maxmind geoip databases
+area: Ingest Node
+type: enhancement
+issues: []

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -51,10 +51,12 @@ field instead.
 *Depends on what is available in `database_file`:
 
 * If a GeoLite2 City or GeoIP2 City database is used, then the following fields may be added under the `target_field`: `ip`,
-`country_iso_code`, `country_name`, `continent_code`, `continent_name`, `region_iso_code`, `region_name`, `city_name`, `timezone`,
-and `location`. The fields actually added depend on what has been found and which properties were configured in `properties`.
+`country_iso_code`, `country_name`, `country_in_european_union`, `registered_country_iso_code`, `registered_country_name`, `registered_country_in_european_union`,
+`continent_code`, `continent_name`, `region_iso_code`, `region_name`, `city_name`, `postal_code`, `timezone`,
+`location`, and `accuracy_radius`. The fields actually added depend on what has been found and which properties were configured in `properties`.
 * If a GeoLite2 Country or GeoIP2 Country database is used, then the following fields may be added under the `target_field`: `ip`,
-`country_iso_code`, `country_name`, `continent_code`, and `continent_name`. The fields actually added depend on what has been found
+`country_iso_code`, `country_name`, `country_in_european_union`, `registered_country_iso_code`, `registered_country_name`, `registered_country_in_european_union`,
+`continent_code`, and `continent_name`. The fields actually added depend on what has been found
 and which properties were configured in `properties`.
 * If the GeoLite2 ASN database is used, then the following fields may be added under the `target_field`: `ip`,
 `asn`, `organization_name` and `network`. The fields actually added depend on what has been found and which properties were configured
@@ -70,10 +72,12 @@ The fields actually added depend on what has been found and which properties wer
 `organization_name`, `network`, `isp`, `isp_organization_name`, `mobile_country_code`, and `mobile_network_code`. The fields actually added
 depend on what has been found and which properties were configured in `properties`.
 * If the GeoIP2 Enterprise database is used, then the following fields may be added under the `target_field`: `ip`,
-`country_iso_code`, `country_name`, `continent_code`, `continent_name`, `region_iso_code`, `region_name`, `city_name`, `timezone`,
-`location`, `asn`, `organization_name`, `network`, `hosting_provider`, `tor_exit_node`, `anonymous_vpn`, `anonymous`, `public_proxy`,
+`country_iso_code`, `country_name`, `country_in_european_union`, `registered_country_iso_code`, `registered_country_name`, `registered_country_in_european_union`,
+`continent_code`, `continent_name`, `region_iso_code`, `region_name`, `city_name`, `postal_code`, `timezone`,
+`location`, `accuracy_radius`, `country_confidence`, `city_confidence`, `postal_confidence`, `asn`, `organization_name`, `network`,
+`hosting_provider`, `tor_exit_node`, `anonymous_vpn`, `anonymous`, `public_proxy`,
 `residential_proxy`, `domain`, `isp`, `isp_organization_name`, `mobile_country_code`, `mobile_network_code`, `user_type`, and
-`connection_type`. The fields actually added  depend on what has been found and which properties were configured in `properties`.
+`connection_type`. The fields actually added depend on what has been found and which properties were configured in `properties`.
 
 preview::["Do not use the GeoIP2 Anonymous IP, GeoIP2 Connection Type, GeoIP2 Domain, GeoIP2 ISP, and GeoIP2 Enterprise databases in production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Document new ip geolocation fields (#116603)