### PR TITLE
[8.x] [Docs] Fix sharepoint docs for 8.16 release (#116661)

### DIFF
--- a/docs/reference/connector/docs/_connectors-overview-table.asciidoc
+++ b/docs/reference/connector/docs/_connectors-overview-table.asciidoc
@@ -44,7 +44,7 @@ NOTE: All connectors are available as self-managed <<es-build-connector,self-man
 |<<es-connectors-salesforce,Salesforce>>|*GA*|8.12+|8.12+|8.11+|8.13+|8.13+|https://github.com/elastic/connectors/tree/main/connectors/sources/salesforce.py[View code]
 |<<es-connectors-servicenow,ServiceNow>>|*GA*|8.10+|8.10+|8.11+|8.13+|8.13+|https://github.com/elastic/connectors/tree/main/connectors/sources/servicenow.py[View code]
 |<<es-connectors-sharepoint-online,Sharepoint Online>>|*GA*|8.9+|8.9+|8.9+|8.9+|8.9+|https://github.com/elastic/connectors/tree/main/connectors/sources/sharepoint_online.py[View code]
-|<<es-connectors-sharepoint,Sharepoint Server>>|*Beta*|8.15+|-|8.11+|8.13+|8.14+|https://github.com/elastic/connectors/tree/main/connectors/sources/sharepoint_server.py[View code]
+|<<es-connectors-sharepoint,Sharepoint Server>>|*Beta*|8.15+|-|8.11+|8.13+|8.15+|https://github.com/elastic/connectors/tree/main/connectors/sources/sharepoint_server.py[View code]
 |<<es-connectors-slack,Slack>>|*Preview*|8.14+|-|-|-|-|https://github.com/elastic/connectors/tree/main/connectors/sources/slack.py[View code]
 |<<es-connectors-teams,Teams>>|*Preview*|8.14+|-|-|8.13+|-|https://github.com/elastic/connectors/tree/main/connectors/sources/teams.py[View code]
 |<<es-connectors-zoom,Zoom>>|*Preview*|8.14+|-|8.11+|8.13+|-|https://github.com/elastic/connectors/tree/main/connectors/sources/zoom.py[View code]

--- a/docs/reference/connector/docs/connectors-sharepoint.asciidoc
+++ b/docs/reference/connector/docs/connectors-sharepoint.asciidoc
@@ -67,6 +67,9 @@ The following SharePoint Server versions are compatible:
 
 The following configuration fields are required to set up the connector:
 
+`authentication`::
+Authentication mode, either *Basic* or *NTLM*.
+
 `username`::
 The username of the account for the SharePoint Server instance.
 
@@ -133,7 +136,7 @@ The connector syncs the following SharePoint object types:
 [NOTE]
 ====
 * Content from files bigger than 10 MB won't be extracted by default. Use the <<es-connectors-content-extraction-local, self-managed local extraction service>> to handle larger binary files.
-* Permissions are not synced. **All documents** indexed to an Elastic deployment will be visible to **all users with access** to that Elasticsearch Index.
+* Permissions are not synced by default. Enable <<es-dls, document-level security (DLS)>> to sync permissions.
 ====
 
 [discrete#es-connectors-sharepoint-sync-types]
@@ -191,7 +194,7 @@ This connector is written in Python using the {connectors-python}[Elastic connec
 
 View the {connectors-python}/connectors/sources/sharepoint_server.py[source code for this connector^] (branch _{connectors-branch}_, compatible with Elastic _{minor-version}_).
 
-// Closing the collapsible section 
+// Closing the collapsible section
 ===============
 
 
@@ -253,6 +256,9 @@ Once connected, you'll be able to update these values in Kibana.
 ====
 
 The following configuration fields are required to set up the connector:
+
+`authentication`::
+Authentication mode, either *Basic* or *NTLM*.
 
 `username`::
 The username of the account for the SharePoint Server instance.
@@ -408,5 +414,5 @@ This connector is written in Python using the {connectors-python}[Elastic connec
 
 View the {connectors-python}/connectors/sources/sharepoint_server.py[source code for this connector^] (branch _{connectors-branch}_, compatible with Elastic _{minor-version}_).
 
-// Closing the collapsible section 
+// Closing the collapsible section
 ===============


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [Docs] Fix sharepoint docs for 8.16 release (#116661)