### PR TITLE
[DOCS] Re-add transient settings migration guide

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -60,7 +60,7 @@ An example of a transient update:
 We no longer recommend using transient cluster settings. Use persistent cluster
 settings instead. If a cluster becomes unstable, transient settings can clear
 unexpectedly, resulting in a potentially undesired cluster configuration.
-// See the <<transient-settings-migration-guide>>.
+Refer to <<transient-settings-migration-guide>>.
 ====
 // end::transient-settings-warning[]
 

--- a/docs/reference/migration/migrate_9_0.asciidoc
+++ b/docs/reference/migration/migrate_9_0.asciidoc
@@ -299,3 +299,4 @@ The `elser` service of the inference API will be removed in an upcoming release.
 In the current version there is no impact. In a future version, users of the `elser` service will no longer be able to use it, and will be required to use the `elasticsearch` service to access elser through the inference API.
 ====
 
+include::migrate_9_0/transient-settings-migration-guide.asciidoc[]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/117293, https://github.com/elastic/elasticsearch/pull/115375

If the "Transient settings migration guide" page is required in 9.0, this PR re-adds it to the navigation such that it has the same type of location as in https://www.elastic.co/guide/en/elasticsearch/reference/current/transient-settings-migration-guide.html



