### PR TITLE
Camel-case "Json"

### DIFF
--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -270,7 +270,7 @@ public class FileSettingsServiceTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void testInvalidJSON() throws Exception {
+    public void testInvalidJson() throws Exception {
         doAnswer((Answer<Void>) invocation -> {
             invocation.getArgument(1, XContentParser.class).map(); // Throw if JSON is invalid
             ((Consumer<Exception>) invocation.getArgument(3)).accept(null);


### PR DESCRIPTION
Apparently, with the original name `testInvalidJSON` (uppercase `JSON`) Gradle had trouble finding this test case. Now it works for `testInvalidJson`.

Fixes #116521