### PR TITLE
[8.x] Fixing bug setting index when parsing Google Vertex AI results (#117287)

### DIFF
--- a/docs/changelog/117287.yaml
+++ b/docs/changelog/117287.yaml
@@ -1,0 +1,5 @@
+pr: 117287
+summary: Fixing bug setting index when parsing Google Vertex AI results
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fixing bug setting index when parsing Google Vertex AI results (#117287)