### PR TITLE
[8.x] Use the current term in a logging where it is relevant (#116786)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -467,7 +467,7 @@ public class CoordinationState {
             logger.debug(
                 "handleCommit: ignored commit request due to term mismatch "
                     + "(expected: [term {} version {}], actual: [term {} version {}])",
-                getLastAcceptedTerm(),
+                getCurrentTerm(),
                 getLastAcceptedVersion(),
                 applyCommit.getTerm(),
                 applyCommit.getVersion()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use the current term in a logging where it is relevant (#116786)](https://github.com/elastic/elasticsearch/pull/116786)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)