### PR TITLE
Rename tsdb yml test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/90_unsupported_operations.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/90_unsupported_operations.yml
@@ -129,7 +129,7 @@ noop update:
             {}
 
 ---
-update:
+regular update:
   - requires:
       cluster_features: ["gte_v8.2.0"]
       reason: tsdb indexing changed in 8.2.0


### PR DESCRIPTION
The current name doesn't allow skipping it to workaround compatibility test failures:

```
> Task :rest-api-spec:yamlRestCompatTestTransform FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rest-api-spec:yamlRestCompatTestTransform'.
> class com.fasterxml.jackson.databind.node.ObjectNode cannot be cast to class com.fasterxml.jackson.databind.node.ArrayNode (com.fasterxml.jackson.databind.node.ObjectNode and com.fasterxml.jackson.databind.node.ArrayNode are in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader$InstrumentingVisitableURLClassLoader @15eaac09)
```