### PR TITLE
Fast refresh indices to use search shards

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -201,6 +201,7 @@ public class TransportVersions {
     public static final TransportVersion QUERY_RULES_LIST_INCLUDES_TYPES = def(8_792_00_0);
     public static final TransportVersion INDEX_STATS_ADDITIONAL_FIELDS = def(8_793_00_0);
     public static final TransportVersion INDEX_STATS_ADDITIONAL_FIELDS_REVERT = def(8_794_00_0);
+    public static final TransportVersion FAST_REFRESH_RCO_2 = def(8_795_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
 
-import static org.elasticsearch.TransportVersions.FAST_REFRESH_RCO;
+import static org.elasticsearch.TransportVersions.FAST_REFRESH_RCO_2;
 import static org.elasticsearch.index.IndexSettings.INDEX_FAST_REFRESH_SETTING;
 
 public class TransportUnpromotableShardRefreshAction extends TransportBroadcastUnpromotableAction<
@@ -76,17 +76,17 @@ public class TransportUnpromotableShardRefreshAction extends TransportBroadcastU
             return;
         }
 
-        // During an upgrade to FAST_REFRESH_RCO, we expect search shards to be first upgraded before the primary is upgraded. Thus,
+        // During an upgrade to FAST_REFRESH_RCO_2, we expect search shards to be first upgraded before the primary is upgraded. Thus,
         // when the primary is upgraded, and starts to deliver unpromotable refreshes, we expect the search shards to be upgraded already.
         // Note that the fast refresh setting is final.
         // TODO: remove assertion (ES-9563)
         assert INDEX_FAST_REFRESH_SETTING.get(shard.indexSettings().getSettings()) == false
-            || transportService.getLocalNodeConnection().getTransportVersion().onOrAfter(FAST_REFRESH_RCO)
+            || transportService.getLocalNodeConnection().getTransportVersion().onOrAfter(FAST_REFRESH_RCO_2)
             : "attempted to refresh a fast refresh search shard "
                 + shard
                 + " on transport version "
                 + transportService.getLocalNodeConnection().getTransportVersion()
-                + " (before FAST_REFRESH_RCO)";
+                + " (before FAST_REFRESH_RCO_2)";
 
         ActionListener.run(responseListener, listener -> {
             shard.waitForPrimaryTermAndGeneration(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.TransportVersions.FAST_REFRESH_RCO;
+import static org.elasticsearch.TransportVersions.FAST_REFRESH_RCO_2;
 import static org.elasticsearch.index.IndexSettings.INDEX_FAST_REFRESH_SETTING;
 
 public class OperationRouting {
@@ -309,7 +309,7 @@ public class OperationRouting {
         // TODO: remove if and always return isSearchable (ES-9563)
         if (INDEX_FAST_REFRESH_SETTING.get(clusterState.metadata().index(shardRouting.index()).getSettings())) {
             // Until all the cluster is upgraded, we send searches/gets to the primary (even if it has been upgraded) to execute locally.
-            if (clusterState.getMinTransportVersion().onOrAfter(FAST_REFRESH_RCO)) {
+            if (clusterState.getMinTransportVersion().onOrAfter(FAST_REFRESH_RCO_2)) {
                 return shardRouting.isSearchable();
             } else {
                 return shardRouting.isPromotableToPrimary();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexRoutingTableTests.java
@@ -20,7 +20,7 @@ import org.mockito.Mockito;
 
 import java.util.List;
 
-import static org.elasticsearch.TransportVersions.FAST_REFRESH_RCO;
+import static org.elasticsearch.TransportVersions.FAST_REFRESH_RCO_2;
 import static org.elasticsearch.index.IndexSettings.INDEX_FAST_REFRESH_SETTING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -43,7 +43,7 @@ public class IndexRoutingTableTests extends ESTestCase {
             Settings.builder().put(INDEX_FAST_REFRESH_SETTING.getKey(), fastRefresh).build()
         );
         when(clusterState.getMinTransportVersion()).thenReturn(
-            beforeFastRefreshRCO ? TransportVersion.fromId(FAST_REFRESH_RCO.id() - 1_00_0) : TransportVersion.current()
+            beforeFastRefreshRCO ? TransportVersion.fromId(FAST_REFRESH_RCO_2.id() - 1_00_0) : TransportVersion.current()
         );
         // 2 primaries that are search and index
         ShardId p1 = new ShardId(index, 0);


### PR DESCRIPTION
Backport of PR #116658.

Changes of this PR are ineffective for stateful, and backport is not used in serverless. This is mostly to adopt the new transport version in stateful to keep them consecutive (e.g., to avoid [this](https://gradle-enterprise.elastic.co/s/3ra26mql726ym)).

Relates ES-9573