### PR TITLE
[8.x] ESQL: Docs: COUNT: add an explanation to the use of the 3VL (#116684)

### DIFF
--- a/docs/reference/esql/functions/examples/count.asciidoc
+++ b/docs/reference/esql/functions/examples/count.asciidoc
@@ -37,7 +37,7 @@ include::{esql-specs}/stats.csv-spec[tag=count-where]
 |===
 include::{esql-specs}/stats.csv-spec[tag=count-where-result]
 |===
-To count the same stream of data based on two different expressions use the pattern `COUNT(<expression> OR NULL)`
+To count the same stream of data based on two different expressions use the pattern `COUNT(<expression> OR NULL)`. This builds on the three-valued logic ({wikipedia}/Three-valued_logic[3VL]) of the language: `TRUE OR NULL` is `TRUE`, but `FALSE OR NULL` is `NULL`, plus the way COUNT handles `NULL`s: `COUNT(TRUE)` and `COUNT(FALSE)` are both 1, but `COUNT(NULL)` is 0.
 [source.merge.styled,esql]
 ----
 include::{esql-specs}/stats.csv-spec[tag=count-or-null]

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -58,7 +58,9 @@ public class Count extends AggregateFunction implements ToAggregator, SurrogateE
             ),
             @Example(
                 description = "To count the same stream of data based on two different expressions "
-                    + "use the pattern `COUNT(<expression> OR NULL)`",
+                    + "use the pattern `COUNT(<expression> OR NULL)`. This builds on the three-valued logic "
+                    + "({wikipedia}/Three-valued_logic[3VL]) of the language: `TRUE OR NULL` is `TRUE`, but `FALSE OR NULL` is `NULL`, "
+                    + "plus the way COUNT handles `NULL`s: `COUNT(TRUE)` and `COUNT(FALSE)` are both 1, but `COUNT(NULL)` is 0.",
                 file = "stats",
                 tag = "count-or-null"
             ) }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Docs: COUNT: add an explanation to the use of the 3VL (#116684)