### PR TITLE
[8.x] Fix long metric deserialize & add - auto-resize needs to be set manually (#117105)

### DIFF
--- a/docs/changelog/117105.yaml
+++ b/docs/changelog/117105.yaml
@@ -1,0 +1,6 @@
+pr: 117105
+summary: Fix long metric deserialize & add - auto-resize needs to be set manually
+area: CCS
+type: bug
+issues:
+ - 116914

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/LongMetric.java
@@ -74,6 +74,7 @@ public class LongMetric {
             try {
                 // TODO: not sure what is the good value for minBarForHighestToLowestValueRatio here?
                 Histogram dh = Histogram.decodeFromCompressedByteBuffer(bb, 1);
+                dh.setAutoResize(true);
                 return new LongMetricValue(dh);
             } catch (DataFormatException e) {
                 throw new IOException(e);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/CCSTelemetrySnapshotTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.action.admin.cluster.stats;
 import org.elasticsearch.action.admin.cluster.stats.CCSTelemetrySnapshot.PerClusterCCSTelemetry;
 import org.elasticsearch.action.admin.cluster.stats.LongMetric.LongMetricValue;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
@@ -32,9 +33,13 @@ import static org.hamcrest.Matchers.equalTo;
 public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<CCSTelemetrySnapshot> {
 
     private LongMetricValue randomLongMetricValue() {
+        return randomLongMetricValueBetween(0, 1_000_000);
+    }
+
+    private LongMetricValue randomLongMetricValueBetween(int low, int high) {
         LongMetric v = new LongMetric();
         for (int i = 0; i < randomIntBetween(5, 10); i++) {
-            v.record(randomIntBetween(0, 1_000_000));
+            v.record(randomIntBetween(low, high));
         }
         return v.getValue();
     }
@@ -329,5 +334,22 @@ public class CCSTelemetrySnapshotTests extends AbstractWireSerializingTestCase<C
             }
             return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    public void testRanges() throws IOException {
+        var value1 = randomLongMetricValueBetween(1_000_000, 10_000_000);
+        var count1 = value1.count();
+        var max1 = value1.max();
+        var output = new BytesStreamOutput();
+        value1.writeTo(output);
+        var value1Read = LongMetricValue.fromStream(output.bytes().streamInput());
+        var value2 = randomLongMetricValueBetween(0, 100);
+        var count2 = value2.count();
+        output = new BytesStreamOutput();
+        value2.writeTo(output);
+        var value2Read = LongMetricValue.fromStream(output.bytes().streamInput());
+        value2Read.add(value1Read);
+        assertThat(value2Read.count(), equalTo(count1 + count2));
+        assertThat(value2Read.max(), equalTo(max1));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix long metric deserialize & add - auto-resize needs to be set manually (#117105)