### PR TITLE
[8.x] [DOCS] Rename how-to subsection, move recipes to search relevance (#117044)

### DIFF
--- a/docs/reference/how-to.asciidoc
+++ b/docs/reference/how-to.asciidoc
@@ -1,23 +1,21 @@
 [[how-to]]
-= How to
+= Optimizations
 
-[partintro]
---
-Elasticsearch ships with defaults which are intended to give a good out of
-the box experience. Full text search, highlighting, aggregations, and indexing
-should all just work without the user having to change anything.
+Elasticsearch's default settings provide a good out-of-box experience for basic operations like full text search, highlighting, aggregations, and indexing. 
 
-Once you better understand how you want to use Elasticsearch, however,
-there are a number of optimizations you can make to improve performance
-for your use case.
+However, there are a number of optimizations you can make to improve performance for your use case.
 
-This section provides guidance about which changes should and shouldn't be
-made.
---
+This section provides recommendations for various use cases.
+
+* <<general-recommendations>>
+* <<tune-for-indexing-speed>>
+* <<tune-for-search-speed>>
+* <<tune-knn-search>>
+* <<tune-for-disk-usage>>
+* <<size-your-shards>>
+* <<use-elasticsearch-for-time-series-data>>
 
 include::how-to/general.asciidoc[]
-
-include::how-to/recipes.asciidoc[]
 
 include::how-to/indexing-speed.asciidoc[]
 

--- a/docs/reference/how-to/recipes.asciidoc
+++ b/docs/reference/how-to/recipes.asciidoc
@@ -1,7 +1,7 @@
 [[recipes]]
-== Recipes
+== Search relevance optimizations
 
-This section includes a few recipes to help with common problems:
+This section includes a few recipes to help with common search relevance issues:
 
 * <<mixing-exact-search-with-stemming,Mixing exact search with stemming>>
 * <<consistent-scoring,Getting consistent scores>>

--- a/docs/reference/how-to/recipes/scoring.asciidoc
+++ b/docs/reference/how-to/recipes/scoring.asciidoc
@@ -88,8 +88,9 @@ pages independently of the query.
 
 There are two main queries that allow combining static score contributions with
 textual relevance, eg. as computed with BM25:
- - <<query-dsl-script-score-query,`script_score` query>>
- - <<query-dsl-rank-feature-query,`rank_feature` query>>
+
+* <<query-dsl-script-score-query,`script_score` query>>
+* <<query-dsl-rank-feature-query,`rank_feature` query>>
 
 For instance imagine that you have a `pagerank` field that you wish to
 combine with the BM25 score so that the final score is equal to

--- a/docs/reference/search/search-your-data/search-your-data.asciidoc
+++ b/docs/reference/search/search-your-data/search-your-data.asciidoc
@@ -43,6 +43,8 @@ DSL, with a simplified user experience. Create search applications based on your
 results directly in the Kibana Search UI.
 
 include::search-api.asciidoc[]
+include::../../how-to/recipes.asciidoc[]
+// ☝️ search relevance recipes
 include::retrievers-overview.asciidoc[]
 include::knn-search.asciidoc[]
 include::semantic-search.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [DOCS] Rename how-to subsection, move recipes to search relevance (#117044)