### PR TITLE
ESQL: Add tests for single count with filter (#117180)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -2642,6 +2642,26 @@ c2:l |c2_f:l |m2:i |m2_f:i |c:l
 1    |1      |5    |5      |21
 ;
 
+simpleCountOnFieldWithFilteringAndNoGrouping
+required_capability: per_agg_filtering
+from employees
+| stats c1 = count(emp_no) where emp_no < 10042
+;
+
+c1:long
+41
+;
+
+simpleCountOnStarWithFilteringAndNoGrouping
+required_capability: per_agg_filtering
+from employees
+| stats c1 = count(*) where emp_no < 10042
+;
+
+c1:long
+41
+;
+
 commonFilterExtractionWithAliasing
 required_capability: per_agg_filtering
 from employees


### PR DESCRIPTION
Test that filters work on sigle count(...) with no group.

Related #115522

(cherry picked from commit c190c5762bf659461dc8aa455b01fa1789001c39)
