### PR TITLE
Index stats enhancement: creation date and tier_preference (#116339)

### DIFF
--- a/docs/changelog/116339.yaml
+++ b/docs/changelog/116339.yaml
@@ -1,0 +1,5 @@
+pr: 116339
+summary: "Index stats enhancement: creation date and `tier_preference`"
+area: Stats
+type: feature
+issues: []

--- a/docs/changelog/116867.yaml
+++ b/docs/changelog/116867.yaml
@@ -1,0 +1,5 @@
+pr: 116867
+summary: "Index stats enhancement: creation date and `tier_preference`"
+area: Stats
+type: feature
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/16_creation_date_tier_preference.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/16_creation_date_tier_preference.yml
@@ -1,0 +1,14 @@
+---
+"Ensure index creation date and tier preference are exposed":
+  - requires:
+      cluster_features: ["stats.tier_creation_date"]
+      reason: index creation date and tier preference added to stats in 8.17
+
+  - do:
+      indices.create:
+        index: myindex
+  - do:
+      indices.stats: {}
+
+  - is_true: indices.myindex.creation_date
+  - is_true: indices.myindex.tier_preference

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -420,6 +420,7 @@ module org.elasticsearch.server {
 
     provides org.elasticsearch.features.FeatureSpecification
         with
+            org.elasticsearch.action.admin.indices.stats.IndicesStatsFeatures,
             org.elasticsearch.action.bulk.BulkFeatures,
             org.elasticsearch.features.FeatureInfrastructureFeatures,
             org.elasticsearch.health.HealthFeatures,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -199,6 +199,7 @@ public class TransportVersions {
     public static final TransportVersion VERTEX_AI_INPUT_TYPE_ADDED = def(8_790_00_0);
     public static final TransportVersion SKIP_INNER_HITS_SEARCH_SOURCE = def(8_791_00_0);
     public static final TransportVersion QUERY_RULES_LIST_INCLUDES_TYPES = def(8_792_00_0);
+    public static final TransportVersion INDEX_STATS_ADDITIONAL_FIELDS = def(8_793_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndexStats.java
@@ -12,6 +12,7 @@ package org.elasticsearch.action.admin.indices.stats;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.NodeFeature;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,6 +22,8 @@ import java.util.Map;
 
 public class IndexStats implements Iterable<IndexShardStats> {
 
+    public static final NodeFeature TIER_CREATION_DATE = new NodeFeature("stats.tier_creation_date");
+
     private final String index;
 
     private final String uuid;
@@ -29,6 +32,10 @@ public class IndexStats implements Iterable<IndexShardStats> {
 
     private final IndexMetadata.State state;
 
+    private final List<String> tierPreference;
+
+    private final Long creationDate;
+
     private final ShardStats shards[];
 
     public IndexStats(
@@ -36,12 +43,16 @@ public class IndexStats implements Iterable<IndexShardStats> {
         String uuid,
         @Nullable ClusterHealthStatus health,
         @Nullable IndexMetadata.State state,
+        @Nullable List<String> tierPreference,
+        @Nullable Long creationDate,
         ShardStats[] shards
     ) {
         this.index = index;
         this.uuid = uuid;
         this.health = health;
         this.state = state;
+        this.tierPreference = tierPreference;
+        this.creationDate = creationDate;
         this.shards = shards;
     }
 
@@ -59,6 +70,14 @@ public class IndexStats implements Iterable<IndexShardStats> {
 
     public IndexMetadata.State getState() {
         return state;
+    }
+
+    public List<String> getTierPreference() {
+        return tierPreference;
+    }
+
+    public Long getCreationDate() {
+        return creationDate;
     }
 
     public ShardStats[] getShards() {
@@ -129,13 +148,24 @@ public class IndexStats implements Iterable<IndexShardStats> {
         private final String uuid;
         private final ClusterHealthStatus health;
         private final IndexMetadata.State state;
+        private final List<String> tierPreference;
+        private final Long creationDate;
         private final List<ShardStats> shards = new ArrayList<>();
 
-        public IndexStatsBuilder(String indexName, String uuid, @Nullable ClusterHealthStatus health, @Nullable IndexMetadata.State state) {
+        public IndexStatsBuilder(
+            String indexName,
+            String uuid,
+            @Nullable ClusterHealthStatus health,
+            @Nullable IndexMetadata.State state,
+            @Nullable List<String> tierPreference,
+            @Nullable Long creationDate
+        ) {
             this.indexName = indexName;
             this.uuid = uuid;
             this.health = health;
             this.state = state;
+            this.tierPreference = tierPreference;
+            this.creationDate = creationDate;
         }
 
         public IndexStatsBuilder add(ShardStats shardStats) {
@@ -144,7 +174,15 @@ public class IndexStats implements Iterable<IndexShardStats> {
         }
 
         public IndexStats build() {
-            return new IndexStats(indexName, uuid, health, state, shards.toArray(new ShardStats[shards.size()]));
+            return new IndexStats(
+                indexName,
+                uuid,
+                health,
+                state,
+                tierPreference,
+                creationDate,
+                shards.toArray(new ShardStats[shards.size()])
+            );
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsFeatures.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsFeatures.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.stats;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class IndicesStatsFeatures implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(IndexStats.TIER_CREATION_DATE);
+    }
+}

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -7,6 +7,7 @@
 # License v3.0 only", or the "Server Side Public License, v 1".
 #
 
+org.elasticsearch.action.admin.indices.stats.IndicesStatsFeatures
 org.elasticsearch.action.bulk.BulkFeatures
 org.elasticsearch.features.FeatureInfrastructureFeatures
 org.elasticsearch.health.HealthFeatures

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
@@ -189,7 +189,10 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         shardStats[0] = sStats;
 
         mockXPackInfo(true, true);
-        mockIndexStatsCall(indexName, new IndexStats(indexName, "uuid", ClusterHealthStatus.GREEN, IndexMetadata.State.OPEN, shardStats));
+        mockIndexStatsCall(
+            indexName,
+            new IndexStats(indexName, "uuid", ClusterHealthStatus.GREEN, IndexMetadata.State.OPEN, null, null, shardStats)
+        );
 
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
@@ -289,7 +292,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         for (int i = 0; i < numOfShards; i++) {
             shardStats[i] = randomShardStats(isLeaderIndex);
         }
-        return new IndexStats(randomAlphaOfLength(5), randomAlphaOfLength(10), null, null, shardStats);
+        return new IndexStats(randomAlphaOfLength(5), randomAlphaOfLength(10), null, null, null, null, shardStats);
     }
 
     private ShardStats randomShardStats(boolean isLeaderIndex) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
@@ -53,6 +53,8 @@ public class IndicesStatsMonitoringDocTests extends BaseFilteredMonitoringDocTes
                 "dcvO5uZATE-EhIKc3tk9Bg",
                 null,
                 null,
+                null,
+                null,
                 new ShardStats[] {
                     // Primaries
                     new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0),


### PR DESCRIPTION
Backport #116339 to 8.x

* Expose tier preference as part of the index stats
* Also expose index creation date in index stats
* Added test