### PR TITLE
[8.15] [Apm-data]: disable date_detection for all apm data streams (#116995)

### DIFF
--- a/docs/changelog/116995.yaml
+++ b/docs/changelog/116995.yaml
@@ -1,0 +1,5 @@
+pr: 116995
+summary: "Apm-data: disable date_detection for all apm data streams"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
@@ -4,6 +4,7 @@ _meta:
   managed: true
 template:
   mappings:
+    date_detection: false
     dynamic: true
     dynamic_templates:
     - numeric_labels:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Apm-data]: disable date_detection for all apm data streams (#116995)](https://github.com/elastic/elasticsearch/pull/116995)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)