### PR TITLE
[8.x] Unmute Categorize VerifierTests and require snapshot on them (#117016)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -359,15 +359,6 @@ tests:
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/115631
-- class: org.elasticsearch.xpack.esql.analysis.VerifierTests
-  method: testCategorizeNestedGrouping
-  issue: https://github.com/elastic/elasticsearch/issues/116858
-- class: org.elasticsearch.xpack.esql.analysis.VerifierTests
-  method: testCategorizeSingleGrouping
-  issue: https://github.com/elastic/elasticsearch/issues/116857
-- class: org.elasticsearch.xpack.esql.analysis.VerifierTests
-  method: testCategorizeWithinAggregations
-  issue: https://github.com/elastic/elasticsearch/issues/116856
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1732,7 +1732,8 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testCategorizeSingleGrouping() {
-        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+        assumeTrue("requires Categorize capability", EsqlCapabilities.Cap.CATEGORIZE.isEnabled());
+
         query("from test | STATS COUNT(*) BY CATEGORIZE(first_name)");
         query("from test | STATS COUNT(*) BY cat = CATEGORIZE(first_name)");
 
@@ -1760,7 +1761,8 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testCategorizeNestedGrouping() {
-        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+        assumeTrue("requires Categorize capability", EsqlCapabilities.Cap.CATEGORIZE.isEnabled());
+
         query("from test | STATS COUNT(*) BY CATEGORIZE(LENGTH(first_name)::string)");
 
         assertEquals(
@@ -1774,7 +1776,8 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testCategorizeWithinAggregations() {
-        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+        assumeTrue("requires Categorize capability", EsqlCapabilities.Cap.CATEGORIZE.isEnabled());
+
         query("from test | STATS MV_COUNT(cat), COUNT(*) BY cat = CATEGORIZE(first_name)");
 
         assertEquals(


### PR DESCRIPTION
8.x backport of https://github.com/elastic/elasticsearch/pull/117016
Issues: https://github.com/elastic/elasticsearch/issues/116856 https://github.com/elastic/elasticsearch/issues/116857 https://github.com/elastic/elasticsearch/issues/116858