### PR TITLE
Update BwcVersionsSpec to use current version numbers

### DIFF
--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/BwcVersionsSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/BwcVersionsSpec.groovy
@@ -17,232 +17,201 @@ import org.elasticsearch.gradle.internal.BwcVersions.UnreleasedVersionInfo
 class BwcVersionsSpec extends Specification {
     List<String> versionLines = []
 
-    def "current version is next major with last minor staged"() {
-        given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.16.2', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
-        addVersion('8.1.0', '9.0.0')
-
-        when:
-        def bwc = new BwcVersions(versionLines, v('8.1.0'))
-        def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
-
-        then:
-        unreleased == [
-            (v('7.16.2')): new UnreleasedVersionInfo(v('7.16.2'), '7.16', ':distribution:bwc:bugfix'),
-            (v('7.17.0')): new UnreleasedVersionInfo(v('7.17.0'), '7.17', ':distribution:bwc:staged'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), '8.x', ':distribution:bwc:minor'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
-        ]
-        bwc.wireCompatible == [v('7.17.0'), v('8.0.0'), v('8.1.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.16.2'), v('7.17.0'), v('8.0.0'), v('8.1.0')]
-        bwc.minimumWireCompatibleVersion == v('7.17.0')
-    }
-
     def "current version is next minor with next major and last minor both staged"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
-        addVersion('8.1.0', '9.1.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.16.1', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
+        addVersion('9.1.0', '10.1.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.1.0'))
+        def bwc = new BwcVersions(versionLines, v('9.1.0'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.16.1')): new UnreleasedVersionInfo(v('7.16.1'), '7.16', ':distribution:bwc:bugfix'),
-            (v('7.17.0')): new UnreleasedVersionInfo(v('7.17.0'), '7.17', ':distribution:bwc:staged'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), '8.x', ':distribution:bwc:minor'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
+            (v('8.16.1')): new UnreleasedVersionInfo(v('8.16.1'), '8.16', ':distribution:bwc:bugfix'),
+            (v('8.17.0')): new UnreleasedVersionInfo(v('8.17.0'), '8.17', ':distribution:bwc:staged'),
+            (v('9.0.0')): new UnreleasedVersionInfo(v('9.0.0'), '9.x', ':distribution:bwc:minor'),
+            (v('9.1.0')): new UnreleasedVersionInfo(v('9.1.0'), 'main', ':distribution')
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('8.0.0'), v('8.1.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('8.0.0'), v('8.1.0')]
+        bwc.wireCompatible == [v('8.17.0'), v('9.0.0'), v('9.1.0')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.16.1'), v('8.17.0'), v('9.0.0'), v('9.1.0')]
     }
 
     def "current is next minor with upcoming minor staged"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('7.17.1', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
-        addVersion('8.1.0', '9.1.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.16.1', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('8.17.1', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
+        addVersion('9.1.0', '10.1.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.1.0'))
+        def bwc = new BwcVersions(versionLines, v('9.1.0'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:bugfix'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), '8.0', ':distribution:bwc:staged'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
+            (v('8.17.1')): new UnreleasedVersionInfo(v('8.17.1'), '8.17', ':distribution:bwc:bugfix'),
+            (v('9.0.0')): new UnreleasedVersionInfo(v('9.0.0'), '9.0', ':distribution:bwc:staged'),
+            (v('9.1.0')): new UnreleasedVersionInfo(v('9.1.0'), 'main', ':distribution')
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.1.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.1.0')]
+        bwc.wireCompatible == [v('8.17.0'), v('8.17.1'), v('9.0.0'), v('9.1.0')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.16.1'), v('8.17.0'), v('8.17.1'), v('9.0.0'), v('9.1.0')]
     }
 
     def "current version is staged major"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('7.17.1', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.16.1', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('8.17.1', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.0.0'))
+        def bwc = new BwcVersions(versionLines, v('9.0.0'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:bugfix'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), 'main', ':distribution'),
+            (v('8.17.1')): new UnreleasedVersionInfo(v('8.17.1'), '8.17', ':distribution:bwc:bugfix'),
+            (v('9.0.0')): new UnreleasedVersionInfo(v('9.0.0'), 'main', ':distribution'),
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0')]
+        bwc.wireCompatible == [v('8.17.0'), v('8.17.1'), v('9.0.0')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.16.1'), v('8.17.0'), v('8.17.1'), v('9.0.0')]
     }
 
     def "current version is major with unreleased next minor"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.16.1', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.0.0'))
+        def bwc = new BwcVersions(versionLines, v('9.0.0'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.16.1')): new UnreleasedVersionInfo(v('7.16.1'), '7.16', ':distribution:bwc:bugfix'),
-            (v('7.17.0')): new UnreleasedVersionInfo(v('7.17.0'), '7.x', ':distribution:bwc:minor'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), 'main', ':distribution'),
+            (v('8.16.1')): new UnreleasedVersionInfo(v('8.16.1'), '8.16', ':distribution:bwc:bugfix'),
+            (v('8.17.0')): new UnreleasedVersionInfo(v('8.17.0'), '8.x', ':distribution:bwc:minor'),
+            (v('9.0.0')): new UnreleasedVersionInfo(v('9.0.0'), 'main', ':distribution'),
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('8.0.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('8.0.0')]
+        bwc.wireCompatible == [v('8.17.0'), v('9.0.0')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.16.1'), v('8.17.0'), v('9.0.0')]
     }
 
     def "current version is major with staged next minor"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.0.0'))
+        def bwc = new BwcVersions(versionLines, v('9.0.0'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.15.2')): new UnreleasedVersionInfo(v('7.15.2'), '7.15', ':distribution:bwc:bugfix'),
-            (v('7.16.0')): new UnreleasedVersionInfo(v('7.16.0'), '7.16', ':distribution:bwc:staged'),
-            (v('7.17.0')): new UnreleasedVersionInfo(v('7.17.0'), '7.x', ':distribution:bwc:minor'),
-            (v('8.0.0')): new UnreleasedVersionInfo(v('8.0.0'), 'main', ':distribution'),
+            (v('8.15.2')): new UnreleasedVersionInfo(v('8.15.2'), '8.15', ':distribution:bwc:bugfix'),
+            (v('8.16.0')): new UnreleasedVersionInfo(v('8.16.0'), '8.16', ':distribution:bwc:staged'),
+            (v('8.17.0')): new UnreleasedVersionInfo(v('8.17.0'), '8.x', ':distribution:bwc:minor'),
+            (v('9.0.0')): new UnreleasedVersionInfo(v('9.0.0'), 'main', ':distribution'),
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('8.0.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.17.0'), v('8.0.0')]
+        bwc.wireCompatible == [v('8.17.0'), v('9.0.0')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.17.0'), v('9.0.0')]
     }
 
     def "current version is next bugfix"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('7.17.1', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
-        addVersion('8.0.1', '9.0.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.16.1', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('8.17.1', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
+        addVersion('9.0.1', '10.0.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.0.1'))
+        def bwc = new BwcVersions(versionLines, v('9.0.1'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:maintenance'),
-            (v('8.0.1')): new UnreleasedVersionInfo(v('8.0.1'), 'main', ':distribution'),
+            (v('8.17.1')): new UnreleasedVersionInfo(v('8.17.1'), '8.17', ':distribution:bwc:maintenance'),
+            (v('9.0.1')): new UnreleasedVersionInfo(v('9.0.1'), 'main', ':distribution'),
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1')]
+        bwc.wireCompatible == [v('8.17.0'), v('8.17.1'), v('9.0.0'), v('9.0.1')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.16.1'), v('8.17.0'), v('8.17.1'), v('9.0.0'), v('9.0.1')]
     }
 
     def "current version is next minor with no staged releases"() {
         given:
-        addVersion('7.14.0', '8.9.0')
-        addVersion('7.14.1', '8.9.0')
-        addVersion('7.14.2', '8.9.0')
-        addVersion('7.15.0', '8.9.0')
-        addVersion('7.15.1', '8.9.0')
-        addVersion('7.15.2', '8.9.0')
-        addVersion('7.16.0', '8.10.0')
-        addVersion('7.16.1', '8.10.0')
-        addVersion('7.17.0', '8.10.0')
-        addVersion('7.17.1', '8.10.0')
-        addVersion('8.0.0', '9.0.0')
-        addVersion('8.0.1', '9.0.0')
-        addVersion('8.1.0', '9.1.0')
+        addVersion('8.14.0', '9.9.0')
+        addVersion('8.14.1', '9.9.0')
+        addVersion('8.14.2', '9.9.0')
+        addVersion('8.15.0', '9.9.0')
+        addVersion('8.15.1', '9.9.0')
+        addVersion('8.15.2', '9.9.0')
+        addVersion('8.16.0', '9.10.0')
+        addVersion('8.16.1', '9.10.0')
+        addVersion('8.17.0', '9.10.0')
+        addVersion('8.17.1', '9.10.0')
+        addVersion('9.0.0', '10.0.0')
+        addVersion('9.0.1', '10.0.0')
+        addVersion('9.1.0', '10.1.0')
 
         when:
-        def bwc = new BwcVersions(versionLines, v('8.1.0'))
+        def bwc = new BwcVersions(versionLines, v('9.1.0'))
         def unreleased = bwc.unreleased.collectEntries { [it, bwc.unreleasedInfo(it)] }
 
         then:
         unreleased == [
-            (v('7.17.1')): new UnreleasedVersionInfo(v('7.17.1'), '7.17', ':distribution:bwc:maintenance'),
-            (v('8.0.1')): new UnreleasedVersionInfo(v('8.0.1'), '8.0', ':distribution:bwc:bugfix'),
-            (v('8.1.0')): new UnreleasedVersionInfo(v('8.1.0'), 'main', ':distribution')
+            (v('8.17.1')): new UnreleasedVersionInfo(v('8.17.1'), '8.17', ':distribution:bwc:maintenance'),
+            (v('9.0.1')): new UnreleasedVersionInfo(v('9.0.1'), '9.0', ':distribution:bwc:bugfix'),
+            (v('9.1.0')): new UnreleasedVersionInfo(v('9.1.0'), 'main', ':distribution')
         ]
-        bwc.wireCompatible == [v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1'), v('8.1.0')]
-        bwc.indexCompatible == [v('7.14.0'), v('7.14.1'), v('7.14.2'), v('7.15.0'), v('7.15.1'), v('7.15.2'), v('7.16.0'), v('7.16.1'), v('7.17.0'), v('7.17.1'), v('8.0.0'), v('8.0.1'), v('8.1.0')]
+        bwc.wireCompatible == [v('8.17.0'), v('8.17.1'), v('9.0.0'), v('9.0.1'), v('9.1.0')]
+        bwc.indexCompatible == [v('8.14.0'), v('8.14.1'), v('8.14.2'), v('8.15.0'), v('8.15.1'), v('8.15.2'), v('8.16.0'), v('8.16.1'), v('8.17.0'), v('8.17.1'), v('9.0.0'), v('9.0.1'), v('9.1.0')]
     }
 
     private void addVersion(String elasticsearch, String lucene) {


### PR DESCRIPTION
This simply updates this test to use major versions matching what our current development branches are on so that it's easier to grok the logic since it maps to current reality. This is mainly preparation for some other changes here, that will make it easier to understand future pull requests.