### PR TITLE
[8.16] [ESQL] Add generated source files to IntelliJ (#116436) (#116778)

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'idea'
+}
+
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask;
 import org.elasticsearch.gradle.internal.util.SourceDirectoryCommandLineArgumentProvider;
@@ -51,12 +55,17 @@ dependencies {
   internalClusterTestImplementation project(":modules:mapper-extras")
 }
 
+def generatedPath = "src/main/generated"
 def projectDirectory = project.layout.projectDirectory
-def generatedSourceDir = projectDirectory.dir("src/main/generated")
+def generatedSourceDir = projectDirectory.dir(generatedPath)
 tasks.named("compileJava").configure {
   options.compilerArgumentProviders.add(new SourceDirectoryCommandLineArgumentProvider(generatedSourceDir))
   // IntelliJ sticks generated files here and we can't stop it....
   exclude { it.file.toString().contains("src/main/generated-src/generated") }
+}
+
+idea.module {
+  sourceDirs += file(generatedPath)
 }
 
 interface Injected {


### PR DESCRIPTION
Backports the following commits to 8.16:
 - [ESQL] Add generated source files to IntelliJ (#116436) (#116778)