### PR TITLE
[DOCS] Remove 'rescore' from retriever.asciidoc

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -704,5 +704,3 @@ Instead they are only allowed as elements of specific retrievers:
 * <<search-after, `search_after`>>
 * <<request-body-search-terminate-after, `terminate_after`>>
 * <<search-sort-param, `sort`>>
-* <<rescore, `rescore`>>
-


### PR DESCRIPTION
h/t @daixque

ℹ️ `rescore` is not yet available in retrievers