### PR TITLE
[8.x] Fix NPE in EnrichLookupService on mixed clusters with <8.14 versions (#116583)

### DIFF
--- a/docs/changelog/116583.yaml
+++ b/docs/changelog/116583.yaml
@@ -1,0 +1,7 @@
+pr: 116583
+summary: Fix NPE in `EnrichLookupService` on mixed clusters with <8.14 versions
+area: ES|QL
+type: bug
+issues:
+ - 116529
+ - 116544

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -183,10 +183,13 @@ abstract class AbstractLookupService<R extends AbstractLookupService.Request, T 
         Block block,
         DataType inputDataType
     ) {
+        if (inputDataType == null) {
+            return QueryList.rawTermQueryList(field, searchExecutionContext, block);
+        }
         return switch (inputDataType) {
             case IP -> QueryList.ipTermQueryList(field, searchExecutionContext, (BytesRefBlock) block);
             case DATETIME -> QueryList.dateTermQueryList(field, searchExecutionContext, (LongBlock) block);
-            case null, default -> QueryList.rawTermQueryList(field, searchExecutionContext, block);
+            default -> QueryList.rawTermQueryList(field, searchExecutionContext, block);
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -45,6 +45,7 @@ import org.elasticsearch.compute.operator.lookup.EnrichQuerySourceOperator;
 import org.elasticsearch.compute.operator.lookup.MergePositionsOperator;
 import org.elasticsearch.compute.operator.lookup.QueryList;
 import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -185,7 +186,7 @@ abstract class AbstractLookupService<R extends AbstractLookupService.Request, T 
         return switch (inputDataType) {
             case IP -> QueryList.ipTermQueryList(field, searchExecutionContext, (BytesRefBlock) block);
             case DATETIME -> QueryList.dateTermQueryList(field, searchExecutionContext, (LongBlock) block);
-            default -> QueryList.rawTermQueryList(field, searchExecutionContext, block);
+            case null, default -> QueryList.rawTermQueryList(field, searchExecutionContext, block);
         };
     }
 
@@ -459,6 +460,10 @@ abstract class AbstractLookupService<R extends AbstractLookupService.Request, T 
     abstract static class TransportRequest extends org.elasticsearch.transport.TransportRequest implements IndicesRequest {
         final String sessionId;
         final ShardId shardId;
+        /**
+         * For mixed clusters with nodes &lt;8.14, this will be null.
+         */
+        @Nullable
         final DataType inputDataType;
         final Page inputPage;
         final List<NamedExpression> extractFields;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -127,9 +127,9 @@ public class EnrichLookupService extends AbstractLookupService<EnrichLookupServi
             TaskId parentTaskId = TaskId.readFromStream(in);
             String sessionId = in.readString();
             ShardId shardId = new ShardId(in);
-            DataType inputDataType = DataType.fromTypeName(
-                (in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) ? in.readString() : "unknown"
-            );
+            DataType inputDataType = (in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0))
+                ? DataType.fromTypeName(in.readString())
+                : null;
             String matchType = in.readString();
             String matchField = in.readString();
             Page inputPage;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix NPE in EnrichLookupService on mixed clusters with <8.14 versions (#116583)