### PR TITLE
[Test] Ensure latest cluster info is used in tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -240,9 +240,6 @@ tests:
 - class: org.elasticsearch.index.mapper.vectors.MultiDenseVectorScriptDocValuesTests
   method: testFloatGetVectorValueAndGetMagnitude
   issue: https://github.com/elastic/elasticsearch/issues/116863
-- class: org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceReconcilerMetricsIT
-  method: testDesiredBalanceMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/116870
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/116542

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerMetricsIT.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteUtils;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.InternalClusterInfoService;
@@ -68,6 +69,7 @@ public class DesiredBalanceReconcilerMetricsIT extends ESIntegTestCase {
         final var infoService = (InternalClusterInfoService) internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
         ClusterInfoServiceUtils.setUpdateFrequency(infoService, TimeValue.timeValueMillis(200));
         assertNotNull("info should not be null", ClusterInfoServiceUtils.refresh(infoService));
+        ClusterRerouteUtils.reroute(client()); // ensure we leverage the latest cluster info
 
         final var telemetryPlugin = getTelemetryPlugin(internalCluster().getMasterName());
         telemetryPlugin.collect();


### PR DESCRIPTION
DesiredBalanceMetrics#updateMetrics is called on reroute which is frequent but not guaranteed. It can also takes some time to complete. This PR adds an explicit reroute to ensure the latest cluster info is picked up.

Resolves: #116870
