### PR TITLE
ESQL: add tests on use of grouping functions in agg filters (#117184)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/bucket.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/bucket.csv-spec
@@ -760,3 +760,19 @@ c:long |b:date
 3      |2025-10-01T00:00:00.000Z
 4      |2023-11-01T00:00:00.000Z
 ;
+
+bucketWithFilteredCountRefingBucket
+required_capability: implicit_casting_string_literal_to_temporal_amount
+
+FROM employees
+| STATS c = COUNT(*) WHERE b > "1953-01-01T00:00:00.000Z" AND emp_no > 10020 BY b = BUCKET(birth_date, 1 year)
+| SORT c, b
+| LIMIT 4
+;
+
+c:long |b:date
+0      |1952-01-01T00:00:00.000Z
+0      |1953-01-01T00:00:00.000Z
+0      |null
+1      |1965-01-01T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -405,6 +405,11 @@ public class VerifierTests extends ESTestCase {
 
         // but fails if it's different
         assertEquals(
+            "1:32: can only use grouping function [bucket(a, 3)] part of the BY clause",
+            error("row a = 1 | stats sum(a) where bucket(a, 3) > -1 by bucket(a,2)")
+        );
+
+        assertEquals(
             "1:40: can only use grouping function [bucket(salary, 10)] part of the BY clause",
             error("from test | stats max(languages) WHERE bucket(salary, 10) > 1 by emp_no")
         );


### PR DESCRIPTION
Add tests on use of grouping functions in agg filters: check that reusing the BUCKET expression from grouping is allowed, but no other variation.

Related: #115521
(cherry picked from commit fefa0f009fbcb786651dc2a12571f696f2f74363)
