### PR TITLE
[Build] Make checkPart4 configuration cache compatible

### DIFF
--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -8,4 +8,3 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
-      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -7,5 +7,5 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: n2-highmem-32
+      machineType: custom-32-98304
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -2,7 +2,7 @@ config:
   skip-target-branches: "7.17"
 steps:
   - label: part-4
-    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed checkPart4 --configuration-cache --stacktrace
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed checkPart4
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -2,9 +2,10 @@ config:
   skip-target-branches: "7.17"
 steps:
   - label: part-4
-    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed checkPart4 --configuration-cache
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed checkPart4 --configuration-cache --stacktrace
     timeout_in_minutes: 300
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: n2-highmem-32
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -2,7 +2,7 @@ config:
   skip-target-branches: "7.17"
 steps:
   - label: part-4
-    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed checkPart4
+    command: .ci/scripts/run-gradle.sh -Dignore.tests.seed checkPart4 --configuration-cache
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/scripts/gradle-configuration-cache-validation.sh
+++ b/.buildkite/scripts/gradle-configuration-cache-validation.sh
@@ -3,16 +3,16 @@
 set -euo pipefail
 
 # This is a workaround for https://github.com/gradle/gradle/issues/28159
-.ci/scripts/run-gradle.sh --no-daemon precommit
+.ci/scripts/run-gradle.sh --no-daemon $@
 
-.ci/scripts/run-gradle.sh --configuration-cache precommit -Dorg.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=build/*.tar.bz2
+.ci/scripts/run-gradle.sh --configuration-cache -Dorg.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=build/*.tar.bz2 $@
 
 # Create a temporary file
 tmpOutputFile=$(mktemp)
 trap "rm $tmpOutputFile" EXIT
 
 echo "2nd run"
-.ci/scripts/run-gradle.sh --configuration-cache precommit -Dorg.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=build/*.tar.bz2 | tee $tmpOutputFile
+.ci/scripts/run-gradle.sh --configuration-cache -Dorg.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=build/*.tar.bz2 $@ | tee $tmpOutputFile
 
 # Check if the command was successful
 if grep -q "Configuration cache entry reused." $tmpOutputFile; then

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -104,7 +104,6 @@ public class BwcSetupExtension {
             loggedExec.dependsOn("checkoutBwcBranch");
             loggedExec.getWorkingDir().set(checkoutDir.get());
 
-
             loggedExec.doFirst(new Action<Task>() {
                 @Override
                 public void execute(Task task) {
@@ -177,8 +176,8 @@ public class BwcSetupExtension {
             .map(launcher -> launcher.getMetadata().getInstallationPath().getAsFile().getAbsolutePath());
     }
 
-
     public abstract static class JavaHomeValueSource implements ValueSource<String, JavaHomeValueSource.Params> {
+
         private String minimumCompilerVersionPath(Version bwcVersion) {
             return (bwcVersion.onOrAfter(BUILD_TOOL_MINIMUM_VERSION))
                 ? "build-tools-internal/" + MINIMUM_COMPILER_VERSION_PATH

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -16,6 +16,7 @@ import org.elasticsearch.gradle.Version;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -103,10 +104,17 @@ public class BwcSetupExtension {
             loggedExec.dependsOn("checkoutBwcBranch");
             loggedExec.getWorkingDir().set(checkoutDir.get());
 
-            loggedExec.getNonTrackedEnvironment().put("JAVA_HOME", providerFactory.of(JavaHomeValueSource.class, spec -> {
-                spec.getParameters().getVersion().set(unreleasedVersionInfo.map(it -> it.version()));
-                spec.getParameters().getCheckoutDir().set(checkoutDir);
-            }).flatMap(s -> getJavaHome(objectFactory, toolChainService, Integer.parseInt(s))));
+
+            loggedExec.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    Provider<String> minimumCompilerVersionValueSource = providerFactory.of(JavaHomeValueSource.class, spec -> {
+                        spec.getParameters().getVersion().set(unreleasedVersionInfo.map(it -> it.version()));
+                        spec.getParameters().getCheckoutDir().set(checkoutDir);
+                    }).flatMap(s -> getJavaHome(objectFactory, toolChainService, Integer.parseInt(s)));
+                    loggedExec.getNonTrackedEnvironment().put("JAVA_HOME", minimumCompilerVersionValueSource.get());
+                }
+            });
 
             if (isCi && OS.current() != OS.WINDOWS) {
                 // TODO: Disabled for now until we can figure out why files are getting corrupted
@@ -169,20 +177,20 @@ public class BwcSetupExtension {
             .map(launcher -> launcher.getMetadata().getInstallationPath().getAsFile().getAbsolutePath());
     }
 
-    private static String readFromFile(File file) {
-        try {
-            return FileUtils.readFileToString(file).trim();
-        } catch (IOException ioException) {
-            throw new GradleException("Cannot read java properties file.", ioException);
-        }
-    }
 
     public abstract static class JavaHomeValueSource implements ValueSource<String, JavaHomeValueSource.Params> {
-
         private String minimumCompilerVersionPath(Version bwcVersion) {
             return (bwcVersion.onOrAfter(BUILD_TOOL_MINIMUM_VERSION))
                 ? "build-tools-internal/" + MINIMUM_COMPILER_VERSION_PATH
                 : "buildSrc/" + MINIMUM_COMPILER_VERSION_PATH;
+        }
+
+        private static String readFromFile(File file) {
+            try {
+                return FileUtils.readFileToString(file).trim();
+            } catch (IOException ioException) {
+                throw new GradleException("Cannot read java properties file.", ioException);
+            }
         }
 
         @Override

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -58,15 +58,16 @@ subprojects {
       project.gradle.sharedServices,
       TestClustersPlugin.REGISTRY_SERVICE_NAME
     )
-    project.getProviders().of(TestClusterValueSource.class) {
+
+    def clusterInfo = project.getProviders().of(TestClusterValueSource.class) {
       it.parameters.path.set(clusterPath)
       it.parameters.clusterName.set("javaRestTest")
       it.parameters.service = serviceProvider
     }
 
     nonInputProperties.systemProperty 'tests.audit.logfile',
-      "${-> testClusters.javaRestTest.singleNode().getAuditLog()}"
+      "${-> clusterInfo.map { it.auditLogs.get(0) } }"
     nonInputProperties.systemProperty 'tests.audit.yesterday.logfile',
-      "${-> testClusters.javaRestTest.singleNode().getAuditLog().getParentFile()}/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}.json"
+      "${-> clusterInfo.map { it.auditLogs.get(0).getParentFile()} }/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}.json"
   }
 }

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -50,6 +50,7 @@ subprojects {
 
 
   tasks.withType(RestIntegTestTask).configureEach {
+    def taskName = name
     dependsOn copyTestClasses
     classpath += configurations.testArtifacts
     testClassesDirs = project.files(testArtifactsDir)
@@ -61,13 +62,12 @@ subprojects {
 
     def clusterInfo = project.getProviders().of(TestClusterValueSource.class) {
       it.parameters.path.set(clusterPath)
-      it.parameters.clusterName.set("javaRestTest")
+      it.parameters.clusterName.set(taskName)
       it.parameters.service = serviceProvider
     }
 
-    nonInputProperties.systemProperty 'tests.audit.logfile',
-      "${-> clusterInfo.map { it.auditLogs.get(0) } }"
+    nonInputProperties.systemProperty 'tests.audit.logfile', clusterInfo.map { it.auditLogs.get(0) }
     nonInputProperties.systemProperty 'tests.audit.yesterday.logfile',
-      "${-> clusterInfo.map { it.auditLogs.get(0).getParentFile()} }/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}.json"
+      clusterInfo.map { it.auditLogs.get(0).getParentFile().toString() + "/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}-1.json" }
   }
 }

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -1,3 +1,9 @@
+import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.testclusters.TestClusterValueSource
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin
+import org.elasticsearch.gradle.testclusters.TestClustersRegistry
+import org.elasticsearch.gradle.util.GradleUtils
+
 apply plugin: 'elasticsearch.internal-test-artifact'
 
 dependencies {
@@ -15,6 +21,8 @@ Project mainProject = project
 subprojects {
   // Use tests from the root security qa project in subprojects
   configurations.create('testArtifacts').transitive(false)
+
+  def clusterPath = getPath()
 
   dependencies {
     javaRestTestImplementation project(":x-pack:plugin:core")
@@ -50,12 +58,23 @@ subprojects {
 
   tasks.named("javaRestTest").configure {
     dependsOn copyTestClasses
+
+    Provider<TestClustersRegistry> serviceProvider = GradleUtils.getBuildService(
+      project.gradle.sharedServices,
+      TestClustersPlugin.REGISTRY_SERVICE_NAME
+    )
+
+    def clusterInfo = project.getProviders().of(TestClusterValueSource.class) {
+      it.parameters.path.set(clusterPath)
+      it.parameters.clusterName.set("javaRestTest")
+      it.parameters.service = serviceProvider
+    }
+
     testClassesDirs += project.files(testArtifactsDir)
     classpath += configurations.testArtifacts
-    nonInputProperties.systemProperty 'tests.audit.logfile',
-      "${-> testClusters.javaRestTest.singleNode().getAuditLog()}"
+    nonInputProperties.systemProperty 'tests.audit.logfile', clusterInfo.map { it.auditLogs.get(0) }
     nonInputProperties.systemProperty 'tests.audit.yesterday.logfile',
-      "${-> testClusters.javaRestTest.singleNode().getAuditLog().getParentFile()}/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}-1.json.gz"
+      clusterInfo.map { it.auditLogs.get(0).getParentFile().toString() + "/javaRestTest_audit-${new Date().format('yyyy-MM-dd')}-1.json.gz"}
   }
 
 }


### PR DESCRIPTION
This makes checkPart4 tasks in general configuration cache compliant. 

We do not enable it by default in our pipelines yet. That will eventually be done in separate PRs.
To track any regressions we cover the checkPart4 task in the weekly gradle cache validation build job 