### PR TITLE
[TestFix] DocsClientYamlTestSuiteIT test {yaml=reference/watcher/example-watches/example-watch-clusterstatus/line_137} failing (#115809)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -121,9 +121,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
   issue: https://github.com/elastic/elasticsearch/issues/115808
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/watcher/example-watches/example-watch-clusterstatus/line_137}
-  issue: https://github.com/elastic/elasticsearch/issues/115809
 - class: org.elasticsearch.search.StressSearchServiceReaperIT
   method: testStressReaper
   issue: https://github.com/elastic/elasticsearch/issues/115816


### PR DESCRIPTION
Currently there's an issue, as described in https://github.com/elastic/elasticsearch/issues/99517 that causes watcher YAML tests to error if the watch actually executes during the test.

This PR mitigates the issue by ensuring the watcher service is stopped before any watcher APIs are called by the Docs YAML tests. This prevents any watches running and erroring the tests.

Fixes #115809