### PR TITLE
apm-data plugin: disable date_detection

### DIFF
--- a/docs/changelog/116995.yaml
+++ b/docs/changelog/116995.yaml
@@ -1,0 +1,5 @@
+pr: 116995
+summary: "Apm-data: disable date_detection for all apm data streams"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
@@ -4,6 +4,7 @@ _meta:
   managed: true
 template:
   mappings:
+    date_detection: false
     dynamic: true
     dynamic_templates:
     - numeric_labels:


### PR DESCRIPTION
Disable `date_detection` in apm-data plugin to match otel-data plugin mappings.