### PR TITLE
[8.x] Disable KqlQueryBuilderTests on non-snapshots build. (#117025)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -311,8 +311,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/60_enrich/Enrich on keyword with fields}
   issue: https://github.com/elastic/elasticsearch/issues/116593
-- class: org.elasticsearch.xpack.kql.query.KqlQueryBuilderTests
-  issue: https://github.com/elastic/elasticsearch/issues/116487
 - class: org.elasticsearch.xpack.spatial.search.GeoGridAggAndQueryConsistencyIT
   method: testGeoShapeGeoTile
   issue: https://github.com/elastic/elasticsearch/issues/115717

--- a/x-pack/plugin/kql/build.gradle
+++ b/x-pack/plugin/kql/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.internal.info.BuildParams
-
 import static org.elasticsearch.gradle.util.PlatformUtils.normalize
 
 apply plugin: 'elasticsearch.internal-es-plugin'
@@ -28,12 +26,6 @@ dependencies {
 
 tasks.named('yamlRestTest') {
   usesDefaultDistribution()
-}.configure {
-  /****************************************************************
-  *  Enable QA/rest integration tests for snapshot builds only   *
-  *  TODO: Enable for all builds upon this feature release       *
-    ****************************************************************/
-  enabled = BuildParams.isSnapshotBuild()
 }
 
 /**********************************

--- a/x-pack/plugin/kql/src/test/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilderTests.java
+++ b/x-pack/plugin/kql/src/test/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilderTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.kql.query;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Build;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -21,6 +22,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.xpack.kql.KqlPlugin;
 import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -34,6 +36,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class KqlQueryBuilderTests extends AbstractQueryTestCase<KqlQueryBuilder> {
+    @BeforeClass
+    protected static void ensureSnapshotBuild() {
+        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+    }
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Disable KqlQueryBuilderTests on non-snapshots build. (#117025)](https://github.com/elastic/elasticsearch/pull/117025)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)