### PR TITLE
Minor fix in documentation

### DIFF
--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -54,7 +54,7 @@ or a range of versions followed by a colon.
 +
 To apply a setting to a specific version and any later versions,
 omit the upper bound of the range.
-For example, this setting applies to Java 8 and later:
+For example, this setting applies to Java 17 and later:
 +
 [source,text]
 -------------------------------------


### PR DESCRIPTION
Just a very small fix in the documentation - the example was updated with recent java version by not the related text. 