### PR TITLE
[8.x] [DOCS] Remove 'rescore' from retriever.asciidoc (#116921)

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -704,5 +704,3 @@ Instead they are only allowed as elements of specific retrievers:
 * <<search-after, `search_after`>>
 * <<request-body-search-terminate-after, `terminate_after`>>
 * <<search-sort-param, `sort`>>
-* <<rescore, `rescore`>>
-


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [DOCS] Remove 'rescore' from retriever.asciidoc (#116921)