### PR TITLE
[8.x] fix formatting errors (#116843)

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -117,12 +117,10 @@ that sacrifices result accuracy for improved speed.
 The `dense_vector` type supports quantization to reduce the memory footprint required when <<approximate-knn, searching>> `float` vectors.
 The three following quantization strategies are supported:
 
-+
---
-`int8` - Quantizes each dimension of the vector to 1-byte integers. This reduces the memory footprint by 75% (or 4x) at the cost of some accuracy.
-`int4` - Quantizes each dimension of the vector to half-byte integers. This reduces the memory footprint by 87% (or 8x) at the cost of accuracy.
-`bbq` - experimental:[] Better binary quantization which reduces each dimension to a single bit precision. This reduces the memory footprint by 96% (or 32x) at a larger cost of accuracy. Generally, oversampling during query time and reranking can help mitigate the accuracy loss.
---
+* `int8` - Quantizes each dimension of the vector to 1-byte integers. This reduces the memory footprint by 75% (or 4x) at the cost of some accuracy.
+* `int4` - Quantizes each dimension of the vector to half-byte integers. This reduces the memory footprint by 87% (or 8x) at the cost of accuracy.
+* `bbq` - experimental:[] Better binary quantization which reduces each dimension to a single bit precision. This reduces the memory footprint by 96% (or 32x) at a larger cost of accuracy. Generally, oversampling during query time and reranking can help mitigate the accuracy loss.
+
 
 When using a quantized format, you may want to oversample and rescore the results to improve accuracy. See <<dense-vector-knn-search-reranking, oversampling and rescoring>> for more information.
 
@@ -245,12 +243,11 @@ their vector field's similarity to the query vector. The `_score` of each
 document will be derived from the similarity, in a way that ensures scores are
 positive and that a larger score corresponds to a higher ranking.
 Defaults to `l2_norm` when `element_type: bit` otherwise defaults to `cosine`.
-
-NOTE: `bit` vectors only support `l2_norm` as their similarity metric.
-
 +
 ^*^ This parameter can only be specified when `index` is `true`.
 +
+NOTE: `bit` vectors only support `l2_norm` as their similarity metric.
+
 .Valid values for `similarity`
 [%collapsible%open]
 ====


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [fix formatting errors (#116843)](https://github.com/elastic/elasticsearch/pull/116843)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)