### PR TITLE
[8.16] Adding missing json spec for allow_partial_search_results in point-in-time (#117121)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -55,6 +55,10 @@
         "type": "string",
         "description": "Specific the time to live for the point in time",
         "required": true
+      },
+      "allow_partial_search_results": {
+        "type": "boolean",
+        "description": "Specify whether to tolerate shards missing when creating the point-in-time, or otherwise throw an exception. (default: false)"
       }
     },
     "body":{


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Adding missing json spec for allow_partial_search_results in point-in-time (#117121)