### PR TITLE
Remove method #getBucketByKey from SignificantTerms.Bucket

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -32,7 +32,6 @@ public abstract class InternalMappedSignificantTerms<
     protected final long supersetSize;
     protected final SignificanceHeuristic significanceHeuristic;
     protected final List<B> buckets;
-    protected Map<String, B> bucketMap;
 
     protected InternalMappedSignificantTerms(
         String name,
@@ -83,14 +82,6 @@ public abstract class InternalMappedSignificantTerms<
     }
 
     @Override
-    public B getBucketByKey(String term) {
-        if (bucketMap == null) {
-            bucketMap = buckets.stream().collect(Collectors.toMap(InternalSignificantTerms.Bucket::getKeyAsString, Function.identity()));
-        }
-        return bucketMap.get(term);
-    }
-
-    @Override
     protected long getSubsetSize() {
         return subsetSize;
     }
@@ -116,13 +107,12 @@ public abstract class InternalMappedSignificantTerms<
             && subsetSize == that.subsetSize
             && supersetSize == that.supersetSize
             && Objects.equals(significanceHeuristic, that.significanceHeuristic)
-            && Objects.equals(buckets, that.buckets)
-            && Objects.equals(bucketMap, that.bucketMap);
+            && Objects.equals(buckets, that.buckets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), format, subsetSize, supersetSize, significanceHeuristic, buckets, bucketMap);
+        return Objects.hash(super.hashCode(), format, subsetSize, supersetSize, significanceHeuristic, buckets);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTerms.java
@@ -53,9 +53,5 @@ public interface SignificantTerms extends MultiBucketsAggregation, Iterable<Sign
     @Override
     List<? extends Bucket> getBuckets();
 
-    /**
-     * Get the bucket for the given term, or null if there is no such bucket.
-     */
-    Bucket getBucketByKey(String term);
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
@@ -143,11 +143,6 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
     }
 
     @Override
-    public SignificantTerms.Bucket getBucketByKey(String term) {
-        return null;
-    }
-
-    @Override
     protected SignificanceHeuristic getSignificanceHeuristic() {
         throw new UnsupportedOperationException();
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -136,9 +136,9 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
-                assertNull(terms.getBucketByKey("even"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNotNull(terms.getBucketByKey("odd"));
+                assertNull(getBucketByKey(terms, "even"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNotNull(getBucketByKey(terms, "odd"));
 
                 // Search even
                 terms = searchAndReduce(
@@ -148,18 +148,18 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
-                assertNull(terms.getBucketByKey("odd"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNotNull(terms.getBucketByKey("even"));
+                assertNull(getBucketByKey(terms, "odd"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNotNull(getBucketByKey(terms, "even"));
 
                 // Search odd with regex includeexcludes
                 sigAgg.includeExclude(new IncludeExclude("o.d", null, null, null));
                 terms = searchAndReduce(reader, new AggTestConfig(sigAgg, textFieldType).withQuery(new TermQuery(new Term("text", "odd"))));
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
-                assertNotNull(terms.getBucketByKey("odd"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNull(terms.getBucketByKey("even"));
+                assertNotNull(getBucketByKey(terms, "odd"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNull(getBucketByKey(terms, "even"));
 
                 // Search with string-based includeexcludes
                 SortedSet<BytesRef> oddStrings = new TreeSet<>(Set.of(new BytesRef("odd"), new BytesRef("weird")));
@@ -170,24 +170,33 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 terms = searchAndReduce(reader, new AggTestConfig(sigAgg, textFieldType).withQuery(new TermQuery(new Term("text", "odd"))));
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
-                assertNotNull(terms.getBucketByKey("odd"));
-                assertNull(terms.getBucketByKey("weird"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNull(terms.getBucketByKey("even"));
-                assertNull(terms.getBucketByKey("regular"));
+                assertNotNull(getBucketByKey(terms, "odd"));
+                assertNull(getBucketByKey(terms, "weird"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNull(getBucketByKey(terms, "even"));
+                assertNull(getBucketByKey(terms, "regular"));
 
                 sigAgg.includeExclude(new IncludeExclude(null, null, evenStrings, oddStrings));
                 terms = searchAndReduce(reader, new AggTestConfig(sigAgg, textFieldType).withQuery(new TermQuery(new Term("text", "odd"))));
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(0, terms.getBuckets().size());
-                assertNull(terms.getBucketByKey("odd"));
-                assertNull(terms.getBucketByKey("weird"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNull(terms.getBucketByKey("even"));
-                assertNull(terms.getBucketByKey("regular"));
+                assertNull(getBucketByKey(terms, "odd"));
+                assertNull(getBucketByKey(terms, "weird"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNull(getBucketByKey(terms, "even"));
+                assertNull(getBucketByKey(terms, "regular"));
 
             }
         }
+    }
+
+    private static SignificantTerms.Bucket getBucketByKey(SignificantTerms terms, String term) {
+        for (SignificantTerms.Bucket bucket : terms.getBuckets()) {
+            if (bucket.getKey().toString().equals(term)) {
+                return bucket;
+            }
+        }
+        return null;
     }
 
     /**
@@ -282,9 +291,9 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertEquals(1, terms.getBuckets().size());
                 assertThat(terms.getSubsetSize(), equalTo(5L));
 
-                assertNull(terms.getBucketByKey(Long.toString(EVEN_VALUE)));
-                assertNull(terms.getBucketByKey(Long.toString(COMMON_VALUE)));
-                assertNotNull(terms.getBucketByKey(Long.toString(ODD_VALUE)));
+                assertNull(getBucketByKey(terms, Long.toString(EVEN_VALUE)));
+                assertNull(getBucketByKey(terms, Long.toString(COMMON_VALUE)));
+                assertNotNull(getBucketByKey(terms, Long.toString(ODD_VALUE)));
 
                 terms = searchAndReduce(
                     reader,
@@ -293,9 +302,9 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertEquals(1, terms.getBuckets().size());
                 assertThat(terms.getSubsetSize(), equalTo(5L));
 
-                assertNull(terms.getBucketByKey(Long.toString(ODD_VALUE)));
-                assertNull(terms.getBucketByKey(Long.toString(COMMON_VALUE)));
-                assertNotNull(terms.getBucketByKey(Long.toString(EVEN_VALUE)));
+                assertNull(getBucketByKey(terms, Long.toString(ODD_VALUE)));
+                assertNull(getBucketByKey(terms, Long.toString(COMMON_VALUE)));
+                assertNotNull(getBucketByKey(terms, Long.toString(EVEN_VALUE)));
 
             }
         }
@@ -328,9 +337,9 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 );
                 assertEquals(0, terms.getBuckets().size());
 
-                assertNull(terms.getBucketByKey("even"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNull(terms.getBucketByKey("odd"));
+                assertNull(getBucketByKey(terms, "even"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNull(getBucketByKey(terms, "odd"));
 
             }
         }
@@ -604,17 +613,17 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                     );
                     assertThat(result.getSubsetSize(), equalTo(1000L));
                     for (int i = 0; i < 10; i++) {
-                        SignificantStringTerms.Bucket iBucket = result.getBucketByKey(Integer.toString(i));
+                        SignificantTerms.Bucket iBucket = getBucketByKey(result, Integer.toString(i));
                         assertThat(iBucket.getDocCount(), equalTo(100L));
                         SignificantStringTerms jAgg = iBucket.getAggregations().get("j");
                         assertThat(jAgg.getSubsetSize(), equalTo(100L));
                         for (int j = 0; j < 10; j++) {
-                            SignificantStringTerms.Bucket jBucket = jAgg.getBucketByKey(Integer.toString(j));
+                            SignificantTerms.Bucket jBucket = getBucketByKey(jAgg, Integer.toString(j));
                             assertThat(jBucket.getDocCount(), equalTo(10L));
                             SignificantStringTerms kAgg = jBucket.getAggregations().get("k");
                             assertThat(kAgg.getSubsetSize(), equalTo(10L));
                             for (int k = 0; k < 10; k++) {
-                                SignificantStringTerms.Bucket kBucket = kAgg.getBucketByKey(Integer.toString(k));
+                                SignificantTerms.Bucket kBucket = getBucketByKey(kAgg, Integer.toString(k));
                                 assertThat(jAgg.getSubsetSize(), equalTo(100L));
                                 assertThat(kBucket.getDocCount(), equalTo(1L));
                             }
@@ -653,17 +662,17 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                     );
                     assertThat(result.getSubsetSize(), equalTo(1000L));
                     for (int i = 0; i < 10; i++) {
-                        SignificantLongTerms.Bucket iBucket = result.getBucketByKey(Integer.toString(i));
+                        SignificantTerms.Bucket iBucket = getBucketByKey(result, Integer.toString(i));
                         assertThat(iBucket.getDocCount(), equalTo(100L));
                         SignificantLongTerms jAgg = iBucket.getAggregations().get("j");
                         assertThat(jAgg.getSubsetSize(), equalTo(100L));
                         for (int j = 0; j < 10; j++) {
-                            SignificantLongTerms.Bucket jBucket = jAgg.getBucketByKey(Integer.toString(j));
+                            SignificantTerms.Bucket jBucket = getBucketByKey(jAgg, Integer.toString(j));
                             assertThat(jBucket.getDocCount(), equalTo(10L));
                             SignificantLongTerms kAgg = jBucket.getAggregations().get("k");
                             assertThat(kAgg.getSubsetSize(), equalTo(10L));
                             for (int k = 0; k < 10; k++) {
-                                SignificantLongTerms.Bucket kBucket = kAgg.getBucketByKey(Integer.toString(k));
+                                SignificantTerms.Bucket kBucket = getBucketByKey(kAgg, Integer.toString(k));
                                 assertThat(kBucket.getDocCount(), equalTo(1L));
                             }
                         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -93,10 +93,10 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 );
                 SignificantTerms terms = sampler.getAggregations().get("sig_text");
 
-                assertNull(terms.getBucketByKey("even"));
-                assertNull(terms.getBucketByKey("duplicate"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNotNull(terms.getBucketByKey("odd"));
+                assertNull(getBucketByKey(terms, "even"));
+                assertNull(getBucketByKey(terms, "duplicate"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNotNull(getBucketByKey(terms, "odd"));
 
                 // Search "even" which will have duplication
                 sampler = searchAndReduce(
@@ -105,14 +105,14 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 );
                 terms = sampler.getAggregations().get("sig_text");
 
-                assertNull(terms.getBucketByKey("odd"));
-                assertNull(terms.getBucketByKey("duplicate"));
-                assertNull(terms.getBucketByKey("common"));
-                assertNull(terms.getBucketByKey("separator2"));
-                assertNull(terms.getBucketByKey("separator4"));
-                assertNull(terms.getBucketByKey("separator6"));
+                assertNull(getBucketByKey(terms, "odd"));
+                assertNull(getBucketByKey(terms, "duplicate"));
+                assertNull(getBucketByKey(terms, "common"));
+                assertNull(getBucketByKey(terms, "separator2"));
+                assertNull(getBucketByKey(terms, "separator4"));
+                assertNull(getBucketByKey(terms, "separator6"));
 
-                assertNotNull(terms.getBucketByKey("even"));
+                assertNotNull(getBucketByKey(terms, "even"));
 
                 assertTrue(AggregationInspectionHelper.hasValue(sampler));
             }
@@ -151,8 +151,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                     );
                     SignificantTerms terms = sampler.getAggregations().get("sig_text");
 
-                    assertNull(terms.getBucketByKey("even"));
-                    assertNotNull(terms.getBucketByKey("duplicate"));
+                    assertNull(getBucketByKey(terms, "even"));
+                    assertNotNull(getBucketByKey(terms, "duplicate"));
                     assertTrue(AggregationInspectionHelper.hasValue(sampler));
 
                 }
@@ -172,8 +172,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                     );
                     SignificantTerms terms = sampler.getAggregations().get("sig_text");
 
-                    assertNotNull(terms.getBucketByKey("even"));
-                    assertNull(terms.getBucketByKey("duplicate"));
+                    assertNotNull(getBucketByKey(terms, "even"));
+                    assertNull(getBucketByKey(terms, "duplicate"));
                     assertTrue(AggregationInspectionHelper.hasValue(sampler));
 
                 }
@@ -283,19 +283,19 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
                 StringTerms terms = searchAndReduce(reader, new AggTestConfig(aggBuilder, textFieldType, keywordField("kwd")));
                 SignificantTerms sigOdd = terms.getBucketByKey("odd").getAggregations().get("sig_text");
-                assertNull(sigOdd.getBucketByKey("even"));
-                assertNull(sigOdd.getBucketByKey("duplicate"));
-                assertNull(sigOdd.getBucketByKey("common"));
-                assertNotNull(sigOdd.getBucketByKey("odd"));
+                assertNull(getBucketByKey(sigOdd, "even"));
+                assertNull(getBucketByKey(sigOdd, "duplicate"));
+                assertNull(getBucketByKey(sigOdd, "common"));
+                assertNotNull(getBucketByKey(sigOdd, "odd"));
 
                 SignificantStringTerms sigEven = terms.getBucketByKey("even").getAggregations().get("sig_text");
-                assertNull(sigEven.getBucketByKey("odd"));
-                assertNull(sigEven.getBucketByKey("duplicate"));
-                assertNull(sigEven.getBucketByKey("common"));
-                assertNull(sigEven.getBucketByKey("separator2"));
-                assertNull(sigEven.getBucketByKey("separator4"));
-                assertNull(sigEven.getBucketByKey("separator6"));
-                assertNotNull(sigEven.getBucketByKey("even"));
+                assertNull(getBucketByKey(sigEven, "odd"));
+                assertNull(getBucketByKey(sigEven, "duplicate"));
+                assertNull(getBucketByKey(sigEven, "common"));
+                assertNull(getBucketByKey(sigEven, "separator2"));
+                assertNull(getBucketByKey(sigEven, "separator4"));
+                assertNull(getBucketByKey(sigEven, "separator6"));
+                assertNotNull(getBucketByKey(sigEven, "even"));
             }
         }
     }
@@ -346,6 +346,15 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 // with the internal exception discovered in issue https://github.com/elastic/elasticsearch/issues/25029
             }
         }
+    }
+
+    private static SignificantTerms.Bucket getBucketByKey(SignificantTerms terms, String term) {
+        for (SignificantTerms.Bucket bucket : terms.getBuckets()) {
+            if (bucket.getKey().toString().equals(term)) {
+                return bucket;
+            }
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This method is only used in test and it is making the InternalMappedSignificantTerms implementation more complex than it should be.