### PR TITLE
[CI][ML] Unmute InferenceRestIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -228,9 +228,6 @@ tests:
 - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
   method: testRandomDirectoryIOExceptions
   issue: https://github.com/elastic/elasticsearch/issues/114824
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/116542
 - class: org.elasticsearch.compute.lucene.LuceneQueryExpressionEvaluatorTests
   method: testTermQuery
   issue: https://github.com/elastic/elasticsearch/issues/116879


### PR DESCRIPTION
Unmutes the test muted in #116542
The test was fixed in https://github.com/elastic/elasticsearch/pull/116749

Closes #116542