### PR TITLE
Add back gte conditions on full restart tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -245,36 +245,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Failed to snapshot indices with synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/117082
-- class: org.elasticsearch.upgrades.FullClusterRestartDownsampleIT
-  method: testRollupIndex {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/117084
-- class: org.elasticsearch.upgrades.FullClusterRestartDownsampleIT
-  method: testRollupIndex {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/117086
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testNewReplicasTimeSeriesMode {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/117087
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testNewReplicasTimeSeriesMode {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/117088
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSearchTimeSeriesMode {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/117089
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSearchTimeSeriesMode {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/117090
-- class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
-  method: testNewReplicasTimeSeriesMode {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/117091
-- class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
-  method: testSearchTimeSeriesMode {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/117092
-- class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
-  method: testNewReplicasTimeSeriesMode {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/117093
-- class: org.elasticsearch.xpack.restart.CoreFullClusterRestartIT
-  method: testSearchTimeSeriesMode {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/117094
 - class: org.elasticsearch.discovery.ClusterDisruptionIT
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
@@ -268,6 +268,7 @@ public class FullClusterRestartDownsampleIT extends ParameterizedFullClusterRest
     }
 
     public void testRollupIndex() throws Exception {
+        assumeTrue("Downsample got many stability improvements in 8.10.0", oldClusterHasFeature("gte_v8.10.0"));
         if (isRunningAgainstOldCluster()) {
             createIlmPolicy();
             createIndex();

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -261,6 +261,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
     }
 
     public void testSearchTimeSeriesMode() throws Exception {
+        assumeTrue("indexing time series indices changed in 8.2.0", oldClusterHasFeature("gte_v8.2.0"));
         int numDocs;
         if (isRunningAgainstOldCluster()) {
             numDocs = createTimeSeriesModeIndex(1);
@@ -298,6 +299,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
     }
 
     public void testNewReplicasTimeSeriesMode() throws Exception {
+        assumeTrue("indexing time series indices changed in 8.2.0", oldClusterHasFeature("gte_v8.2.0"));
         if (isRunningAgainstOldCluster()) {
             createTimeSeriesModeIndex(0);
         } else {


### PR DESCRIPTION
Conditions on full cluster restart tests were removed by #116929. It's still valid to do a full restart from any v8 cluster to a v9 cluster, so we still need these conditions for full restart tests. Fortunately we now have `gte_v` features we can use instead, rather than historical features.

Fixes https://github.com/elastic/elasticsearch/issues/117084
Fixes https://github.com/elastic/elasticsearch/issues/117086
Fixes https://github.com/elastic/elasticsearch/issues/117087
Fixes https://github.com/elastic/elasticsearch/issues/117088
Fixes https://github.com/elastic/elasticsearch/issues/117089
Fixes https://github.com/elastic/elasticsearch/issues/117090
Fixes https://github.com/elastic/elasticsearch/issues/117091
Fixes https://github.com/elastic/elasticsearch/issues/117092
Fixes https://github.com/elastic/elasticsearch/issues/117093
Fixes https://github.com/elastic/elasticsearch/issues/117094