### PR TITLE
[8.x] ESQL: Honor skip_unavailable setting for nonmatching indices errors at planning time (#116348)

### DIFF
--- a/docs/changelog/116348.yaml
+++ b/docs/changelog/116348.yaml
@@ -1,0 +1,5 @@
+pr: 116348
+summary: "ESQL: Honor skip_unavailable setting for nonmatching indices errors at planning time"
+area: ES|QL
+type: enhancement
+issues: [ 114531 ]

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersQueryIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.action;
 import org.elasticsearch.Build;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Priority;
@@ -21,12 +22,16 @@ import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
@@ -35,30 +40,36 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
-    private static final String REMOTE_CLUSTER = "cluster-a";
+    private static final String REMOTE_CLUSTER_1 = "cluster-a";
+    private static final String REMOTE_CLUSTER_2 = "remote-b";
 
     @Override
     protected Collection<String> remoteClusterAlias() {
-        return List.of(REMOTE_CLUSTER);
+        return List.of(REMOTE_CLUSTER_1, REMOTE_CLUSTER_2);
     }
 
     @Override
     protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
-        return Map.of(REMOTE_CLUSTER, randomBoolean());
+        return Map.of(REMOTE_CLUSTER_1, randomBoolean());
     }
 
     @Override
@@ -90,7 +101,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
         Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
         Boolean requestIncludeMeta = includeCCSMetadata.v1();
         boolean responseExpectMeta = includeCCSMetadata.v2();
-        try (EsqlQueryResponse resp = runQuery("from logs-*,*:logs-* | stats sum (v)", requestIncludeMeta)) {
+        try (EsqlQueryResponse resp = runQuery("from logs-*,c*:logs-* | stats sum (v)", requestIncludeMeta)) {
             List<List<Object>> values = getValuesList(resp);
             assertThat(values, hasSize(1));
             assertThat(values.get(0), equalTo(List.of(330L)));
@@ -102,9 +113,9 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
             assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, LOCAL_CLUSTER)));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("logs-*"));
             assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
             assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -128,7 +139,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertClusterMetadataInResponse(resp, responseExpectMeta);
         }
 
-        try (EsqlQueryResponse resp = runQuery("from logs-*,*:logs-* | stats count(*) by tag | sort tag | keep tag", requestIncludeMeta)) {
+        try (EsqlQueryResponse resp = runQuery("from logs-*,c*:logs-* | stats count(*) by tag | sort tag | keep tag", requestIncludeMeta)) {
             List<List<Object>> values = getValuesList(resp);
             assertThat(values, hasSize(2));
             assertThat(values.get(0), equalTo(List.of("local")));
@@ -141,9 +152,9 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
             assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, LOCAL_CLUSTER)));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("logs-*"));
             assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
             assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -168,171 +179,695 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
         }
     }
 
-    public void testSearchesWhereMissingIndicesAreSpecified() {
-        Map<String, Object> testClusterInfo = setupTwoClusters();
-        int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
-        int remoteNumShards = (Integer) testClusterInfo.get("remote.num_shards");
+    public void testSearchesAgainstNonMatchingIndicesWithLocalOnly() {
+        Map<String, Object> testClusterInfo = setupClusters(2);
+        String localIndex = (String) testClusterInfo.get("local.index");
+
+        {
+            String q = "FROM nomatch," + localIndex;
+            IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> runQuery(q, false));
+            assertThat(e.getDetailedMessage(), containsString("no such index [nomatch]"));
+
+            // MP TODO: am I able to fix this from the field-caps call? Yes, if we detect concrete vs. wildcard expressions in user query
+            // TODO bug - this does not throw; uncomment this test once https://github.com/elastic/elasticsearch/issues/114495 is fixed
+            // String limit0 = q + " | LIMIT 0";
+            // VerificationException ve = expectThrows(VerificationException.class, () -> runQuery(limit0, false));
+            // assertThat(ve.getDetailedMessage(), containsString("No matching indices for [nomatch]"));
+        }
+
+        {
+            // no failure since concrete index matches, so wildcard matching is lenient
+            String q = "FROM nomatch*," + localIndex;
+            try (EsqlQueryResponse resp = runQuery(q, false)) {
+                // we are only testing that this does not throw an Exception, so the asserts below are minimal
+                assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.isCrossClusterSearch(), is(false));
+            }
+
+            String limit0 = q + " | LIMIT 0";
+            try (EsqlQueryResponse resp = runQuery(limit0, false)) {
+                // we are only testing that this does not throw an Exception, so the asserts below are minimal
+                assertThat(resp.columns().size(), greaterThanOrEqualTo(1));
+                assertThat(getValuesList(resp).size(), equalTo(0));
+                EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                assertThat(executionInfo.isCrossClusterSearch(), is(false));
+            }
+        }
+        {
+            String q = "FROM nomatch";
+            VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, false));
+            assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch]"));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(VerificationException.class, () -> runQuery(limit0, false));
+            assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch]"));
+        }
+        {
+            String q = "FROM nomatch*";
+            VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, false));
+            assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch*]"));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(VerificationException.class, () -> runQuery(limit0, false));
+            assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch*]"));
+        }
+    }
+
+    public void testSearchesAgainstIndicesWithNoMappingsSkipUnavailableTrue() {
+        int numClusters = 2;
+        setupClusters(numClusters);
+        Map<String, String> clusterToEmptyIndexMap = createEmptyIndicesWithNoMappings(numClusters);
+        setSkipUnavailable(REMOTE_CLUSTER_1, randomBoolean());
 
         Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
         Boolean requestIncludeMeta = includeCCSMetadata.v1();
         boolean responseExpectMeta = includeCCSMetadata.v2();
 
-        // since a valid local index was specified, the invalid index on cluster-a does not throw an exception,
-        // but instead is simply ignored - ensure this is captured in the EsqlExecutionInfo
-        try (EsqlQueryResponse resp = runQuery("from logs-*,cluster-a:no_such_index | stats sum (v)", requestIncludeMeta)) {
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values, hasSize(1));
-            assertThat(values.get(0), equalTo(List.of(45L)));
+        try {
+            String emptyIndex = clusterToEmptyIndexMap.get(REMOTE_CLUSTER_1);
+            String q = Strings.format("FROM cluster-a:%s", emptyIndex);
+            // query without referring to fields should work
+            {
+                String limit1 = q + " | LIMIT 1";
+                try (EsqlQueryResponse resp = runQuery(limit1, requestIncludeMeta)) {
+                    assertThat(resp.columns().size(), equalTo(1));
+                    assertThat(resp.columns().get(0).name(), equalTo("<no-fields>"));
+                    assertThat(getValuesList(resp).size(), equalTo(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(new ExpectedCluster(REMOTE_CLUSTER_1, emptyIndex, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0))
+                    );
+                }
 
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            long overallTookMillis = executionInfo.overallTook().millis();
-            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
-            assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(resp.columns().size(), equalTo(1));
+                    assertThat(resp.columns().get(0).name(), equalTo("<no-fields>"));
+                    assertThat(getValuesList(resp).size(), equalTo(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(new ExpectedCluster(REMOTE_CLUSTER_1, emptyIndex, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0))
+                    );
+                }
+            }
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+            // query that refers to missing fields should throw:
+            // "type": "verification_exception",
+            // "reason": "Found 1 problem\nline 2:7: Unknown column [foo]",
+            {
+                String keepQuery = q + " | KEEP foo | LIMIT 100";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(keepQuery, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown column [foo]"));
+            }
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));  // 0 since no matching index, thus no shards to search
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
-
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+        } finally {
+            clearSkipUnavailable();
         }
+    }
 
-        // since the remote cluster has a valid index expression, the missing local index is ignored
-        // make this is captured in the EsqlExecutionInfo
-        try (
-            EsqlQueryResponse resp = runQuery(
-                "from no_such_index,*:logs-* | stats count(*) by tag | sort tag | keep tag",
-                requestIncludeMeta
-            )
-        ) {
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values, hasSize(1));
-            assertThat(values.get(0), equalTo(List.of("remote")));
+    public void testSearchesAgainstNonMatchingIndicesWithSkipUnavailableTrue() {
+        int numClusters = 3;
+        Map<String, Object> testClusterInfo = setupClusters(numClusters);
+        int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
+        int remote1NumShards = (Integer) testClusterInfo.get("remote.num_shards");
+        int remote2NumShards = (Integer) testClusterInfo.get("remote2.num_shards");
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remote1Index = (String) testClusterInfo.get("remote.index");
+        String remote2Index = (String) testClusterInfo.get("remote2.index");
 
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            long overallTookMillis = executionInfo.overallTook().millis();
-            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
-            assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+        createIndexAliases(numClusters);
+        setSkipUnavailable(REMOTE_CLUSTER_1, true);
+        setSkipUnavailable(REMOTE_CLUSTER_2, true);
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+        Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
+        Boolean requestIncludeMeta = includeCCSMetadata.v1();
+        boolean responseExpectMeta = includeCCSMetadata.v2();
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+        try {
+            // missing concrete local index is fatal
+            {
+                String q = "FROM nomatch,cluster-a:" + randomFrom(remote1Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch]"));
 
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("no_such_index"));
-            // TODO: a follow on PR will change this to throw an Exception when the local cluster requests a concrete index that is missing
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(0));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch]"));
+            }
+
+            // missing concrete remote index is not fatal when skip_unavailable=true (as long as an index matches on another cluster)
+            {
+                String localIndexName = randomFrom(localIndex, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM %s,cluster-a:nomatch", localIndexName);
+                try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            new ExpectedCluster(LOCAL_CLUSTER, localIndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, localNumShards),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0)
+                        )
+                    );
+                }
+
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(resp.columns().size(), greaterThan(0));
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            new ExpectedCluster(LOCAL_CLUSTER, localIndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0)
+                        )
+                    );
+                }
+            }
+
+            // since there is at least one matching index in the query, the missing wildcarded local index is not an error
+            {
+                String remoteIndexName = randomFrom(remote1Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = "FROM nomatch*,cluster-a:" + remoteIndexName;
+                try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(
+                                REMOTE_CLUSTER_1,
+                                remoteIndexName,
+                                EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                                remote1NumShards
+                            )
+                        )
+                    );
+                }
+
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), equalTo(0));
+                    assertThat(resp.columns().size(), greaterThan(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            // LIMIT 0 searches always have total shards = 0
+                            new ExpectedCluster(REMOTE_CLUSTER_1, remoteIndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0)
+                        )
+                    );
+                }
+            }
+
+            // since at least one index of the query matches on some cluster, a wildcarded index on skip_un=true is not an error
+            {
+                String localIndexName = randomFrom(localIndex, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM %s,cluster-a:nomatch*", localIndexName);
+                try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            new ExpectedCluster(LOCAL_CLUSTER, localIndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, localNumShards),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch*", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0)
+                        )
+                    );
+                }
+
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(resp.columns().size(), greaterThan(0));
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            new ExpectedCluster(LOCAL_CLUSTER, localIndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch*", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0)
+                        )
+                    );
+                }
+            }
+
+            // an error is thrown if there are no matching indices at all, even when the cluster is skip_unavailable=true
+            {
+                // with non-matching concrete index
+                String q = "FROM cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+            }
+
+            // an error is thrown if there are no matching indices at all, even when the cluster is skip_unavailable=true and the
+            // index was wildcarded
+            {
+                // with non-matching wildcard index
+                String q = "FROM cluster-a:nomatch*";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with wildcard, remote with concrete
+            {
+                String q = "FROM nomatch*,cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with wildcard, remote with wildcard
+            {
+                String q = "FROM nomatch*,cluster-a:nomatch*";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with concrete, remote with concrete
+            {
+                String q = "FROM nomatch,cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with concrete, remote with wildcard
+            {
+                String q = "FROM nomatch,cluster-a:nomatch*";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch]"));
+            }
+
+            // since cluster-a is skip_unavailable=true and at least one cluster has a matching indices, no error is thrown
+            {
+                // TODO solve in follow-on PR which does skip_unavailable handling at execution time
+                // String q = Strings.format("FROM %s,cluster-a:nomatch,cluster-a:%s*", localIndex, remote1Index);
+                // try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                // assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                // EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                // assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                // assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                // assertExpectedClustersForMissingIndicesTests(executionInfo, List.of(
+                // // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                // new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0),
+                // new ExpectedCluster(REMOTE_CLUSTER_1, "*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, remote2NumShards)
+                // ));
+                // }
+
+                // TODO: handle LIMIT 0 for this case in follow-on PR
+                // String limit0 = q + " | LIMIT 0";
+                // try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                // assertThat(resp.columns().size(), greaterThanOrEqualTo(1));
+                // assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(0));
+                // EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                // assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                // assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                // assertExpectedClustersForMissingIndicesTests(executionInfo, List.of(
+                // // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                // new ExpectedCluster(LOCAL_CLUSTER, localIndex, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                // new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch," + remote1Index + "*", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0)
+                // ));
+                // }
+            }
+
+            // tests with three clusters ---
+
+            // since cluster-a is skip_unavailable=true and at least one cluster has a matching indices, no error is thrown
+            // cluster-a should be marked as SKIPPED with VerificationException
+            {
+                String remote2IndexName = randomFrom(remote2Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM nomatch*,cluster-a:nomatch,%s:%s", REMOTE_CLUSTER_2, remote2IndexName);
+                try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0),
+                            new ExpectedCluster(
+                                REMOTE_CLUSTER_2,
+                                remote2IndexName,
+                                EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                                remote2NumShards
+                            )
+                        )
+                    );
+                }
+
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(resp.columns().size(), greaterThanOrEqualTo(1));
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_2, remote2IndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0)
+                        )
+                    );
+                }
+            }
+
+            // since cluster-a is skip_unavailable=true and at least one cluster has a matching indices, no error is thrown
+            // cluster-a should be marked as SKIPPED with a "NoMatchingIndicesException" since a wildcard index was requested
+            {
+                String remote2IndexName = randomFrom(remote2Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM nomatch*,cluster-a:nomatch*,%s:%s", REMOTE_CLUSTER_2, remote2IndexName);
+                try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch*", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0),
+                            new ExpectedCluster(
+                                REMOTE_CLUSTER_2,
+                                remote2IndexName,
+                                EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                                remote2NumShards
+                            )
+                        )
+                    );
+                }
+
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(resp.columns().size(), greaterThanOrEqualTo(1));
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_1, "nomatch*", EsqlExecutionInfo.Cluster.Status.SKIPPED, 0),
+                            new ExpectedCluster(REMOTE_CLUSTER_2, remote2IndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0)
+                        )
+                    );
+                }
+            }
+        } finally {
+            clearSkipUnavailable();
         }
+    }
 
-        // when multiple invalid indices are specified on the remote cluster, both should be ignored and present
-        // in the index expression of the EsqlExecutionInfo and with an indication that zero shards were searched
-        try (
-            EsqlQueryResponse resp = runQuery(
-                "FROM no_such_index*,*:no_such_index1,*:no_such_index2,logs-1 | STATS COUNT(*) by tag | SORT tag | KEEP tag",
-                requestIncludeMeta
-            )
-        ) {
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values, hasSize(1));
-            assertThat(values.get(0), equalTo(List.of("local")));
+    public void testSearchesAgainstNonMatchingIndicesWithSkipUnavailableFalse() {
+        int numClusters = 3;
+        Map<String, Object> testClusterInfo = setupClusters(numClusters);
+        int remote1NumShards = (Integer) testClusterInfo.get("remote.num_shards");
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remote1Index = (String) testClusterInfo.get("remote.index");
+        String remote2Index = (String) testClusterInfo.get("remote2.index");
 
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            long overallTookMillis = executionInfo.overallTook().millis();
-            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
-            assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+        createIndexAliases(numClusters);
+        setSkipUnavailable(REMOTE_CLUSTER_1, false);
+        setSkipUnavailable(REMOTE_CLUSTER_2, false);
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+        Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
+        Boolean requestIncludeMeta = includeCCSMetadata.v1();
+        boolean responseExpectMeta = includeCCSMetadata.v2();
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index1,no_such_index2"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+        try {
+            // missing concrete local index is an error
+            {
+                String q = "FROM nomatch,cluster-a:" + remote1Index;
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch]"));
 
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("no_such_index*,logs-1"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [nomatch]"));
+            }
+
+            // missing concrete remote index is fatal when skip_unavailable=false
+            {
+                String q = "FROM logs*,cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+            }
+
+            // No error since local non-matching has wildcard and the remote cluster matches
+            {
+                String remote1IndexName = randomFrom(remote1Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM nomatch*,%s:%s", REMOTE_CLUSTER_1, remote1IndexName);
+                try (EsqlQueryResponse resp = runQuery(q, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), greaterThanOrEqualTo(1));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matcing indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            new ExpectedCluster(
+                                REMOTE_CLUSTER_1,
+                                remote1IndexName,
+                                EsqlExecutionInfo.Cluster.Status.SUCCESSFUL,
+                                remote1NumShards
+                            )
+                        )
+                    );
+                }
+
+                String limit0 = q + " | LIMIT 0";
+                try (EsqlQueryResponse resp = runQuery(limit0, requestIncludeMeta)) {
+                    assertThat(getValuesList(resp).size(), equalTo(0));
+                    assertThat(resp.columns().size(), greaterThan(0));
+                    EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
+                    assertThat(executionInfo.isCrossClusterSearch(), is(true));
+                    assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+                    assertExpectedClustersForMissingIndicesTests(
+                        executionInfo,
+                        List.of(
+                            // local cluster is never marked as SKIPPED even when no matcing indices - just marked as 0 shards searched
+                            new ExpectedCluster(LOCAL_CLUSTER, "nomatch*", EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0),
+                            // LIMIT 0 searches always have total shards = 0
+                            new ExpectedCluster(REMOTE_CLUSTER_1, remote1IndexName, EsqlExecutionInfo.Cluster.Status.SUCCESSFUL, 0)
+                        )
+                    );
+                }
+            }
+
+            // query is fatal since cluster-a has skip_unavailable=false and has no matching indices
+            {
+                String q = Strings.format("FROM %s,cluster-a:nomatch*", randomFrom(localIndex, IDX_ALIAS, FILTERED_IDX_ALIAS));
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - single remote cluster with concrete index expression
+            {
+                String q = "FROM cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - single remote cluster with wildcard index expression
+            {
+                String q = "FROM cluster-a:nomatch*";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with wildcard, remote with concrete
+            {
+                String q = "FROM nomatch*,cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with wildcard, remote with wildcard
+            {
+                String q = "FROM nomatch*,cluster-a:nomatch*";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch*]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with concrete, remote with concrete
+            {
+                String q = "FROM nomatch,cluster-a:nomatch";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch,nomatch]"));
+            }
+
+            // an error is thrown if there are no matching indices at all - local with concrete, remote with wildcard
+            {
+                String q = "FROM nomatch,cluster-a:nomatch*";
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch]"));
+            }
+
+            // Missing concrete index on skip_unavailable=false cluster is a fatal error, even when another index expression
+            // against that cluster matches
+            {
+                String remote2IndexName = randomFrom(remote2Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM %s,cluster-a:nomatch,cluster-a:%s*", localIndex, remote2IndexName);
+                IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("no such index [nomatch]"));
+
+                // TODO: in follow on PR, add support for throwing a VerificationException from this scenario
+                // String limit0 = q + " | LIMIT 0";
+                // VerificationException e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                // assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*,nomatch]"));
+            }
+
+            // --- test against 3 clusters
+
+            // skip_unavailable=false cluster having no matching indices is a fatal error. This error
+            // is fatal at plan time, so it throws VerificationException, not IndexNotFoundException (thrown at execution time)
+            {
+                String localIndexName = randomFrom(localIndex, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String remote2IndexName = randomFrom(remote2Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM %s*,cluster-a:nomatch,%s:%s*", localIndexName, REMOTE_CLUSTER_2, remote2IndexName);
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch]"));
+            }
+
+            // skip_unavailable=false cluster having no matching indices is a fatal error (even if wildcarded)
+            {
+                String localIndexName = randomFrom(localIndex, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String remote2IndexName = randomFrom(remote2Index, IDX_ALIAS, FILTERED_IDX_ALIAS);
+                String q = Strings.format("FROM %s*,cluster-a:nomatch*,%s:%s*", localIndexName, REMOTE_CLUSTER_2, remote2IndexName);
+                VerificationException e = expectThrows(VerificationException.class, () -> runQuery(q, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+
+                String limit0 = q + " | LIMIT 0";
+                e = expectThrows(VerificationException.class, () -> runQuery(limit0, requestIncludeMeta));
+                assertThat(e.getDetailedMessage(), containsString("Unknown index [cluster-a:nomatch*]"));
+            }
+        } finally {
+            clearSkipUnavailable();
         }
+    }
 
-        // wildcard on remote cluster that matches nothing - should be present in EsqlExecutionInfo marked as SKIPPED, no shards searched
-        try (EsqlQueryResponse resp = runQuery("from cluster-a:no_such_index*,logs-* | stats sum (v)", requestIncludeMeta)) {
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            List<List<Object>> values = getValuesList(resp);
-            assertThat(values, hasSize(1));
-            assertThat(values.get(0), equalTo(List.of(45L)));
+    record ExpectedCluster(String clusterAlias, String indexExpression, EsqlExecutionInfo.Cluster.Status status, Integer totalShards) {}
 
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            long overallTookMillis = executionInfo.overallTook().millis();
-            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
-            assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
+    public void assertExpectedClustersForMissingIndicesTests(EsqlExecutionInfo executionInfo, List<ExpectedCluster> expected) {
+        long overallTookMillis = executionInfo.overallTook().millis();
+        assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+        Set<String> expectedClusterAliases = expected.stream().map(c -> c.clusterAlias()).collect(Collectors.toSet());
+        assertThat(executionInfo.clusterAliases(), equalTo(expectedClusterAliases));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
-
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+        for (ExpectedCluster expectedCluster : expected) {
+            EsqlExecutionInfo.Cluster cluster = executionInfo.getCluster(expectedCluster.clusterAlias());
+            String msg = cluster.getClusterAlias();
+            assertThat(msg, cluster.getIndexExpression(), equalTo(expectedCluster.indexExpression()));
+            assertThat(msg, cluster.getStatus(), equalTo(expectedCluster.status()));
+            assertThat(msg, cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+            assertThat(msg, cluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
+            assertThat(msg, cluster.getTotalShards(), equalTo(expectedCluster.totalShards()));
+            if (cluster.getStatus() == EsqlExecutionInfo.Cluster.Status.SUCCESSFUL) {
+                assertThat(msg, cluster.getSuccessfulShards(), equalTo(expectedCluster.totalShards()));
+                assertThat(msg, cluster.getSkippedShards(), equalTo(0));
+            } else if (cluster.getStatus() == EsqlExecutionInfo.Cluster.Status.SKIPPED) {
+                assertThat(msg, cluster.getSuccessfulShards(), equalTo(0));
+                assertThat(msg, cluster.getSkippedShards(), equalTo(expectedCluster.totalShards()));
+                assertThat(msg, cluster.getFailures().size(), equalTo(1));
+                assertThat(msg, cluster.getFailures().get(0).getCause(), instanceOf(VerificationException.class));
+                String expectedMsg = "Unknown index [" + expectedCluster.indexExpression() + "]";
+                assertThat(msg, cluster.getFailures().get(0).getCause().getMessage(), containsString(expectedMsg));
+            }
+            // currently failed shards is always zero - change this once we start allowing partial data for individual shard failures
+            assertThat(msg, cluster.getFailedShards(), equalTo(0));
         }
     }
 
@@ -359,6 +894,10 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
         }
 
+        // skip_un must be true for the next test or it will fail on "cluster-a:no_such_index*" with a
+        // VerificationException because there are no matching indices for that skip_un=false cluster.
+        setSkipUnavailable(REMOTE_CLUSTER_1, true);
+
         // cluster-foo* matches nothing and so should not be present in the EsqlExecutionInfo
         try (
             EsqlQueryResponse resp = runQuery(
@@ -376,9 +915,9 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
             assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
 
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, LOCAL_CLUSTER)));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index*"));
             assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
             assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -395,6 +934,8 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
             assertThat(localCluster.getSkippedShards(), equalTo(0));
             assertThat(localCluster.getFailedShards(), equalTo(0));
+        } finally {
+            clearSkipUnavailable();
         }
     }
 
@@ -403,10 +944,12 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
      * (which involves cross-cluster field-caps calls), it is a coordinator only operation at query time
      * which uses a different pathway compared to queries that require data node (and remote data node) operations
      * at query time.
+     *
+     * Note: the tests covering "nonmatching indices" also do LIMIT 0 tests.
+     * This one is mostly focuses on took time values.
      */
     public void testCCSExecutionOnSearchesWithLimit0() {
         setupTwoClusters();
-
         Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
         Boolean requestIncludeMeta = includeCCSMetadata.v1();
         boolean responseExpectMeta = includeCCSMetadata.v2();
@@ -427,9 +970,9 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             long overallTookMillis = executionInfo.overallTook().millis();
             assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
             assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
+            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, LOCAL_CLUSTER)));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("*"));
             assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
             assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -441,66 +984,6 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
-        }
-
-        try (EsqlQueryResponse resp = runQuery("FROM logs*,cluster-a:nomatch* | LIMIT 0", requestIncludeMeta)) {
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            long overallTookMillis = executionInfo.overallTook().millis();
-            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
-            assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
-
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("nomatch*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
-
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(0));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
-        }
-
-        try (EsqlQueryResponse resp = runQuery("FROM nomatch*,cluster-a:* | LIMIT 0", requestIncludeMeta)) {
-            EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
-            assertNotNull(executionInfo);
-            assertThat(executionInfo.isCrossClusterSearch(), is(true));
-            long overallTookMillis = executionInfo.overallTook().millis();
-            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
-            assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
-            assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER, LOCAL_CLUSTER)));
-
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
-
-            EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("nomatch*"));
             assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
             assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
             assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
@@ -536,7 +1019,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
             assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
             assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
             assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -571,12 +1054,12 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).put("index.routing.rebalance.enable", "none"))
             .get();
         waitForNoInitializingShards(client(LOCAL_CLUSTER), TimeValue.timeValueSeconds(30), "logs-1");
-        client(REMOTE_CLUSTER).admin()
+        client(REMOTE_CLUSTER_1).admin()
             .indices()
             .prepareUpdateSettings("logs-2")
             .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).put("index.routing.rebalance.enable", "none"))
             .get();
-        waitForNoInitializingShards(client(REMOTE_CLUSTER), TimeValue.timeValueSeconds(30), "logs-2");
+        waitForNoInitializingShards(client(REMOTE_CLUSTER_1), TimeValue.timeValueSeconds(30), "logs-2");
         final int localOnlyProfiles;
         {
             EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
@@ -593,7 +1076,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
 
                 EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
                 assertNotNull(executionInfo);
-                EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+                EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
                 assertNull(remoteCluster);
                 assertThat(executionInfo.isCrossClusterSearch(), is(false));
                 assertThat(executionInfo.includeCCSMetadata(), is(false));
@@ -621,7 +1104,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
                 assertThat(executionInfo.includeCCSMetadata(), is(false));
                 assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-                EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+                EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
                 assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
                 assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
                 assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -654,7 +1137,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
                 assertThat(executionInfo.includeCCSMetadata(), is(false));
                 assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-                EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+                EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
                 assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
                 assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
                 assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -704,7 +1187,7 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             assertThat(executionInfo.includeCCSMetadata(), is(false));
             assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
-            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER);
+            EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
             assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
             assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
@@ -792,28 +1275,135 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
     }
 
     Map<String, Object> setupTwoClusters() {
-        String localIndex = "logs-1";
-        int numShardsLocal = randomIntBetween(1, 5);
-        populateLocalIndices(localIndex, numShardsLocal);
+        return setupClusters(2);
+    }
 
-        String remoteIndex = "logs-2";
+    private static String LOCAL_INDEX = "logs-1";
+    private static String IDX_ALIAS = "alias1";
+    private static String FILTERED_IDX_ALIAS = "alias-filtered-1";
+    private static String REMOTE_INDEX = "logs-2";
+
+    Map<String, Object> setupClusters(int numClusters) {
+        assert numClusters == 2 || numClusters == 3 : "2 or 3 clusters supported not: " + numClusters;
+        int numShardsLocal = randomIntBetween(1, 5);
+        populateLocalIndices(LOCAL_INDEX, numShardsLocal);
+
         int numShardsRemote = randomIntBetween(1, 5);
-        populateRemoteIndices(remoteIndex, numShardsRemote);
+        populateRemoteIndices(REMOTE_CLUSTER_1, REMOTE_INDEX, numShardsRemote);
 
         Map<String, Object> clusterInfo = new HashMap<>();
         clusterInfo.put("local.num_shards", numShardsLocal);
-        clusterInfo.put("local.index", localIndex);
+        clusterInfo.put("local.index", LOCAL_INDEX);
         clusterInfo.put("remote.num_shards", numShardsRemote);
-        clusterInfo.put("remote.index", remoteIndex);
+        clusterInfo.put("remote.index", REMOTE_INDEX);
 
-        String skipUnavailableKey = Strings.format("cluster.remote.%s.skip_unavailable", REMOTE_CLUSTER);
-        Setting<?> skipUnavailableSetting = cluster(REMOTE_CLUSTER).clusterService().getClusterSettings().get(skipUnavailableKey);
+        if (numClusters == 3) {
+            int numShardsRemote2 = randomIntBetween(1, 5);
+            populateRemoteIndices(REMOTE_CLUSTER_2, REMOTE_INDEX, numShardsRemote2);
+            clusterInfo.put("remote2.index", REMOTE_INDEX);
+            clusterInfo.put("remote2.num_shards", numShardsRemote2);
+        }
+
+        String skipUnavailableKey = Strings.format("cluster.remote.%s.skip_unavailable", REMOTE_CLUSTER_1);
+        Setting<?> skipUnavailableSetting = cluster(REMOTE_CLUSTER_1).clusterService().getClusterSettings().get(skipUnavailableKey);
         boolean skipUnavailable = (boolean) cluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).clusterService()
             .getClusterSettings()
             .get(skipUnavailableSetting);
         clusterInfo.put("remote.skip_unavailable", skipUnavailable);
 
         return clusterInfo;
+    }
+
+    /**
+     * For the local cluster and REMOTE_CLUSTER_1 it creates a standard alias to the index created in populateLocalIndices
+     * and populateRemoteIndices. It also creates a filtered alias against those indices that looks like:
+     * PUT /_aliases
+     * {
+     *   "actions": [
+     *     {
+     *       "add": {
+     *         "index": "my_index",
+     *         "alias": "my_alias",
+     *         "filter": {
+     *           "terms": {
+     *             "v": [1, 2, 4]
+     *           }
+     *         }
+     *       }
+     *     }
+     *   ]
+     * }
+     */
+    void createIndexAliases(int numClusters) {
+        assert numClusters == 2 || numClusters == 3 : "Only 2 or 3 clusters allowed in createIndexAliases";
+
+        int[] allowed = new int[] { 1, 2, 4 };
+        QueryBuilder filterBuilder = new TermsQueryBuilder("v", allowed);
+
+        {
+            Client localClient = client(LOCAL_CLUSTER);
+            IndicesAliasesResponse indicesAliasesResponse = localClient.admin()
+                .indices()
+                .prepareAliases()
+                .addAlias(LOCAL_INDEX, IDX_ALIAS)
+                .addAlias(LOCAL_INDEX, FILTERED_IDX_ALIAS, filterBuilder)
+                .get();
+            assertFalse(indicesAliasesResponse.hasErrors());
+        }
+        {
+            Client remoteClient = client(REMOTE_CLUSTER_1);
+            IndicesAliasesResponse indicesAliasesResponse = remoteClient.admin()
+                .indices()
+                .prepareAliases()
+                .addAlias(REMOTE_INDEX, IDX_ALIAS)
+                .addAlias(REMOTE_INDEX, FILTERED_IDX_ALIAS, filterBuilder)
+                .get();
+            assertFalse(indicesAliasesResponse.hasErrors());
+        }
+        if (numClusters == 3) {
+            Client remoteClient = client(REMOTE_CLUSTER_2);
+            IndicesAliasesResponse indicesAliasesResponse = remoteClient.admin()
+                .indices()
+                .prepareAliases()
+                .addAlias(REMOTE_INDEX, IDX_ALIAS)
+                .addAlias(REMOTE_INDEX, FILTERED_IDX_ALIAS, filterBuilder)
+                .get();
+            assertFalse(indicesAliasesResponse.hasErrors());
+        }
+    }
+
+    Map<String, String> createEmptyIndicesWithNoMappings(int numClusters) {
+        assert numClusters == 2 || numClusters == 3 : "Only 2 or 3 clusters supported in createEmptyIndicesWithNoMappings";
+
+        Map<String, String> clusterToEmptyIndexMap = new HashMap<>();
+
+        String localIndexName = randomAlphaOfLength(14).toLowerCase(Locale.ROOT) + "1";
+        clusterToEmptyIndexMap.put(LOCAL_CLUSTER, localIndexName);
+        Client localClient = client(LOCAL_CLUSTER);
+        assertAcked(
+            localClient.admin().indices().prepareCreate(localIndexName).setSettings(Settings.builder().put("index.number_of_shards", 1))
+        );
+
+        String remote1IndexName = randomAlphaOfLength(14).toLowerCase(Locale.ROOT) + "2";
+        clusterToEmptyIndexMap.put(REMOTE_CLUSTER_1, remote1IndexName);
+        Client remote1Client = client(REMOTE_CLUSTER_1);
+        assertAcked(
+            remote1Client.admin().indices().prepareCreate(remote1IndexName).setSettings(Settings.builder().put("index.number_of_shards", 1))
+        );
+
+        if (numClusters == 3) {
+            String remote2IndexName = randomAlphaOfLength(14).toLowerCase(Locale.ROOT) + "3";
+            clusterToEmptyIndexMap.put(REMOTE_CLUSTER_2, remote2IndexName);
+            Client remote2Client = client(REMOTE_CLUSTER_2);
+            assertAcked(
+                remote2Client.admin()
+                    .indices()
+                    .prepareCreate(remote2IndexName)
+                    .setSettings(Settings.builder().put("index.number_of_shards", 1))
+            );
+        }
+
+        return clusterToEmptyIndexMap;
     }
 
     void populateLocalIndices(String indexName, int numShards) {
@@ -831,8 +1421,8 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
         localClient.admin().indices().prepareRefresh(indexName).get();
     }
 
-    void populateRemoteIndices(String indexName, int numShards) {
-        Client remoteClient = client(REMOTE_CLUSTER);
+    void populateRemoteIndices(String clusterAlias, String indexName, int numShards) {
+        Client remoteClient = client(clusterAlias);
         assertAcked(
             remoteClient.admin()
                 .indices()
@@ -844,5 +1434,24 @@ public class CrossClustersQueryIT extends AbstractMultiClustersTestCase {
             remoteClient.prepareIndex(indexName).setSource("id", "remote-" + i, "tag", "remote", "v", i * i).get();
         }
         remoteClient.admin().indices().prepareRefresh(indexName).get();
+    }
+
+    private void setSkipUnavailable(String clusterAlias, boolean skip) {
+        client(LOCAL_CLUSTER).admin()
+            .cluster()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .setPersistentSettings(Settings.builder().put("cluster.remote." + clusterAlias + ".skip_unavailable", skip).build())
+            .get();
+    }
+
+    private void clearSkipUnavailable() {
+        Settings.Builder settingsBuilder = Settings.builder()
+            .putNull("cluster.remote." + REMOTE_CLUSTER_1 + ".skip_unavailable")
+            .putNull("cluster.remote." + REMOTE_CLUSTER_2 + ".skip_unavailable");
+        client(LOCAL_CLUSTER).admin()
+            .cluster()
+            .prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+            .setPersistentSettings(settingsBuilder.build())
+            .get();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
@@ -12,22 +12,37 @@ import org.elasticsearch.core.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public final class IndexResolution {
 
-    public static IndexResolution valid(EsIndex index, Map<String, FieldCapabilitiesFailure> unavailableClusters) {
+    /**
+     * @param index EsIndex encapsulating requested index expression, resolved mappings and index modes from field-caps.
+     * @param resolvedIndices Set of concrete indices resolved by field-caps. (This information is not always present in the EsIndex).
+     * @param unavailableClusters Remote clusters that could not be contacted during planning
+     * @return valid IndexResolution
+     */
+    public static IndexResolution valid(
+        EsIndex index,
+        Set<String> resolvedIndices,
+        Map<String, FieldCapabilitiesFailure> unavailableClusters
+    ) {
         Objects.requireNonNull(index, "index must not be null if it was found");
+        Objects.requireNonNull(resolvedIndices, "resolvedIndices must not be null");
         Objects.requireNonNull(unavailableClusters, "unavailableClusters must not be null");
-        return new IndexResolution(index, null, unavailableClusters);
+        return new IndexResolution(index, null, resolvedIndices, unavailableClusters);
     }
 
+    /**
+     * Use this method only if the set of concrete resolved indices is the same as EsIndex#concreteIndices().
+     */
     public static IndexResolution valid(EsIndex index) {
-        return valid(index, Collections.emptyMap());
+        return valid(index, index.concreteIndices(), Collections.emptyMap());
     }
 
     public static IndexResolution invalid(String invalid) {
         Objects.requireNonNull(invalid, "invalid must not be null to signal that the index is invalid");
-        return new IndexResolution(null, invalid, Collections.emptyMap());
+        return new IndexResolution(null, invalid, Collections.emptySet(), Collections.emptyMap());
     }
 
     public static IndexResolution notFound(String name) {
@@ -39,12 +54,20 @@ public final class IndexResolution {
     @Nullable
     private final String invalid;
 
+    // all indices found by field-caps
+    private final Set<String> resolvedIndices;
     // remote clusters included in the user's index expression that could not be connected to
     private final Map<String, FieldCapabilitiesFailure> unavailableClusters;
 
-    private IndexResolution(EsIndex index, @Nullable String invalid, Map<String, FieldCapabilitiesFailure> unavailableClusters) {
+    private IndexResolution(
+        EsIndex index,
+        @Nullable String invalid,
+        Set<String> resolvedIndices,
+        Map<String, FieldCapabilitiesFailure> unavailableClusters
+    ) {
         this.index = index;
         this.invalid = invalid;
+        this.resolvedIndices = resolvedIndices;
         this.unavailableClusters = unavailableClusters;
     }
 
@@ -64,8 +87,8 @@ public final class IndexResolution {
     }
 
     /**
-     * Is the index valid for use with ql? Returns {@code false} if the
-     * index wasn't found.
+     * Is the index valid for use with ql?
+     * @return {@code false} if the index wasn't found.
      */
     public boolean isValid() {
         return invalid == null;
@@ -75,8 +98,15 @@ public final class IndexResolution {
      * @return Map of unavailable clusters (could not be connected to during field-caps query). Key of map is cluster alias,
      * value is the {@link FieldCapabilitiesFailure} describing the issue.
      */
-    public Map<String, FieldCapabilitiesFailure> getUnavailableClusters() {
+    public Map<String, FieldCapabilitiesFailure> unavailableClusters() {
         return unavailableClusters;
+    }
+
+    /**
+     * @return all indices found by field-caps (regardless of whether they had any mappings)
+     */
+    public Set<String> resolvedIndices() {
+        return resolvedIndices;
     }
 
     @Override
@@ -87,16 +117,29 @@ public final class IndexResolution {
         IndexResolution other = (IndexResolution) obj;
         return Objects.equals(index, other.index)
             && Objects.equals(invalid, other.invalid)
+            && Objects.equals(resolvedIndices, other.resolvedIndices)
             && Objects.equals(unavailableClusters, other.unavailableClusters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, invalid, unavailableClusters);
+        return Objects.hash(index, invalid, resolvedIndices, unavailableClusters);
     }
 
     @Override
     public String toString() {
-        return invalid != null ? invalid : index.name();
+        return invalid != null
+            ? invalid
+            : "IndexResolution{"
+                + "index="
+                + index
+                + ", invalid='"
+                + invalid
+                + '\''
+                + ", resolvedIndices="
+                + resolvedIndices
+                + ", unavailableClusters="
+                + unavailableClusters
+                + '}';
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -251,19 +251,17 @@ public class ComputeService {
         if (execInfo.isCrossClusterSearch()) {
             assert execInfo.planningTookTime() != null : "Planning took time should be set on EsqlExecutionInfo but is null";
             for (String clusterAlias : execInfo.clusterAliases()) {
-                // took time and shard counts for SKIPPED clusters were added at end of planning, so only update other cases here
-                if (execInfo.getCluster(clusterAlias).getStatus() != EsqlExecutionInfo.Cluster.Status.SKIPPED) {
-                    execInfo.swapCluster(
-                        clusterAlias,
-                        (k, v) -> new EsqlExecutionInfo.Cluster.Builder(v).setTook(execInfo.overallTook())
-                            .setStatus(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL)
-                            .setTotalShards(0)
-                            .setSuccessfulShards(0)
-                            .setSkippedShards(0)
-                            .setFailedShards(0)
-                            .build()
-                    );
-                }
+                execInfo.swapCluster(clusterAlias, (k, v) -> {
+                    var builder = new EsqlExecutionInfo.Cluster.Builder(v).setTook(execInfo.overallTook())
+                        .setTotalShards(0)
+                        .setSuccessfulShards(0)
+                        .setSkippedShards(0)
+                        .setFailedShards(0);
+                    if (v.getStatus() == EsqlExecutionInfo.Cluster.Status.RUNNING) {
+                        builder.setStatus(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL);
+                    }
+                    return builder.build();
+                });
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -309,7 +309,7 @@ public class EsqlSession {
                 // resolution to updateExecutionInfo
                 if (indexResolution.isValid()) {
                     EsqlSessionCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, indexResolution);
-                    EsqlSessionCCSUtils.updateExecutionInfoWithUnavailableClusters(executionInfo, indexResolution.getUnavailableClusters());
+                    EsqlSessionCCSUtils.updateExecutionInfoWithUnavailableClusters(executionInfo, indexResolution.unavailableClusters());
                     if (executionInfo.isCrossClusterSearch()
                         && executionInfo.getClusterStateCount(EsqlExecutionInfo.Cluster.Status.RUNNING) == 0) {
                         // for a CCS, if all clusters have been marked as SKIPPED, nothing to search so send a sentinel

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1MissingIndicesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1MissingIndicesIT.java
@@ -1,0 +1,574 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.remotecluster;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.hamcrest.Matchers;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Tests cross-cluster ES|QL queries under RCS1.0 security model for cases where index expressions do not match
+ * to ensure handling of those matches the expected rules defined in EsqlSessionCrossClusterUtils.
+ */
+public class CrossClusterEsqlRCS1MissingIndicesIT extends AbstractRemoteClusterSecurityTestCase {
+
+    private static final AtomicBoolean SSL_ENABLED_REF = new AtomicBoolean();
+
+    static {
+        // remote cluster
+        fulfillingCluster = ElasticsearchCluster.local()
+            .name("fulfilling-cluster")
+            .nodes(1)
+            .module("x-pack-esql")
+            .module("x-pack-enrich")
+            .apply(commonClusterConfig)
+            .setting("remote_cluster.port", "0")
+            .setting("xpack.ml.enabled", "false")
+            .setting("xpack.security.remote_cluster_server.ssl.enabled", () -> String.valueOf(SSL_ENABLED_REF.get()))
+            .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")
+            .setting("xpack.security.remote_cluster_server.ssl.certificate", "remote-cluster.crt")
+            .setting("xpack.security.authc.token.enabled", "true")
+            .keystore("xpack.security.remote_cluster_server.ssl.secure_key_passphrase", "remote-cluster-password")
+            .node(0, spec -> spec.setting("remote_cluster_server.enabled", "true"))
+            .build();
+
+        // "local" cluster
+        queryCluster = ElasticsearchCluster.local()
+            .name("query-cluster")
+            .module("x-pack-esql")
+            .module("x-pack-enrich")
+            .apply(commonClusterConfig)
+            .setting("xpack.ml.enabled", "false")
+            .setting("xpack.security.remote_cluster_client.ssl.enabled", () -> String.valueOf(SSL_ENABLED_REF.get()))
+            .build();
+    }
+
+    @ClassRule
+    public static TestRule clusterRule = RuleChain.outerRule(fulfillingCluster).around(queryCluster);
+
+    private static final String INDEX1 = "points"; // on local cluster only
+    private static final String INDEX2 = "squares"; // on local and remote clusters
+
+    record ExpectedCluster(String clusterAlias, String indexExpression, String status, Integer totalShards) {}
+
+    @SuppressWarnings("unchecked")
+    public void assertExpectedClustersForMissingIndicesTests(Map<String, Object> responseMap, List<ExpectedCluster> expected) {
+        Map<String, ?> clusters = (Map<String, ?>) responseMap.get("_clusters");
+        assertThat((int) responseMap.get("took"), greaterThan(0));
+
+        Map<String, ?> detailsMap = (Map<String, ?>) clusters.get("details");
+        assertThat(detailsMap.size(), is(expected.size()));
+
+        assertThat((int) clusters.get("total"), is(expected.size()));
+        assertThat((int) clusters.get("successful"), is((int) expected.stream().filter(ec -> ec.status().equals("successful")).count()));
+        assertThat((int) clusters.get("skipped"), is((int) expected.stream().filter(ec -> ec.status().equals("skipped")).count()));
+        assertThat((int) clusters.get("failed"), is((int) expected.stream().filter(ec -> ec.status().equals("failed")).count()));
+
+        for (ExpectedCluster expectedCluster : expected) {
+            Map<String, ?> clusterDetails = (Map<String, ?>) detailsMap.get(expectedCluster.clusterAlias());
+            String msg = expectedCluster.clusterAlias();
+
+            assertThat(msg, (int) clusterDetails.get("took"), greaterThan(0));
+            assertThat(msg, clusterDetails.get("status"), is(expectedCluster.status()));
+            Map<String, ?> shards = (Map<String, ?>) clusterDetails.get("_shards");
+            if (expectedCluster.totalShards() == null) {
+                assertThat(msg, (int) shards.get("total"), greaterThan(0));
+            } else {
+                assertThat(msg, (int) shards.get("total"), is(expectedCluster.totalShards()));
+            }
+
+            if (expectedCluster.status().equals("successful")) {
+                assertThat((int) shards.get("successful"), is((int) shards.get("total")));
+                assertThat((int) shards.get("skipped"), is(0));
+
+            } else if (expectedCluster.status().equals("skipped")) {
+                assertThat((int) shards.get("successful"), is(0));
+                assertThat((int) shards.get("skipped"), is((int) shards.get("total")));
+                ArrayList<?> failures = (ArrayList<?>) clusterDetails.get("failures");
+                assertThat(failures.size(), is(1));
+                Map<String, ?> failure1 = (Map<String, ?>) failures.get(0);
+                Map<String, ?> innerReason = (Map<String, ?>) failure1.get("reason");
+                String expectedMsg = "Unknown index [" + expectedCluster.indexExpression() + "]";
+                assertThat(innerReason.get("reason").toString(), containsString(expectedMsg));
+                assertThat(innerReason.get("type").toString(), containsString("verification_exception"));
+
+            } else {
+                fail(msg + "; Unexpected status: " + expectedCluster.status());
+            }
+            // currently failed shards is always zero - change this once we start allowing partial data for individual shard failures
+            assertThat((int) shards.get("failed"), is(0));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSearchesAgainstNonMatchingIndicesWithSkipUnavailableTrue() throws Exception {
+        setupRolesAndPrivileges();
+        setupIndex();
+
+        configureRemoteCluster(REMOTE_CLUSTER_ALIAS, fulfillingCluster, true, randomBoolean(), true);
+
+        // missing concrete local index is an error
+        {
+            String q = Strings.format("FROM nomatch,%s:%s | STATS count(*)", REMOTE_CLUSTER_ALIAS, INDEX2);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString("Unknown index [nomatch]"));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), Matchers.containsString("Unknown index [nomatch]"));
+        }
+
+        // missing concrete remote index is not fatal when skip_unavailable=true (as long as an index matches on another cluster)
+        {
+            String q = Strings.format("FROM %s,%s:nomatch | STATS count(*)", INDEX1, REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            Response response = client().performRequest(esqlRequest(limit1));
+            assertOK(response);
+
+            Map<String, Object> map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), greaterThanOrEqualTo(1));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    new ExpectedCluster("(local)", INDEX1, "successful", null),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, "nomatch", "skipped", 0)
+                )
+            );
+
+            String limit0 = q + " | LIMIT 0";
+            response = client().performRequest(esqlRequest(limit0));
+            assertOK(response);
+
+            map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), is(0));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    new ExpectedCluster("(local)", INDEX1, "successful", 0),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, "nomatch", "skipped", 0)
+                )
+            );
+        }
+
+        // since there is at least one matching index in the query, the missing wildcarded local index is not an error
+        {
+            String q = Strings.format("FROM nomatch*,%s:%s", REMOTE_CLUSTER_ALIAS, INDEX2);
+
+            String limit1 = q + " | LIMIT 1";
+            Response response = client().performRequest(esqlRequest(limit1));
+            assertOK(response);
+
+            Map<String, Object> map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), greaterThanOrEqualTo(1));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                    new ExpectedCluster("(local)", "nomatch*", "successful", 0),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, INDEX2, "successful", null)
+                )
+            );
+
+            String limit0 = q + " | LIMIT 0";
+            response = client().performRequest(esqlRequest(limit0));
+            assertOK(response);
+
+            map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), is(0));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                    new ExpectedCluster("(local)", "nomatch*", "successful", 0),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, INDEX2, "successful", 0)
+                )
+            );
+        }
+
+        // since at least one index of the query matches on some cluster, a wildcarded index on skip_un=true is not an error
+        {
+            String q = Strings.format("FROM %s,%s:nomatch*", INDEX1, REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            Response response = client().performRequest(esqlRequest(limit1));
+            assertOK(response);
+
+            Map<String, Object> map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), greaterThanOrEqualTo(1));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    new ExpectedCluster("(local)", INDEX1, "successful", null),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, "nomatch*", "skipped", 0)
+                )
+            );
+
+            String limit0 = q + " | LIMIT 0";
+            response = client().performRequest(esqlRequest(limit0));
+            assertOK(response);
+
+            map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), is(0));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    new ExpectedCluster("(local)", INDEX1, "successful", 0),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, "nomatch*", "skipped", 0)
+                )
+            );
+        }
+
+        // an error is thrown if there are no matching indices at all, even when the cluster is skip_unavailable=true
+        {
+            // with non-matching concrete index
+            String q = Strings.format("FROM %s:nomatch", REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+        }
+
+        // an error is thrown if there are no matching indices at all, even when the cluster is skip_unavailable=true and the
+        // index was wildcarded
+        {
+            String q = Strings.format("FROM %s:nomatch*", REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch*]", REMOTE_CLUSTER_ALIAS)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch*]", REMOTE_CLUSTER_ALIAS)));
+        }
+
+        // an error is thrown if there are no matching indices at all
+        {
+            String localExpr = randomFrom("nomatch", "nomatch*");
+            String remoteExpr = randomFrom("nomatch", "nomatch*");
+            String q = Strings.format("FROM %s,%s:%s", localExpr, REMOTE_CLUSTER_ALIAS, remoteExpr);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString("Unknown index"));
+            assertThat(e.getMessage(), containsString(Strings.format("%s:%s", REMOTE_CLUSTER_ALIAS, remoteExpr)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), containsString("Unknown index"));
+            assertThat(e.getMessage(), containsString(Strings.format("%s:%s", REMOTE_CLUSTER_ALIAS, remoteExpr)));
+        }
+
+        // TODO uncomment and test in follow-on PR which does skip_unavailable handling at execution time
+        // {
+        // String q = Strings.format("FROM %s,%s:nomatch,%s:%s*", INDEX1, REMOTE_CLUSTER_ALIAS, REMOTE_CLUSTER_ALIAS, INDEX2);
+        //
+        // String limit1 = q + " | LIMIT 1";
+        // Response response = client().performRequest(esqlRequest(limit1));
+        // assertOK(response);
+        //
+        // Map<String, Object> map = responseAsMap(response);
+        // assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+        // assertThat(((ArrayList<?>) map.get("values")).size(), greaterThanOrEqualTo(1));
+        //
+        // assertExpectedClustersForMissingIndicesTests(map,
+        // List.of(
+        // new ExpectedCluster("(local)", INDEX1, "successful", null),
+        // new ExpectedCluster(REMOTE_CLUSTER_ALIAS, "nomatch," + INDEX2 + "*", "skipped", 0)
+        // )
+        // );
+        //
+        // String limit0 = q + " | LIMIT 0";
+        // response = client().performRequest(esqlRequest(limit0));
+        // assertOK(response);
+        //
+        // map = responseAsMap(response);
+        // assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+        // assertThat(((ArrayList<?>) map.get("values")).size(), is(0));
+        //
+        // assertExpectedClustersForMissingIndicesTests(map,
+        // List.of(
+        // new ExpectedCluster("(local)", INDEX1, "successful", 0),
+        // new ExpectedCluster(REMOTE_CLUSTER_ALIAS, "nomatch," + INDEX2 + "*", "skipped", 0)
+        // )
+        // );
+        // }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSearchesAgainstNonMatchingIndicesWithSkipUnavailableFalse() throws Exception {
+        // Remote cluster is closed and skip_unavailable is set to false.
+        // Although the other cluster is open, we expect an Exception.
+
+        setupRolesAndPrivileges();
+        setupIndex();
+
+        configureRemoteCluster(REMOTE_CLUSTER_ALIAS, fulfillingCluster, true, randomBoolean(), false);
+
+        // missing concrete local index is an error
+        {
+            String q = Strings.format("FROM nomatch,%s:%s | STATS count(*)", REMOTE_CLUSTER_ALIAS, INDEX2);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString("Unknown index [nomatch]"));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), Matchers.containsString("Unknown index [nomatch]"));
+        }
+
+        // missing concrete remote index is not fatal when skip_unavailable=true (as long as an index matches on another cluster)
+        {
+            String q = Strings.format("FROM %s,%s:nomatch | STATS count(*)", INDEX1, REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), Matchers.containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+        }
+
+        // since there is at least one matching index in the query, the missing wildcarded local index is not an error
+        {
+            String q = Strings.format("FROM nomatch*,%s:%s", REMOTE_CLUSTER_ALIAS, INDEX2);
+
+            String limit1 = q + " | LIMIT 1";
+            Response response = client().performRequest(esqlRequest(limit1));
+            assertOK(response);
+
+            Map<String, Object> map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), greaterThanOrEqualTo(1));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                    new ExpectedCluster("(local)", "nomatch*", "successful", 0),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, INDEX2, "successful", null)
+                )
+            );
+
+            String limit0 = q + " | LIMIT 0";
+            response = client().performRequest(esqlRequest(limit0));
+            assertOK(response);
+
+            map = responseAsMap(response);
+            assertThat(((ArrayList<?>) map.get("columns")).size(), greaterThanOrEqualTo(1));
+            assertThat(((ArrayList<?>) map.get("values")).size(), is(0));
+
+            assertExpectedClustersForMissingIndicesTests(
+                map,
+                List.of(
+                    // local cluster is never marked as SKIPPED even when no matching indices - just marked as 0 shards searched
+                    new ExpectedCluster("(local)", "nomatch*", "successful", 0),
+                    new ExpectedCluster(REMOTE_CLUSTER_ALIAS, INDEX2, "successful", 0)
+                )
+            );
+        }
+
+        // query is fatal since the remote cluster has skip_unavailable=false and has no matching indices
+        {
+            String q = Strings.format("FROM %s,%s:nomatch*", INDEX1, REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch*]", REMOTE_CLUSTER_ALIAS)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), Matchers.containsString(Strings.format("Unknown index [%s:nomatch*]", REMOTE_CLUSTER_ALIAS)));
+        }
+
+        // an error is thrown if there are no matching indices at all
+        {
+            // with non-matching concrete index
+            String q = Strings.format("FROM %s:nomatch", REMOTE_CLUSTER_ALIAS);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+        }
+
+        // an error is thrown if there are no matching indices at all
+        {
+            String localExpr = randomFrom("nomatch", "nomatch*");
+            String remoteExpr = randomFrom("nomatch", "nomatch*");
+            String q = Strings.format("FROM %s,%s:%s", localExpr, REMOTE_CLUSTER_ALIAS, remoteExpr);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString("Unknown index"));
+            assertThat(e.getMessage(), containsString(Strings.format("%s:%s", REMOTE_CLUSTER_ALIAS, remoteExpr)));
+
+            String limit0 = q + " | LIMIT 0";
+            e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            assertThat(e.getMessage(), containsString("Unknown index"));
+            assertThat(e.getMessage(), containsString(Strings.format("%s:%s", REMOTE_CLUSTER_ALIAS, remoteExpr)));
+        }
+
+        // error since the remote cluster with skip_unavailable=false specified a concrete index that is not found
+        {
+            String q = Strings.format("FROM %s,%s:nomatch,%s:%s*", INDEX1, REMOTE_CLUSTER_ALIAS, REMOTE_CLUSTER_ALIAS, INDEX2);
+
+            String limit1 = q + " | LIMIT 1";
+            ResponseException e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit1)));
+            assertThat(e.getMessage(), containsString(Strings.format("no such index [nomatch]", REMOTE_CLUSTER_ALIAS)));
+            assertThat(e.getMessage(), containsString(Strings.format("index_not_found_exception", REMOTE_CLUSTER_ALIAS)));
+
+            // TODO: in follow on PR, add support for throwing a VerificationException from this scenario
+            // String limit0 = q + " | LIMIT 0";
+            // e = expectThrows(ResponseException.class, () -> client().performRequest(esqlRequest(limit0)));
+            // assertThat(e.getMessage(), containsString(Strings.format("Unknown index [%s:nomatch]", REMOTE_CLUSTER_ALIAS)));
+        }
+    }
+
+    private void setupRolesAndPrivileges() throws IOException {
+        var putUserRequest = new Request("PUT", "/_security/user/" + REMOTE_SEARCH_USER);
+        putUserRequest.setJsonEntity("""
+            {
+              "password": "x-pack-test-password",
+              "roles" : ["remote_search"]
+            }""");
+        assertOK(adminClient().performRequest(putUserRequest));
+
+        var putRoleOnRemoteClusterRequest = new Request("PUT", "/_security/role/" + REMOTE_SEARCH_ROLE);
+        putRoleOnRemoteClusterRequest.setJsonEntity("""
+            {
+              "indices": [
+                {
+                  "names": ["points", "squares"],
+                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"]
+                }
+              ],
+              "remote_indices": [
+                {
+                  "names": ["points", "squares"],
+                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"],
+                  "clusters": ["my_remote_cluster"]
+                }
+              ]
+            }""");
+        assertOK(adminClient().performRequest(putRoleOnRemoteClusterRequest));
+    }
+
+    private void setupIndex() throws IOException {
+        Request createIndex = new Request("PUT", INDEX1);
+        createIndex.setJsonEntity("""
+            {
+                "mappings": {
+                    "properties": {
+                      "id": { "type": "integer" },
+                      "score": { "type": "integer" }
+                    }
+                }
+            }
+            """);
+        assertOK(client().performRequest(createIndex));
+
+        Request bulkRequest = new Request("POST", "/_bulk?refresh=true");
+        bulkRequest.setJsonEntity("""
+            { "index": { "_index": "points" } }
+            { "id": 1, "score": 75}
+            { "index": { "_index": "points" } }
+            { "id": 2, "score": 125}
+            { "index": { "_index": "points" } }
+            { "id": 3, "score": 100}
+            { "index": { "_index": "points" } }
+            { "id": 4, "score": 50}
+            { "index": { "_index": "points" } }
+            { "id": 5, "score": 150}
+            """);
+        assertOK(client().performRequest(bulkRequest));
+
+        createIndex = new Request("PUT", INDEX2);
+        createIndex.setJsonEntity("""
+            {
+                "mappings": {
+                    "properties": {
+                      "num": { "type": "integer" },
+                      "square": { "type": "integer" }
+                    }
+                }
+            }
+            """);
+        assertOK(client().performRequest(createIndex));
+
+        bulkRequest = new Request("POST", "/_bulk?refresh=true");
+        bulkRequest.setJsonEntity("""
+            { "index": {"_index": "squares"}}
+            { "num": 1, "square": 1 }
+            { "index": {"_index": "squares"}}
+            { "num": 4, "square": 4 }
+            { "index": {"_index": "squares"}}
+            { "num": 3, "square": 9 }
+            { "index": {"_index": "squares"}}
+            { "num": 4, "square": 16 }
+            """);
+        assertOK(performRequestAgainstFulfillingCluster(bulkRequest));
+    }
+
+    private Request esqlRequest(String query) throws IOException {
+        XContentBuilder body = JsonXContent.contentBuilder();
+
+        body.startObject();
+        body.field("query", query);
+        body.field("include_ccs_metadata", true);
+        body.endObject();
+
+        Request request = new Request("POST", "_query");
+        request.setJsonEntity(org.elasticsearch.common.Strings.toString(body));
+
+        return request;
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Honor skip_unavailable setting for nonmatching indices errors at planning time (#116348)