### PR TITLE
[8.x] Distinguish `LicensedFeature` by family field (#116809)

### DIFF
--- a/docs/changelog/116809.yaml
+++ b/docs/changelog/116809.yaml
@@ -1,0 +1,5 @@
+pr: 116809
+summary: "Distinguish `LicensedFeature` by family field"
+area: License
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicensedFeature.java
@@ -136,11 +136,11 @@ public abstract class LicensedFeature {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LicensedFeature that = (LicensedFeature) o;
-        return Objects.equals(name, that.name);
+        return Objects.equals(name, that.name) && Objects.equals(family, that.family);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return Objects.hash(name, family);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Distinguish `LicensedFeature` by family field (#116809)