### PR TITLE
Fix url in docs page

### DIFF
--- a/docs/reference/security/securing-communications/security-basic-setup.asciidoc
+++ b/docs/reference/security/securing-communications/security-basic-setup.asciidoc
@@ -175,7 +175,7 @@ matches the DNS or IP address. See the
 . Complete the previous steps for each node in your cluster.
 
 . On *every* node in your cluster, start {es}. The method for
-<<starting-elasticsearch,starting>> and <<starting-elasticsearch,stopping>> {es}
+<<starting-elasticsearch,starting>> and <<stopping-elasticsearch,stopping>> {es}
 varies depending on how you installed it.
 +
 For example, if you installed {es} with an archive distribution


### PR DESCRIPTION
Fix Starting -> Stopping

In [https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html](url),
when click stopping link, It linked to the same url as the route next to it.(starting)
