### PR TITLE
Enable test-fixture test suites

### DIFF
--- a/test/fixtures/build.gradle
+++ b/test/fixtures/build.gradle
@@ -1,9 +1,0 @@
-
-subprojects {
-  // fixtures don't have tests, these are external projects used by the build
-  pluginManager.withPlugin('java') {
-    tasks.named('test').configure {
-      enabled = false
-    }
-  }
-}


### PR DESCRIPTION
Today the `:test:fixtures` modules' test suites are disabled, but in
fact these fixtures do have nontrivial behaviour that wants testing in
its own right, so we should run their tests.

This commit reinstates the disabled tests and fixes one which should
have been fixed as part of #116212.