### PR TITLE
Updating PivotConfig max_page_search_size deprecation warning to critical (#117051)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/PivotConfig.java
@@ -184,7 +184,7 @@ public class PivotConfig implements Writeable, ToXContentObject {
             onDeprecation.accept(
                 // max_page_search_size got deprecated in 7.8, still accepted for 8.x, to be removed in 9.x
                 new DeprecationIssue(
-                    Level.WARNING,
+                    Level.CRITICAL,
                     "Transform [" + id + "] uses the deprecated setting [max_page_search_size]",
                     TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                     TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigTests.java
@@ -930,7 +930,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             equalTo(
                 Collections.singletonList(
                     new DeprecationIssue(
-                        Level.WARNING,
+                        Level.CRITICAL,
                         "Transform [" + id + "] uses the deprecated setting [max_page_search_size]",
                         TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
@@ -952,7 +952,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
             equalTo(
                 List.of(
                     new DeprecationIssue(
-                        Level.WARNING,
+                        Level.CRITICAL,
                         "Transform [" + id + "] uses the deprecated setting [max_page_search_size]",
                         TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,
@@ -982,7 +982,7 @@ public class TransformConfigTests extends AbstractSerializingTransformTestCase<T
                         null
                     ),
                     new DeprecationIssue(
-                        Level.WARNING,
+                        Level.CRITICAL,
                         "Transform [" + id + "] uses the deprecated setting [max_page_search_size]",
                         TransformDeprecations.MAX_PAGE_SEARCH_SIZE_BREAKING_CHANGES_URL,
                         TransformDeprecations.ACTION_MAX_PAGE_SEARCH_SIZE_IS_DEPRECATED,


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/117051