### PR TITLE
[Entitlements] Consider only system modules in the boot layer

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -33,9 +33,12 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         var systemModulesDescriptors = ModuleFinder.ofSystem()
             .findAll()
             .stream()
-            .map(ModuleReference::descriptor).collect(Collectors.toUnmodifiableSet());
+            .map(ModuleReference::descriptor)
+            .collect(Collectors.toUnmodifiableSet());
 
-        var systemModules = ModuleLayer.boot().modules().stream()
+        var systemModules = ModuleLayer.boot()
+            .modules()
+            .stream()
             .filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
             .collect(Collectors.toUnmodifiableSet());
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -36,14 +36,11 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
             .map(ModuleReference::descriptor)
             .collect(Collectors.toUnmodifiableSet());
 
-        var systemModules = ModuleLayer.boot()
+        return ModuleLayer.boot()
             .modules()
             .stream()
             .filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
             .collect(Collectors.toUnmodifiableSet());
-
-        logger.info("System modules: " + systemModules);
-        return systemModules;
     }
 
     @Override
@@ -88,7 +85,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     private static boolean isTriviallyAllowed(Module requestingModule) {
         if (requestingModule == null) {
-            logger.debug("Trivially allowed: Entire call stack is in the boot module layer");
+            logger.debug("Trivially allowed: entire call stack is in composed of classes in system modules");
             return true;
         }
         logger.trace("Not trivially allowed");

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -13,7 +13,11 @@ import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of the {@link EntitlementChecker} interface, providing additional
@@ -23,12 +27,35 @@ import java.util.Optional;
 public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     private static final Logger logger = LogManager.getLogger(ElasticsearchEntitlementChecker.class);
 
+    private static final Set<Module> systemModules = findSystemModules();
+
+    private static Set<Module> findSystemModules() {
+        var systemModulesDescriptors = ModuleFinder.ofSystem()
+            .findAll()
+            .stream()
+            .map(ModuleReference::descriptor).collect(Collectors.toUnmodifiableSet());
+
+        var systemModules = ModuleLayer.boot().modules().stream()
+            .filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
+            .collect(Collectors.toUnmodifiableSet());
+
+        logger.info("System modules: " + systemModules);
+        return systemModules;
+    }
+
     @Override
     public void checkSystemExit(Class<?> callerClass, int status) {
         var requestingModule = requestingModule(callerClass);
         if (isTriviallyAllowed(requestingModule)) {
             return;
         }
+
+        // TODO: this will be checked using policies
+        if (requestingModule.isNamed() && requestingModule.getName().equals("org.elasticsearch.server")) {
+            logger.debug("Allowed: caller in {} is entitled to exit the JVM", requestingModule.getName());
+            return;
+        }
+
         // Hard-forbidden until we develop the permission granting scheme
         throw new NotEntitledException("Missing entitlement for " + requestingModule);
     }
@@ -36,7 +63,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     private static Module requestingModule(Class<?> callerClass) {
         if (callerClass != null) {
             Module callerModule = callerClass.getModule();
-            if (callerModule.getLayer() != ModuleLayer.boot()) {
+            if (systemModules.contains(callerModule) == false) {
                 // fast path
                 return callerModule;
             }
@@ -50,7 +77,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
             .walk(
                 s -> s.skip(framesToSkip)
                     .map(f -> f.getDeclaringClass().getModule())
-                    .filter(m -> m.getLayer() != ModuleLayer.boot())
+                    .filter(m -> systemModules.contains(m) == false)
                     .findFirst()
             );
         return module.orElse(null);
@@ -59,10 +86,6 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     private static boolean isTriviallyAllowed(Module requestingModule) {
         if (requestingModule == null) {
             logger.debug("Trivially allowed: Entire call stack is in the boot module layer");
-            return true;
-        }
-        if (requestingModule == System.class.getModule()) {
-            logger.debug("Trivially allowed: Caller is in {}", System.class.getModule().getName());
             return true;
         }
         logger.trace("Not trivially allowed");


### PR DESCRIPTION
The JDK methods we instrument with _entitlement checks_ call an `EntitlementChecker`. This `EntitlementChecker` needs to establish if the caller is entitled to do some action. The production implementation of Entitlements does that by using modules: the `EntitlementChecker` starts with the module of the caller class and look up for the "requesting module" in the call chain. The "requesting module" is the first non-JDK module (typically, and ES module); for that, we want to filter out JDK (system) modules that may stand in between (e.g. JDK method calling another JDK method).

Currently we filter out all modules in the boot layer; this is incorrect, as everything on the module path (i.e. everything directly in the ES lib dir, which is server and its dependencies) is in the boot layer.

This PR adds a map of modules that are in the boot layer _and_ are system modules (i.e. the modules in the Java run-time image) as located by the system module finder `ModuleFinder.ofSystem()`. This map is then used to check if the module in the call chain is a system module or not.