### PR TITLE
Removing testGet from muted tests as it no longer exists

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -97,9 +97,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.TextEmbeddingCrudIT
   method: testPutE5Small_withPlatformSpecificVariant
   issue: https://github.com/elastic/elasticsearch/issues/113950
-- class: org.elasticsearch.xpack.inference.InferenceCrudIT
-  method: testGet
-  issue: https://github.com/elastic/elasticsearch/issues/114135
 - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
   method: test {yaml=reference/rest-api/usage/line_38}
   issue: https://github.com/elastic/elasticsearch/issues/113694


### PR DESCRIPTION
Issue - https://github.com/elastic/elasticsearch/issues/114135

Removing `testGet` from muted tests. Explanation for why from the issue above:
Looks like testGet was updated to testCRUD in [this change](https://github.com/elastic/elasticsearch/commit/6b714e28f36852c514f966cda31f3f2a19c6e871). Looking back at the assertion that was failing, it looks related to the total number of endpoints we expect to exist (see [here](https://github.com/elastic/elasticsearch/blob/4d4626513e5362d5b06eece2c17e328088884b3d/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java)). testCRUD is not muted and has not been failing so it seems the updates we've made should have accounted for this. I'll go ahead and remove this from the muted tests.