### PR TITLE
Optimize PipelineConfiguration-checking ClusterStateListeners

### DIFF
--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
@@ -28,8 +28,12 @@ public class PipelineConfigurationBridge extends StableBridgeAPI.Proxy<PipelineC
         return delegate.getId();
     }
 
-    public Map<String, Object> getConfigAsMap() {
+    public Map<String, Object> getConfig() {
         return delegate.getConfig();
+    }
+
+    public Map<String, Object> getConfig(final boolean unmodifiable) {
+        return delegate.getConfig(unmodifiable);
     }
 
     @Override

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
@@ -29,7 +29,7 @@ public class PipelineConfigurationBridge extends StableBridgeAPI.Proxy<PipelineC
     }
 
     public Map<String, Object> getConfigAsMap() {
-        return delegate.getConfigAsMap();
+        return delegate.getConfig();
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -268,7 +268,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
         Set<String> ids = new HashSet<>();
         // note: this loop is unrolled rather than streaming-style because it's hot enough to show up in a flamegraph
         for (PipelineConfiguration configuration : configurations) {
-            List<Map<String, Object>> processors = (List<Map<String, Object>>) configuration.getConfigAsMap().get(Pipeline.PROCESSORS_KEY);
+            List<Map<String, Object>> processors = (List<Map<String, Object>>) configuration.getConfig().get(Pipeline.PROCESSORS_KEY);
             if (hasAtLeastOneGeoipProcessor(processors, downloadDatabaseOnPipelineCreation)) {
                 ids.add(configuration.getId());
             }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -203,6 +203,7 @@ public class TransportVersions {
     public static final TransportVersion INDEX_STATS_ADDITIONAL_FIELDS_REVERT = def(8_794_00_0);
     public static final TransportVersion FAST_REFRESH_RCO_2 = def(8_795_00_0);
     public static final TransportVersion ESQL_ENRICH_RUNTIME_WARNINGS = def(8_796_00_0);
+    public static final TransportVersion INGEST_PIPELINE_CONFIGURATION_AS_MAP = def(8_797_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -80,7 +80,7 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         for (PipelineConfiguration pipeline : pipelines) {
-            builder.field(pipeline.getId(), summary ? Map.of() : pipeline.getConfigAsMap());
+            builder.field(pipeline.getId(), summary ? Map.of() : pipeline.getConfig());
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -782,7 +782,7 @@ public class MetadataIndexTemplateService {
     private void emitWarningIfPipelineIsDeprecated(String name, Map<String, PipelineConfiguration> pipelines, String pipelineName) {
         Optional.ofNullable(pipelineName)
             .map(pipelines::get)
-            .filter(p -> Boolean.TRUE.equals(p.getConfigAsMap().get("deprecated")))
+            .filter(p -> Boolean.TRUE.equals(p.getConfig().get("deprecated")))
             .ifPresent(
                 p -> deprecationLogger.warn(
                     DeprecationCategory.TEMPLATES,

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1292,7 +1292,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             try {
                 Pipeline newPipeline = Pipeline.create(
                     newConfiguration.getId(),
-                    newConfiguration.getConfigAsMap(),
+                    newConfiguration.parseConfigAsMap(),
                     processorFactories,
                     scriptService
                 );
@@ -1416,7 +1416,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
     public synchronized void reloadPipeline(String id) throws Exception {
         PipelineHolder holder = pipelines.get(id);
-        Pipeline updatedPipeline = Pipeline.create(id, holder.configuration.getConfigAsMap(), processorFactories, scriptService);
+        Pipeline updatedPipeline = Pipeline.create(id, holder.configuration.parseConfigAsMap(), processorFactories, scriptService);
         Map<String, PipelineHolder> updatedPipelines = new HashMap<>(this.pipelines);
         updatedPipelines.put(id, new PipelineHolder(holder.configuration, updatedPipeline));
         this.pipelines = Map.copyOf(updatedPipelines);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -519,7 +519,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             && currentIngestMetadata.getPipelines().containsKey(request.getId())) {
             var pipelineConfig = XContentHelper.convertToMap(request.getSource(), false, request.getXContentType()).v2();
             var currentPipeline = currentIngestMetadata.getPipelines().get(request.getId());
-            if (currentPipeline.getConfigAsMap().equals(pipelineConfig)) {
+            if (currentPipeline.getConfig().equals(pipelineConfig)) {
                 return true;
             }
         }
@@ -1292,7 +1292,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             try {
                 Pipeline newPipeline = Pipeline.create(
                     newConfiguration.getId(),
-                    newConfiguration.getConfigAsMap(false),
+                    newConfiguration.getConfig(false),
                     processorFactories,
                     scriptService
                 );
@@ -1416,7 +1416,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
     public synchronized void reloadPipeline(String id) throws Exception {
         PipelineHolder holder = pipelines.get(id);
-        Pipeline updatedPipeline = Pipeline.create(id, holder.configuration.getConfigAsMap(false), processorFactories, scriptService);
+        Pipeline updatedPipeline = Pipeline.create(id, holder.configuration.getConfig(false), processorFactories, scriptService);
         Map<String, PipelineHolder> updatedPipelines = new HashMap<>(this.pipelines);
         updatedPipelines.put(id, new PipelineHolder(holder.configuration, updatedPipeline));
         this.pipelines = Map.copyOf(updatedPipelines);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1292,7 +1292,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             try {
                 Pipeline newPipeline = Pipeline.create(
                     newConfiguration.getId(),
-                    newConfiguration.parseConfigAsMap(),
+                    newConfiguration.getConfigAsMap(false),
                     processorFactories,
                     scriptService
                 );
@@ -1416,7 +1416,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
     public synchronized void reloadPipeline(String id) throws Exception {
         PipelineHolder holder = pipelines.get(id);
-        Pipeline updatedPipeline = Pipeline.create(id, holder.configuration.parseConfigAsMap(), processorFactories, scriptService);
+        Pipeline updatedPipeline = Pipeline.create(id, holder.configuration.getConfigAsMap(false), processorFactories, scriptService);
         Map<String, PipelineHolder> updatedPipelines = new HashMap<>(this.pipelines);
         updatedPipelines.put(id, new PipelineHolder(holder.configuration, updatedPipeline));
         this.pipelines = Map.copyOf(updatedPipelines);

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -86,11 +86,11 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
         return id;
     }
 
-    public Map<String, Object> getConfigAsMap() {
-        return getConfigAsMap(true);
+    public Map<String, Object> getConfig() {
+        return getConfig(true);
     }
 
-    public Map<String, Object> getConfigAsMap(boolean unmodifiable) {
+    public Map<String, Object> getConfig(boolean unmodifiable) {
         if (unmodifiable) {
             return config; // already unmodifiable
         } else {
@@ -203,7 +203,8 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
      * <p>The given upgrader is applied to the config map for any processor of the given type.
      */
     PipelineConfiguration maybeUpgradeProcessors(String type, IngestMetadata.ProcessorConfigUpgrader upgrader) {
-        Map<String, Object> mutableConfigMap = parseConfigAsMap();
+        Map<String, Object> mutableConfigMap = getConfig(false);
+        ;
         boolean changed = false;
         // This should be a List of Maps, where the keys are processor types and the values are config maps.
         // But we'll skip upgrading rather than fail if not.

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -41,7 +41,6 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
             contentBuilder.generator().copyCurrentStructure(parser);
             builder.setConfig(BytesReference.bytes(contentBuilder), contentBuilder.contentType());
         }, new ParseField("config"), ObjectParser.ValueType.OBJECT);
-
     }
 
     public static ContextParser<Void, PipelineConfiguration> getParser() {

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -227,7 +227,6 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
      */
     PipelineConfiguration maybeUpgradeProcessors(String type, IngestMetadata.ProcessorConfigUpgrader upgrader) {
         Map<String, Object> mutableConfigMap = getConfig(false);
-        ;
         boolean changed = false;
         // This should be a List of Maps, where the keys are processor types and the values are config maps.
         // But we'll skip upgrading rather than fail if not.

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -78,6 +78,14 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
         this.config = deepCopy(config, true); // defensive deep copy
     }
 
+    /**
+     * A convenience constructor that parses some bytes as a map representing a pipeline's config and then delegates to the
+     * conventional {@link #PipelineConfiguration(String, Map)} constructor.
+     *
+     * @param id the id of the pipeline
+     * @param config a parse-able bytes reference that will return a pipeline configuration
+     * @param xContentType the content-type to use while parsing the pipeline configuration
+     */
     public PipelineConfiguration(String id, BytesReference config, XContentType xContentType) {
         this(id, XContentHelper.convertToMap(config, true, xContentType).v2());
     }
@@ -86,10 +94,18 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
         return id;
     }
 
+    /**
+     * @return a reference to the unmodifiable configuration map for this pipeline
+     */
     public Map<String, Object> getConfig() {
         return getConfig(true);
     }
 
+    /**
+     * @param unmodifiable whether the returned map should be unmodifiable or not
+     * @return a reference to the unmodifiable config map (if unmodifiable is true) or
+     * a reference to a freshly-created mutable deep copy of the config map (if unmodifiable is false)
+     */
     public Map<String, Object> getConfig(boolean unmodifiable) {
         if (unmodifiable) {
             return config; // already unmodifiable

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -136,12 +136,11 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
                 copy.add(innerDeepCopy(itemValue, unmodifiable));
             }
             return unmodifiable ? Collections.unmodifiableList(copy) : copy;
-        } else if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean) {
-            return value;
         } else {
-            // if the previous list of expected value types ends up not being exhaustive, then we want to learn about that
+            // if this list of expected value types ends up not being exhaustive, then we want to learn about that
             // at development time, but it's probably better to err on the side of passing through the value at runtime
-            assert false : "unexpected value type [" + value.getClass() + "]";
+            assert (value == null || value instanceof String || value instanceof Number || value instanceof Boolean)
+                : "unexpected value type [" + value.getClass() + "]";
             return value;
         }
     }

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -34,7 +34,11 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Encapsulates a pipeline's id and configuration as a blob
+ * Encapsulates a pipeline's id and configuration as a loosely typed map -- see {@link Pipeline} for the
+ * parsed and processed object(s) that a pipeline configuration will become. This class is used for things
+ * like keeping track of pipelines in the cluster state (where a pipeline is 'just some json') whereas the
+ * {@link Pipeline} class is used in the actual processing of ingest documents through pipelines in the
+ * {@link IngestService}.
  */
 public final class PipelineConfiguration implements SimpleDiffable<PipelineConfiguration>, ToXContentObject {
 

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -139,7 +139,10 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
         } else if (value == null || value instanceof String || value instanceof Number || value instanceof Boolean) {
             return value;
         } else {
-            throw new IllegalArgumentException("unexpected value type [" + value.getClass() + "]");
+            // if the previous list of expected value types ends up not being exhaustive, then we want to learn about that
+            // at development time, but it's probably better to err on the side of passing through the value at runtime
+            assert false : "unexpected value type [" + value.getClass() + "]";
+            return value;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -172,7 +172,7 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
         if (in.getTransportVersion().onOrAfter(TransportVersions.INGEST_PIPELINE_CONFIGURATION_AS_MAP)) {
             config = in.readGenericMap();
         } else {
-            final BytesReference bytes = in.readBytesReference();
+            final BytesReference bytes = in.readSlicedBytesReference();
             final XContentType type = in.readEnum(XContentType.class);
             config = XContentHelper.convertToMap(bytes, true, type).v2();
         }

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineConfiguration.java
@@ -87,11 +87,15 @@ public final class PipelineConfiguration implements SimpleDiffable<PipelineConfi
     }
 
     public Map<String, Object> getConfigAsMap() {
-        return config;
+        return getConfigAsMap(true);
     }
 
-    public Map<String, Object> parseConfigAsMap() {
-        return deepCopy(config, false);
+    public Map<String, Object> getConfigAsMap(boolean unmodifiable) {
+        if (unmodifiable) {
+            return config; // already unmodifiable
+        } else {
+            return deepCopy(config, false);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
@@ -79,7 +79,7 @@ public class GetPipelineResponseTests extends AbstractXContentSerializingTestCas
         assertEquals(actualPipelines.size(), parsedPipelines.size());
         for (PipelineConfiguration pipeline : parsedPipelines) {
             assertTrue(pipelinesMap.containsKey(pipeline.getId()));
-            assertEquals(pipelinesMap.get(pipeline.getId()).getConfigAsMap(), pipeline.getConfigAsMap());
+            assertEquals(pipelinesMap.get(pipeline.getId()).getConfig(), pipeline.getConfig());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -56,8 +56,8 @@ public class IngestMetadataTests extends ESTestCase {
             assertEquals(2, custom.getPipelines().size());
             assertEquals("1", custom.getPipelines().get("1").getId());
             assertEquals("2", custom.getPipelines().get("2").getId());
-            assertEquals(pipeline.getConfigAsMap(), custom.getPipelines().get("1").getConfigAsMap());
-            assertEquals(pipeline2.getConfigAsMap(), custom.getPipelines().get("2").getConfigAsMap());
+            assertEquals(pipeline.getConfig(), custom.getPipelines().get("1").getConfig());
+            assertEquals(pipeline2.getConfig(), custom.getPipelines().get("2").getConfig());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -39,12 +39,12 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             new BytesArray("{}".getBytes(StandardCharsets.UTF_8)),
             XContentType.JSON
         );
-        assertThat(configuration.getConfigAsMap(), anEmptyMap());
+        assertThat(configuration.getConfig(), anEmptyMap());
         BytesStreamOutput out = new BytesStreamOutput();
         configuration.writeTo(out);
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         PipelineConfiguration serialized = PipelineConfiguration.readFrom(in);
-        assertThat(serialized.getConfigAsMap(), anEmptyMap());
+        assertThat(serialized.getConfig(), anEmptyMap());
     }
 
     public void testMetaSerialization() throws IOException {
@@ -61,7 +61,7 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
         PipelineConfiguration serialized = PipelineConfiguration.readFrom(in);
         assertEquals(
             XContentHelper.convertToMap(new BytesArray(configJson.getBytes(StandardCharsets.UTF_8)), true, XContentType.JSON).v2(),
-            serialized.getConfigAsMap()
+            serialized.getConfig()
         );
     }
 
@@ -81,7 +81,7 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, bytes.streamInput());
         PipelineConfiguration parsed = parser.parse(xContentParser, null);
         assertThat(parsed.getId(), equalTo("1"));
-        assertThat(parsed.getConfigAsMap(), anEmptyMap());
+        assertThat(parsed.getConfig(), anEmptyMap());
     }
 
     public void testGetVersion() {

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -26,12 +26,44 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class PipelineConfigurationTests extends AbstractXContentTestCase<PipelineConfiguration> {
+
+    public void testConfigInvariants() {
+        Map<String, Object> original = Map.of("a", 1);
+        Map<String, Object> mutable = new HashMap<>(original);
+        PipelineConfiguration configuration = new PipelineConfiguration("1", mutable);
+        // the config is equal to the original & mutable map, regardless of how you get a reference to it
+        assertThat(configuration.getConfig(), equalTo(original));
+        assertThat(configuration.getConfig(), equalTo(mutable));
+        assertThat(configuration.getConfig(), equalTo(configuration.getConfig(false)));
+        assertThat(configuration.getConfig(), equalTo(configuration.getConfig(true)));
+        // the config is the same instance as itself when unmodifiable is true
+        assertThat(configuration.getConfig(), sameInstance(configuration.getConfig()));
+        assertThat(configuration.getConfig(), sameInstance(configuration.getConfig(true)));
+        // but it's not the same instance as the original mutable map, nor if unmodifiable is false
+        assertThat(configuration.getConfig(), not(sameInstance(mutable)));
+        assertThat(configuration.getConfig(), not(sameInstance(configuration.getConfig(false))));
+
+        // changing the mutable map doesn't alter the pipeline's configuration
+        mutable.put("b", 2);
+        assertThat(configuration.getConfig(), equalTo(original));
+
+        // the modifiable map can be modified
+        Map<String, Object> modifiable = configuration.getConfig(false);
+        modifiable.put("c", 3); // this doesn't throw an exception
+        assertThat(modifiable.get("c"), equalTo(3));
+        // but the next modifiable copy is a new fresh copy, and doesn't reflect those changes
+        assertThat(configuration.getConfig(), equalTo(configuration.getConfig(false)));
+    }
 
     public void testSerialization() throws IOException {
         PipelineConfiguration configuration = new PipelineConfiguration(

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Predicate;
 
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PipelineConfigurationTests extends AbstractXContentTestCase<PipelineConfiguration> {
@@ -38,7 +39,7 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             new BytesArray("{}".getBytes(StandardCharsets.UTF_8)),
             XContentType.JSON
         );
-        assertEquals(XContentType.JSON, configuration.getXContentType());
+        assertThat(configuration.getConfigAsMap(), anEmptyMap());
 
         BytesStreamOutput out = new BytesStreamOutput();
         configuration.writeTo(out);
@@ -81,8 +82,8 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, bytes.streamInput());
         PipelineConfiguration parsed = parser.parse(xContentParser, null);
         assertEquals(xContentType.canonical(), parsed.getXContentType());
+        assertThat(parsed.getId(), equalTo("1"));
         assertEquals("{}", XContentHelper.convertToJson(parsed.getConfig(), false, parsed.getXContentType()));
-        assertEquals("1", parsed.getId());
     }
 
     public void testGetVersion() {

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -40,13 +40,11 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             XContentType.JSON
         );
         assertThat(configuration.getConfigAsMap(), anEmptyMap());
-
         BytesStreamOutput out = new BytesStreamOutput();
         configuration.writeTo(out);
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         PipelineConfiguration serialized = PipelineConfiguration.readFrom(in);
-        assertEquals(XContentType.JSON, serialized.getXContentType());
-        assertEquals("{}", serialized.getConfig().utf8ToString());
+        assertThat(serialized.getConfigAsMap(), anEmptyMap());
     }
 
     public void testMetaSerialization() throws IOException {
@@ -57,13 +55,14 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
             new BytesArray(configJson.getBytes(StandardCharsets.UTF_8)),
             XContentType.JSON
         );
-        assertEquals(XContentType.JSON, configuration.getXContentType());
         BytesStreamOutput out = new BytesStreamOutput();
         configuration.writeTo(out);
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         PipelineConfiguration serialized = PipelineConfiguration.readFrom(in);
-        assertEquals(XContentType.JSON, serialized.getXContentType());
-        assertEquals(configJson, serialized.getConfig().utf8ToString());
+        assertEquals(
+            XContentHelper.convertToMap(new BytesArray(configJson.getBytes(StandardCharsets.UTF_8)), true, XContentType.JSON).v2(),
+            serialized.getConfigAsMap()
+        );
     }
 
     public void testParser() throws IOException {
@@ -81,9 +80,8 @@ public class PipelineConfigurationTests extends AbstractXContentTestCase<Pipelin
         XContentParser xContentParser = xContentType.xContent()
             .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, bytes.streamInput());
         PipelineConfiguration parsed = parser.parse(xContentParser, null);
-        assertEquals(xContentType.canonical(), parsed.getXContentType());
         assertThat(parsed.getId(), equalTo("1"));
-        assertEquals("{}", XContentHelper.convertToJson(parsed.getConfig(), false, parsed.getXContentType()));
+        assertThat(parsed.getConfigAsMap(), anEmptyMap());
     }
 
     public void testGetVersion() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/InferenceProcessorInfoExtractor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/InferenceProcessorInfoExtractor.java
@@ -51,7 +51,7 @@ public final class InferenceProcessorInfoExtractor {
         }
         Counter counter = Counter.newCounter();
         ingestMetadata.getPipelines().forEach((pipelineId, configuration) -> {
-            Map<String, Object> configMap = configuration.getConfigAsMap();
+            Map<String, Object> configMap = configuration.getConfig();
             List<Map<String, Object>> processorConfigs = (List<Map<String, Object>>) configMap.get(PROCESSORS_KEY);
             for (Map<String, Object> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
@@ -73,7 +73,7 @@ public final class InferenceProcessorInfoExtractor {
 
         Set<String> modelIds = new LinkedHashSet<>();
         ingestMetadata.getPipelines().forEach((pipelineId, configuration) -> {
-            Map<String, Object> configMap = configuration.getConfigAsMap();
+            Map<String, Object> configMap = configuration.getConfig();
             List<Map<String, Object>> processorConfigs = readList(configMap, PROCESSORS_KEY);
             for (Map<String, Object> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
@@ -100,7 +100,7 @@ public final class InferenceProcessorInfoExtractor {
             return pipelineIdsByModelIds;
         }
         ingestMetadata.getPipelines().forEach((pipelineId, configuration) -> {
-            Map<String, Object> configMap = configuration.getConfigAsMap();
+            Map<String, Object> configMap = configuration.getConfig();
             List<Map<String, Object>> processorConfigs = readList(configMap, PROCESSORS_KEY);
             for (Map<String, Object> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
@@ -131,7 +131,7 @@ public final class InferenceProcessorInfoExtractor {
             return pipelineIds;
         }
         ingestMetadata.getPipelines().forEach((pipelineId, configuration) -> {
-            Map<String, Object> configMap = configuration.getConfigAsMap();
+            Map<String, Object> configMap = configuration.getConfig();
             List<Map<String, Object>> processorConfigs = readList(configMap, PROCESSORS_KEY);
             for (Map<String, Object> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
@@ -726,7 +726,7 @@ public class IndexTemplateRegistryTests extends ESTestCase {
             putRequest.getSource(),
             putRequest.getXContentType()
         );
-        List<?> processors = (List<?>) pipelineConfiguration.getConfigAsMap().get("processors");
+        List<?> processors = (List<?>) pipelineConfiguration.getConfig().get("processors");
         assertThat(processors, hasSize(1));
         Map<?, ?> setProcessor = (Map<?, ?>) ((Map<?, ?>) processors.get(0)).get("set");
         assertNotNull(setProcessor.get("field"));

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyReindexPipeline.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyReindexPipeline.java
@@ -56,7 +56,7 @@ public class EnrichPolicyReindexPipeline {
         if (ingestMetadata != null) {
             final PipelineConfiguration pipeline = ingestMetadata.getPipelines().get(pipelineName());
             if (pipeline != null) {
-                Object version = pipeline.getConfigAsMap().get("version");
+                Object version = pipeline.getConfig().get("version");
                 return version instanceof Number number && number.intValue() >= ENRICH_PIPELINE_LAST_UPDATED_VERSION;
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -981,7 +981,7 @@ public class ModelLoadingService implements ClusterStateListener {
             return allReferencedModelKeys;
         }
         ingestMetadata.getPipelines().forEach((pipelineId, pipelineConfiguration) -> {
-            Object processors = pipelineConfiguration.getConfigAsMap().get("processors");
+            Object processors = pipelineConfiguration.getConfig().get("processors");
             if (processors instanceof List<?>) {
                 for (Object processor : (List<?>) processors) {
                     if (processor instanceof Map<?, ?>) {

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistryTests.java
@@ -56,7 +56,7 @@ public class LegacyStackTemplateRegistryTests extends ESTestCase {
         registry.getIngestPipelines()
             .stream()
             .map(ipc -> new PipelineConfiguration(ipc.getId(), ipc.loadConfig(), XContentType.JSON))
-            .map(PipelineConfiguration::getConfigAsMap)
+            .map(PipelineConfiguration::getConfig)
             .forEach(p -> assertTrue((Boolean) p.get("deprecated")));
     }
 

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -516,7 +516,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
         registry.getIngestPipelines()
             .stream()
             .map(ipc -> new PipelineConfiguration(ipc.getId(), ipc.loadConfig(), XContentType.JSON))
-            .map(PipelineConfiguration::getConfigAsMap)
+            .map(PipelineConfiguration::getConfig)
             .forEach(p -> assertFalse((Boolean) p.get("deprecated")));
     }
 


### PR DESCRIPTION
Before (this PR and the various semi-associated PRs that have already been merged):

<img width="1653" alt="Screenshot 2024-11-19 at 10 47 11 AM" src="https://github.com/user-attachments/assets/171655fa-019f-47ea-8811-47d391b8730a">

After (this PR and the various semi-associated PRs that have already been merged):

<img width="1658" alt="Screenshot 2024-11-19 at 10 47 28 AM" src="https://github.com/user-attachments/assets/51d35a05-c370-4f86-8d9d-3bb14845dbf1">

-----

I ran into this in the `/_nodes/hot_threads` output of a real in-the-wild cluster and it's been on my list ever since.

Two of our `ClusterStateListener`s are operating on `PipelineConfiguration`: the `GeoIpDownloaderTaskExecutor` and the `IndexTemplateRegistry`. Both of them ask the `PipelineConfiguration` for details that it doesn't actually have on hand, so we need to parse the XContent of the pipeline in order to retrieve those details. As a consequence, we're parsing the XContent of some of these pipelines twice (once per listener) on every cluster state update. In the case of `GeoIpDownloaderTaskExecutor` we have to do that for every pipeline that there is, so we're adding a cost to the master that scales on the order of the number of pipelines, which means that for clusters with large numbers of pipelines the actual CPU cost expended can start to matter (computers are very fast, of course, but things like this can add up). This doesn't change the big-O of that part of the work (since we're still asking questions of every pipeline) but it does change the code so that we can answer those questions with objects that are hanging around in memory rather than needing to parse yaml-or-json to get them.

In terms of implementation, `PipelineConfiguration` holds the core of the changes. Rather than keeping the unparsed XContent around, it now maintains an unmodifiable parsed version of the same data. Other parts of ingest (most notably, creating a `Pipeline` from a `PipelineConfiguration`) rely on having a **mutable** copy of the `PipelineConfiguration`'s `config`, so there's a getter that accepts a boolean which can be used to ask for that.

-----

Related to https://github.com/elastic/elasticsearch/pull/116988, https://github.com/elastic/elasticsearch/pull/115355, https://github.com/elastic/elasticsearch/pull/115348, and https://github.com/elastic/elasticsearch/pull/115347 -- those were small 'jab' optimization PRs laying the groundwork for this final one. Similarly see also https://github.com/elastic/elasticsearch/pull/115425, https://github.com/elastic/elasticsearch/pull/115423, and https://github.com/elastic/elasticsearch/pull/115421 -- the cleanups in those PRs were mostly intended to make this PR more readable and simpler in the end.

Closes https://github.com/elastic/elasticsearch/issues/97382