### PR TITLE
ES|QL: fix validation of SORT by aggregate functions

### DIFF
--- a/docs/changelog/117316.yaml
+++ b/docs/changelog/117316.yaml
@@ -1,0 +1,5 @@
+pr: 117316
+summary: Fix validation of SORT by aggregate functions
+area: ES|QL
+type: bug
+issues: []

--- a/docs/reference/esql/functions/kibana/definition/match_operator.json
+++ b/docs/reference/esql/functions/kibana/definition/match_operator.json
@@ -26,6 +26,42 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "Field that the query will target."
+        },
+        {
+          "name" : "query",
+          "type" : "text",
+          "optional" : false,
+          "description" : "Text you wish to find in the provided field."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "boolean"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "Field that the query will target."
+        },
+        {
+          "name" : "query",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "Text you wish to find in the provided field."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "boolean"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "text",
           "optional" : false,
           "description" : "Field that the query will target."

--- a/docs/reference/esql/functions/types/match_operator.asciidoc
+++ b/docs/reference/esql/functions/types/match_operator.asciidoc
@@ -6,5 +6,7 @@
 |===
 field | query | result
 keyword | keyword | boolean
+keyword | text | boolean
+text | keyword | boolean
 text | text | boolean
 |===

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -114,6 +114,14 @@ public class Verifier {
 
             if (p instanceof Unresolvable u) {
                 failures.add(fail(p, u.unresolvedMessage()));
+            } else if (p instanceof OrderBy ob) {
+                ob.order().forEach(o -> {
+                    o.forEachDown(Function.class, f -> {
+                        if (f instanceof AggregateFunction) {
+                            failures.add(fail(f, "Aggregate functions are not allowed in SORT [{}]", f.functionName()));
+                        }
+                    });
+                });
             }
             // p is resolved, skip
             else if (p.resolved()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -114,17 +114,18 @@ public class Verifier {
 
             if (p instanceof Unresolvable u) {
                 failures.add(fail(p, u.unresolvedMessage()));
-            } else if (p instanceof OrderBy ob) {
-                ob.order().forEach(o -> {
-                    o.forEachDown(Function.class, f -> {
-                        if (f instanceof AggregateFunction) {
-                            failures.add(fail(f, "Aggregate functions are not allowed in SORT [{}]", f.functionName()));
-                        }
-                    });
-                });
             }
             // p is resolved, skip
             else if (p.resolved()) {
+                if (p instanceof OrderBy ob) {
+                    ob.order().forEach(o -> {
+                        o.forEachDown(Function.class, f -> {
+                            if (f instanceof AggregateFunction) {
+                                failures.add(fail(f, "Aggregate functions are not allowed in SORT [{}]", f.functionName()));
+                            }
+                        });
+                    });
+                }
                 p.forEachExpressionUp(Alias.class, a -> aliases.put(a.toAttribute(), a.child()));
                 return;
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1793,6 +1793,13 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testSortByAggregate() {
+        assertEquals("1:18: Aggregate functions are not allowed in SORT [COUNT]", error("ROW a = 1 | SORT count(*)"));
+        assertEquals("1:28: Aggregate functions are not allowed in SORT [COUNT]", error("ROW a = 1 | SORT to_string(count(*))"));
+        assertEquals("1:22: Aggregate functions are not allowed in SORT [MAX]", error("ROW a = 1 | SORT 1 + max(a)"));
+        assertEquals("1:18: Aggregate functions are not allowed in SORT [COUNT]", error("FROM test | SORT count(*)"));
+    }
+
     private void query(String query) {
         defaultAnalyzer.analyze(parser.createStatement(query));
     }


### PR DESCRIPTION
`SORT <expression>` is translated to `EVAL x = <expression> | SORT x`.

If the expression contains aggregate functions, it should fail validation (and now it does).

Fixes: https://github.com/elastic/elasticsearch/issues/117314