### PR TITLE
Always check if index mode is logsdb

### DIFF
--- a/docs/changelog/116922.yaml
+++ b/docs/changelog/116922.yaml
@@ -1,0 +1,5 @@
+pr: 116922
+summary: Always check if index mode is logsdb
+area: Logs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -167,8 +167,7 @@ public abstract class IndexRouting {
             // generate id if not already provided
             final String id = indexRequest.id();
             if (id == null) {
-                if (creationVersion.between(IndexVersions.TIME_BASED_K_ORDERED_DOC_ID_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
-                    || creationVersion.onOrAfter(IndexVersions.TIME_BASED_K_ORDERED_DOC_ID) && indexMode == IndexMode.LOGSDB) {
+                if (shouldUseTimeBasedId(indexMode, creationVersion)) {
                     indexRequest.autoGenerateTimeBasedId();
                 } else {
                     indexRequest.autoGenerateId();
@@ -176,6 +175,15 @@ public abstract class IndexRouting {
             } else if (id.isEmpty()) {
                 throw new IllegalArgumentException("if _id is specified it must not be empty");
             }
+        }
+
+        private static boolean shouldUseTimeBasedId(final IndexMode indexMode, final IndexVersion creationVersion) {
+            return indexMode == IndexMode.LOGSDB && isNewIndexVersion(creationVersion);
+        }
+
+        private static boolean isNewIndexVersion(final IndexVersion creationVersion) {
+            return creationVersion.between(IndexVersions.TIME_BASED_K_ORDERED_DOC_ID_BACKPORT, IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
+                || creationVersion.onOrAfter(IndexVersions.TIME_BASED_K_ORDERED_DOC_ID);
         }
 
         @Override


### PR DESCRIPTION
We need to check the index mode no matter the index creation version.
The way the condition was written before relies on precedence rules with
`&&` and `||`.

In the backport there is only one condition when it comes to index version.
As a result, there is no need to backport this change.

See https://github.com/elastic/elasticsearch/pull/116810