### PR TITLE
[8.x] Simplify entitlement agent REST tests (#116779)

### DIFF
--- a/qa/entitlements/build.gradle
+++ b/qa/entitlements/build.gradle
@@ -18,21 +18,8 @@ esplugin {
   classname 'org.elasticsearch.test.entitlements.EntitlementsCheckPlugin'
 }
 
-configurations {
-  entitlementBridge {
-    canBeConsumed = false
-  }
-}
-
 dependencies {
   clusterPlugins project(':qa:entitlements')
-  entitlementBridge project(':libs:entitlement:bridge')
-}
-
-tasks.named('javaRestTest') {
-  systemProperty "tests.entitlement-bridge.jar-name", configurations.entitlementBridge.singleFile.getName()
-  usesDefaultDistribution()
-  systemProperty "tests.security.manager", "false"
 }
 
 tasks.named("javadoc").configure {

--- a/qa/entitlements/src/javaRestTest/java/org/elasticsearch/test/entitlements/EntitlementsIT.java
+++ b/qa/entitlements/src/javaRestTest/java/org/elasticsearch/test/entitlements/EntitlementsIT.java
@@ -10,9 +10,7 @@
 package org.elasticsearch.test.entitlements;
 
 import org.elasticsearch.client.Request;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.ClassRule;
 
@@ -20,21 +18,13 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
 
-@ESTestCase.WithoutSecurityManager
 public class EntitlementsIT extends ESRestTestCase {
-
-    private static final String ENTITLEMENT_BRIDGE_JAR_NAME = System.getProperty("tests.entitlement-bridge.jar-name");
 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.INTEG_TEST)
         .plugin("entitlement-qa")
         .systemProperty("es.entitlements.enabled", "true")
         .setting("xpack.security.enabled", "false")
-        .jvmArg("-Djdk.attach.allowAttachSelf=true")
-        .jvmArg("-XX:+EnableDynamicAgentLoading")
-        .jvmArg("--patch-module=java.base=lib/entitlement-bridge/" + ENTITLEMENT_BRIDGE_JAR_NAME)
-        .jvmArg("--add-exports=java.base/org.elasticsearch.entitlement.bridge=org.elasticsearch.entitlement")
         .build();
 
     @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -59,6 +59,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.function.Predicate.not;
 import static org.elasticsearch.test.cluster.local.distribution.DistributionType.DEFAULT;
 import static org.elasticsearch.test.cluster.util.OS.WINDOWS;
 
@@ -755,18 +756,16 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
             }
 
             String heapSize = System.getProperty("tests.heap.size", "512m");
-            final String esJavaOpts = Stream.of(
-                "-Xms" + heapSize,
-                "-Xmx" + heapSize,
-                "-ea",
-                "-esa",
-                System.getProperty("tests.jvm.argline", ""),
-                featureFlagProperties,
-                systemProperties,
-                jvmArgs,
-                debugArgs
-            ).filter(s -> s.isEmpty() == false).collect(Collectors.joining(" "));
+            List<String> serverOpts = List.of("-Xms" + heapSize, "-Xmx" + heapSize, debugArgs, featureFlagProperties);
+            List<String> commonOpts = List.of("-ea", "-esa", System.getProperty("tests.jvm.argline", ""), systemProperties, jvmArgs);
+
+            String esJavaOpts = Stream.concat(serverOpts.stream(), commonOpts.stream())
+                .filter(not(String::isEmpty))
+                .collect(Collectors.joining(" "));
+            String cliJavaOpts = commonOpts.stream().filter(not(String::isEmpty)).collect(Collectors.joining(" "));
+
             environment.put("ES_JAVA_OPTS", esJavaOpts);
+            environment.put("CLI_JAVA_OPTS", cliJavaOpts);
 
             return environment;
         }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Simplify entitlement agent REST tests (#116779)