### PR TITLE
[8.x] ESQL: Fix double lookup and HashJoinExec.addedFields (#115616)

### DIFF
--- a/docs/changelog/115616.yaml
+++ b/docs/changelog/115616.yaml
@@ -1,0 +1,6 @@
+pr: 115616
+summary: Fix double lookup failure on ESQL
+area: ES|QL
+type: bug
+issues:
+  - 111398

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/HashJoinExec.java
@@ -91,7 +91,7 @@ public class HashJoinExec extends BinaryExec implements EstimatesRowSize {
 
     public Set<Attribute> addedFields() {
         if (lazyAddedFields == null) {
-            lazyAddedFields = outputSet();
+            lazyAddedFields = new AttributeSet(output());
             lazyAddedFields.removeAll(left().output());
         }
         return lazyAddedFields;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fix double lookup and HashJoinExec.addedFields (#115616)