### PR TITLE
Avoid adding extra indices to snapshots

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -41,8 +41,9 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot
         wait_for_completion: true
-        body: |
-          { "indices": "test_index" }
+        body:
+          indices: "test_index"
+          feature_states: [ "none" ]
 
   - match: { snapshot.snapshot: test_snapshot }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
Feature state indices are added to the snapshot implicitly even if they are not listed int the indices field. This change is disabling snapshotting features explicitly to avoid adding .ml* indices.

Closes: #117295