### PR TITLE
[8.x] [Docs] Link to ECK Azure snapshot docs (#111586)

### DIFF
--- a/docs/reference/snapshot-restore/repository-azure.asciidoc
+++ b/docs/reference/snapshot-restore/repository-azure.asciidoc
@@ -181,7 +181,7 @@ is running.
 
 When running {es} in
 https://azure.microsoft.com/en-gb/products/kubernetes-service[Azure Kubernetes
-Service], for instance using {eck-ref}[{eck}], you should use
+Service], for instance using {eck-ref}/k8s-snapshots.html#k8s-azure-workload-identity[{eck}], you should use
 https://azure.github.io/azure-workload-identity/docs/introduction.html[Azure
 Workload Identity] to provide credentials to {es}. To use Azure Workload
 Identity, mount the `azure-identity-token` volume as a subdirectory of the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Docs] Link to ECK Azure snapshot docs (#111586)](https://github.com/elastic/elasticsearch/pull/111586)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)