### PR TITLE
[8.16] Update elastic-connectors docker namespace to integrations (#113839)

### DIFF
--- a/docs/reference/connector/docs/_connectors-docker-instructions.asciidoc
+++ b/docs/reference/connector/docs/_connectors-docker-instructions.asciidoc
@@ -59,7 +59,7 @@ docker run \
 --network "elastic" \
 --tty \
 --rm \
-docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
+docker.elastic.co/integrations/elastic-connectors:{version}.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ----
@@ -67,7 +67,7 @@ docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
 
 Refer to {connectors-python}/docs/DOCKER.md[`DOCKER.md`^] in the `elastic/connectors` repo for more details.
 
-Find all available Docker images in the https://www.docker.elastic.co/r/enterprise-search/elastic-connectors[official registry].
+Find all available Docker images in the https://www.docker.elastic.co/r/integrations/elastic-connectors[official registry].
 
 [TIP]
 ====

--- a/docs/reference/connector/docs/connectors-API-tutorial.asciidoc
+++ b/docs/reference/connector/docs/connectors-API-tutorial.asciidoc
@@ -300,7 +300,7 @@ docker run \
 --rm \
 --tty -i \
 --network host \
-docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
+docker.elastic.co/integrations/elastic-connectors:{version}.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ----

--- a/docs/reference/connector/docs/connectors-content-extraction.asciidoc
+++ b/docs/reference/connector/docs/connectors-content-extraction.asciidoc
@@ -282,7 +282,7 @@ $ docker run \
   --network "elastic" \
   --tty \
   --rm \
-  docker.elastic.co/enterprise-search/elastic-connectors:$CONNECTOR_CLIENT_VERSION \
+  docker.elastic.co/integrations/elastic-connectors:$CONNECTOR_CLIENT_VERSION \
   /app/bin/elastic-ingest \
   -c /config/config.yml
 ----

--- a/docs/reference/connector/docs/connectors-run-from-docker.asciidoc
+++ b/docs/reference/connector/docs/connectors-run-from-docker.asciidoc
@@ -62,7 +62,7 @@ docker run \
 --rm \
 --tty -i \
 --network host \
-docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
+docker.elastic.co/integrations/elastic-connectors:{version}.0 \
 /app/bin/elastic-ingest \
 -c /config/config.yml
 ----
@@ -70,10 +70,10 @@ docker.elastic.co/enterprise-search/elastic-connectors:{version}.0 \
 [TIP]
 ====
 For unreleased versions, append the `-SNAPSHOT` suffix to the version number.
-For example, `docker.elastic.co/enterprise-search/elastic-connectors:8.14.0.0-SNAPSHOT`.
+For example, `docker.elastic.co/integrations/elastic-connectors:8.14.0.0-SNAPSHOT`.
 ====
 
-Find all available Docker images in the https://www.docker.elastic.co/r/enterprise-search/elastic-connectors[official registry].
+Find all available Docker images in the https://www.docker.elastic.co/r/integrations/elastic-connectors[official registry].
 
 [discrete#es-build-connector-finalizes-kibana]
 ==== Enter data source details in Kibana


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Update elastic-connectors docker namespace to integrations (#113839)](https://github.com/elastic/elasticsearch/pull/113839)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)