### PR TITLE
[8.x] Update service-elser.asciidoc (#116272)

### DIFF
--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -7,6 +7,12 @@ You can also deploy ELSER by using the <<infer-service-elasticsearch>>.
 NOTE: The API request will automatically download and deploy the ELSER model if
 it isn't already downloaded.
 
+[WARNING]
+.Deprecated in 8.16
+====
+The elser service is deprecated and will be removed in a future release. 
+Use the <<infer-service-elasticsearch>> instead, with model_id included in the service_settings.
+====
 
 [discrete]
 [[infer-service-elser-api-request]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update service-elser.asciidoc (#116272)](https://github.com/elastic/elasticsearch/pull/116272)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)