### PR TITLE
[8.15] Change synthetic source logic for constant_keyword (#117182)

### DIFF
--- a/docs/changelog/117182.yaml
+++ b/docs/changelog/117182.yaml
@@ -1,0 +1,6 @@
+pr: 117182
+summary: Change synthetic source logic for `constant_keyword`
+area: Mapping
+type: bug
+issues:
+ - 117083

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.constantkeyword.mapper;
 
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -57,7 +56,6 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 /**
  * A {@link FieldMapper} that assigns every document the same value.
@@ -345,48 +343,14 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
     @Override
     protected SyntheticSourceMode syntheticSourceMode() {
-        return SyntheticSourceMode.NATIVE;
-    }
+        /*
+        If there was no value in the document, synthetic source should not have the value too.
+        This is consistent with stored source behavior and is important for scenarios
+        like reindexing into an index that has a different value of this value in the mapping.
 
-    @Override
-    public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        String value = fieldType().value();
-        ;
-        if (value == null) {
-            return SourceLoader.SyntheticFieldLoader.NOTHING;
-        }
-        return new SourceLoader.SyntheticFieldLoader() {
-            @Override
-            public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
-                return Stream.of();
-            }
-
-            @Override
-            public DocValuesLoader docValuesLoader(LeafReader reader, int[] docIdsInLeaf) {
-                return docId -> true;
-            }
-
-            @Override
-            public boolean hasValue() {
-                return true;
-            }
-
-            @Override
-            public void write(XContentBuilder b) throws IOException {
-                if (fieldType().value != null) {
-                    b.field(leafName(), fieldType().value);
-                }
-            }
-
-            @Override
-            public void reset() {
-                // NOOP
-            }
-
-            @Override
-            public String fieldName() {
-                return fullPath();
-            }
-        };
+        In order to do that we use fallback logic which implements exactly such logic (_source only contains value
+        if it was in the original document).
+         */
+        return SyntheticSourceMode.FALLBACK;
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -40,7 +40,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -328,12 +328,12 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
     }
 
     public void testNoValueInDocumentSyntheticSource() throws IOException {
-        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
+        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
             b.startObject("field");
             b.field("type", "constant_keyword");
             b.field("value", randomAlphaOfLength(5));
             b.endObject();
-        })).documentMapper();
+        }));
 
         assertThat(syntheticSource(mapper, b -> {}), equalTo("{}"));
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -327,6 +327,17 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
         assertThat(syntheticSource(mapper, b -> {}), equalTo("{}"));
     }
 
+    public void testNoValueInDocumentSyntheticSource() throws IOException {
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "constant_keyword");
+            b.field("value", randomAlphaOfLength(5));
+            b.endObject();
+        })).documentMapper();
+
+        assertThat(syntheticSource(mapper, b -> {}), equalTo("{}"));
+    }
+
     @Override
     protected boolean supportsEmptyInputArray() {
         return false;

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
@@ -1,7 +1,7 @@
 constant_keyword:
   - requires:
-      cluster_features: ["gte_v8.4.0"]
-      reason: introduced in 8.4.0
+      cluster_features: "gte_v8.15.0"
+      reason: behavior change in 8.15
 
   - do:
       indices.create:
@@ -26,12 +26,34 @@ constant_keyword:
           kwd: foo
 
   - do:
+      index:
+        index:   test
+        id:      2
+        refresh: true
+        body:
+          kwd: foo
+          const_kwd: bar
+
+  - do:
       search:
         index: test
         body:
           query:
             ids:
               values: [1]
+
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [2]
+
   - match:
       hits.hits.0._source:
         kwd: foo


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Change synthetic source logic for constant_keyword (#117182)](https://github.com/elastic/elasticsearch/pull/117182)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)