### PR TITLE
Remove support for deprecated force_source highlighting parameter

### DIFF
--- a/docs/changelog/116943.yaml
+++ b/docs/changelog/116943.yaml
@@ -1,11 +1,11 @@
 pr: 116943
 summary: Remove support for deprecated `force_source` highlighting parameter
-area: Search
+area: Highlighting
 type: breaking
 issues: []
 breaking:
   title: Remove support for deprecated `force_source` highlighting parameter
-  area: Highlighting
+  area: REST API
   details: The deprecated highlighting `force_source` parameter is no longer supported.
   impact: Users should remove usages of the `force_source` parameter from their search requests.
   notable: false

--- a/docs/changelog/116943.yaml
+++ b/docs/changelog/116943.yaml
@@ -1,6 +1,6 @@
 pr: 116943
 summary: Remove support for deprecated `force_source` highlighting parameter
-area: Highlighting
+area: REST API
 type: breaking
 issues: []
 breaking:

--- a/docs/changelog/116943.yaml
+++ b/docs/changelog/116943.yaml
@@ -1,0 +1,12 @@
+pr: 116943
+summary: Remove support for deprecated `force_source` higlighting parameter
+area: Highlighting
+type: breaking
+issues: []
+breaking:
+  title: Remove support for deprecated `force_source` higlighting parameter
+  area: Highlighting
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/116943.yaml
+++ b/docs/changelog/116943.yaml
@@ -1,6 +1,6 @@
 pr: 116943
 summary: Remove support for deprecated `force_source` highlighting parameter
-area: REST API
+area: Search
 type: breaking
 issues: []
 breaking:

--- a/docs/changelog/116943.yaml
+++ b/docs/changelog/116943.yaml
@@ -1,12 +1,11 @@
 pr: 116943
-summary: Remove support for deprecated `force_source` higlighting parameter
+summary: Remove support for deprecated `force_source` highlighting parameter
 area: Highlighting
 type: breaking
 issues: []
 breaking:
-  title: Remove support for deprecated `force_source` higlighting parameter
+  title: Remove support for deprecated `force_source` highlighting parameter
   area: Highlighting
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: The deprecated highlighting `force_source` parameter is no longer supported.
+  impact: Users should remove usages of the `force_source` parameter from their search requests.
   notable: false

--- a/docs/reference/search/search-your-data/highlighting.asciidoc
+++ b/docs/reference/search/search-your-data/highlighting.asciidoc
@@ -176,8 +176,6 @@ fragmenter:: Specifies how text should be broken up in highlight
 snippets: `simple` or `span`. Only valid for the `plain` highlighter.
 Defaults to `span`.
 
-force_source:: deprecated; this parameter has no effect
-
 `simple`::: Breaks up text into same-sized fragments.
 `span`::: Breaks up text into same-sized fragments, but tries to avoid
 breaking up text between highlighted terms. This is helpful when you're

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -64,7 +64,6 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
     public static final ParseField TYPE_FIELD = new ParseField("type");
     public static final ParseField FRAGMENTER_FIELD = new ParseField("fragmenter");
     public static final ParseField NO_MATCH_SIZE_FIELD = new ParseField("no_match_size");
-    public static final ParseField FORCE_SOURCE_FIELD = new ParseField("force_source").withAllDeprecated();
     public static final ParseField PHRASE_LIMIT_FIELD = new ParseField("phrase_limit");
     public static final ParseField OPTIONS_FIELD = new ParseField("options");
     public static final ParseField HIGHLIGHT_QUERY_FIELD = new ParseField("highlight_query");
@@ -152,9 +151,6 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         }
         order(in.readOptionalWriteable(Order::readFromStream));
         highlightFilter(in.readOptionalBoolean());
-        if (in.getTransportVersion().before(TransportVersions.V_8_8_0)) {
-            in.readOptionalBoolean();   // force_source, now deprecated
-        }
         boundaryScannerType(in.readOptionalWriteable(BoundaryScannerType::readFromStream));
         boundaryMaxScan(in.readOptionalVInt());
         if (in.readBoolean()) {
@@ -193,9 +189,6 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         }
         out.writeOptionalWriteable(order);
         out.writeOptionalBoolean(highlightFilter);
-        if (out.getTransportVersion().before(TransportVersions.V_8_8_0)) {
-            out.writeOptionalBoolean(false);
-        }
         out.writeOptionalWriteable(boundaryScannerType);
         out.writeOptionalVInt(boundaryMaxScan);
         boolean hasBounaryChars = boundaryChars != null;
@@ -674,7 +667,6 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         parser.declareString(HB::highlighterType, TYPE_FIELD);
         parser.declareString(HB::fragmenter, FRAGMENTER_FIELD);
         parser.declareInt(HB::noMatchSize, NO_MATCH_SIZE_FIELD);
-        parser.declareBoolean((builder, value) -> {}, FORCE_SOURCE_FIELD);  // force_source is ignored
         parser.declareInt(HB::phraseLimit, PHRASE_LIMIT_FIELD);
         parser.declareInt(HB::maxAnalyzedOffset, MAX_ANALYZED_OFFSET_FIELD);
         parser.declareObject(HB::options, (XContentParser p, Void c) -> {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -607,17 +607,6 @@ public class HighlightBuilderTests extends ESTestCase {
         }
     }
 
-    public void testForceSourceDeprecation() throws IOException {
-        String highlightJson = """
-            { "fields" : { }, "force_source" : true }
-            """;
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, highlightJson)) {
-            HighlightBuilder.fromXContent(parser);
-        }
-
-        assertWarnings("Deprecated field [force_source] used, this field is unused and will be removed entirely");
-    }
-
     protected static XContentBuilder toXContent(HighlightBuilder highlight, XContentType contentType) throws IOException {
         XContentBuilder builder = XContentFactory.contentBuilder(contentType);
         if (randomBoolean()) {


### PR DESCRIPTION
force_source is being parsed as a no-op since 8.8. This commit removes support for it at REST, meaning a search request that provides it gets now an error back.