### PR TITLE
Fix ELASTIC_PASSWORD with KEYSTORE_PASSWORD docker usage

### DIFF
--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -50,8 +50,7 @@ if [[ -f bin/elasticsearch-users ]]; then
       # keystore requires password
       if ! (echo "$KEYSTORE_PASSWORD" \
           | elasticsearch-keystore list | grep -q '^bootstrap.password$') ; then
-        COMMANDS="$(printf "%s\n%s" "$KEYSTORE_PASSWORD" "$ELASTIC_PASSWORD")"
-        (echo "$COMMANDS" | elasticsearch-keystore add -x 'bootstrap.password')
+        (echo "$KEYSTORE_PASSWORD" | elasticsearch-keystore add-file 'bootstrap.password' <(echo -n "$ELASTIC_PASSWORD"))
       fi
     fi
   fi


### PR DESCRIPTION
A simple fix for https://github.com/elastic/elasticsearch/issues/98115

Instead of trying to pass the secret value through stdin, this uses `elasticsearch-keystore add-file` with process substitution. 