### PR TITLE
Fix testServerCloseConnectionMidStream

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4IncrementalRequestHandlingIT.java
@@ -210,7 +210,9 @@ public class Netty4IncrementalRequestHandlingIT extends ESNetty4IntegTestCase {
             // terminate connection on server and wait resources are released
             handler.channel.request().getHttpChannel().close();
             assertBusy(() -> {
-                assertNull(handler.stream.buf());
+                // Cannot be simplified to assertNull.
+                // assertNull requires object to not fail on toString() method, but closing buffer can
+                assertTrue(handler.stream.buf() == null);
                 assertTrue(handler.streamClosed);
             });
         }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -241,9 +241,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/116752
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryGroupsResolverTests
   issue: https://github.com/elastic/elasticsearch/issues/116182
-- class: org.elasticsearch.http.netty4.Netty4IncrementalRequestHandlingIT
-  method: testServerCloseConnectionMidStream
-  issue: https://github.com/elastic/elasticsearch/issues/116774
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
   issue: https://github.com/elastic/elasticsearch/issues/116775


### PR DESCRIPTION
Closes #116774

`stream.buf()` only exposed in tests and might have race condition in assertion. The problem happens when `stream.buf()` is not null but it's closing in another thread. The `assertNull(obj)` will try `toString()` closing buffer and it might fail in the middle. 

Adding synchronization to the source of `Netty4HttpRequestBodyStream` does not seems necessary, that code should be executed in single thread.

Also, the `.buf()` can be replaced with something like `.bufSize()`. Since most of test only care about presence of buffered data, and only one so far tests exact buffer size. 