### PR TITLE
Make IDE setup lenient to support composite builds

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -145,7 +145,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
 
     doLast {
       ['main', 'test'].each { sourceSet ->
-        modifyXml(".idea/modules/libs/native/elasticsearch.libs.${project.project(':libs:native').name}.${sourceSet}.iml") { xml ->
+        modifyXml(".idea/modules/libs/native/elasticsearch.libs.native.${sourceSet}.iml") { xml ->
           xml.component.find { it.'@name' == 'NewModuleRootManager' }?.'@LANGUAGE_LEVEL' = 'JDK_21_PREVIEW'
         }
       }


### PR DESCRIPTION
We had originally made this strict to ensure refactored projects would result in an error but this doesn't work well for composite builds so we're making this lenient again.