### PR TITLE
Simplify entitlement agent REST tests

### DIFF
--- a/qa/entitlements/build.gradle
+++ b/qa/entitlements/build.gradle
@@ -18,21 +18,8 @@ esplugin {
   classname 'org.elasticsearch.test.entitlements.EntitlementsCheckPlugin'
 }
 
-configurations {
-  entitlementBridge {
-    canBeConsumed = false
-  }
-}
-
 dependencies {
   clusterPlugins project(':qa:entitlements')
-  entitlementBridge project(':libs:entitlement:bridge')
-}
-
-tasks.named('javaRestTest') {
-  systemProperty "tests.entitlement-bridge.jar-name", configurations.entitlementBridge.singleFile.getName()
-  usesDefaultDistribution()
-  systemProperty "tests.security.manager", "false"
 }
 
 tasks.named("javadoc").configure {

--- a/qa/entitlements/src/javaRestTest/java/org/elasticsearch/test/entitlements/EntitlementsIT.java
+++ b/qa/entitlements/src/javaRestTest/java/org/elasticsearch/test/entitlements/EntitlementsIT.java
@@ -10,9 +10,7 @@
 package org.elasticsearch.test.entitlements;
 
 import org.elasticsearch.client.Request;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.ClassRule;
 
@@ -20,21 +18,13 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 
-@ESTestCase.WithoutSecurityManager
 public class EntitlementsIT extends ESRestTestCase {
-
-    private static final String ENTITLEMENT_BRIDGE_JAR_NAME = System.getProperty("tests.entitlement-bridge.jar-name");
 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.INTEG_TEST)
         .plugin("entitlement-qa")
         .systemProperty("es.entitlements.enabled", "true")
         .setting("xpack.security.enabled", "false")
-        .jvmArg("-Djdk.attach.allowAttachSelf=true")
-        .jvmArg("-XX:+EnableDynamicAgentLoading")
-        .jvmArg("--patch-module=java.base=lib/entitlement-bridge/" + ENTITLEMENT_BRIDGE_JAR_NAME)
-        .jvmArg("--add-exports=java.base/org.elasticsearch.entitlement.bridge=org.elasticsearch.entitlement")
         .build();
 
     @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -55,7 +55,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -758,13 +757,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
             String heapSize = System.getProperty("tests.heap.size", "512m");
             List<String> serverOpts = List.of("-Xms" + heapSize, "-Xmx" + heapSize, debugArgs, featureFlagProperties);
-            List<String> commonOpts = List.of(
-                "-ea",
-                "-esa",
-                System.getProperty("tests.jvm.argline", ""),
-                systemProperties,
-                jvmArgs
-            );
+            List<String> commonOpts = List.of("-ea", "-esa", System.getProperty("tests.jvm.argline", ""), systemProperties, jvmArgs);
 
             String esJavaOpts = Stream.concat(serverOpts.stream(), commonOpts.stream())
                 .filter(not(String::isEmpty))


### PR DESCRIPTION
Follow up to #116435 which simplifies the setup of the entitlement agent Java REST tests to eliminate the dependency on the entitlement bridge artifact.