### PR TITLE
[8.x] MultiBucketsAggregation.Bucket does not implement ToXContent anymore (#117240)

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -81,14 +81,12 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
             return aggregations;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(CommonFields.KEY.getPreferredName(), key);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -237,7 +235,7 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (InternalBucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params);
         }
         builder.endArray();
         return builder;

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -99,8 +99,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
             return Instant.ofEpochMilli(key).atZone(ZoneOffset.UTC);
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params, DocValueFormat format) throws IOException {
             String keyAsString = format.format(key).toString();
             builder.startObject();
             if (format != DocValueFormat.RAW) {
@@ -110,7 +109,6 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -597,7 +595,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params, format);
         }
         builder.endArray();
         builder.field("interval", getInterval().toString());

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -36,24 +36,21 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
      */
     public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket {
         protected long bucketOrd;
-        protected final boolean keyed;
         protected final BytesRef key;
         // TODO: make computing docCount optional
         protected long docCount;
         protected InternalAggregations aggregations;
 
-        public InternalBucket(BytesRef key, long docCount, InternalAggregations aggregations, boolean keyed) {
+        public InternalBucket(BytesRef key, long docCount, InternalAggregations aggregations) {
             this.key = key;
             this.docCount = docCount;
             this.aggregations = aggregations;
-            this.keyed = keyed;
         }
 
         /**
          * Read from a stream.
          */
-        public InternalBucket(StreamInput in, boolean keyed) throws IOException {
-            this.keyed = keyed;
+        public InternalBucket(StreamInput in) throws IOException {
             key = in.readBytesRef();
             docCount = in.readVLong();
             aggregations = InternalAggregations.readFrom(in);
@@ -86,8 +83,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
             return aggregations;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params, boolean keyed) throws IOException {
             // Use map key in the xcontent response:
             var key = getKey();
             if (keyed) {
@@ -99,7 +95,6 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -112,14 +107,13 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
             }
             InternalTimeSeries.InternalBucket that = (InternalTimeSeries.InternalBucket) other;
             return Objects.equals(key, that.key)
-                && Objects.equals(keyed, that.keyed)
                 && Objects.equals(docCount, that.docCount)
                 && Objects.equals(aggregations, that.aggregations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getClass(), key, keyed, docCount, aggregations);
+            return Objects.hash(getClass(), key, docCount, aggregations);
         }
     }
 
@@ -143,7 +137,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
         int size = in.readVInt();
         List<InternalTimeSeries.InternalBucket> buckets = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            buckets.add(new InternalTimeSeries.InternalBucket(in, keyed));
+            buckets.add(new InternalTimeSeries.InternalBucket(in));
         }
         this.buckets = buckets;
         this.bucketMap = null;
@@ -162,7 +156,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
         for (InternalBucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params, keyed);
         }
         if (keyed) {
             builder.endObject();
@@ -252,14 +246,14 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
 
     @Override
     public InternalBucket createBucket(InternalAggregations aggregations, InternalBucket prototype) {
-        return new InternalBucket(prototype.key, prototype.docCount, aggregations, prototype.keyed);
+        return new InternalBucket(prototype.key, prototype.docCount, aggregations);
     }
 
     private InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
         InternalTimeSeries.InternalBucket reduced = null;
         for (InternalTimeSeries.InternalBucket bucket : buckets) {
             if (reduced == null) {
-                reduced = new InternalTimeSeries.InternalBucket(bucket.key, bucket.docCount, bucket.aggregations, bucket.keyed);
+                reduced = new InternalTimeSeries.InternalBucket(bucket.key, bucket.docCount, bucket.aggregations);
             } else {
                 reduced.docCount += bucket.docCount;
             }

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -83,8 +83,7 @@ public class TimeSeriesAggregator extends BucketsAggregator {
                     InternalTimeSeries.InternalBucket bucket = new InternalTimeSeries.InternalBucket(
                         BytesRef.deepCopyOf(spare), // Closing bucketOrds will corrupt the bytes ref, so need to make a deep copy here.
                         docCount,
-                        null,
-                        keyed
+                        null
                     );
                     bucket.bucketOrd = ordsEnum.ord();
                     buckets.add(bucket);

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeriesTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeriesTests.java
@@ -49,7 +49,7 @@ public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTe
             }
             try {
                 var key = TimeSeriesIdFieldMapper.buildLegacyTsid(routingPathFields).toBytesRef();
-                bucketList.add(new InternalBucket(key, docCount, aggregations, keyed));
+                bucketList.add(new InternalBucket(key, docCount, aggregations));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -108,10 +108,10 @@ public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTe
         InternalTimeSeries first = new InternalTimeSeries(
             "ts",
             List.of(
-                new InternalBucket(new BytesRef("1"), 3, InternalAggregations.EMPTY, false),
-                new InternalBucket(new BytesRef("10"), 6, InternalAggregations.EMPTY, false),
-                new InternalBucket(new BytesRef("2"), 2, InternalAggregations.EMPTY, false),
-                new InternalBucket(new BytesRef("9"), 5, InternalAggregations.EMPTY, false)
+                new InternalBucket(new BytesRef("1"), 3, InternalAggregations.EMPTY),
+                new InternalBucket(new BytesRef("10"), 6, InternalAggregations.EMPTY),
+                new InternalBucket(new BytesRef("2"), 2, InternalAggregations.EMPTY),
+                new InternalBucket(new BytesRef("9"), 5, InternalAggregations.EMPTY)
             ),
             false,
             Map.of()
@@ -119,8 +119,8 @@ public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTe
         InternalTimeSeries second = new InternalTimeSeries(
             "ts",
             List.of(
-                new InternalBucket(new BytesRef("2"), 1, InternalAggregations.EMPTY, false),
-                new InternalBucket(new BytesRef("3"), 3, InternalAggregations.EMPTY, false)
+                new InternalBucket(new BytesRef("2"), 1, InternalAggregations.EMPTY),
+                new InternalBucket(new BytesRef("3"), 3, InternalAggregations.EMPTY)
             ),
             false,
             Map.of()
@@ -128,9 +128,9 @@ public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTe
         InternalTimeSeries third = new InternalTimeSeries(
             "ts",
             List.of(
-                new InternalBucket(new BytesRef("1"), 2, InternalAggregations.EMPTY, false),
-                new InternalBucket(new BytesRef("3"), 4, InternalAggregations.EMPTY, false),
-                new InternalBucket(new BytesRef("9"), 4, InternalAggregations.EMPTY, false)
+                new InternalBucket(new BytesRef("1"), 2, InternalAggregations.EMPTY),
+                new InternalBucket(new BytesRef("3"), 4, InternalAggregations.EMPTY),
+                new InternalBucket(new BytesRef("9"), 4, InternalAggregations.EMPTY)
             ),
             false,
             Map.of()

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregatorTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregatorTests.java
@@ -176,19 +176,19 @@ public class TimeSeriesAggregatorTests extends AggregationTestCase {
             InternalDateHistogram byTimeStampBucket = ts.getBucketByKey("{dim1=aaa, dim2=xxx}").getAggregations().get("by_timestamp");
             assertThat(
                 byTimeStampBucket.getBuckets(),
-                contains(new InternalDateHistogram.Bucket(startTime, 2, false, null, InternalAggregations.EMPTY))
+                contains(new InternalDateHistogram.Bucket(startTime, 2, null, InternalAggregations.EMPTY))
             );
             assertThat(ts.getBucketByKey("{dim1=aaa, dim2=yyy}").docCount, equalTo(2L));
             byTimeStampBucket = ts.getBucketByKey("{dim1=aaa, dim2=yyy}").getAggregations().get("by_timestamp");
             assertThat(
                 byTimeStampBucket.getBuckets(),
-                contains(new InternalDateHistogram.Bucket(startTime, 2, false, null, InternalAggregations.EMPTY))
+                contains(new InternalDateHistogram.Bucket(startTime, 2, null, InternalAggregations.EMPTY))
             );
             assertThat(ts.getBucketByKey("{dim1=bbb, dim2=zzz}").docCount, equalTo(4L));
             byTimeStampBucket = ts.getBucketByKey("{dim1=bbb, dim2=zzz}").getAggregations().get("by_timestamp");
             assertThat(
                 byTimeStampBucket.getBuckets(),
-                contains(new InternalDateHistogram.Bucket(startTime, 4, false, null, InternalAggregations.EMPTY))
+                contains(new InternalDateHistogram.Bucket(startTime, 4, null, InternalAggregations.EMPTY))
             );
         };
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
@@ -12,7 +12,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.HasAggregations;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.xcontent.ToXContent;
 
 import java.util.List;
 
@@ -24,7 +23,7 @@ public interface MultiBucketsAggregation extends Aggregation {
      * A bucket represents a criteria to which all documents that fall in it adhere to. It is also uniquely identified
      * by a key, and can potentially hold sub-aggregations computed over all documents in it.
      */
-    interface Bucket extends HasAggregations, ToXContent {
+    interface Bucket extends HasAggregations {
         /**
          * @return The key associated with the bucket
          */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -465,14 +465,6 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
             return 0;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            /**
-             * See {@link CompositeAggregation#bucketToXContent}
-             */
-            throw new UnsupportedOperationException("not implemented");
-        }
-
         InternalBucket finalizeSampling(SamplingContext samplingContext) {
             return new InternalBucket(
                 sourceNames,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
@@ -215,15 +215,9 @@ public abstract class FiltersAggregator extends BucketsAggregator {
             filters.size() + (otherBucketKey == null ? 0 : 1),
             (offsetInOwningOrd, docCount, subAggregationResults) -> {
                 if (offsetInOwningOrd < filters.size()) {
-                    return new InternalFilters.InternalBucket(
-                        filters.get(offsetInOwningOrd).key(),
-                        docCount,
-                        subAggregationResults,
-                        keyed,
-                        keyedBucket
-                    );
+                    return new InternalFilters.InternalBucket(filters.get(offsetInOwningOrd).key(), docCount, subAggregationResults);
                 }
-                return new InternalFilters.InternalBucket(otherBucketKey, docCount, subAggregationResults, keyed, keyedBucket);
+                return new InternalFilters.InternalBucket(otherBucketKey, docCount, subAggregationResults);
             },
             buckets -> new InternalFilters(name, buckets, keyed, keyedBucket, metadata())
         );
@@ -234,12 +228,12 @@ public abstract class FiltersAggregator extends BucketsAggregator {
         InternalAggregations subAggs = buildEmptySubAggregations();
         List<InternalFilters.InternalBucket> buckets = new ArrayList<>(filters.size() + (otherBucketKey == null ? 0 : 1));
         for (QueryToFilterAdapter filter : filters) {
-            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(filter.key(), 0, subAggs, keyed, keyedBucket);
+            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(filter.key(), 0, subAggs);
             buckets.add(bucket);
         }
 
         if (otherBucketKey != null) {
-            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(otherBucketKey, 0, subAggs, keyed, keyedBucket);
+            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(otherBucketKey, 0, subAggs);
             buckets.add(bucket);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -32,26 +32,20 @@ import java.util.Objects;
 public class InternalFilters extends InternalMultiBucketAggregation<InternalFilters, InternalFilters.InternalBucket> implements Filters {
     public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements Filters.Bucket {
 
-        private final boolean keyed;
-        private final boolean keyedBucket;
         private final String key;
         private long docCount;
         InternalAggregations aggregations;
 
-        public InternalBucket(String key, long docCount, InternalAggregations aggregations, boolean keyed, boolean keyedBucket) {
+        public InternalBucket(String key, long docCount, InternalAggregations aggregations) {
             this.key = key;
-            this.keyedBucket = keyedBucket;
             this.docCount = docCount;
             this.aggregations = aggregations;
-            this.keyed = keyed;
         }
 
         /**
          * Read from a stream.
          */
-        public InternalBucket(StreamInput in, boolean keyed, boolean keyedBucket) throws IOException {
-            this.keyed = keyed;
-            this.keyedBucket = keyedBucket;
+        public InternalBucket(StreamInput in) throws IOException {
             key = in.readOptionalString();
             docCount = in.readVLong();
             aggregations = InternalAggregations.readFrom(in);
@@ -84,8 +78,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
             return aggregations;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params, boolean keyed, boolean keyedBucket) throws IOException {
             if (keyed && keyedBucket) {
                 builder.startObject(key);
             } else {
@@ -97,7 +90,6 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -110,24 +102,20 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
             }
             InternalBucket that = (InternalBucket) other;
             return Objects.equals(key, that.key)
-                && Objects.equals(keyed, that.keyed)
-                && Objects.equals(keyedBucket, that.keyedBucket)
                 && Objects.equals(docCount, that.docCount)
                 && Objects.equals(aggregations, that.aggregations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getClass(), key, keyed, keyedBucket, docCount, aggregations);
+            return Objects.hash(getClass(), key, docCount, aggregations);
         }
 
         InternalBucket finalizeSampling(SamplingContext samplingContext) {
             return new InternalBucket(
                 key,
                 samplingContext.scaleUp(docCount),
-                InternalAggregations.finalizeSampling(aggregations, samplingContext),
-                keyed,
-                keyedBucket
+                InternalAggregations.finalizeSampling(aggregations, samplingContext)
             );
         }
     }
@@ -155,7 +143,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
         int size = in.readVInt();
         List<InternalBucket> buckets = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            buckets.add(new InternalBucket(in, keyed, keyedBucket));
+            buckets.add(new InternalBucket(in));
         }
         this.buckets = buckets;
         this.bucketMap = null;
@@ -182,7 +170,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
 
     @Override
     public InternalBucket createBucket(InternalAggregations aggregations, InternalBucket prototype) {
-        return new InternalBucket(prototype.key, prototype.docCount, aggregations, prototype.keyed, keyedBucket);
+        return new InternalBucket(prototype.key, prototype.docCount, aggregations);
     }
 
     @Override
@@ -211,7 +199,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
             ) {
                 @Override
                 protected InternalBucket createBucket(InternalBucket proto, long docCount, InternalAggregations aggregations) {
-                    return new InternalBucket(proto.key, docCount, aggregations, proto.keyed, proto.keyedBucket);
+                    return new InternalBucket(proto.key, docCount, aggregations);
                 }
             };
 
@@ -252,7 +240,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
         for (InternalBucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params, keyed, keyedBucket);
         }
         if (keyed && keyedBucket) {
             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
@@ -152,7 +152,7 @@ public abstract class InternalGeoGrid<B extends InternalGeoGridBucket> extends I
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (InternalGeoGridBucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params);
         }
         builder.endArray();
         return builder;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGridBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGridBucket.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -76,14 +77,12 @@ public abstract class InternalGeoGridBucket extends InternalMultiBucketAggregati
         return 0;
     }
 
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+    final void bucketToXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
         builder.field(Aggregation.CommonFields.KEY.getPreferredName(), getKeyAsString());
         builder.field(Aggregation.CommonFields.DOC_COUNT.getPreferredName(), docCount);
         aggregations.toXContentInternal(builder, params);
         builder.endObject();
-        return builder;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramAggregator.java
@@ -84,7 +84,7 @@ public abstract class AbstractHistogramAggregator extends BucketsAggregator {
         return buildAggregationsForVariableBuckets(owningBucketOrds, bucketOrds, (bucketValue, docCount, subAggregationResults) -> {
             double roundKey = Double.longBitsToDouble(bucketValue);
             double key = roundKey * interval + offset;
-            return new InternalHistogram.Bucket(key, docCount, keyed, formatter, subAggregationResults);
+            return new InternalHistogram.Bucket(key, docCount, formatter, subAggregationResults);
         }, (owningBucketOrd, buckets) -> {
             // the contract of the histogram aggregation is that shards must return buckets ordered by key in ascending order
             CollectionUtil.introSort(buckets, BucketOrder.key(true).comparator());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -340,7 +340,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
     @Override
     public InternalAggregation[] buildAggregations(LongArray owningBucketOrds) throws IOException {
         return buildAggregationsForVariableBuckets(owningBucketOrds, bucketOrds, (bucketValue, docCount, subAggregationResults) -> {
-            return new InternalDateHistogram.Bucket(bucketValue, docCount, keyed, formatter, subAggregationResults);
+            return new InternalDateHistogram.Bucket(bucketValue, docCount, formatter, subAggregationResults);
         }, (owningBucketOrd, buckets) -> {
             // the contract of the histogram aggregation is that shards must return buckets ordered by key in ascending order
             CollectionUtil.introSort(buckets, BucketOrder.key(true).comparator());
@@ -466,7 +466,6 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
                         new InternalDateHistogram.Bucket(
                             rangeBucket.getFrom().toInstant().toEpochMilli(),
                             rangeBucket.getDocCount(),
-                            keyed,
                             format,
                             rangeBucket.getAggregations()
                         )

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -171,7 +171,6 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
             (bucketValue, docCount, subAggregationResults) -> new InternalDateHistogram.Bucket(
                 bucketValue,
                 docCount,
-                keyed,
                 formatter,
                 subAggregationResults
             ),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -53,19 +53,17 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
     public static class Bucket extends AbstractHistogramBucket implements KeyComparable<Bucket> {
 
         final long key;
-        private final transient boolean keyed;
 
-        public Bucket(long key, long docCount, boolean keyed, DocValueFormat format, InternalAggregations aggregations) {
+        public Bucket(long key, long docCount, DocValueFormat format, InternalAggregations aggregations) {
             super(docCount, aggregations, format);
-            this.keyed = keyed;
             this.key = key;
         }
 
         /**
          * Read from a stream.
          */
-        public static Bucket readFrom(StreamInput in, boolean keyed, DocValueFormat format) throws IOException {
-            return new Bucket(in.readLong(), in.readVLong(), keyed, format, InternalAggregations.readFrom(in));
+        public static Bucket readFrom(StreamInput in, DocValueFormat format) throws IOException {
+            return new Bucket(in.readLong(), in.readVLong(), format, InternalAggregations.readFrom(in));
         }
 
         @Override
@@ -101,8 +99,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
             return Instant.ofEpochMilli(key).atZone(ZoneOffset.UTC);
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params, boolean keyed) throws IOException {
             String keyAsString = format.format(key).toString();
             if (keyed) {
                 builder.startObject(keyAsString);
@@ -116,7 +113,6 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -124,15 +120,10 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
             return Long.compare(key, other.key);
         }
 
-        public boolean getKeyed() {
-            return keyed;
-        }
-
         Bucket finalizeSampling(SamplingContext samplingContext) {
             return new Bucket(
                 key,
                 samplingContext.scaleUp(docCount),
-                keyed,
                 format,
                 InternalAggregations.finalizeSampling(aggregations, samplingContext)
             );
@@ -237,7 +228,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         } else {
             downsampledResultsOffset = false;
         }
-        buckets = in.readCollectionAsList(stream -> Bucket.readFrom(stream, keyed, format));
+        buckets = in.readCollectionAsList(stream -> Bucket.readFrom(stream, format));
         // we changed the order format in 8.13 for partial reduce, therefore we need to order them to perform merge sort
         if (in.getTransportVersion().between(TransportVersions.V_8_13_0, TransportVersions.V_8_14_0)) {
             // list is mutable by #readCollectionAsList contract
@@ -301,7 +292,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     @Override
     public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
-        return new Bucket(prototype.key, prototype.docCount, prototype.keyed, prototype.format, aggregations);
+        return new Bucket(prototype.key, prototype.docCount, prototype.format, aggregations);
     }
 
     private List<Bucket> reduceBuckets(final PriorityQueue<IteratorAndCurrent<Bucket>> pq, AggregationReduceContext reduceContext) {
@@ -398,7 +389,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
                     reduceContext.consumeBucketsAndMaybeBreak(size);
                     size = 0;
                 }
-                iter.add(new InternalDateHistogram.Bucket(key, 0, keyed, format, reducedEmptySubAggs));
+                iter.add(new InternalDateHistogram.Bucket(key, 0, format, reducedEmptySubAggs));
             }
         });
     }
@@ -546,7 +537,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
         for (Bucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params, keyed);
         }
         if (keyed) {
             builder.endObject();
@@ -603,7 +594,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     @Override
     public Bucket createBucket(Number key, long docCount, InternalAggregations aggregations) {
-        return new Bucket(key.longValue(), docCount, keyed, format, aggregations);
+        return new Bucket(key.longValue(), docCount, format, aggregations);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -144,8 +144,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
             return centroid;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params) throws IOException {
             String keyAsString = format.format((double) getKey()).toString();
             builder.startObject();
 
@@ -167,7 +166,6 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -555,7 +553,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params);
         }
         builder.endArray();
         return builder;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -38,9 +38,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
             IpPrefix.Bucket,
             KeyComparable<InternalIpPrefix.Bucket> {
 
-        private final transient DocValueFormat format;
         private final BytesRef key;
-        private final boolean keyed;
         private final boolean isIpv6;
         private final int prefixLength;
         private final boolean appendPrefixLength;
@@ -48,18 +46,14 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         private final InternalAggregations aggregations;
 
         public Bucket(
-            DocValueFormat format,
             BytesRef key,
-            boolean keyed,
             boolean isIpv6,
             int prefixLength,
             boolean appendPrefixLength,
             long docCount,
             InternalAggregations aggregations
         ) {
-            this.format = format;
             this.key = key;
-            this.keyed = keyed;
             this.isIpv6 = isIpv6;
             this.prefixLength = prefixLength;
             this.appendPrefixLength = appendPrefixLength;
@@ -70,9 +64,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         /**
          * Read from a stream.
          */
-        public Bucket(StreamInput in, DocValueFormat format, boolean keyed) throws IOException {
-            this.format = format;
-            this.keyed = keyed;
+        public Bucket(StreamInput in) throws IOException {
             this.key = in.readBytesRef();
             this.isIpv6 = in.readBoolean();
             this.prefixLength = in.readVInt();
@@ -81,8 +73,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
             this.aggregations = InternalAggregations.readFrom(in);
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params, boolean keyed) throws IOException {
             String key = DocValueFormat.IP.format(this.key);
             if (appendPrefixLength) {
                 key = key + "/" + prefixLength;
@@ -101,7 +92,6 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
             builder.field(IpPrefixAggregationBuilder.PREFIX_LENGTH_FIELD.getPreferredName(), prefixLength);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         private static BytesRef netmask(int prefixLength) {
@@ -116,10 +106,6 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
             out.writeBoolean(appendPrefixLength);
             out.writeLong(docCount);
             aggregations.writeTo(out);
-        }
-
-        public DocValueFormat getFormat() {
-            return format;
         }
 
         public BytesRef getKey() {
@@ -162,14 +148,13 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
                 && prefixLength == bucket.prefixLength
                 && appendPrefixLength == bucket.appendPrefixLength
                 && docCount == bucket.docCount
-                && Objects.equals(format, bucket.format)
                 && Objects.equals(key, bucket.key)
                 && Objects.equals(aggregations, bucket.aggregations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(format, key, isIpv6, prefixLength, appendPrefixLength, docCount, aggregations);
+            return Objects.hash(key, isIpv6, prefixLength, appendPrefixLength, docCount, aggregations);
         }
 
         @Override
@@ -206,7 +191,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
         minDocCount = in.readVLong();
-        buckets = in.readCollectionAsList(stream -> new Bucket(stream, format, keyed));
+        buckets = in.readCollectionAsList(Bucket::new);
     }
 
     @Override
@@ -298,7 +283,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
         for (InternalIpPrefix.Bucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params, keyed);
         }
         if (keyed) {
             builder.endObject();
@@ -316,9 +301,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
     @Override
     public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
         return new Bucket(
-            format,
             prototype.key,
-            prototype.keyed,
             prototype.isIpv6,
             prototype.prefixLength,
             prototype.appendPrefixLength,
@@ -328,16 +311,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
     }
 
     private Bucket createBucket(Bucket prototype, InternalAggregations aggregations, long docCount) {
-        return new Bucket(
-            format,
-            prototype.key,
-            prototype.keyed,
-            prototype.isIpv6,
-            prototype.prefixLength,
-            prototype.appendPrefixLength,
-            docCount,
-            aggregations
-        );
+        return new Bucket(prototype.key, prototype.isIpv6, prototype.prefixLength, prototype.appendPrefixLength, docCount, aggregations);
     }
 
     private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregator.java
@@ -200,9 +200,7 @@ public final class IpPrefixAggregator extends BucketsAggregator {
                         checkRealMemoryCBForInternalBucket();
                         buckets.add(
                             new InternalIpPrefix.Bucket(
-                                config.format(),
                                 BytesRef.deepCopyOf(ipAddress),
-                                keyed,
                                 ipPrefix.isIpv6,
                                 ipPrefix.prefixLength,
                                 ipPrefix.appendPrefixLength,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
@@ -365,7 +365,7 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
             ranges.length,
             (offsetInOwningOrd, docCount, subAggregationResults) -> {
                 Range range = ranges[offsetInOwningOrd];
-                return new InternalBinaryRange.Bucket(format, keyed, range.key, range.from, range.to, docCount, subAggregationResults);
+                return new InternalBinaryRange.Bucket(format, range.key, range.from, range.to, docCount, subAggregationResults);
             },
             buckets -> new InternalBinaryRange(name, format, keyed, buckets, metadata())
         );
@@ -377,7 +377,7 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
         InternalAggregations subAggs = buildEmptySubAggregations();
         List<InternalBinaryRange.Bucket> buckets = new ArrayList<>(ranges.length);
         for (Range range : ranges) {
-            InternalBinaryRange.Bucket bucket = new InternalBinaryRange.Bucket(format, keyed, range.key, range.from, range.to, 0, subAggs);
+            InternalBinaryRange.Bucket bucket = new InternalBinaryRange.Bucket(format, range.key, range.from, range.to, 0, subAggs);
             buckets.add(bucket);
         }
         return new InternalBinaryRange(name, format, keyed, buckets, metadata());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -39,23 +39,13 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
 
         private final transient DocValueFormat format;
-        private final transient boolean keyed;
         private final String key;
         private final BytesRef from, to;
         private final long docCount;
         private final InternalAggregations aggregations;
 
-        public Bucket(
-            DocValueFormat format,
-            boolean keyed,
-            String key,
-            BytesRef from,
-            BytesRef to,
-            long docCount,
-            InternalAggregations aggregations
-        ) {
+        public Bucket(DocValueFormat format, String key, BytesRef from, BytesRef to, long docCount, InternalAggregations aggregations) {
             this.format = format;
-            this.keyed = keyed;
             this.key = key;
             this.from = from;
             this.to = to;
@@ -67,7 +57,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
             return (from == null ? "*" : format.format(from)) + "-" + (to == null ? "*" : format.format(to));
         }
 
-        private static Bucket createFromStream(StreamInput in, DocValueFormat format, boolean keyed) throws IOException {
+        private static Bucket createFromStream(StreamInput in, DocValueFormat format) throws IOException {
             // NOTE: the key is required in version == 8.0.0 and version <= 7.17.0,
             // while it is optional for all subsequent versions.
             String key = in.getTransportVersion().equals(TransportVersions.V_8_0_0) ? in.readString()
@@ -78,7 +68,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
             long docCount = in.readLong();
             InternalAggregations aggregations = InternalAggregations.readFrom(in);
 
-            return new Bucket(format, keyed, key, from, to, docCount, aggregations);
+            return new Bucket(format, key, from, to, docCount, aggregations);
         }
 
         @Override
@@ -116,8 +106,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
             return aggregations;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params, boolean keyed) throws IOException {
             final String key = getKeyAsString();
             if (keyed) {
                 builder.startObject(key);
@@ -134,7 +123,6 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -180,7 +168,6 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         Bucket finalizeSampling(SamplingContext samplingContext) {
             return new Bucket(
                 format,
-                keyed,
                 key,
                 from,
                 to,
@@ -208,7 +195,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         super(in);
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
-        buckets = in.readCollectionAsList(stream -> Bucket.createFromStream(stream, format, keyed));
+        buckets = in.readCollectionAsList(stream -> Bucket.createFromStream(stream, format));
     }
 
     @Override
@@ -235,7 +222,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
 
     @Override
     public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
-        return new Bucket(format, keyed, prototype.key, prototype.from, prototype.to, prototype.docCount, aggregations);
+        return new Bucket(format, prototype.key, prototype.from, prototype.to, prototype.docCount, aggregations);
     }
 
     @Override
@@ -251,7 +238,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
 
                 @Override
                 protected Bucket createBucket(Bucket proto, long docCount, InternalAggregations aggregations) {
-                    return new Bucket(proto.format, proto.keyed, proto.key, proto.from, proto.to, docCount, aggregations);
+                    return new Bucket(proto.format, proto.key, proto.from, proto.to, docCount, aggregations);
                 }
             };
 
@@ -299,7 +286,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
         for (Bucket range : buckets) {
-            range.toXContent(builder, params);
+            range.bucketToXContent(builder, params, keyed);
         }
         if (keyed) {
             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRange.java
@@ -34,19 +34,11 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
             boolean keyed,
             DocValueFormat formatter
         ) {
-            super(key, from, to, docCount, InternalAggregations.from(aggregations), keyed, formatter);
+            super(key, from, to, docCount, InternalAggregations.from(aggregations), formatter);
         }
 
-        public Bucket(
-            String key,
-            double from,
-            double to,
-            long docCount,
-            InternalAggregations aggregations,
-            boolean keyed,
-            DocValueFormat formatter
-        ) {
-            super(key, from, to, docCount, aggregations, keyed, formatter);
+        public Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, DocValueFormat formatter) {
+            super(key, from, to, docCount, aggregations, formatter);
         }
 
         @Override
@@ -99,10 +91,9 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
             double to,
             long docCount,
             InternalAggregations aggregations,
-            boolean keyed,
             DocValueFormat formatter
         ) {
-            return new Bucket(key, from, to, docCount, aggregations, keyed, formatter);
+            return new Bucket(key, from, to, docCount, aggregations, formatter);
         }
 
         @Override
@@ -113,7 +104,6 @@ public class InternalDateRange extends InternalRange<InternalDateRange.Bucket, I
                 prototype.internalGetTo(),
                 prototype.getDocCount(),
                 aggregations,
-                prototype.getKeyed(),
                 prototype.getFormat()
             );
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistance.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistance.java
@@ -23,8 +23,8 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
 
     static class Bucket extends InternalRange.Bucket {
 
-        Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, boolean keyed) {
-            super(key, from, to, docCount, aggregations, keyed, DocValueFormat.RAW);
+        Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations) {
+            super(key, from, to, docCount, aggregations, DocValueFormat.RAW);
         }
 
     }
@@ -58,10 +58,9 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
             double to,
             long docCount,
             InternalAggregations aggregations,
-            boolean keyed,
             DocValueFormat format
         ) {
-            return new Bucket(key, from, to, docCount, aggregations, keyed);
+            return new Bucket(key, from, to, docCount, aggregations);
         }
 
         @Override
@@ -71,8 +70,7 @@ public class InternalGeoDistance extends InternalRange<InternalGeoDistance.Bucke
                 ((Number) prototype.getFrom()).doubleValue(),
                 ((Number) prototype.getTo()).doubleValue(),
                 prototype.getDocCount(),
-                aggregations,
-                prototype.getKeyed()
+                aggregations
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -38,7 +38,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
     public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
 
-        protected final transient boolean keyed;
         protected final transient DocValueFormat format;
         protected final double from;
         protected final double to;
@@ -46,16 +45,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         private final InternalAggregations aggregations;
         private final String key;
 
-        public Bucket(
-            String key,
-            double from,
-            double to,
-            long docCount,
-            InternalAggregations aggregations,
-            boolean keyed,
-            DocValueFormat format
-        ) {
-            this.keyed = keyed;
+        public Bucket(String key, double from, double to, long docCount, InternalAggregations aggregations, DocValueFormat format) {
             this.format = format;
             this.key = key;
             this.from = from;
@@ -82,10 +72,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         @Override
         public Object getTo() {
             return to;
-        }
-
-        public boolean getKeyed() {
-            return keyed;
         }
 
         public DocValueFormat getFormat() {
@@ -120,8 +106,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             return aggregations;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public XContentBuilder bucketToXContent(XContentBuilder builder, Params params, boolean keyed) throws IOException {
             final String key = getKeyAsString();
             if (keyed) {
                 builder.startObject(key);
@@ -207,16 +192,8 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         }
 
         @SuppressWarnings("unchecked")
-        public B createBucket(
-            String key,
-            double from,
-            double to,
-            long docCount,
-            InternalAggregations aggregations,
-            boolean keyed,
-            DocValueFormat format
-        ) {
-            return (B) new Bucket(key, from, to, docCount, aggregations, keyed, format);
+        public B createBucket(String key, double from, double to, long docCount, InternalAggregations aggregations, DocValueFormat format) {
+            return (B) new Bucket(key, from, to, docCount, aggregations, format);
         }
 
         @SuppressWarnings("unchecked")
@@ -232,7 +209,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
                 prototype.to,
                 prototype.getDocCount(),
                 aggregations,
-                prototype.keyed,
                 prototype.format
             );
         }
@@ -285,7 +261,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             }
             long docCount = in.readVLong();
             InternalAggregations aggregations = InternalAggregations.readFrom(in);
-            ranges.add(getFactory().createBucket(key, from, to, docCount, aggregations, keyed, format));
+            ranges.add(getFactory().createBucket(key, from, to, docCount, aggregations, format));
         }
         this.ranges = ranges;
     }
@@ -335,7 +311,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
                 @Override
                 protected Bucket createBucket(Bucket proto, long docCount, InternalAggregations aggregations) {
-                    return getFactory().createBucket(proto.key, proto.from, proto.to, docCount, aggregations, proto.keyed, proto.format);
+                    return getFactory().createBucket(proto.key, proto.from, proto.to, docCount, aggregations, proto.format);
                 }
             };
 
@@ -371,7 +347,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
                         b.to,
                         samplingContext.scaleUp(b.getDocCount()),
                         InternalAggregations.finalizeSampling(b.getAggregations(), samplingContext),
-                        b.keyed,
                         b.format
                     )
                 )
@@ -390,7 +365,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
         for (B range : ranges) {
-            range.toXContent(builder, params);
+            range.bucketToXContent(builder, params, keyed);
         }
         if (keyed) {
             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -538,15 +538,7 @@ public abstract class RangeAggregator extends BucketsAggregator {
             ranges.length,
             (offsetInOwningOrd, docCount, subAggregationResults) -> {
                 Range range = ranges[offsetInOwningOrd];
-                return rangeFactory.createBucket(
-                    range.key,
-                    range.originalFrom,
-                    range.originalTo,
-                    docCount,
-                    subAggregationResults,
-                    keyed,
-                    format
-                );
+                return rangeFactory.createBucket(range.key, range.originalFrom, range.originalTo, docCount, subAggregationResults, format);
             },
             buckets -> rangeFactory.create(name, buckets, format, keyed, metadata())
         );
@@ -564,7 +556,6 @@ public abstract class RangeAggregator extends BucketsAggregator {
                 range.originalTo,
                 0,
                 subAggs,
-                keyed,
                 format
             );
             buckets.add(bucket);
@@ -614,7 +605,7 @@ public abstract class RangeAggregator extends BucketsAggregator {
             InternalAggregations subAggs = buildEmptySubAggregations();
             List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = new ArrayList<>(ranges.length);
             for (RangeAggregator.Range range : ranges) {
-                buckets.add(factory.createBucket(range.key, range.originalFrom, range.originalTo, 0, subAggs, keyed, format));
+                buckets.add(factory.createBucket(range.key, range.originalFrom, range.originalTo, 0, subAggs, format));
             }
             return factory.create(name, buckets, format, keyed, metadata());
         }
@@ -886,7 +877,7 @@ public abstract class RangeAggregator extends BucketsAggregator {
                 Range r = ranges[i];
                 InternalFilters.InternalBucket b = filters.getBuckets().get(i);
                 buckets.add(
-                    rangeFactory.createBucket(r.getKey(), r.originalFrom, r.originalTo, b.getDocCount(), b.getAggregations(), keyed, format)
+                    rangeFactory.createBucket(r.getKey(), r.originalFrom, r.originalTo, b.getDocCount(), b.getAggregations(), format)
                 );
             }
             return rangeFactory.create(name(), buckets, format, keyed, filters.getMetadata());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -66,6 +66,8 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         protected abstract boolean getShowDocCountError();
 
         protected abstract long getDocCountError();
+
+        protected abstract void bucketToXContent(XContentBuilder builder, Params params, boolean showDocCountError) throws IOException;
     }
 
     /**
@@ -361,6 +363,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
     protected static XContentBuilder doXContentCommon(
         XContentBuilder builder,
         Params params,
+        boolean showDocCountError,
         Long docCountError,
         long otherDocCount,
         List<? extends AbstractTermsBucket<?>> buckets
@@ -369,7 +372,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         builder.field(SUM_OF_OTHER_DOC_COUNTS.getPreferredName(), otherDocCount);
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (AbstractTermsBucket<?> bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params, showDocCountError);
         }
         builder.endArray();
         return builder;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -134,7 +134,7 @@ public abstract class InternalMappedSignificantTerms<
             // There is a condition (presumably when only one shard has a bucket?) where reduce is not called
             // and I end up with buckets that contravene the user's min_doc_count criteria in my reducer
             if (bucket.subsetDf >= minDocCount) {
-                bucket.toXContent(builder, params);
+                bucket.bucketToXContent(builder, params);
             }
         }
         builder.endArray();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
@@ -145,6 +145,6 @@ public abstract class InternalMappedTerms<A extends InternalTerms<A, B>, B exten
 
     @Override
     public final XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        return doXContentCommon(builder, params, docCountError, otherDocCount, buckets);
+        return doXContentCommon(builder, params, showTermDocCountError, docCountError, otherDocCount, buckets);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
@@ -81,14 +81,12 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
             return aggregations;
         }
 
-        @Override
-        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             keyToXContent(builder);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         protected abstract XContentBuilder keyToXContent(XContentBuilder builder) throws IOException;
@@ -160,7 +158,7 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
         throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket<?> bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params);
         }
         builder.endArray();
         return builder;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -157,8 +157,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
             return Objects.hash(getClass(), aggregations, score, format);
         }
 
-        @Override
-        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        final void bucketToXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             keyToXContent(builder);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
@@ -166,7 +165,6 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
             builder.field(BG_COUNT, supersetDf);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         protected abstract XContentBuilder keyToXContent(XContentBuilder builder) throws IOException;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -136,7 +136,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         }
 
         @Override
-        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public final void bucketToXContent(XContentBuilder builder, Params params, boolean showDocCountError) throws IOException {
             builder.startObject();
             keyToXContent(builder);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
@@ -145,7 +145,6 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
             }
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         protected abstract XContentBuilder keyToXContent(XContentBuilder builder) throws IOException;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -111,7 +111,7 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
 
     @Override
     public final XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        return doXContentCommon(builder, params, 0L, 0, Collections.emptyList());
+        return doXContentCommon(builder, params, false, 0L, 0, Collections.emptyList());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
@@ -639,7 +639,6 @@ public class SearchResponseMergerTests extends ESTestCase {
                     10000D,
                     count,
                     InternalAggregations.EMPTY,
-                    false,
                     DocValueFormat.RAW
                 );
                 InternalDateRange range = factory.create(rangeAggName, singletonList(bucket), DocValueFormat.RAW, false, emptyMap());
@@ -1498,15 +1497,7 @@ public class SearchResponseMergerTests extends ESTestCase {
     private static InternalAggregations createDeterminsticAggregation(String maxAggName, String rangeAggName, double value, int count) {
         Max max = new Max(maxAggName, value, DocValueFormat.RAW, Collections.emptyMap());
         InternalDateRange.Factory factory = new InternalDateRange.Factory();
-        InternalDateRange.Bucket bucket = factory.createBucket(
-            "bucket",
-            0D,
-            10000D,
-            count,
-            InternalAggregations.EMPTY,
-            false,
-            DocValueFormat.RAW
-        );
+        InternalDateRange.Bucket bucket = factory.createBucket("bucket", 0D, 10000D, count, InternalAggregations.EMPTY, DocValueFormat.RAW);
 
         InternalDateRange range = factory.create(rangeAggName, singletonList(bucket), DocValueFormat.RAW, false, emptyMap());
         InternalAggregations aggs = InternalAggregations.from(Arrays.asList(range, max));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationsTests.java
@@ -137,17 +137,15 @@ public class InternalAggregationsTests extends ESTestCase {
                                     new InternalFiltersForF2(
                                         "f2",
                                         List.of(
-                                            new InternalFilters.InternalBucket("f2k1", k1k1, InternalAggregations.EMPTY, true, true),
-                                            new InternalFilters.InternalBucket("f2k2", k1k2, InternalAggregations.EMPTY, true, true)
+                                            new InternalFilters.InternalBucket("f2k1", k1k1, InternalAggregations.EMPTY),
+                                            new InternalFilters.InternalBucket("f2k2", k1k2, InternalAggregations.EMPTY)
                                         ),
                                         true,
                                         true,
                                         null
                                     )
                                 )
-                            ),
-                            true,
-                            true
+                            )
                         ),
                         new InternalFilters.InternalBucket(
                             "f1k2",
@@ -157,17 +155,15 @@ public class InternalAggregationsTests extends ESTestCase {
                                     new InternalFiltersForF2(
                                         "f2",
                                         List.of(
-                                            new InternalFilters.InternalBucket("f2k1", k2k1, InternalAggregations.EMPTY, true, true),
-                                            new InternalFilters.InternalBucket("f2k2", k2k2, InternalAggregations.EMPTY, true, true)
+                                            new InternalFilters.InternalBucket("f2k1", k2k1, InternalAggregations.EMPTY),
+                                            new InternalFilters.InternalBucket("f2k2", k2k2, InternalAggregations.EMPTY)
                                         ),
                                         true,
                                         true,
                                         null
                                     )
                                 )
-                            ),
-                            true,
-                            true
+                            )
                         )
                     ),
                     true,
@@ -192,17 +188,15 @@ public class InternalAggregationsTests extends ESTestCase {
                                     new InternalFilters(
                                         "f2",
                                         List.of(
-                                            new InternalFilters.InternalBucket("f2k1", k1k1, InternalAggregations.EMPTY, true, true),
-                                            new InternalFilters.InternalBucket("f2k2", k1k2, InternalAggregations.EMPTY, true, true)
+                                            new InternalFilters.InternalBucket("f2k1", k1k1, InternalAggregations.EMPTY),
+                                            new InternalFilters.InternalBucket("f2k2", k1k2, InternalAggregations.EMPTY)
                                         ),
                                         true,
                                         true,
                                         null
                                     )
                                 )
-                            ),
-                            true,
-                            true
+                            )
                         ),
                         new InternalFilters.InternalBucket(
                             "f1k2",
@@ -212,17 +206,15 @@ public class InternalAggregationsTests extends ESTestCase {
                                     new InternalFilters(
                                         "f2",
                                         List.of(
-                                            new InternalFilters.InternalBucket("f2k1", k2k1, InternalAggregations.EMPTY, true, true),
-                                            new InternalFilters.InternalBucket("f2k2", k2k2, InternalAggregations.EMPTY, true, true)
+                                            new InternalFilters.InternalBucket("f2k1", k2k1, InternalAggregations.EMPTY),
+                                            new InternalFilters.InternalBucket("f2k2", k2k2, InternalAggregations.EMPTY)
                                         ),
                                         true,
                                         true,
                                         null
                                     )
                                 )
-                            ),
-                            true,
-                            true
+                            )
                         )
                     ),
                     true,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
@@ -59,10 +59,9 @@ public class InternalFiltersTests extends InternalMultiBucketAggregationTestCase
     @Override
     protected InternalFilters createTestInstance(String name, Map<String, Object> metadata, InternalAggregations aggregations) {
         final List<InternalFilters.InternalBucket> buckets = new ArrayList<>();
-        for (int i = 0; i < keys.size(); ++i) {
-            String key = keys.get(i);
+        for (String key : keys) {
             int docCount = randomIntBetween(0, 1000);
-            buckets.add(new InternalFilters.InternalBucket(key, docCount, aggregations, keyed, keyedBucket));
+            buckets.add(new InternalBucket(key, docCount, aggregations));
         }
         return new InternalFilters(name, buckets, keyed, keyedBucket, metadata);
     }
@@ -94,7 +93,7 @@ public class InternalFiltersTests extends InternalMultiBucketAggregationTestCase
             case 0 -> name += randomAlphaOfLength(5);
             case 1 -> {
                 buckets = new ArrayList<>(buckets);
-                buckets.add(new InternalBucket("test", randomIntBetween(0, 1000), InternalAggregations.EMPTY, keyed, keyedBucket));
+                buckets.add(new InternalBucket("test", randomIntBetween(0, 1000), InternalAggregations.EMPTY));
             }
             default -> {
                 if (metadata == null) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -106,7 +106,7 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
             // rarely leave some holes to be filled up with empty buckets in case minDocCount is set to 0
             if (frequently()) {
                 long key = startingDate + intervalMillis * i;
-                buckets.add(new InternalDateHistogram.Bucket(key, randomIntBetween(1, 100), keyed, format, aggregations));
+                buckets.add(new InternalDateHistogram.Bucket(key, randomIntBetween(1, 100), format, aggregations));
             }
         }
         BucketOrder order = BucketOrder.key(randomBoolean());
@@ -181,13 +181,7 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
             case 1 -> {
                 buckets = new ArrayList<>(buckets);
                 buckets.add(
-                    new InternalDateHistogram.Bucket(
-                        randomNonNegativeLong(),
-                        randomIntBetween(1, 100),
-                        keyed,
-                        format,
-                        InternalAggregations.EMPTY
-                    )
+                    new InternalDateHistogram.Bucket(randomNonNegativeLong(), randomIntBetween(1, 100), format, InternalAggregations.EMPTY)
                 );
             }
             case 2 -> order = BucketOrder.count(randomBoolean());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
@@ -74,7 +74,7 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
             // rarely leave some holes to be filled up with empty buckets in case minDocCount is set to 0
             if (frequently()) {
                 final int docCount = TestUtil.nextInt(random(), 1, 50);
-                buckets.add(new InternalHistogram.Bucket(base + i * interval, docCount, keyed, format, aggregations));
+                buckets.add(new InternalHistogram.Bucket(base + i * interval, docCount, format, aggregations));
             }
         }
         BucketOrder order = BucketOrder.key(randomBoolean());
@@ -96,7 +96,7 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
             newBuckets.addAll(buckets.subList(0, buckets.size() - 1));
         }
         InternalHistogram.Bucket b = buckets.get(buckets.size() - 1);
-        newBuckets.add(new InternalHistogram.Bucket(Double.NaN, b.docCount, keyed, b.format, b.aggregations));
+        newBuckets.add(new InternalHistogram.Bucket(Double.NaN, b.docCount, b.format, b.aggregations));
 
         List<InternalAggregation> reduceMe = List.of(histogram, histogram2);
         InternalAggregationTestCase.reduce(reduceMe, mockReduceContext(mockBuilder(reduceMe)).forPartialReduction());
@@ -171,13 +171,7 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
             case 1 -> {
                 buckets = new ArrayList<>(buckets);
                 buckets.add(
-                    new InternalHistogram.Bucket(
-                        randomNonNegativeLong(),
-                        randomIntBetween(1, 100),
-                        keyed,
-                        format,
-                        InternalAggregations.EMPTY
-                    )
+                    new InternalHistogram.Bucket(randomNonNegativeLong(), randomIntBetween(1, 100), format, InternalAggregations.EMPTY)
                 );
             }
             case 2 -> order = BucketOrder.count(randomBoolean());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefixTests.java
@@ -75,16 +75,7 @@ public class InternalIpPrefixTests extends InternalMultiBucketAggregationTestCas
             BytesRef key = itr.next();
             boolean v6 = InetAddressPoint.decode(key.bytes) instanceof Inet6Address;
             buckets.add(
-                new InternalIpPrefix.Bucket(
-                    DocValueFormat.IP,
-                    key,
-                    keyed,
-                    v6,
-                    prefixLength,
-                    appendPrefixLength,
-                    randomLongBetween(0, Long.MAX_VALUE),
-                    aggregations
-                )
+                new InternalIpPrefix.Bucket(key, v6, prefixLength, appendPrefixLength, randomLongBetween(0, Long.MAX_VALUE), aggregations)
             );
         }
 
@@ -126,7 +117,6 @@ public class InternalIpPrefixTests extends InternalMultiBucketAggregationTestCas
         Map<BytesRef, Long> expectedCounts = new HashMap<>();
         for (InternalIpPrefix i : inputs) {
             for (InternalIpPrefix.Bucket b : i.getBuckets()) {
-                assertThat(b.getFormat(), equalTo(DocValueFormat.IP));
                 long acc = expectedCounts.getOrDefault(b.getKey(), 0L);
                 acc += b.getDocCount();
                 expectedCounts.put(b.getKey(), acc);
@@ -146,9 +136,7 @@ public class InternalIpPrefixTests extends InternalMultiBucketAggregationTestCas
 
     public void testPartialReduceNoMinDocCount() {
         InternalIpPrefix.Bucket b1 = new InternalIpPrefix.Bucket(
-            DocValueFormat.IP,
             new BytesRef(InetAddressPoint.encode(InetAddresses.forString("192.168.0.1"))),
-            false,
             false,
             1,
             false,
@@ -156,9 +144,7 @@ public class InternalIpPrefixTests extends InternalMultiBucketAggregationTestCas
             InternalAggregations.EMPTY
         );
         InternalIpPrefix.Bucket b2 = new InternalIpPrefix.Bucket(
-            DocValueFormat.IP,
             new BytesRef(InetAddressPoint.encode(InetAddresses.forString("200.0.0.1"))),
-            false,
             false,
             1,
             false,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -72,7 +72,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
         for (int i = 0; i < ranges.size(); ++i) {
             final int docCount = randomIntBetween(1, 100);
             final String key = (i == nullKey) ? null : randomAlphaOfLength(10);
-            buckets.add(new InternalBinaryRange.Bucket(format, keyed, key, ranges.get(i).v1(), ranges.get(i).v2(), docCount, aggregations));
+            buckets.add(new InternalBinaryRange.Bucket(format, key, ranges.get(i).v1(), ranges.get(i).v2(), docCount, aggregations));
         }
         return new InternalBinaryRange(name, format, keyed, buckets, metadata);
     }
@@ -113,7 +113,6 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
                 buckets.add(
                     new InternalBinaryRange.Bucket(
                         format,
-                        keyed,
                         "range_a",
                         new BytesRef(randomAlphaOfLengthBetween(1, 20)),
                         new BytesRef(randomAlphaOfLengthBetween(1, 20)),

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -81,7 +81,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
             int docCount = randomIntBetween(0, 1000);
             double from = range.v1();
             double to = range.v2();
-            buckets.add(new InternalDateRange.Bucket("range_" + i, from, to, docCount, aggregations, keyed, format));
+            buckets.add(new InternalDateRange.Bucket("range_" + i, from, to, docCount, aggregations, format));
         }
         return new InternalDateRange(name, buckets, format, keyed, metadata);
     }
@@ -105,9 +105,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
                 buckets = new ArrayList<>(buckets);
                 double from = randomDouble();
                 double to = from + randomDouble();
-                buckets.add(
-                    new InternalDateRange.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, false, format)
-                );
+                buckets.add(new InternalDateRange.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, format));
             }
             case 3 -> {
                 if (metadata == null) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
@@ -63,7 +63,7 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
             int docCount = randomIntBetween(0, 1000);
             double from = range.v1();
             double to = range.v2();
-            buckets.add(new InternalGeoDistance.Bucket("range_" + i, from, to, docCount, aggregations, keyed));
+            buckets.add(new InternalGeoDistance.Bucket("range_" + i, from, to, docCount, aggregations));
         }
         return new InternalGeoDistance(name, buckets, keyed, metadata);
     }
@@ -86,9 +86,7 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
                 buckets = new ArrayList<>(buckets);
                 double from = randomDouble();
                 double to = from + randomDouble();
-                buckets.add(
-                    new InternalGeoDistance.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, false)
-                );
+                buckets.add(new InternalGeoDistance.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY));
             }
             case 3 -> {
                 if (metadata == null) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -76,7 +76,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
             int docCount = randomIntBetween(0, 1000);
             double from = range.v1();
             double to = range.v2();
-            buckets.add(new InternalRange.Bucket("range_" + i, from, to, docCount, aggregations, keyed, format));
+            buckets.add(new InternalRange.Bucket("range_" + i, from, to, docCount, aggregations, format));
         }
         return new InternalRange<>(name, buckets, format, keyed, metadata);
     }
@@ -100,9 +100,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
                 buckets = new ArrayList<>(buckets);
                 double from = randomDouble();
                 double to = from + randomDouble();
-                buckets.add(
-                    new InternalRange.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, false, format)
-                );
+                buckets.add(new InternalRange.Bucket("range_a", from, to, randomNonNegativeLong(), InternalAggregations.EMPTY, format));
             }
             case 3 -> {
                 if (metadata == null) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpersTests.java
@@ -82,11 +82,6 @@ public class BucketHelpersTests extends ESTestCase {
             }
 
             @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                return null;
-            }
-
-            @Override
             public Object getProperty(String containingAggName, List<String> path) {
                 return new Object[0];
             }
@@ -158,11 +153,6 @@ public class BucketHelpersTests extends ESTestCase {
 
             @Override
             public InternalAggregations getAggregations() {
-                return null;
-            }
-
-            @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
                 return null;
             }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -122,17 +122,16 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public void bucketToXContent(XContentBuilder builder, Params params, boolean showDocCountError) throws IOException {
             builder.startObject();
             builder.field(CommonFields.KEY.getPreferredName(), getKey());
             builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
-            if (getShowDocCountError()) {
+            if (showDocCountError) {
                 builder.field(DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME.getPreferredName(), getDocCountError());
             }
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         @Override
@@ -589,7 +588,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        return doXContentCommon(builder, params, docCountError, otherDocCount, buckets);
+        return doXContentCommon(builder, params, showTermDocCountError, docCountError, otherDocCount, buckets);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -142,8 +142,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
             aggregations.writeTo(out);
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        private void bucketToXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), serializableCategory.getNumMatches());
             builder.field(CommonFields.KEY.getPreferredName());
@@ -152,7 +151,6 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
             builder.field(CategoryDefinition.MAX_MATCHING_LENGTH.getPreferredName(), serializableCategory.maxMatchingStringLen());
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
-            return builder;
         }
 
         BucketKey getRawKey() {
@@ -280,7 +278,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket bucket : buckets) {
-            bucket.toXContent(builder, params);
+            bucket.bucketToXContent(builder, params);
         }
         builder.endArray();
         return builder;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointBucket.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointBucket.java
@@ -12,12 +12,13 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class ChangePointBucket extends InternalMultiBucketAggregation.InternalBucket {
+public class ChangePointBucket extends InternalMultiBucketAggregation.InternalBucket implements ToXContent {
     private final Object key;
     private final long docCount;
     private final InternalAggregations aggregations;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
@@ -36,7 +36,7 @@ public final class AggregationTestUtils {
     private AggregationTestUtils() {}
 
     static InternalHistogram.Bucket createHistogramBucket(long timestamp, long docCount, List<InternalAggregation> subAggregations) {
-        return new InternalHistogram.Bucket(timestamp, docCount, false, DocValueFormat.RAW, createAggs(subAggregations));
+        return new InternalHistogram.Bucket(timestamp, docCount, DocValueFormat.RAW, createAggs(subAggregations));
     }
 
     static InternalComposite.InternalBucket createCompositeBucket(

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
@@ -444,20 +444,14 @@ public class RollupResponseTranslator {
                 long key = ((InternalDateHistogram) rolled).getKey(bucket).longValue();
                 DocValueFormat formatter = ((InternalDateHistogram.Bucket) bucket).getFormatter();
                 assert bucketCount >= 0;
-                return new InternalDateHistogram.Bucket(
-                    key,
-                    bucketCount,
-                    ((InternalDateHistogram.Bucket) bucket).getKeyed(),
-                    formatter,
-                    subAggs
-                );
+                return new InternalDateHistogram.Bucket(key, bucketCount, formatter, subAggs);
             });
         } else if (rolled instanceof InternalHistogram) {
             return unrollMultiBucket(rolled, original, currentTree, (bucket, bucketCount, subAggs) -> {
                 long key = ((InternalHistogram) rolled).getKey(bucket).longValue();
                 DocValueFormat formatter = ((InternalHistogram.Bucket) bucket).getFormatter();
                 assert bucketCount >= 0;
-                return new InternalHistogram.Bucket(key, bucketCount, ((InternalHistogram.Bucket) bucket).getKeyed(), formatter, subAggs);
+                return new InternalHistogram.Bucket(key, bucketCount, formatter, subAggs);
             });
         } else if (rolled instanceof StringTerms) {
             return unrollMultiBucket(rolled, original, currentTree, (bucket, bucketCount, subAggs) -> {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -39,7 +39,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filters;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.TaskCancelledException;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.ql.execution.search.FieldExtraction;
 import org.elasticsearch.xpack.ql.execution.search.extractor.AbstractFieldHitExtractor;
 import org.elasticsearch.xpack.ql.execution.search.extractor.BucketExtractor;
@@ -361,11 +360,6 @@ public class Querier {
     static class ImplicitGroupActionListener extends BaseAggActionListener {
 
         private static final List<? extends Bucket> EMPTY_BUCKET = singletonList(new Bucket() {
-
-            @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                throw new SqlIllegalArgumentException("No group-by/aggs defined");
-            }
 
             @Override
             public Object getKey() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestBucket.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestBucket.java
@@ -8,9 +8,7 @@ package org.elasticsearch.xpack.sql.execution.search.extractor;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation.Bucket;
-import org.elasticsearch.xcontent.XContentBuilder;
 
-import java.io.IOException;
 import java.util.Map;
 
 class TestBucket implements Bucket {
@@ -23,11 +21,6 @@ class TestBucket implements Bucket {
         this.key = key;
         this.count = count;
         this.aggs = aggs;
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -918,14 +918,14 @@ public class AggregationResultUtilsTests extends ESTestCase {
         Aggregation agg = createRangeAgg(
             "p_agg",
             List.of(
-                new InternalRange.Bucket(null, Double.NEGATIVE_INFINITY, 10.5, 10, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket(null, 10.5, 19.5, 30, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket(null, 19.5, 200, 30, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket(null, 20, Double.POSITIVE_INFINITY, 0, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket(null, -10, -5, 0, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket(null, -11.0, -6.0, 0, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket(null, -11.0, 0, 0, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
-                new InternalRange.Bucket("custom-0", 0, 10, 777, InternalAggregations.EMPTY, false, DocValueFormat.RAW)
+                new InternalRange.Bucket(null, Double.NEGATIVE_INFINITY, 10.5, 10, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket(null, 10.5, 19.5, 30, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket(null, 19.5, 200, 30, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket(null, 20, Double.POSITIVE_INFINITY, 0, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket(null, -10, -5, 0, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket(null, -11.0, -6.0, 0, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket(null, -11.0, 0, 0, InternalAggregations.EMPTY, DocValueFormat.RAW),
+                new InternalRange.Bucket("custom-0", 0, 10, 777, InternalAggregations.EMPTY, DocValueFormat.RAW)
             )
         );
         assertThat(


### PR DESCRIPTION
Backports the following commits to 8.x:
 - MultiBucketsAggregation.Bucket does not implement ToXContent anymore (#117240)