### PR TITLE
Fix false positive date detection with trailing dot

### DIFF
--- a/docs/changelog/116953.yaml
+++ b/docs/changelog/116953.yaml
@@ -1,0 +1,6 @@
+pr: 116953
+summary: Fix false positive date detection with trailing dot
+area: Mapping
+type: bug
+issues:
+ - 116946

--- a/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
@@ -246,7 +246,10 @@ class EpochTime {
         .toFormatter(Locale.ROOT);
 
     // this supports milliseconds ending in dot
-    private static final DateTimeFormatter MILLISECONDS_FORMATTER2 = new DateTimeFormatterBuilder().append(MILLISECONDS_FORMATTER1)
+    private static final DateTimeFormatter MILLISECONDS_FORMATTER2 = new DateTimeFormatterBuilder().optionalStart()
+        .appendText(NEGATIVE_SIGN_FIELD, Map.of(-1L, "-")) // field is only created in the presence of a '-' char.
+        .optionalEnd()
+        .appendValue(UNSIGNED_MILLIS, 1, 19, SignStyle.NOT_NEGATIVE)
         .appendLiteral('.')
         .toFormatter(Locale.ROOT);
 

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -260,6 +260,17 @@ public class DateFormattersTests extends ESTestCase {
             assertThat(formatter.format(instant), is("-0.12345"));
             assertThat(Instant.from(formatter.parse(formatter.format(instant))), is(instant));
         }
+        {
+            Instant instant = Instant.from(formatter.parse("12345."));
+            assertThat(instant.getEpochSecond(), is(12L));
+            assertThat(instant.getNano(), is(345_000_000));
+            assertThat(formatter.format(instant), is("12345"));
+            assertThat(Instant.from(formatter.parse(formatter.format(instant))), is(instant));
+        }
+        {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> formatter.parse("12345.0."));
+            assertThat(e.getMessage(), is("failed to parse date field [12345.0.] with format [epoch_millis]"));
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -597,6 +597,23 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         assertThat(((FieldMapper) update.getRoot().getMapper("quux")).fieldType().typeName(), equalTo("float"));
     }
 
+    public void testDateDetectionEnabled() throws Exception {
+        MapperService mapperService = createMapperService(topMapping(b -> b.field("date_detection", true)));
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source(b -> {
+            b.field("date", "2024-11-18");
+            b.field("no_date", "128.0.");
+        }));
+        assertNotNull(doc.dynamicMappingsUpdate());
+        merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
+
+        Mapper mapper = mapperService.documentMapper().mappers().getMapper("date");
+        assertThat(mapper.typeName(), equalTo("date"));
+
+        mapper = mapperService.documentMapper().mappers().getMapper("no_date");
+        assertThat(mapper.typeName(), equalTo("text"));
+    }
+
     public void testNumericDetectionEnabled() throws Exception {
         MapperService mapperService = createMapperService(topMapping(b -> b.field("numeric_detection", true)));
 


### PR DESCRIPTION
Date detection is not supposed to kick in with numeric values:

https://github.com/elastic/elasticsearch/blob/366fa749b06d30e76344921a15b347447cda35c9/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java#L83-L100

The way this is ensured is that string values that can be parsed as a number are not subject to date detection.

However, there's a case where a string can't be parsed as a number but is still considered a date that can be parsed by the default `epoch_millis` formatter.

That's because the `epoch_millis` format supports parsing numbers with a trailing dot, such as `12345.`, which is equivalent to `12345.0` or `12345`. This was made to retain compatibility with Joda time. 

The issue is that the `MILLISECONDS_FORMATTER2`, built to support trailing dots, is implemented as extension of `MILLISECONDS_FORMATTER1`, which already supports an optional fractional. The result is that `MILLISECONDS_FORMATTER2` supports a fractional and a trailing dot.

The bug got introduced in this PR: https://github.com/elastic/elasticsearch/pull/36914.

A potential alternative to this approach would be to remove `epoch_millis` from the default formatters used in date_detection:

https://github.com/elastic/elasticsearch/blob/d6cc86aa7c5098ed401f0b5c8b159ccff2d8715f/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java#L61-L66

However, the consequence of this is that it will use a non-default formatter for dynamically detected `date` fields (`strict_date_optional_time` instead of [`strict_date_optional_time||epoch_millis`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html)). That means the get mapping API will return `"date": { "type": "date", "format": "strict_date_optional_time" }` for dynamically mapped dates instead of just `"date": { "type": "date" }`.

That's why I've opted for a solution that has a lower chance of unintended side effects.

Fixes https://github.com/elastic/elasticsearch/issues/116946