### PR TITLE
[8.x] Check the real memory circuit breaker when building internal aggregations (#117019)

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -79,6 +79,7 @@ public class TimeSeriesAggregator extends BucketsAggregator {
                 while (ordsEnum.next()) {
                     long docCount = bucketDocCount(ordsEnum.ord());
                     ordsEnum.readValue(spare);
+                    checkRealMemoryCBForInternalBucket();
                     InternalTimeSeries.InternalBucket bucket = new InternalTimeSeries.InternalBucket(
                         BytesRef.deepCopyOf(spare), // Closing bucketOrds will corrupt the bytes ref, so need to make a deep copy here.
                         docCount,
@@ -101,11 +102,7 @@ public class TimeSeriesAggregator extends BucketsAggregator {
             }
             buildSubAggsForAllBuckets(allBucketsPerOrd, b -> b.bucketOrd, (b, a) -> b.aggregations = a);
 
-            InternalAggregation[] result = new InternalAggregation[Math.toIntExact(allBucketsPerOrd.size())];
-            for (int ordIdx = 0; ordIdx < result.length; ordIdx++) {
-                result[ordIdx] = buildResult(allBucketsPerOrd.get(ordIdx));
-            }
-            return result;
+            return buildAggregations(Math.toIntExact(allBucketsPerOrd.size()), ordIdx -> buildResult(allBucketsPerOrd.get(ordIdx)));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -13,6 +13,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.common.CheckedIntFunction;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.Maps;
@@ -48,6 +50,8 @@ public abstract class AggregatorBase extends Aggregator {
 
     private Map<String, Aggregator> subAggregatorbyName;
     private long requestBytesUsed;
+    private final CircuitBreaker breaker;
+    private int callCount;
 
     /**
      * Constructs a new Aggregator.
@@ -72,6 +76,7 @@ public abstract class AggregatorBase extends Aggregator {
         this.metadata = metadata;
         this.parent = parent;
         this.context = context;
+        this.breaker = context.breaker();
         assert factories != null : "sub-factories provided to BucketAggregator must not be null, use AggragatorFactories.EMPTY instead";
         this.subAggregators = factories.createSubAggregators(this, subAggregatorCardinality);
         context.addReleasable(this);
@@ -325,6 +330,30 @@ public abstract class AggregatorBase extends Aggregator {
             aggs.add(aggregator.buildEmptyAggregation());
         }
         return InternalAggregations.from(aggs);
+    }
+
+    /**
+     * Builds the aggregations array with the provided size and populates it using the provided function.
+     */
+    protected final InternalAggregation[] buildAggregations(int size, CheckedIntFunction<InternalAggregation, IOException> aggFunction)
+        throws IOException {
+        final InternalAggregation[] results = new InternalAggregation[size];
+        for (int i = 0; i < results.length; i++) {
+            checkRealMemoryCB("internal_aggregation");
+            results[i] = aggFunction.apply(i);
+        }
+        return results;
+    }
+
+    /**
+     * This method calls the circuit breaker from time to time in order to give it a chance to check available
+     * memory in the parent breaker (Which should be a real memory breaker) and break the execution if we are running out.
+     * To achieve that, we are passing 0 as the estimated bytes every 1024 calls
+     */
+    protected final void checkRealMemoryCB(String label) {
+        if ((++callCount & 0x3FF) == 0) {
+            breaker.addEstimateBytesAndMaybeBreak(0, label);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
@@ -41,10 +41,6 @@ public abstract class NonCollectingAggregator extends AggregatorBase {
 
     @Override
     public InternalAggregation[] buildAggregations(LongArray owningBucketOrds) throws IOException {
-        InternalAggregation[] results = new InternalAggregation[Math.toIntExact(owningBucketOrds.size())];
-        for (int ordIdx = 0; ordIdx < results.length; ordIdx++) {
-            results[ordIdx] = buildEmptyAggregation();
-        }
-        return results;
+        return buildAggregations(Math.toIntExact(owningBucketOrds.size()), ordIdx -> buildEmptyAggregation());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
@@ -144,6 +144,7 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid<?>> extends Bu
                     LongKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds.get(ordIdx));
                     while (ordsEnum.next()) {
                         if (spare == null) {
+                            checkRealMemoryCBForInternalBucket();
                             spare = newEmptyBucket();
                         }
 
@@ -162,11 +163,10 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid<?>> extends Bu
                 }
             }
             buildSubAggsForAllBuckets(topBucketsPerOrd, b -> b.bucketOrd, (b, aggs) -> b.aggregations = aggs);
-            InternalAggregation[] results = new InternalAggregation[Math.toIntExact(topBucketsPerOrd.size())];
-            for (int ordIdx = 0; ordIdx < results.length; ordIdx++) {
-                results[ordIdx] = buildAggregation(name, requiredSize, Arrays.asList(topBucketsPerOrd.get(ordIdx)), metadata());
-            }
-            return results;
+            return buildAggregations(
+                Math.toIntExact(owningBucketOrds.size()),
+                ordIdx -> buildAggregation(name, requiredSize, Arrays.asList(topBucketsPerOrd.get(ordIdx)), metadata())
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -696,11 +696,10 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         private InternalAggregation[] buildAggregations(LongArray owningBucketOrds) throws IOException {
 
             if (valueCount == 0) { // no context in this reader
-                InternalAggregation[] results = new InternalAggregation[Math.toIntExact(owningBucketOrds.size())];
-                for (int ordIdx = 0; ordIdx < results.length; ordIdx++) {
-                    results[ordIdx] = buildNoValuesResult(owningBucketOrds.get(ordIdx));
-                }
-                return results;
+                return GlobalOrdinalsStringTermsAggregator.this.buildAggregations(
+                    Math.toIntExact(owningBucketOrds.size()),
+                    ordIdx -> buildNoValuesResult(owningBucketOrds.get(ordIdx))
+                );
             }
             try (
                 LongArray otherDocCount = bigArrays().newLongArray(owningBucketOrds.size(), true);
@@ -727,6 +726,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                                 otherDocCount.increment(finalOrdIdx, docCount);
                                 if (docCount >= bucketCountThresholds.getShardMinDocCount()) {
                                     if (spare == null) {
+                                        checkRealMemoryCBForInternalBucket();
                                         spare = buildEmptyTemporaryBucket();
                                     }
                                     updater.updateBucket(spare, globalOrd, bucketOrd, docCount);
@@ -738,6 +738,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                         // Get the top buckets
                         topBucketsPreOrd.set(ordIdx, buildBuckets((int) ordered.size()));
                         for (int i = (int) ordered.size() - 1; i >= 0; --i) {
+                            checkRealMemoryCBForInternalBucket();
                             B bucket = convertTempBucketToRealBucket(ordered.pop(), lookupGlobalOrd);
                             topBucketsPreOrd.get(ordIdx)[i] = bucket;
                             otherDocCount.increment(ordIdx, -bucket.getDocCount());
@@ -747,11 +748,10 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
 
                 buildSubAggs(topBucketsPreOrd);
 
-                InternalAggregation[] results = new InternalAggregation[Math.toIntExact(topBucketsPreOrd.size())];
-                for (int ordIdx = 0; ordIdx < results.length; ordIdx++) {
-                    results[ordIdx] = buildResult(owningBucketOrds.get(ordIdx), otherDocCount.get(ordIdx), topBucketsPreOrd.get(ordIdx));
-                }
-                return results;
+                return GlobalOrdinalsStringTermsAggregator.this.buildAggregations(
+                    Math.toIntExact(owningBucketOrds.size()),
+                    ordIdx -> buildResult(owningBucketOrds.get(ordIdx), otherDocCount.get(ordIdx), topBucketsPreOrd.get(ordIdx))
+                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -304,6 +304,7 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
                                 continue;
                             }
                             if (spare == null) {
+                                checkRealMemoryCBForInternalBucket();
                                 spare = emptyBucketBuilder.get();
                             }
                             updateBucket(spare, ordsEnum, docCount);
@@ -320,11 +321,11 @@ public final class MapStringTermsAggregator extends AbstractStringTermsAggregato
                 }
 
                 buildSubAggs(topBucketsPerOrd);
-                InternalAggregation[] result = new InternalAggregation[Math.toIntExact(topBucketsPerOrd.size())];
-                for (int ordIdx = 0; ordIdx < result.length; ordIdx++) {
-                    result[ordIdx] = buildResult(owningBucketOrds.get(ordIdx), otherDocCounts.get(ordIdx), topBucketsPerOrd.get(ordIdx));
-                }
-                return result;
+
+                return MapStringTermsAggregator.this.buildAggregations(
+                    Math.toIntExact(owningBucketOrds.size()),
+                    ordIdx -> buildResult(owningBucketOrds.get(ordIdx), otherDocCounts.get(ordIdx), topBucketsPerOrd.get(ordIdx))
+                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -185,6 +185,7 @@ public final class NumericTermsAggregator extends TermsAggregator {
                                 continue;
                             }
                             if (spare == null) {
+                                checkRealMemoryCBForInternalBucket();
                                 spare = emptyBucketBuilder.get();
                             }
                             updateBucket(spare, ordsEnum, docCount);
@@ -203,11 +204,10 @@ public final class NumericTermsAggregator extends TermsAggregator {
 
                 buildSubAggs(topBucketsPerOrd);
 
-                InternalAggregation[] result = new InternalAggregation[Math.toIntExact(topBucketsPerOrd.size())];
-                for (int ordIdx = 0; ordIdx < result.length; ordIdx++) {
-                    result[ordIdx] = buildResult(owningBucketOrds.get(ordIdx), otherDocCounts.get(ordIdx), topBucketsPerOrd.get(ordIdx));
-                }
-                return result;
+                return NumericTermsAggregator.this.buildAggregations(
+                    Math.toIntExact(owningBucketOrds.size()),
+                    ordIdx -> buildResult(owningBucketOrds.get(ordIdx), otherDocCounts.get(ordIdx), topBucketsPerOrd.get(ordIdx))
+                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MetricsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MetricsAggregator.java
@@ -38,10 +38,6 @@ public abstract class MetricsAggregator extends AggregatorBase {
 
     @Override
     public final InternalAggregation[] buildAggregations(LongArray owningBucketOrds) throws IOException {
-        InternalAggregation[] results = new InternalAggregation[Math.toIntExact(owningBucketOrds.size())];
-        for (int ordIdx = 0; ordIdx < results.length; ordIdx++) {
-            results[ordIdx] = buildAggregation(owningBucketOrds.get(ordIdx));
-        }
-        return results;
+        return buildAggregations(Math.toIntExact(owningBucketOrds.size()), ordIdx -> buildAggregation(owningBucketOrds.get(ordIdx)));
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
@@ -264,6 +264,7 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
                             continue;
                         }
                         if (spare == null) {
+                            checkRealMemoryCBForInternalBucket();
                             spare = new InternalMultiTerms.Bucket(null, 0, null, showTermDocCountError, 0, formats, keyConverters);
                             spareKey = new BytesRef();
                         }
@@ -287,11 +288,10 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
 
             buildSubAggsForAllBuckets(topBucketsPerOrd, b -> b.bucketOrd, (b, a) -> b.aggregations = a);
 
-            InternalAggregation[] result = new InternalAggregation[Math.toIntExact(owningBucketOrds.size())];
-            for (int ordIdx = 0; ordIdx < result.length; ordIdx++) {
-                result[ordIdx] = buildResult(otherDocCounts.get(ordIdx), topBucketsPerOrd.get(ordIdx));
-            }
-            return result;
+            return buildAggregations(
+                Math.toIntExact(owningBucketOrds.size()),
+                ordIdx -> buildResult(otherDocCounts.get(ordIdx), topBucketsPerOrd.get(ordIdx))
+            );
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregator.java
@@ -121,21 +121,22 @@ public class CategorizeTextAggregator extends DeferableBucketAggregator {
                     continue;
                 }
                 int size = (int) Math.min(bucketOrds.bucketsInOrd(ordIdx), bucketCountThresholds.getShardSize());
+                checkRealMemoryCBForInternalBucket();
                 topBucketsPerOrd.set(ordIdx, categorizer.toOrderedBuckets(size));
             }
             buildSubAggsForAllBuckets(topBucketsPerOrd, Bucket::getBucketOrd, Bucket::setAggregations);
-            InternalAggregation[] results = new InternalAggregation[Math.toIntExact(ordsToCollect.size())];
-            for (int ordIdx = 0; ordIdx < results.length; ordIdx++) {
-                results[ordIdx] = new InternalCategorizationAggregation(
+
+            return buildAggregations(
+                Math.toIntExact(ordsToCollect.size()),
+                ordIdx -> new InternalCategorizationAggregation(
                     name,
                     bucketCountThresholds.getRequiredSize(),
                     bucketCountThresholds.getMinDocCount(),
                     similarityThreshold,
                     metadata(),
                     Arrays.asList(topBucketsPerOrd.get(ordIdx))
-                );
-            }
-            return results;
+                )
+            );
         }
     }
 


### PR DESCRIPTION
checks periodically the real memory circuit breaker when allocating objects.

backport of https://github.com/elastic/elasticsearch/pull/117019