### PR TITLE
[8.15] [DOCS] Remove &#x27;rescore&#x27; from retriever.asciidoc (#116921)

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -554,5 +554,3 @@ at the top-level and instead are only allowed as elements of specific retrievers
 * <<search-after, `search_after`>>
 * <<request-body-search-terminate-after, `terminate_after`>>
 * <<search-sort-param, `sort`>>
-* <<rescore, `rescore`>>
-* <<search-api-min-score, `min_score`>>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[DOCS] Remove &#x27;rescore&#x27; from retriever.asciidoc (#116921)](https://github.com/elastic/elasticsearch/pull/116921)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)