### PR TITLE
[8.x] [DOCS] Remove tech preview from bulk create/update/delete roles (#116601)

### DIFF
--- a/docs/reference/rest-api/security/bulk-create-roles.asciidoc
+++ b/docs/reference/rest-api/security/bulk-create-roles.asciidoc
@@ -1,7 +1,6 @@
 [role="xpack"]
 [[security-api-bulk-put-role]]
 === Bulk create or update roles API
-preview::[]
 ++++
 <titleabbrev>Bulk create or update roles API</titleabbrev>
 ++++

--- a/docs/reference/rest-api/security/bulk-delete-roles.asciidoc
+++ b/docs/reference/rest-api/security/bulk-delete-roles.asciidoc
@@ -1,7 +1,6 @@
 [role="xpack"]
 [[security-api-bulk-delete-role]]
 === Bulk delete roles API
-preview::[]
 ++++
 <titleabbrev>Bulk delete roles API</titleabbrev>
 ++++


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Remove tech preview from bulk create/update/delete roles (#116601)](https://github.com/elastic/elasticsearch/pull/116601)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)