### PR TITLE
[DOCS] document `Content-Type` breaking change from 8.0

### DIFF
--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -1141,7 +1141,7 @@ To detect a server timeout, check the `timed_out` field of the JSON response.
 [%collapsible]
 ====
 *Details* +
-The `Content-Type` response header no longer specifies the charset. This information is not required when transferring JSON data, as UTF is the default encoding.
+The `Content-Type` response header no longer specifies the charset. This information is not required when transferring JSON data, because JSON text is always encoded in Unicode, with UTF-8 being the default encoding.
 
 *Impact* +
 Some applications and utilities, such as PowerShell's https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod[Invoke-RestMethod], must receive charset information to display data correctly. If your application or utility relies on charset information in the `Content-Type` response header, UTF-8 encoded characters will be rendered incorrectly in the response body.

--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -1136,3 +1136,21 @@ for both cases.
 *Impact* +
 To detect a server timeout, check the `timed_out` field of the JSON response.
 ====
+
+.The `Content-Type` response header no longer specifies the charset.
+[%collapsible]
+====
+*Details* +
+The `Content-Type` response header no longer specifies the charset. This information is not required when transferring JSON data, as UTF is the default encoding.
+
+*Impact* +
+Some applications and utilities, such as PowerShell's https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod[Invoke-RestMethod], must receive charset information to display data correctly. If your application or utility relies on charset information in the `Content-Type` response header, UTF-8 encoded characters will be rendered incorrectly in the response body.
+
+As a workaround, to render non-ASCII characters, include an HTTP `Accept` header in your requests, specifying the charset: 
+
+[source,sh]
+----
+Accept: application/json; charset=utf-8
+----
+// NOTCONSOLE
+====

--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -1141,7 +1141,7 @@ To detect a server timeout, check the `timed_out` field of the JSON response.
 [%collapsible]
 ====
 *Details* +
-The `Content-Type` response header no longer specifies the charset. This information is not required when transferring JSON data, because JSON text is always encoded in Unicode, with UTF-8 being the default encoding.
+The `Content-Type` response header no longer specifies the charset. This information is not required when transferring JSON data, because JSON text will always be encoded in Unicode, with UTF-8 being the default encoding.
 
 *Impact* +
 Some applications and utilities, such as PowerShell's https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-restmethod[Invoke-RestMethod], must receive charset information to display data correctly. If your application or utility relies on charset information in the `Content-Type` response header, UTF-8 encoded characters will be rendered incorrectly in the response body.

--- a/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
+++ b/docs/reference/migration/migrate_8_0/rest-api-changes.asciidoc
@@ -1152,5 +1152,4 @@ As a workaround, to render non-ASCII characters, include an HTTP `Accept` header
 ----
 Accept: application/json; charset=utf-8
 ----
-// NOTCONSOLE
 ====


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/114669

Documents a breaking change [introduced in 8.0](https://github.com/elastic/elasticsearch/pull/61427). Added to the list of REST API breaking changes.

Tagging Core/Infra for confirmation

<img width="585" alt="image" src="https://github.com/user-attachments/assets/bfd57658-56e7-4cb3-967d-36af957777d9">
