### PR TITLE
FIx async search tests - do not warn on the presence of .async-search

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -226,9 +226,6 @@ tests:
 - class: org.elasticsearch.upgrades.QueryBuilderBWCIT
   method: testQueryBuilderBWC {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/116990
-- class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
-  method: test {yaml=reference/esql/esql-across-clusters/line_197}
-  issue: https://github.com/elastic/elasticsearch/issues/117099
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1131,6 +1131,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             }
             final Request deleteRequest = new Request("DELETE", Strings.collectionToCommaDelimitedString(indexPatterns));
             deleteRequest.addParameter("expand_wildcards", "open,closed,hidden");
+            deleteRequest.setOptions(deleteRequest.getOptions().toBuilder().setWarningsHandler(ignoreAsyncSearchWarning()).build());
             final Response response = adminClient().performRequest(deleteRequest);
             try (InputStream is = response.getEntity().getContent()) {
                 assertTrue((boolean) XContentHelper.convertToMap(XContentType.JSON.xContent(), is, true).get("acknowledged"));
@@ -1141,6 +1142,30 @@ public abstract class ESRestTestCase extends ESTestCase {
                 throw e;
             }
         }
+    }
+
+    // Make warnings handler that ignores the .async-search warning since .async-search may randomly appear when async requests are slow
+    // See: https://github.com/elastic/elasticsearch/issues/117099
+    protected static WarningsHandler ignoreAsyncSearchWarning() {
+        return new WarningsHandler() {
+            @Override
+            public boolean warningsShouldFailRequest(List<String> warnings) {
+                if (warnings.isEmpty()) {
+                    return false;
+                }
+                return warnings.equals(
+                    List.of(
+                        "this request accesses system indices: [.async-search], "
+                            + "but in a future major version, direct access to system indices will be prevented by default"
+                    )
+                ) == false;
+            }
+
+            @Override
+            public String toString() {
+                return "ignore .async-search warning";
+            }
+        };
     }
 
     protected static void wipeDataStreams() throws IOException {


### PR DESCRIPTION
`.async-search` can sometimes appear if async request is slow, and there's no point for the test cleanup to complain about it. 

Fixes https://github.com/elastic/elasticsearch/issues/117099