### PR TITLE
ESQL: Skip test with per agg WHERE on older nodes

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -2468,6 +2468,7 @@ count:long     |values:keyword        |job_positions:keyword
 ;
 
 prunedStatsFollowedByStats
+required_capability: per_agg_filtering
 from employees
 | eval my_length = length(concat(first_name, null))
 | stats count = count(my_length) where false,


### PR DESCRIPTION
This is technically not needed because on main/9.0 and 8.x/8.17 the nodes have the capability to perform `STATS COUNT() WHERE ...` (no pipe) - but let's add this, anyway, to avoid confusion, be in line with 8.x and avoid issues if we later perform this test in CCQ scenarios.

Relates https://github.com/elastic/elasticsearch/pull/116947.