### PR TITLE
Make `remove_binary` required on `attachment` processors

### DIFF
--- a/docs/changelog/116768.yaml
+++ b/docs/changelog/116768.yaml
@@ -1,0 +1,12 @@
+pr: 116768
+summary: Make `remove_binary` required on `attachment` processors
+area: Ingest Node
+type: breaking
+issues: []
+breaking:
+  title: Make `remove_binary` required on `attachment` processors
+  area: Ingest Node
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/116768.yaml
+++ b/docs/changelog/116768.yaml
@@ -5,8 +5,13 @@ type: breaking
 issues: []
 breaking:
   title: Make `remove_binary` required on `attachment` processors
-  area: Ingest Node
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  area: Ingest
+  details: >-
+    The `remove_binary` option is now required on the `attachment` ingest processor. (Previously, not setting it would
+    result in a deprecation warning and a value of false.)
+  impact: >-
+    Users should specify a value for the `remove_binary` option when creating `attachment` ingest processors. They
+    can set it to false to preserve the previous behavior. However, this can consume a lot of resources, so it is
+    normally recommended to set to true. The option will be set to false on existing processors stored in the cluster
+    state on upgrade, to preserve the previous behavior.
   notable: false

--- a/docs/reference/ingest/processors/attachment.asciidoc
+++ b/docs/reference/ingest/processors/attachment.asciidoc
@@ -82,7 +82,6 @@ The document's `attachment` object contains extracted properties for the file:
   "_seq_no": 22,
   "_primary_term": 1,
   "_source": {
-    "data": "e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=",
     "attachment": {
       "content_type": "application/rtf",
       "language": "ro",
@@ -95,7 +94,8 @@ The document's `attachment` object contains extracted properties for the file:
 // TESTRESPONSE[s/"_seq_no": \d+/"_seq_no" : $body._seq_no/ s/"_primary_term" : 1/"_primary_term" : $body._primary_term/]
 
 NOTE: Keeping the binary as a field within the document might consume a lot of resources. It is highly recommended
-      to remove that field from the document. Set `remove_binary` to `true` to automatically remove the field.
+      to remove that field from the document. Set `remove_binary` to `true` to automatically remove the field, as in
+      the examples shown here.
 
 [[attachment-fields]]
 ==== Exported fields
@@ -250,7 +250,6 @@ Returns this:
   "_seq_no": 35,
   "_primary_term": 1,
   "_source": {
-    "data": "e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=",
     "attachment": {
       "content_type": "application/rtf",
       "language": "is",
@@ -299,7 +298,6 @@ Returns this:
   "_seq_no": 40,
   "_primary_term": 1,
   "_source": {
-    "data": "e1xydGYxXGFuc2kNCkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0DQpccGFyIH0=",
     "max_size": 5,
     "attachment": {
       "content_type": "application/rtf",
@@ -396,7 +394,6 @@ Returns this:
     "attachments" : [
       {
         "filename" : "ipsum.txt",
-        "data" : "dGhpcyBpcwpqdXN0IHNvbWUgdGV4dAo=",
         "attachment" : {
           "content_type" : "text/plain; charset=ISO-8859-1",
           "language" : "en",
@@ -406,7 +403,6 @@ Returns this:
       },
       {
         "filename" : "test.txt",
-        "data" : "VGhpcyBpcyBhIHRlc3QK",
         "attachment" : {
           "content_type" : "text/plain; charset=ISO-8859-1",
           "language" : "en",

--- a/docs/reference/ingest/processors/attachment.asciidoc
+++ b/docs/reference/ingest/processors/attachment.asciidoc
@@ -26,7 +26,7 @@ representation. The processor will skip the base64 decoding then.
 | `indexed_chars_field`  | no        | `null`           | Field name from which you can overwrite the number of chars being used for extraction. See `indexed_chars`.
 | `properties`           | no        | all properties   | Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`
 | `ignore_missing`       | no        | `false`          | If `true` and `field` does not exist, the processor quietly exits without modifying the document
-| `remove_binary`        | no        | `false`          | If `true`, the binary `field` will be removed from the document
+| `remove_binary`        | yes       | -                | If `true`, the binary `field` will be removed from the document
 | `resource_name`        | no        |                  | Field containing the name of the resource to decode. If specified, the processor passes this resource name to the underlying Tika library to enable https://tika.apache.org/1.24.1/detection.html#Resource_Name_Based_Detection[Resource Name Based Detection].
 |======
 
@@ -58,7 +58,7 @@ PUT _ingest/pipeline/attachment
     {
       "attachment" : {
         "field" : "data",
-        "remove_binary": false
+        "remove_binary": true
       }
     }
   ]
@@ -143,7 +143,7 @@ PUT _ingest/pipeline/attachment
       "attachment" : {
         "field" : "data",
         "properties": [ "content", "title" ],
-        "remove_binary": false
+        "remove_binary": true
       }
     }
   ]
@@ -170,7 +170,7 @@ PUT _ingest/pipeline/cbor-attachment
     {
       "attachment" : {
         "field" : "data",
-        "remove_binary": false
+        "remove_binary": true
       }
     }
   ]
@@ -226,7 +226,7 @@ PUT _ingest/pipeline/attachment
         "field" : "data",
         "indexed_chars" : 11,
         "indexed_chars_field" : "max_size",
-        "remove_binary": false
+        "remove_binary": true
       }
     }
   ]
@@ -274,7 +274,7 @@ PUT _ingest/pipeline/attachment
         "field" : "data",
         "indexed_chars" : 11,
         "indexed_chars_field" : "max_size",
-        "remove_binary": false
+        "remove_binary": true
       }
     }
   ]
@@ -358,7 +358,7 @@ PUT _ingest/pipeline/attachment
           "attachment": {
             "target_field": "_ingest._value.attachment",
             "field": "_ingest._value.data",
-            "remove_binary": false
+            "remove_binary": true
           }
         }
       }

--- a/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -328,4 +328,12 @@ public final class AttachmentProcessor extends AbstractProcessor {
             return this.toString().toLowerCase(Locale.ROOT);
         }
     }
+
+    public static boolean maybeUpgradeConfig(Map<String, Object> config) {
+        // Instances created before 9.0 may not have the remove_binary option.
+        // On upgrade to 9.x, we explicitly set it to false, which was considered the default.
+        boolean changed = config.putIfAbsent("remove_binary", false) == null;
+        System.out.printf("Looking at attachment processor for field %s - changed = %s%n", config.get("field"), changed);
+        return changed;
+    }
 }

--- a/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -16,9 +16,7 @@ import org.apache.tika.metadata.Office;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.core.UpdateForV9;
+import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
@@ -34,14 +32,13 @@ import java.util.Set;
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
 import static org.elasticsearch.ingest.ConfigurationUtils.readBooleanProperty;
 import static org.elasticsearch.ingest.ConfigurationUtils.readIntProperty;
-import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalBooleanProperty;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalList;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalStringProperty;
+import static org.elasticsearch.ingest.ConfigurationUtils.readRequiredBooleanProperty;
 import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
 
 public final class AttachmentProcessor extends AbstractProcessor {
 
-    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(AttachmentProcessor.class);
     private static final int NUMBER_OF_CHARS_INDEXED = 100000;
 
     public static final String TYPE = "attachment";
@@ -196,7 +193,7 @@ public final class AttachmentProcessor extends AbstractProcessor {
      * @param property          property to add
      * @param value             value to add
      */
-    private <T> void addAdditionalField(Map<String, Object> additionalFields, Property property, String value) {
+    private void addAdditionalField(Map<String, Object> additionalFields, Property property, String value) {
         if (properties.contains(property) && Strings.hasLength(value)) {
             additionalFields.put(property.toLowerCase(), value);
         }
@@ -233,7 +230,7 @@ public final class AttachmentProcessor extends AbstractProcessor {
             String processorTag,
             String description,
             Map<String, Object> config
-        ) throws Exception {
+        ) {
             String field = readStringProperty(TYPE, processorTag, config, "field");
             String resourceName = readOptionalStringProperty(TYPE, processorTag, config, "resource_name");
             String targetField = readStringProperty(TYPE, processorTag, config, "target_field", "attachment");
@@ -241,19 +238,10 @@ public final class AttachmentProcessor extends AbstractProcessor {
             int indexedChars = readIntProperty(TYPE, processorTag, config, "indexed_chars", NUMBER_OF_CHARS_INDEXED);
             boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
             String indexedCharsField = readOptionalStringProperty(TYPE, processorTag, config, "indexed_chars_field");
-            @UpdateForV9(owner = UpdateForV9.Owner.DATA_MANAGEMENT)
-            // update the [remove_binary] default to be 'true' assuming enough time has passed. Deprecated in September 2022.
-            Boolean removeBinary = readOptionalBooleanProperty(TYPE, processorTag, config, "remove_binary");
-            if (removeBinary == null) {
-                DEPRECATION_LOGGER.warn(
-                    DeprecationCategory.PARSING,
-                    "attachment-remove-binary",
-                    "The default [remove_binary] value of 'false' is deprecated and will be "
-                        + "set to 'true' in a future release. Set [remove_binary] explicitly to "
-                        + "'true' or 'false' to ensure no behavior change."
-                );
-                removeBinary = false;
-            }
+            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            // Consider making this optional with a default of true in V10.
+            // (It was optional with a default of false up to V8 and required in V9.)
+            boolean removeBinary = readRequiredBooleanProperty(TYPE, processorTag, config, "remove_binary");
 
             final Set<Property> properties;
             if (propertyNames != null) {

--- a/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -320,8 +320,6 @@ public final class AttachmentProcessor extends AbstractProcessor {
     public static boolean maybeUpgradeConfig(Map<String, Object> config) {
         // Instances created before 9.0 may not have the remove_binary option.
         // On upgrade to 9.x, we explicitly set it to false, which was considered the default.
-        boolean changed = config.putIfAbsent("remove_binary", false) == null;
-        System.out.printf("Looking at attachment processor for field %s - changed = %s%n", config.get("field"), changed);
-        return changed;
+        return config.putIfAbsent("remove_binary", false) == null;
     }
 }

--- a/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/IngestAttachmentPlugin.java
+++ b/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/IngestAttachmentPlugin.java
@@ -9,16 +9,34 @@
 
 package org.elasticsearch.ingest.attachment;
 
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.core.UpdateForV10;
+import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 public class IngestAttachmentPlugin extends Plugin implements IngestPlugin {
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         return Map.of(AttachmentProcessor.TYPE, new AttachmentProcessor.Factory());
+    }
+
+    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    // This can be removed in V10. It's not possible to create an instance without the remove_binary property in V9, and all instances
+    // created by V8 or earlier will have been fixed when upgraded to V9.
+    @Override
+    public Map<String, UnaryOperator<Metadata.Custom>> getCustomMetadataUpgraders() {
+        return Map.of(
+            IngestMetadata.TYPE,
+            ingestMetadata -> ((IngestMetadata) ingestMetadata).maybeUpgradeProcessors(
+                AttachmentProcessor.TYPE,
+                AttachmentProcessor::maybeUpgradeConfig
+            )
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -214,7 +214,7 @@ public final class ConfigurationUtils {
         if (value == null) {
             return defaultValue;
         } else {
-            return readBoolean(processorType, processorTag, propertyName, value).booleanValue();
+            return readBoolean(processorType, processorTag, propertyName, value);
         }
     }
 
@@ -227,6 +227,20 @@ public final class ConfigurationUtils {
     ) {
         Object value = configuration.remove(propertyName);
         return readBoolean(processorType, processorTag, propertyName, value);
+    }
+
+    public static boolean readRequiredBooleanProperty(
+        String processorType,
+        String processorTag,
+        Map<String, Object> configuration,
+        String propertyName
+    ) {
+        Boolean value = readOptionalBooleanProperty(processorType, processorTag, configuration, propertyName);
+        if (value == null) {
+            throw newConfigurationException(processorType, processorTag, propertyName, "required property is missing");
+        } else {
+            return value;
+        }
     }
 
     private static Boolean readBoolean(String processorType, String processorTag, String propertyName, Object value) {
@@ -268,7 +282,7 @@ public final class ConfigurationUtils {
                 processorType,
                 processorTag,
                 propertyName,
-                "property cannot be converted to an int [" + value.toString() + "]"
+                "property cannot be converted to an int [" + value + "]"
             );
         }
     }
@@ -296,7 +310,7 @@ public final class ConfigurationUtils {
                 processorType,
                 processorTag,
                 propertyName,
-                "property cannot be converted to a double [" + value.toString() + "]"
+                "property cannot be converted to a double [" + value + "]"
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
@@ -65,11 +65,12 @@ public class ConfigurationUtilsTests extends ESTestCase {
     }
 
     public void testReadStringPropertyInvalidType() {
-        try {
-            ConfigurationUtils.readStringProperty(null, null, config, "arr");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), equalTo("[arr] property isn't a string, but of type [java.util.Arrays$ArrayList]"));
-        }
+        ElasticsearchParseException caught = assertThrows(
+            ElasticsearchParseException.class,
+            () -> ConfigurationUtils.readStringProperty(null, null, config, "arr")
+        );
+        assertThat(caught.getMessage(), equalTo("[arr] property isn't a string, but of type [java.util.Arrays$ArrayList]"));
+
     }
 
     public void testReadBooleanProperty() {
@@ -82,12 +83,35 @@ public class ConfigurationUtilsTests extends ESTestCase {
         assertThat(val, equalTo(false));
     }
 
+    public void testReadOptionalBooleanProperty() {
+        Boolean val = ConfigurationUtils.readOptionalBooleanProperty(null, null, config, "boolVal");
+        assertThat(val, equalTo(true));
+    }
+
+    public void testReadNullOptionalBooleanProperty() {
+        Boolean val = ConfigurationUtils.readOptionalBooleanProperty(null, null, config, "null");
+        assertThat(val, nullValue());
+    }
+
+    public void testReadRequiredBooleanProperty() {
+        Boolean val = ConfigurationUtils.readRequiredBooleanProperty(null, null, config, "boolVal");
+        assertThat(val, equalTo(true));
+    }
+
+    public void testReadNullRequiredBooleanProperty() {
+        ElasticsearchParseException caught = assertThrows(
+            ElasticsearchParseException.class,
+            () -> ConfigurationUtils.readRequiredBooleanProperty(null, null, config, "null")
+        );
+        assertThat(caught.getMessage(), equalTo("[null] required property is missing"));
+    }
+
     public void testReadBooleanPropertyInvalidType() {
-        try {
-            ConfigurationUtils.readBooleanProperty(null, null, config, "arr", true);
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), equalTo("[arr] property isn't a boolean, but of type [java.util.Arrays$ArrayList]"));
-        }
+        ElasticsearchParseException caught = assertThrows(
+            ElasticsearchParseException.class,
+            () -> ConfigurationUtils.readBooleanProperty(null, null, config, "arr", true)
+        );
+        assertThat(caught.getMessage(), equalTo("[arr] property isn't a boolean, but of type [java.util.Arrays$ArrayList]"));
     }
 
     public void testReadStringOrIntProperty() {
@@ -98,11 +122,11 @@ public class ConfigurationUtilsTests extends ESTestCase {
     }
 
     public void testReadStringOrIntPropertyInvalidType() {
-        try {
-            ConfigurationUtils.readStringOrIntProperty(null, null, config, "arr", null);
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), equalTo("[arr] property isn't a string or int, but of type [java.util.Arrays$ArrayList]"));
-        }
+        ElasticsearchParseException caught = assertThrows(
+            ElasticsearchParseException.class,
+            () -> ConfigurationUtils.readStringOrIntProperty(null, null, config, "arr", null)
+        );
+        assertThat(caught.getMessage(), equalTo("[arr] property isn't a string or int, but of type [java.util.Arrays$ArrayList]"));
     }
 
     public void testReadMediaProperty() {


### PR DESCRIPTION
This makes this field required when creating processors (previously, not setting it resulted in a deprecation warning and a value of false). It also applies a migration on startup to set it to it's old default value from any processors in the cluster state.