### PR TITLE
Upgrade the build's ASM to 9.7.1 (#116963)

### DIFF
--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-asm = "9.6"
+asm = "9.7.1"
 jackson = "2.15.0"
 junit5 = "5.8.1"
 spock = "2.1-groovy-3.0"


### PR DESCRIPTION
Primarily this allows forbidden apis to read java 23 class files.