### PR TITLE
[8.x] Remove unused method introduced in #113194 (#116793)

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -1086,13 +1086,6 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         return true;
     }
 
-    public static boolean assertTestThreadPool() {
-        final var threadName = Thread.currentThread().getName();
-        final var executorName = EsExecutors.executorName(threadName);
-        assert threadName.startsWith("TEST-") || threadName.startsWith("LuceneTestCase") : threadName + " is not a test thread";
-        return true;
-    }
-
     public static boolean assertInSystemContext(ThreadPool threadPool) {
         final var threadName = Thread.currentThread().getName();
         assert threadName.startsWith("TEST-") || threadName.startsWith("LuceneTestCase") || threadPool.getThreadContext().isSystemContext()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Remove unused method introduced in #113194 (#116793)](https://github.com/elastic/elasticsearch/pull/116793)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)