### PR TITLE
ESQL add missing capabilities check for tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -734,6 +734,8 @@ count:long  |  @timestamp:date
 Multi Index millis to nanos stats
 required_capability: union_types
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
+required_capability: date_trunc_date_nanos
 
 FROM sample_data, sample_data_ts_nanos
 | EVAL @timestamp = DATE_TRUNC(1 hour, TO_DATE_NANOS(@timestamp))


### PR DESCRIPTION
This should fix a couple of tests failures due to incorrect capabilities checks.  I already added them manually to 8.x to resolve a failure there (see https://github.com/elastic/elasticsearch/pull/116602) so this doesn't need to be backported.