### PR TITLE
[ES|QL] Update docs format (missing space before '=')

### DIFF
--- a/docs/reference/esql/functions/kibana/definition/bit_length.json
+++ b/docs/reference/esql/functions/kibana/definition/bit_length.json
@@ -31,7 +31,7 @@
     }
   ],
   "examples" : [
-    "FROM airports\n| WHERE country == \"India\"\n| KEEP city\n| EVAL fn_length=LENGTH(city), fn_bit_length = BIT_LENGTH(city)"
+    "FROM airports\n| WHERE country == \"India\"\n| KEEP city\n| EVAL fn_length = LENGTH(city), fn_bit_length = BIT_LENGTH(city)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/esql/functions/kibana/definition/byte_length.json
+++ b/docs/reference/esql/functions/kibana/definition/byte_length.json
@@ -31,7 +31,7 @@
     }
   ],
   "examples" : [
-    "FROM airports\n| WHERE country == \"India\"\n| KEEP city\n| EVAL fn_length=LENGTH(city), fn_byte_length = BYTE_LENGTH(city)"
+    "FROM airports\n| WHERE country == \"India\"\n| KEEP city\n| EVAL fn_length = LENGTH(city), fn_byte_length = BYTE_LENGTH(city)"
   ],
   "preview" : false,
   "snapshot_only" : false

--- a/docs/reference/esql/functions/kibana/docs/bit_length.md
+++ b/docs/reference/esql/functions/kibana/docs/bit_length.md
@@ -9,6 +9,6 @@ Returns the bit length of a string.
 FROM airports
 | WHERE country == "India"
 | KEEP city
-| EVAL fn_length=LENGTH(city), fn_bit_length = BIT_LENGTH(city)
+| EVAL fn_length = LENGTH(city), fn_bit_length = BIT_LENGTH(city)
 ```
 Note: All strings are in UTF-8, so a single character can use multiple bytes.

--- a/docs/reference/esql/functions/kibana/docs/byte_length.md
+++ b/docs/reference/esql/functions/kibana/docs/byte_length.md
@@ -9,6 +9,6 @@ Returns the byte length of a string.
 FROM airports
 | WHERE country == "India"
 | KEEP city
-| EVAL fn_length=LENGTH(city), fn_byte_length = BYTE_LENGTH(city)
+| EVAL fn_length = LENGTH(city), fn_byte_length = BYTE_LENGTH(city)
 ```
 Note: All strings are in UTF-8, so a single character can use multiple bytes.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -663,7 +663,7 @@ required_capability: fn_bit_length
 FROM airports
 | WHERE country == "India"
 | KEEP city
-| EVAL fn_length=LENGTH(city), fn_bit_length = BIT_LENGTH(city)
+| EVAL fn_length = LENGTH(city), fn_bit_length = BIT_LENGTH(city)
 // end::bitLength[]
 | SORT city
 | LIMIT 3

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -379,7 +379,7 @@ required_capability: fn_byte_length
 FROM airports
 | WHERE country == "India"
 | KEEP city
-| EVAL fn_length=LENGTH(city), fn_byte_length = BYTE_LENGTH(city)
+| EVAL fn_length = LENGTH(city), fn_byte_length = BYTE_LENGTH(city)
 // end::byteLength[]
 | SORT city
 | LIMIT 3


### PR DESCRIPTION
Fix length functions formatting from `x=FUNC(...)` to `x = FUNC(...)`. This fixes the bad formatting introduced in #116591.