### PR TITLE
[8.x] Bump major version for feature migration system indices (#117243)

### DIFF
--- a/docs/changelog/117243.yaml
+++ b/docs/changelog/117243.yaml
@@ -1,0 +1,5 @@
+pr: 117243
+summary: Bump major version for feature migration system indices
+area: Infra/Core
+type: upgrade
+issues: []

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -208,7 +208,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".int-man-old-reindexed-for-8",
+            ".int-man-old-reindexed-for-9",
             INTERNAL_MANAGED_FLAG_VALUE,
             true,
             true,
@@ -216,7 +216,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".int-unman-old-reindexed-for-8",
+            ".int-unman-old-reindexed-for-9",
             INTERNAL_UNMANAGED_FLAG_VALUE,
             false,
             true,
@@ -224,7 +224,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".ext-man-old-reindexed-for-8",
+            ".ext-man-old-reindexed-for-9",
             EXTERNAL_MANAGED_FLAG_VALUE,
             true,
             false,
@@ -232,7 +232,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".ext-unman-old-reindexed-for-8",
+            ".ext-unman-old-reindexed-for-9",
             EXTERNAL_UNMANAGED_FLAG_VALUE,
             false,
             false,

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
@@ -219,7 +219,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         // Finally, verify that all the indices exist and have the properties we expect.
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".int-man-old-reindexed-for-8",
+            ".int-man-old-reindexed-for-9",
             INTERNAL_MANAGED_FLAG_VALUE,
             true,
             true,
@@ -227,7 +227,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".int-unman-old-reindexed-for-8",
+            ".int-unman-old-reindexed-for-9",
             INTERNAL_UNMANAGED_FLAG_VALUE,
             false,
             true,
@@ -235,7 +235,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".ext-man-old-reindexed-for-8",
+            ".ext-man-old-reindexed-for-9",
             EXTERNAL_MANAGED_FLAG_VALUE,
             true,
             false,
@@ -243,7 +243,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         );
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".ext-unman-old-reindexed-for-8",
+            ".ext-unman-old-reindexed-for-9",
             EXTERNAL_UNMANAGED_FLAG_VALUE,
             false,
             false,
@@ -252,7 +252,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         assertIndexHasCorrectProperties(
             finalMetadata,
-            ".second-int-man-old-reindexed-for-8",
+            ".second-int-man-old-reindexed-for-9",
             SECOND_FEATURE_IDX_FLAG_VALUE,
             true,
             true,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.indices.SystemIndices;
@@ -53,18 +52,13 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
     GetFeatureUpgradeStatusRequest,
     GetFeatureUpgradeStatusResponse> {
 
-    /**
-     * Once all feature migrations for 8.x -> 9.x have been tested, we can bump this to Version.V_8_0_0
-     */
-    @UpdateForV9
-    public static final Version NO_UPGRADE_REQUIRED_VERSION = Version.V_7_0_0;
-    public static final IndexVersion NO_UPGRADE_REQUIRED_INDEX_VERSION = IndexVersions.V_7_0_0;
+    public static final Version NO_UPGRADE_REQUIRED_VERSION = Version.V_8_0_0;
+    public static final IndexVersion NO_UPGRADE_REQUIRED_INDEX_VERSION = IndexVersions.V_8_0_0;
 
     private final SystemIndices systemIndices;
     PersistentTasksService persistentTasksService;
 
     @Inject
-    @UpdateForV9 // Once we begin working on 9.x, we need to update our migration classes
     public TransportGetFeatureUpgradeStatusAction(
         TransportService transportService,
         ThreadPool threadPool,
@@ -149,7 +143,6 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
             .map(idxInfo -> ERROR)
             .map(idxStatus -> GetFeatureUpgradeStatusResponse.UpgradeStatus.combine(idxStatus, initialStatus))
             .orElse(initialStatus);
-
         return new GetFeatureUpgradeStatusResponse.FeatureUpgradeStatus(featureName, minimumVersion, status, indexInfos);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -111,7 +111,7 @@ import static org.elasticsearch.tasks.TaskResultsService.TASKS_FEATURE_NAME;
 public class SystemIndices {
     public static final String SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_system_index_access_allowed";
     public static final String EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY = "_external_system_index_access_origin";
-    public static final String UPGRADED_INDEX_SUFFIX = "-reindexed-for-8";
+    public static final String UPGRADED_INDEX_SUFFIX = "-reindexed-for-9";
 
     private static final Automaton EMPTY = Automata.makeEmpty();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Bump major version for feature migration system indices (#117243)](https://github.com/elastic/elasticsearch/pull/117243)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)