### PR TITLE
[TEST] Unmute org.elasticsearch.upgrades.IndexingIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -254,41 +254,7 @@ tests:
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445
-- class: org.elasticsearch.upgrades.DownsampleIT
-  method: testRollupIndex {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/117122
-- class: org.elasticsearch.upgrades.DownsampleIT
-  method: testRollupIndex {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/117123
-- class: org.elasticsearch.upgrades.DownsampleIT
-  method: testRollupIndex {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/117124
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testAutoIdWithOpTypeCreate {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/117125
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testTsdb {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/117126
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testIndexing {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/117127
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testSyntheticSource {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/117128
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/117135
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testTsdb {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/117136
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/117137
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testTsdb {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/117138
-- class: org.elasticsearch.upgrades.IndexingIT
-  issue: https://github.com/elastic/elasticsearch/issues/117140
+
 
 # Examples:
 #


### PR DESCRIPTION
Restore test suite, after submitting rollbacks #117150 and #117151

Fixes #117122
Fixes #117123
Fixes #117124
Fixes #117125 
Fixes #117126
Fixes #117127
Fixes #117128
Fixes #117135
Fixes #117136
Fixes #117137
Fixes #117138
Fixes #117140