### PR TITLE
[8.x] ESQL: Make WEIGHTED_AVG not preview (#117356)

### DIFF
--- a/docs/reference/esql/functions/aggregation-functions.asciidoc
+++ b/docs/reference/esql/functions/aggregation-functions.asciidoc
@@ -20,7 +20,7 @@ The <<esql-stats-by>> command supports these aggregate functions:
 * <<esql-sum>>
 * <<esql-top>>
 * <<esql-values>>
-* experimental:[] <<esql-weighted_avg>>
+* <<esql-weighted_avg>>
 // end::agg_list[]
 
 include::layout/avg.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Make WEIGHTED_AVG not preview (#117356)