### PR TITLE
[Gradle] Fix configuration cache for validateChangelogs task definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -420,8 +420,11 @@ gradle.projectsEvaluated {
   }
 }
 
-tasks.named("validateChangelogs") {
-  onlyIf { project.gradle.startParameter.taskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false }
+tasks.named("validateChangelogs").configure {
+  def triggeredTaskNames = gradle.startParameter.taskNames
+  onlyIf {
+    triggeredTaskNames.any { it.startsWith("checkPart") || it == 'functionalTests' } == false
+  }
 }
 
 tasks.named("precommit") {


### PR DESCRIPTION
This fixes overall configuration cache compatibility of our build. A project object cannot be referenced from the context of an `onlyIf` closure.