### PR TITLE
Wait for all shards to be available in synonyms test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -17,7 +17,7 @@ setup:
 
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
   - do:
       synonyms.get_synonym:
@@ -64,7 +64,7 @@ setup:
 
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
   - do:
       synonyms.get_synonym:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
@@ -14,7 +14,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
@@ -17,7 +17,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
 ---
 "Get synonyms set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -15,7 +15,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 ---
 "Delete synonyms set":
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -13,7 +13,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
   - do:
       synonyms.put_synonym:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
@@ -17,7 +17,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 ---
 "Update a synonyms rule":
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
@@ -17,7 +17,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
 
 ---

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -17,7 +17,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
 ---
 "Delete synonym rule":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
@@ -16,7 +16,7 @@ setup:
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
   # Create an index with synonym_filter that uses that synonyms set
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -28,7 +28,7 @@
   # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
   - do:
       cluster.health:
-        wait_for_no_initializing_shards: true
+        wait_for_active_shards: all
 
   # Create my_index1 with synonym_filter that uses synonyms_set1
   - do:


### PR DESCRIPTION
Now that fast refresh searches go to search nodes, we need to wait for replicas to be available on them before we hit them. See #117217 for context, it's the same issue.
