### PR TITLE
Hides `hugging_face_elser` service from the `GET _inference/_services API`

### DIFF
--- a/docs/changelog/116664.yaml
+++ b/docs/changelog/116664.yaml
@@ -1,0 +1,6 @@
+pr: 116664
+summary: Hides `hugging_face_elser` service from the `GET _inference/_services API`
+area: Machine Learning
+type: bug
+issues:
+ - 116644

--- a/server/src/main/java/org/elasticsearch/inference/InferenceService.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceService.java
@@ -75,6 +75,14 @@ public interface InferenceService extends Closeable {
     InferenceServiceConfiguration getConfiguration();
 
     /**
+     * Whether this service should be hidden from the API. Should be used for services
+     * that are not ready to be used.
+     */
+    default Boolean hideFromConfigurationApi() {
+        return Boolean.FALSE;
+    }
+
+    /**
      * The task types supported by the service
      * @return Set of supported.
      */

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -135,9 +135,9 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
     public void testGetServicesWithoutTaskType() throws IOException {
         List<Object> services = getAllServices();
         if (ElasticInferenceServiceFeature.ELASTIC_INFERENCE_SERVICE_FEATURE_FLAG.isEnabled()) {
-            assertThat(services.size(), equalTo(19));
-        } else {
             assertThat(services.size(), equalTo(18));
+        } else {
+            assertThat(services.size(), equalTo(17));
         }
 
         String[] providers = new String[services.size()];
@@ -160,7 +160,6 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
                 "googleaistudio",
                 "googlevertexai",
                 "hugging_face",
-                "hugging_face_elser",
                 "mistral",
                 "openai",
                 "streaming_completion_test_service",
@@ -259,9 +258,9 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
         List<Object> services = getServices(TaskType.SPARSE_EMBEDDING);
 
         if (ElasticInferenceServiceFeature.ELASTIC_INFERENCE_SERVICE_FEATURE_FLAG.isEnabled()) {
-            assertThat(services.size(), equalTo(6));
-        } else {
             assertThat(services.size(), equalTo(5));
+        } else {
+            assertThat(services.size(), equalTo(4));
         }
 
         String[] providers = new String[services.size()];
@@ -272,9 +271,7 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
 
         Arrays.sort(providers);
 
-        var providerList = new ArrayList<>(
-            Arrays.asList("alibabacloud-ai-search", "elasticsearch", "hugging_face", "hugging_face_elser", "test_service")
-        );
+        var providerList = new ArrayList<>(Arrays.asList("alibabacloud-ai-search", "elasticsearch", "hugging_face", "test_service"));
         if (ElasticInferenceServiceFeature.ELASTIC_INFERENCE_SERVICE_FEATURE_FLAG.isEnabled()) {
             providerList.add(1, "elastic");
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
@@ -126,6 +126,11 @@ public class HuggingFaceElserService extends HuggingFaceBaseService {
     }
 
     @Override
+    public Boolean hideFromConfigurationApi() {
+        return Boolean.TRUE;
+    }
+
+    @Override
     public EnumSet<TaskType> supportedTaskTypes() {
         return supportedTaskTypes;
     }


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/116644

Hides `hugging_face_elser` service from the `GET _inference/_services` API because it's not ready for consumption.