### PR TITLE
[ML] Increase Model Download Timeout In YAML Tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -231,14 +231,9 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
   method: testRandomDirectoryIOExceptions
   issue: https://github.com/elastic/elasticsearch/issues/114824
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/116542
 - class: org.elasticsearch.compute.lucene.LuceneQueryExpressionEvaluatorTests
   method: testTermQuery
   issue: https://github.com/elastic/elasticsearch/issues/116879
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  issue: https://github.com/elastic/elasticsearch/issues/116899
 - class: org.elasticsearch.xpack.restart.QueryBuilderBWCIT
   method: testQueryBuilderBWC {p0=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/116989

--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -36,7 +36,7 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
         var baseSettings = super.restClientSettings();
         return Settings.builder()
             .put(baseSettings)
-            .put(CLIENT_SOCKET_TIMEOUT, "120s")  // Long timeout for model download
+            .put(CLIENT_SOCKET_TIMEOUT, "300s")  // Long timeout for model download
             .build();
     }
 


### PR DESCRIPTION
Increase the timeout used in inference YAML tests for model download. Fixes #116899.
