### PR TITLE
ESQL: Skip more union type tests (#117186)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -718,6 +718,7 @@ count:long  |  @timestamp:date
 multiIndexTsNanosToDatetimeStats
 required_capability: union_types
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data, sample_data_ts_nanos
 | EVAL @timestamp = DATE_TRUNC(1 hour, TO_DATETIME(@timestamp))
@@ -754,6 +755,7 @@ multiIndexTsLongStatsDrop
 required_capability: union_types
 required_capability: union_types_agg_cast
 required_capability: casting_operator
+required_capability: to_date_nanos
 
 FROM sample_data, sample_data_ts_long, sample_data_ts_nanos
 | STATS count=count(*) BY @timestamp::datetime
@@ -774,6 +776,7 @@ multiIndexTsLongStatsInline2
 required_capability: union_types
 required_capability: union_types_agg_cast
 required_capability: casting_operator
+required_capability: to_date_nanos
 
 FROM sample_data, sample_data_ts_long, sample_data_ts_nanos
 | STATS count=count(*) BY @timestamp::datetime
@@ -917,6 +920,7 @@ multiIndexIpStringTsLong
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | EVAL @timestamp = TO_DATETIME(@timestamp), client_ip = TO_IP(client_ip)
@@ -958,6 +962,7 @@ sample_data_ts_nanos | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233    
 multiIndexIpStringTsLongDropped
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | EVAL @timestamp = TO_DATETIME(@timestamp), client_ip = TO_IP(client_ip)
@@ -1000,6 +1005,7 @@ multiIndexIpStringTsLongRename
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | EVAL ts = TO_DATETIME(@timestamp), host_ip = TO_IP(client_ip)
@@ -1041,6 +1047,7 @@ sample_data_ts_nanos | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233    
 multiIndexIpStringTsLongRenameDropped
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | EVAL ts = TO_DATETIME(@timestamp), host_ip = TO_IP(client_ip)
@@ -1083,6 +1090,7 @@ multiIndexIpStringTsLongRenameToString
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | EVAL ts = TO_STRING(TO_DATETIME(@timestamp)), host_ip = TO_STRING(TO_IP(client_ip))
@@ -1125,6 +1133,7 @@ multiIndexWhereIpStringTsLong
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) == "172.21.2.162"
@@ -1141,6 +1150,7 @@ sample_data_ts_long  |  3450233              |  Connected to 10.1.0.3
 multiIndexWhereIpStringTsLongStats
 required_capability: union_types
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data*
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) == "172.21.2.162"
@@ -1157,6 +1167,7 @@ multiIndexWhereIpStringLikeTsLong
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) LIKE "172.21.2.16?"
@@ -1173,6 +1184,7 @@ sample_data_ts_long  |  3450233              |  Connected to 10.1.0.3
 multiIndexWhereIpStringLikeTsLongStats
 required_capability: union_types
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data*
 | WHERE TO_LONG(@timestamp) < 1698068014937 AND TO_STRING(client_ip) LIKE "172.21.2.16?"
@@ -1189,6 +1201,7 @@ multiIndexMultiColumnTypesRename
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | WHERE event_duration > 8000000
@@ -1207,6 +1220,7 @@ multiIndexMultiColumnTypesRenameAndKeep
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | WHERE event_duration > 8000000
@@ -1226,6 +1240,7 @@ multiIndexMultiColumnTypesRenameAndDrop
 required_capability: union_types
 required_capability: metadata_fields
 required_capability: union_types_remove_fields
+required_capability: to_date_nanos
 
 FROM sample_data* METADATA _index
 | WHERE event_duration > 8000000


### PR DESCRIPTION
Skip some more union type tests when running against older versions of Elasticsearch because they *now* require `date_nanos` support.

Closes #117108
