### PR TITLE
Supporting persistent task ids in the task api

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -197,6 +197,7 @@ public class TransportVersions {
     public static final TransportVersion VERTEX_AI_INPUT_TYPE_ADDED = def(8_790_00_0);
     public static final TransportVersion SKIP_INNER_HITS_SEARCH_SOURCE = def(8_791_00_0);
     public static final TransportVersion QUERY_RULES_LIST_INCLUDES_TYPES = def(8_792_00_0);
+    public static final TransportVersion TASK_API_SUPPORTS_PERSISTENT_TASK_ID = def(8_793_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/GetTaskRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/GetTaskRequestBuilder.java
@@ -26,7 +26,7 @@ public class GetTaskRequestBuilder extends ActionRequestBuilder<GetTaskRequest, 
      * Set the TaskId to look up. Required.
      */
     public final GetTaskRequestBuilder setTaskId(TaskId taskId) {
-        request.setTaskId(taskId);
+        request.setTaskId(taskId.toString());
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetTaskAction.java
@@ -40,7 +40,7 @@ public class RestGetTaskAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        TaskId taskId = new TaskId(request.param("task_id"));
+        String taskId = request.param("task_id");
         boolean waitForCompletion = request.paramAsBoolean("wait_for_completion", false);
         TimeValue timeout = getTimeout(request);
 


### PR DESCRIPTION
DRAFT. The taskId passed to the task api can be interpreted as a persistent task id.