### PR TITLE
Unmutes #116332 after backporting tests to v8.x

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -192,9 +192,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
   method: testBottomFieldSort
   issue: https://github.com/elastic/elasticsearch/issues/116249
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=synonyms/90_synonyms_reloading_for_synset/Reload analyzers for specific synonym set}
-  issue: https://github.com/elastic/elasticsearch/issues/116332
 - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
   method: testAllocationPreventedForRemoval
   issue: https://github.com/elastic/elasticsearch/issues/116363


### PR DESCRIPTION
Closes #116332

Follow up to #116609

Test fixes done in #116224 had not been backported to v8.x, which causes BwC tests to fail when 8.x tests are executed against main.

After backporting in #116609, unmute tests so we can check this is solved.