### PR TITLE
[DOCS] Remove broken migration guide link

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -59,8 +59,8 @@ An example of a transient update:
 ====
 We no longer recommend using transient cluster settings. Use persistent cluster
 settings instead. If a cluster becomes unstable, transient settings can clear
-unexpectedly, resulting in a potentially undesired cluster configuration. See
-the <<transient-settings-migration-guide>>.
+unexpectedly, resulting in a potentially undesired cluster configuration.
+// See the <<transient-settings-migration-guide>>.
 ====
 // end::transient-settings-warning[]
 


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/115375

This PR comments out a link that was causing the following build error:

> INFO:build_docs:asciidoctor: WARNING: invalid reference: transient-settings-migration-guide

If the content in `transient-settings-migration-guide.asciidoc` is still necessary, it will need to be mentioned in an `include` statement from some other file to pull it into the build. In 8.x it was included here: https://github.com/elastic/elasticsearch/blob/fe86e2cd2bb482c64bcae436de6433612297b2b2/docs/reference/migration/migrate_8_0.asciidoc?plain=1#L94