### PR TITLE
[8.16] Skip FIPS JVMs in `testReloadCredentialsFromKeystore` (#116814)

### DIFF
--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3RestIT.java
@@ -52,6 +52,8 @@ public class RepositoryS3RestIT extends ESRestTestCase {
     }
 
     public void testReloadCredentialsFromKeystore() throws IOException {
+        assumeFalse("doesn't work in a FIPS JVM, but that's ok", inFipsJvm());
+
         // Register repository (?verify=false because we don't have access to the blob store yet)
         final var repositoryName = randomIdentifier();
         registerRepository(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Skip FIPS JVMs in &#x60;testReloadCredentialsFromKeystore&#x60; (#116814)](https://github.com/elastic/elasticsearch/pull/116814)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)