### PR TITLE
Catch up entitlements backports

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+
 import javax.inject.Inject;
 
 import static de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin.FORBIDDEN_APIS_TASK_NAME;

--- a/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImpl.java
+++ b/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImpl.java
@@ -9,19 +9,29 @@
 
 package org.elasticsearch.entitlement.instrumentation.impl;
 
+import org.elasticsearch.entitlement.instrumentation.CheckerMethod;
 import org.elasticsearch.entitlement.instrumentation.InstrumentationService;
 import org.elasticsearch.entitlement.instrumentation.Instrumenter;
 import org.elasticsearch.entitlement.instrumentation.MethodKey;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
 public class InstrumentationServiceImpl implements InstrumentationService {
+
     @Override
-    public Instrumenter newInstrumenter(String classNameSuffix, Map<MethodKey, Method> instrumentationMethods) {
+    public Instrumenter newInstrumenter(String classNameSuffix, Map<MethodKey, CheckerMethod> instrumentationMethods) {
         return new InstrumenterImpl(classNameSuffix, instrumentationMethods);
     }
 
@@ -33,9 +43,97 @@ public class InstrumentationServiceImpl implements InstrumentationService {
         return new MethodKey(
             Type.getInternalName(targetMethod.getDeclaringClass()),
             targetMethod.getName(),
-            Stream.of(actualType.getArgumentTypes()).map(Type::getInternalName).toList(),
-            Modifier.isStatic(targetMethod.getModifiers())
+            Stream.of(actualType.getArgumentTypes()).map(Type::getInternalName).toList()
         );
     }
 
+    @Override
+    public Map<MethodKey, CheckerMethod> lookupMethodsToInstrument(String entitlementCheckerClassName) throws ClassNotFoundException,
+        IOException {
+        var methodsToInstrument = new HashMap<MethodKey, CheckerMethod>();
+        var checkerClass = Class.forName(entitlementCheckerClassName);
+        var classFileInfo = InstrumenterImpl.getClassFileInfo(checkerClass);
+        ClassReader reader = new ClassReader(classFileInfo.bytecodes());
+        ClassVisitor visitor = new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            public MethodVisitor visitMethod(
+                int access,
+                String checkerMethodName,
+                String checkerMethodDescriptor,
+                String signature,
+                String[] exceptions
+            ) {
+                var mv = super.visitMethod(access, checkerMethodName, checkerMethodDescriptor, signature, exceptions);
+
+                var checkerMethodArgumentTypes = Type.getArgumentTypes(checkerMethodDescriptor);
+                var methodToInstrument = parseCheckerMethodSignature(checkerMethodName, checkerMethodArgumentTypes);
+
+                var checkerParameterDescriptors = Arrays.stream(checkerMethodArgumentTypes).map(Type::getDescriptor).toList();
+                var checkerMethod = new CheckerMethod(Type.getInternalName(checkerClass), checkerMethodName, checkerParameterDescriptors);
+
+                methodsToInstrument.put(methodToInstrument, checkerMethod);
+
+                return mv;
+            }
+        };
+        reader.accept(visitor, 0);
+        return methodsToInstrument;
+    }
+
+    private static final Type CLASS_TYPE = Type.getType(Class.class);
+
+    static MethodKey parseCheckerMethodSignature(String checkerMethodName, Type[] checkerMethodArgumentTypes) {
+        var classNameStartIndex = checkerMethodName.indexOf('$');
+        var classNameEndIndex = checkerMethodName.lastIndexOf('$');
+
+        if (classNameStartIndex == -1 || classNameStartIndex >= classNameEndIndex) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "Checker method %s has incorrect name format. "
+                        + "It should be either check$$methodName (instance) or check$package_ClassName$methodName (static)",
+                    checkerMethodName
+                )
+            );
+        }
+
+        // No "className" (check$$methodName) -> method is static, and we'll get the class from the actual typed argument
+        final boolean targetMethodIsStatic = classNameStartIndex + 1 != classNameEndIndex;
+        final String targetMethodName = checkerMethodName.substring(classNameEndIndex + 1);
+
+        final String targetClassName;
+        final List<String> targetParameterTypes;
+        if (targetMethodIsStatic) {
+            if (checkerMethodArgumentTypes.length < 1 || CLASS_TYPE.equals(checkerMethodArgumentTypes[0]) == false) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "Checker method %s has incorrect argument types. " + "It must have a first argument of Class<?> type.",
+                        checkerMethodName
+                    )
+                );
+            }
+
+            targetClassName = checkerMethodName.substring(classNameStartIndex + 1, classNameEndIndex).replace('_', '/');
+            targetParameterTypes = Arrays.stream(checkerMethodArgumentTypes).skip(1).map(Type::getInternalName).toList();
+        } else {
+            if (checkerMethodArgumentTypes.length < 2
+                || CLASS_TYPE.equals(checkerMethodArgumentTypes[0]) == false
+                || checkerMethodArgumentTypes[1].getSort() != Type.OBJECT) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "Checker method %s has incorrect argument types. "
+                            + "It must have a first argument of Class<?> type, and a second argument of the class containing the method to "
+                            + "instrument",
+                        checkerMethodName
+                    )
+                );
+            }
+            var targetClassType = checkerMethodArgumentTypes[1];
+            targetClassName = targetClassType.getInternalName();
+            targetParameterTypes = Arrays.stream(checkerMethodArgumentTypes).skip(2).map(Type::getInternalName).toList();
+        }
+        return new MethodKey(targetClassName, targetMethodName, targetParameterTypes);
+    }
 }

--- a/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
+++ b/libs/entitlement/asm-provider/src/main/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterImpl.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.entitlement.instrumentation.impl;
 
+import org.elasticsearch.entitlement.instrumentation.CheckerMethod;
 import org.elasticsearch.entitlement.instrumentation.Instrumenter;
 import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.objectweb.asm.AnnotationVisitor;
@@ -23,7 +24,6 @@ import org.objectweb.asm.Type;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -40,9 +40,9 @@ public class InstrumenterImpl implements Instrumenter {
      * To avoid class name collisions during testing without an agent to replace classes in-place.
      */
     private final String classNameSuffix;
-    private final Map<MethodKey, Method> instrumentationMethods;
+    private final Map<MethodKey, CheckerMethod> instrumentationMethods;
 
-    public InstrumenterImpl(String classNameSuffix, Map<MethodKey, Method> instrumentationMethods) {
+    public InstrumenterImpl(String classNameSuffix, Map<MethodKey, CheckerMethod> instrumentationMethods) {
         this.classNameSuffix = classNameSuffix;
         this.instrumentationMethods = instrumentationMethods;
     }
@@ -138,12 +138,7 @@ public class InstrumenterImpl implements Instrumenter {
             var mv = super.visitMethod(access, name, descriptor, signature, exceptions);
             if (isAnnotationPresent == false) {
                 boolean isStatic = (access & ACC_STATIC) != 0;
-                var key = new MethodKey(
-                    className,
-                    name,
-                    Stream.of(Type.getArgumentTypes(descriptor)).map(Type::getInternalName).toList(),
-                    isStatic
-                );
+                var key = new MethodKey(className, name, Stream.of(Type.getArgumentTypes(descriptor)).map(Type::getInternalName).toList());
                 var instrumentationMethod = instrumentationMethods.get(key);
                 if (instrumentationMethod != null) {
                     // LOGGER.debug("Will instrument method {}", key);
@@ -177,7 +172,7 @@ public class InstrumenterImpl implements Instrumenter {
     class EntitlementMethodVisitor extends MethodVisitor {
         private final boolean instrumentedMethodIsStatic;
         private final String instrumentedMethodDescriptor;
-        private final Method instrumentationMethod;
+        private final CheckerMethod instrumentationMethod;
         private boolean hasCallerSensitiveAnnotation = false;
 
         EntitlementMethodVisitor(
@@ -185,7 +180,7 @@ public class InstrumenterImpl implements Instrumenter {
             MethodVisitor methodVisitor,
             boolean instrumentedMethodIsStatic,
             String instrumentedMethodDescriptor,
-            Method instrumentationMethod
+            CheckerMethod instrumentationMethod
         ) {
             super(api, methodVisitor);
             this.instrumentedMethodIsStatic = instrumentedMethodIsStatic;
@@ -262,9 +257,12 @@ public class InstrumenterImpl implements Instrumenter {
         private void invokeInstrumentationMethod() {
             mv.visitMethodInsn(
                 INVOKEINTERFACE,
-                Type.getInternalName(instrumentationMethod.getDeclaringClass()),
-                instrumentationMethod.getName(),
-                Type.getMethodDescriptor(instrumentationMethod),
+                instrumentationMethod.className(),
+                instrumentationMethod.methodName(),
+                Type.getMethodDescriptor(
+                    Type.VOID_TYPE,
+                    instrumentationMethod.parameterDescriptors().stream().map(Type::getType).toArray(Type[]::new)
+                ),
                 true
             );
         }

--- a/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests.java
+++ b/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.instrumentation.impl;
+
+import org.elasticsearch.entitlement.instrumentation.CheckerMethod;
+import org.elasticsearch.entitlement.instrumentation.InstrumentationService;
+import org.elasticsearch.entitlement.instrumentation.MethodKey;
+import org.elasticsearch.test.ESTestCase;
+import org.objectweb.asm.Type;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+
+@ESTestCase.WithoutSecurityManager
+public class InstrumentationServiceImplTests extends ESTestCase {
+
+    final InstrumentationService instrumentationService = new InstrumentationServiceImpl();
+
+    static class TestTargetClass {}
+
+    interface TestChecker {
+        void check$org_example_TestTargetClass$staticMethod(Class<?> clazz, int arg0, String arg1, Object arg2);
+
+        void check$$instanceMethodNoArgs(Class<?> clazz, TestTargetClass that);
+
+        void check$$instanceMethodWithArgs(Class<?> clazz, TestTargetClass that, int x, int y);
+    }
+
+    interface TestCheckerOverloads {
+        void check$org_example_TestTargetClass$staticMethodWithOverload(Class<?> clazz, int x, int y);
+
+        void check$org_example_TestTargetClass$staticMethodWithOverload(Class<?> clazz, int x, String y);
+    }
+
+    public void testInstrumentationTargetLookup() throws IOException, ClassNotFoundException {
+        Map<MethodKey, CheckerMethod> methodsMap = instrumentationService.lookupMethodsToInstrument(TestChecker.class.getName());
+
+        assertThat(methodsMap, aMapWithSize(3));
+        assertThat(
+            methodsMap,
+            hasEntry(
+                equalTo(new MethodKey("org/example/TestTargetClass", "staticMethod", List.of("I", "java/lang/String", "java/lang/Object"))),
+                equalTo(
+                    new CheckerMethod(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestChecker",
+                        "check$org_example_TestTargetClass$staticMethod",
+                        List.of("Ljava/lang/Class;", "I", "Ljava/lang/String;", "Ljava/lang/Object;")
+                    )
+                )
+            )
+        );
+        assertThat(
+            methodsMap,
+            hasEntry(
+                equalTo(
+                    new MethodKey(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetClass",
+                        "instanceMethodNoArgs",
+                        List.of()
+                    )
+                ),
+                equalTo(
+                    new CheckerMethod(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestChecker",
+                        "check$$instanceMethodNoArgs",
+                        List.of(
+                            "Ljava/lang/Class;",
+                            "Lorg/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetClass;"
+                        )
+                    )
+                )
+            )
+        );
+        assertThat(
+            methodsMap,
+            hasEntry(
+                equalTo(
+                    new MethodKey(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetClass",
+                        "instanceMethodWithArgs",
+                        List.of("I", "I")
+                    )
+                ),
+                equalTo(
+                    new CheckerMethod(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestChecker",
+                        "check$$instanceMethodWithArgs",
+                        List.of(
+                            "Ljava/lang/Class;",
+                            "Lorg/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetClass;",
+                            "I",
+                            "I"
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    public void testInstrumentationTargetLookupWithOverloads() throws IOException, ClassNotFoundException {
+        Map<MethodKey, CheckerMethod> methodsMap = instrumentationService.lookupMethodsToInstrument(TestCheckerOverloads.class.getName());
+
+        assertThat(methodsMap, aMapWithSize(2));
+        assertThat(
+            methodsMap,
+            hasEntry(
+                equalTo(new MethodKey("org/example/TestTargetClass", "staticMethodWithOverload", List.of("I", "java/lang/String"))),
+                equalTo(
+                    new CheckerMethod(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestCheckerOverloads",
+                        "check$org_example_TestTargetClass$staticMethodWithOverload",
+                        List.of("Ljava/lang/Class;", "I", "Ljava/lang/String;")
+                    )
+                )
+            )
+        );
+        assertThat(
+            methodsMap,
+            hasEntry(
+                equalTo(new MethodKey("org/example/TestTargetClass", "staticMethodWithOverload", List.of("I", "I"))),
+                equalTo(
+                    new CheckerMethod(
+                        "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestCheckerOverloads",
+                        "check$org_example_TestTargetClass$staticMethodWithOverload",
+                        List.of("Ljava/lang/Class;", "I", "I")
+                    )
+                )
+            )
+        );
+    }
+
+    public void testParseCheckerMethodSignatureStaticMethod() {
+        var methodKey = InstrumentationServiceImpl.parseCheckerMethodSignature(
+            "check$org_example_TestClass$staticMethod",
+            new Type[] { Type.getType(Class.class) }
+        );
+
+        assertThat(methodKey, equalTo(new MethodKey("org/example/TestClass", "staticMethod", List.of())));
+    }
+
+    public void testParseCheckerMethodSignatureStaticMethodWithArgs() {
+        var methodKey = InstrumentationServiceImpl.parseCheckerMethodSignature(
+            "check$org_example_TestClass$staticMethod",
+            new Type[] { Type.getType(Class.class), Type.getType("I"), Type.getType(String.class) }
+        );
+
+        assertThat(methodKey, equalTo(new MethodKey("org/example/TestClass", "staticMethod", List.of("I", "java/lang/String"))));
+    }
+
+    public void testParseCheckerMethodSignatureStaticMethodInnerClass() {
+        var methodKey = InstrumentationServiceImpl.parseCheckerMethodSignature(
+            "check$org_example_TestClass$InnerClass$staticMethod",
+            new Type[] { Type.getType(Class.class) }
+        );
+
+        assertThat(methodKey, equalTo(new MethodKey("org/example/TestClass$InnerClass", "staticMethod", List.of())));
+    }
+
+    public void testParseCheckerMethodSignatureIncorrectName() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> InstrumentationServiceImpl.parseCheckerMethodSignature("check$staticMethod", new Type[] { Type.getType(Class.class) })
+        );
+
+        assertThat(exception.getMessage(), containsString("has incorrect name format"));
+    }
+
+    public void testParseCheckerMethodSignatureStaticMethodIncorrectArgumentCount() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> InstrumentationServiceImpl.parseCheckerMethodSignature("check$ClassName$staticMethod", new Type[] {})
+        );
+        assertThat(exception.getMessage(), containsString("It must have a first argument of Class<?> type"));
+    }
+
+    public void testParseCheckerMethodSignatureStaticMethodIncorrectArgumentType() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> InstrumentationServiceImpl.parseCheckerMethodSignature(
+                "check$ClassName$staticMethod",
+                new Type[] { Type.getType(String.class) }
+            )
+        );
+        assertThat(exception.getMessage(), containsString("It must have a first argument of Class<?> type"));
+    }
+
+    public void testParseCheckerMethodSignatureInstanceMethod() {
+        var methodKey = InstrumentationServiceImpl.parseCheckerMethodSignature(
+            "check$$instanceMethod",
+            new Type[] { Type.getType(Class.class), Type.getType(TestTargetClass.class) }
+        );
+
+        assertThat(
+            methodKey,
+            equalTo(
+                new MethodKey(
+                    "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetClass",
+                    "instanceMethod",
+                    List.of()
+                )
+            )
+        );
+    }
+
+    public void testParseCheckerMethodSignatureInstanceMethodWithArgs() {
+        var methodKey = InstrumentationServiceImpl.parseCheckerMethodSignature(
+            "check$$instanceMethod",
+            new Type[] { Type.getType(Class.class), Type.getType(TestTargetClass.class), Type.getType("I"), Type.getType(String.class) }
+        );
+
+        assertThat(
+            methodKey,
+            equalTo(
+                new MethodKey(
+                    "org/elasticsearch/entitlement/instrumentation/impl/InstrumentationServiceImplTests$TestTargetClass",
+                    "instanceMethod",
+                    List.of("I", "java/lang/String")
+                )
+            )
+        );
+    }
+
+    public void testParseCheckerMethodSignatureInstanceMethodIncorrectArgumentTypes() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> InstrumentationServiceImpl.parseCheckerMethodSignature("check$$instanceMethod", new Type[] { Type.getType(String.class) })
+        );
+        assertThat(exception.getMessage(), containsString("It must have a first argument of Class<?> type"));
+    }
+
+    public void testParseCheckerMethodSignatureInstanceMethodIncorrectArgumentCount() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> InstrumentationServiceImpl.parseCheckerMethodSignature("check$$instanceMethod", new Type[] { Type.getType(Class.class) })
+        );
+        assertThat(exception.getMessage(), containsString("a second argument of the class containing the method to instrument"));
+    }
+
+    public void testParseCheckerMethodSignatureInstanceMethodIncorrectArgumentTypes2() {
+        var exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> InstrumentationServiceImpl.parseCheckerMethodSignature(
+                "check$$instanceMethod",
+                new Type[] { Type.getType(Class.class), Type.getType("I") }
+            )
+        );
+        assertThat(exception.getMessage(), containsString("a second argument of the class containing the method to instrument"));
+    }
+}

--- a/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterTests.java
+++ b/libs/entitlement/asm-provider/src/test/java/org/elasticsearch/entitlement/instrumentation/impl/InstrumenterTests.java
@@ -11,7 +11,9 @@ package org.elasticsearch.entitlement.instrumentation.impl;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
+import org.elasticsearch.entitlement.instrumentation.CheckerMethod;
 import org.elasticsearch.entitlement.instrumentation.InstrumentationService;
+import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
@@ -22,11 +24,12 @@ import org.objectweb.asm.Type;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 import static org.elasticsearch.entitlement.instrumentation.impl.ASMUtils.bytecode2text;
 import static org.elasticsearch.entitlement.instrumentation.impl.InstrumenterImpl.getClassFileInfo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 
 /**
@@ -53,7 +56,12 @@ public class InstrumenterTests extends ESTestCase {
      * Contains all the virtual methods from {@link ClassToInstrument},
      * allowing this test to call them on the dynamically loaded instrumented class.
      */
-    public interface Testable {}
+    public interface Testable {
+        // This method is here to demonstrate Instrumenter does not get confused by overloads
+        void someMethod(int arg);
+
+        void someMethod(int arg, String anotherArg);
+    }
 
     /**
      * This is a placeholder for real class library methods.
@@ -71,9 +79,25 @@ public class InstrumenterTests extends ESTestCase {
         public static void anotherSystemExit(int status) {
             assertEquals(123, status);
         }
+
+        public void someMethod(int arg) {}
+
+        public void someMethod(int arg, String anotherArg) {}
+
+        public static void someStaticMethod(int arg) {}
+
+        public static void someStaticMethod(int arg, String anotherArg) {}
     }
 
     static final class TestException extends RuntimeException {}
+
+    public interface MockEntitlementChecker extends EntitlementChecker {
+        void checkSomeStaticMethod(Class<?> clazz, int arg);
+
+        void checkSomeStaticMethod(Class<?> clazz, int arg, String anotherArg);
+
+        void checkSomeInstanceMethod(Class<?> clazz, Testable that, int arg, String anotherArg);
+    }
 
     /**
      * We're not testing the permission checking logic here;
@@ -82,7 +106,7 @@ public class InstrumenterTests extends ESTestCase {
      * just to demonstrate that the injected bytecodes succeed in calling these methods.
      * It also asserts that the arguments are correct.
      */
-    public static class TestEntitlementChecker implements EntitlementChecker {
+    public static class TestEntitlementChecker implements MockEntitlementChecker {
         /**
          * This allows us to test that the instrumentation is correct in both cases:
          * if the check throws, and if it doesn't.
@@ -90,9 +114,12 @@ public class InstrumenterTests extends ESTestCase {
         volatile boolean isActive;
 
         int checkSystemExitCallCount = 0;
+        int checkSomeStaticMethodIntCallCount = 0;
+        int checkSomeStaticMethodIntStringCallCount = 0;
+        int checkSomeInstanceMethodCallCount = 0;
 
         @Override
-        public void checkSystemExit(Class<?> callerClass, int status) {
+        public void check$java_lang_System$exit(Class<?> callerClass, int status) {
             checkSystemExitCallCount++;
             assertSame(InstrumenterTests.class, callerClass);
             assertEquals(123, status);
@@ -104,11 +131,48 @@ public class InstrumenterTests extends ESTestCase {
                 throw new TestException();
             }
         }
+
+        @Override
+        public void checkSomeStaticMethod(Class<?> callerClass, int arg) {
+            checkSomeStaticMethodIntCallCount++;
+            assertSame(InstrumenterTests.class, callerClass);
+            assertEquals(123, arg);
+            throwIfActive();
+        }
+
+        @Override
+        public void checkSomeStaticMethod(Class<?> callerClass, int arg, String anotherArg) {
+            checkSomeStaticMethodIntStringCallCount++;
+            assertSame(InstrumenterTests.class, callerClass);
+            assertEquals(123, arg);
+            assertEquals("abc", anotherArg);
+            throwIfActive();
+        }
+
+        @Override
+        public void checkSomeInstanceMethod(Class<?> callerClass, Testable that, int arg, String anotherArg) {
+            checkSomeInstanceMethodCallCount++;
+            assertSame(InstrumenterTests.class, callerClass);
+            assertThat(
+                that.getClass().getName(),
+                startsWith("org.elasticsearch.entitlement.instrumentation.impl.InstrumenterTests$ClassToInstrument")
+            );
+            assertEquals(123, arg);
+            assertEquals("def", anotherArg);
+            throwIfActive();
+        }
     }
 
     public void testClassIsInstrumented() throws Exception {
         var classToInstrument = ClassToInstrument.class;
-        var instrumenter = createInstrumenter(classToInstrument, "systemExit");
+
+        CheckerMethod checkerMethod = getCheckerMethod(EntitlementChecker.class, "check$java_lang_System$exit", Class.class, int.class);
+        Map<MethodKey, CheckerMethod> methods = Map.of(
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("systemExit", int.class)),
+            checkerMethod
+        );
+
+        var instrumenter = createInstrumenter(methods);
 
         byte[] newBytecode = instrumenter.instrumentClassFile(classToInstrument).bytecodes();
 
@@ -117,7 +181,7 @@ public class InstrumenterTests extends ESTestCase {
         }
 
         Class<?> newClass = new TestLoader(Testable.class.getClassLoader()).defineClassFromBytes(
-            ClassToInstrument.class.getName() + "_NEW",
+            classToInstrument.getName() + "_NEW",
             newBytecode
         );
 
@@ -134,7 +198,14 @@ public class InstrumenterTests extends ESTestCase {
 
     public void testClassIsNotInstrumentedTwice() throws Exception {
         var classToInstrument = ClassToInstrument.class;
-        var instrumenter = createInstrumenter(classToInstrument, "systemExit");
+
+        CheckerMethod checkerMethod = getCheckerMethod(EntitlementChecker.class, "check$java_lang_System$exit", Class.class, int.class);
+        Map<MethodKey, CheckerMethod> methods = Map.of(
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("systemExit", int.class)),
+            checkerMethod
+        );
+
+        var instrumenter = createInstrumenter(methods);
 
         InstrumenterImpl.ClassFileInfo initial = getClassFileInfo(classToInstrument);
         var internalClassName = Type.getInternalName(classToInstrument);
@@ -146,7 +217,7 @@ public class InstrumenterTests extends ESTestCase {
         logger.trace(() -> Strings.format("Bytecode after 2nd instrumentation:\n%s", bytecode2text(instrumentedTwiceBytecode)));
 
         Class<?> newClass = new TestLoader(Testable.class.getClassLoader()).defineClassFromBytes(
-            ClassToInstrument.class.getName() + "_NEW_NEW",
+            classToInstrument.getName() + "_NEW_NEW",
             instrumentedTwiceBytecode
         );
 
@@ -159,7 +230,16 @@ public class InstrumenterTests extends ESTestCase {
 
     public void testClassAllMethodsAreInstrumentedFirstPass() throws Exception {
         var classToInstrument = ClassToInstrument.class;
-        var instrumenter = createInstrumenter(classToInstrument, "systemExit", "anotherSystemExit");
+
+        CheckerMethod checkerMethod = getCheckerMethod(EntitlementChecker.class, "check$java_lang_System$exit", Class.class, int.class);
+        Map<MethodKey, CheckerMethod> methods = Map.of(
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("systemExit", int.class)),
+            checkerMethod,
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("anotherSystemExit", int.class)),
+            checkerMethod
+        );
+
+        var instrumenter = createInstrumenter(methods);
 
         InstrumenterImpl.ClassFileInfo initial = getClassFileInfo(classToInstrument);
         var internalClassName = Type.getInternalName(classToInstrument);
@@ -171,7 +251,7 @@ public class InstrumenterTests extends ESTestCase {
         logger.trace(() -> Strings.format("Bytecode after 2nd instrumentation:\n%s", bytecode2text(instrumentedTwiceBytecode)));
 
         Class<?> newClass = new TestLoader(Testable.class.getClassLoader()).defineClassFromBytes(
-            ClassToInstrument.class.getName() + "_NEW_NEW",
+            classToInstrument.getName() + "_NEW_NEW",
             instrumentedTwiceBytecode
         );
 
@@ -185,22 +265,78 @@ public class InstrumenterTests extends ESTestCase {
         assertThat(getTestEntitlementChecker().checkSystemExitCallCount, is(2));
     }
 
-    /** This test doesn't replace ClassToInstrument in-place but instead loads a separate
-     * class ClassToInstrument_NEW that contains the instrumentation. Because of this,
-     * we need to configure the Transformer to use a MethodKey and instrumentationMethod
-     * with slightly different signatures (using the common interface Testable) which
-     * is not what would happen when it's run by the agent.
-     */
-    private InstrumenterImpl createInstrumenter(Class<?> classToInstrument, String... methodNames) throws NoSuchMethodException {
-        Method v1 = EntitlementChecker.class.getMethod("checkSystemExit", Class.class, int.class);
-        var methods = Arrays.stream(methodNames).map(name -> {
-            try {
-                return instrumentationService.methodKeyForTarget(classToInstrument.getMethod(name, int.class));
-            } catch (NoSuchMethodException e) {
-                throw new RuntimeException(e);
-            }
-        }).collect(Collectors.toUnmodifiableMap(name -> name, name -> v1));
+    public void testInstrumenterWorksWithOverloads() throws Exception {
+        var classToInstrument = ClassToInstrument.class;
 
+        Map<MethodKey, CheckerMethod> methods = Map.of(
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("someStaticMethod", int.class)),
+            getCheckerMethod(MockEntitlementChecker.class, "checkSomeStaticMethod", Class.class, int.class),
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("someStaticMethod", int.class, String.class)),
+            getCheckerMethod(MockEntitlementChecker.class, "checkSomeStaticMethod", Class.class, int.class, String.class)
+        );
+
+        var instrumenter = createInstrumenter(methods);
+
+        byte[] newBytecode = instrumenter.instrumentClassFile(classToInstrument).bytecodes();
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("Bytecode after instrumentation:\n{}", bytecode2text(newBytecode));
+        }
+
+        Class<?> newClass = new TestLoader(Testable.class.getClassLoader()).defineClassFromBytes(
+            classToInstrument.getName() + "_NEW",
+            newBytecode
+        );
+
+        getTestEntitlementChecker().isActive = true;
+
+        // After checking is activated, everything should throw
+        assertThrows(TestException.class, () -> callStaticMethod(newClass, "someStaticMethod", 123));
+        assertThrows(TestException.class, () -> callStaticMethod(newClass, "someStaticMethod", 123, "abc"));
+
+        assertThat(getTestEntitlementChecker().checkSomeStaticMethodIntCallCount, is(1));
+        assertThat(getTestEntitlementChecker().checkSomeStaticMethodIntStringCallCount, is(1));
+    }
+
+    public void testInstrumenterWorksWithInstanceMethodsAndOverloads() throws Exception {
+        var classToInstrument = ClassToInstrument.class;
+
+        Map<MethodKey, CheckerMethod> methods = Map.of(
+            instrumentationService.methodKeyForTarget(classToInstrument.getMethod("someMethod", int.class, String.class)),
+            getCheckerMethod(MockEntitlementChecker.class, "checkSomeInstanceMethod", Class.class, Testable.class, int.class, String.class)
+        );
+
+        var instrumenter = createInstrumenter(methods);
+
+        byte[] newBytecode = instrumenter.instrumentClassFile(classToInstrument).bytecodes();
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("Bytecode after instrumentation:\n{}", bytecode2text(newBytecode));
+        }
+
+        Class<?> newClass = new TestLoader(Testable.class.getClassLoader()).defineClassFromBytes(
+            classToInstrument.getName() + "_NEW",
+            newBytecode
+        );
+
+        getTestEntitlementChecker().isActive = true;
+
+        Testable testTargetClass = (Testable) (newClass.getConstructor().newInstance());
+
+        // This overload is not instrumented, so it will not throw
+        testTargetClass.someMethod(123);
+        assertThrows(TestException.class, () -> testTargetClass.someMethod(123, "def"));
+
+        assertThat(getTestEntitlementChecker().checkSomeInstanceMethodCallCount, is(1));
+    }
+
+    /** This test doesn't replace classToInstrument in-place but instead loads a separate
+     * class with the same class name plus a "_NEW" suffix (classToInstrument.class.getName() + "_NEW")
+     * that contains the instrumentation. Because of this, we need to configure the Transformer to use a
+     * MethodKey and instrumentationMethod with slightly different signatures (using the common interface
+     * Testable) which is not what would happen when it's run by the agent.
+     */
+    private InstrumenterImpl createInstrumenter(Map<MethodKey, CheckerMethod> methods) throws NoSuchMethodException {
         Method getter = InstrumenterTests.class.getMethod("getTestEntitlementChecker");
         return new InstrumenterImpl("_NEW", methods) {
             /**
@@ -220,13 +356,38 @@ public class InstrumenterTests extends ESTestCase {
         };
     }
 
+    private static CheckerMethod getCheckerMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes)
+        throws NoSuchMethodException {
+        var method = clazz.getMethod(methodName, parameterTypes);
+        return new CheckerMethod(
+            Type.getInternalName(clazz),
+            method.getName(),
+            Arrays.stream(Type.getArgumentTypes(method)).map(Type::getDescriptor).toList()
+        );
+    }
+
     /**
      * Calling a static method of a dynamically loaded class is significantly more cumbersome
      * than calling a virtual method.
      */
-    private static void callStaticMethod(Class<?> c, String methodName, int status) throws NoSuchMethodException, IllegalAccessException {
+    private static void callStaticMethod(Class<?> c, String methodName, int arg) throws NoSuchMethodException, IllegalAccessException {
         try {
-            c.getMethod(methodName, int.class).invoke(null, status);
+            c.getMethod(methodName, int.class).invoke(null, arg);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof TestException n) {
+                // Sometimes we're expecting this one!
+                throw n;
+            } else {
+                throw new AssertionError(cause);
+            }
+        }
+    }
+
+    private static void callStaticMethod(Class<?> c, String methodName, int arg1, String arg2) throws NoSuchMethodException,
+        IllegalAccessException {
+        try {
+            c.getMethod(methodName, int.class, String.class).invoke(null, arg1, arg2);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause instanceof TestException n) {

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -10,5 +10,5 @@
 package org.elasticsearch.entitlement.bridge;
 
 public interface EntitlementChecker {
-    void checkSystemExit(Class<?> callerClass, int status);
+    void check$java_lang_System$exit(Class<?> callerClass, int status);
 }

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementCheckerHandle.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementCheckerHandle.java
@@ -9,9 +9,6 @@
 
 package org.elasticsearch.entitlement.bridge;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 /**
  * Makes the {@link EntitlementChecker} available to injected bytecode.
  */
@@ -35,27 +32,7 @@ public class EntitlementCheckerHandle {
          * The {@code EntitlementInitialization} class is what actually instantiates it and makes it available;
          * here, we copy it into a static final variable for maximum performance.
          */
-        private static final EntitlementChecker instance;
-        static {
-            String initClazz = "org.elasticsearch.entitlement.initialization.EntitlementInitialization";
-            final Class<?> clazz;
-            try {
-                clazz = ClassLoader.getSystemClassLoader().loadClass(initClazz);
-            } catch (ClassNotFoundException e) {
-                throw new AssertionError("java.base cannot find entitlement initialziation", e);
-            }
-            final Method checkerMethod;
-            try {
-                checkerMethod = clazz.getMethod("checker");
-            } catch (NoSuchMethodException e) {
-                throw new AssertionError("EntitlementInitialization is missing checker() method", e);
-            }
-            try {
-                instance = (EntitlementChecker) checkerMethod.invoke(null);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new AssertionError(e);
-            }
-        }
+        private static final EntitlementChecker instance = HandleLoader.load(EntitlementChecker.class);
     }
 
     // no construction

--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/HandleLoader.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/HandleLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.bridge;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+class HandleLoader {
+
+    static <T extends EntitlementChecker> T load(Class<T> checkerClass) {
+        String initClassName = "org.elasticsearch.entitlement.initialization.EntitlementInitialization";
+        final Class<?> initClazz;
+        try {
+            initClazz = ClassLoader.getSystemClassLoader().loadClass(initClassName);
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError("java.base cannot find entitlement initialization", e);
+        }
+        final Method checkerMethod;
+        try {
+            checkerMethod = initClazz.getMethod("checker");
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("EntitlementInitialization is missing checker() method", e);
+        }
+        try {
+            return checkerClass.cast(checkerMethod.invoke(null));
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    // no instance
+    private HandleLoader() {}
+}

--- a/libs/entitlement/bridge/src/main23/java/org/elasticsearch/entitlement/bridge/Java23EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main23/java/org/elasticsearch/entitlement/bridge/Java23EntitlementChecker.java
@@ -7,18 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask
+package org.elasticsearch.entitlement.bridge;
 
-apply plugin: 'elasticsearch.build'
-apply plugin: 'elasticsearch.mrjar'
-
-tasks.named('jar').configure {
-  // guarding for intellij
-  if (sourceSets.findByName("main23")) {
-    from sourceSets.main23.output
-  }
-}
-
-tasks.withType(CheckForbiddenApisTask).configureEach {
-  replaceSignatureFiles 'jdk-signatures'
-}
+public interface Java23EntitlementChecker extends EntitlementChecker {}

--- a/libs/entitlement/bridge/src/main23/java/org/elasticsearch/entitlement/bridge/Java23EntitlementCheckerHandle.java
+++ b/libs/entitlement/bridge/src/main23/java/org/elasticsearch/entitlement/bridge/Java23EntitlementCheckerHandle.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.bridge;
+
+/**
+ * Java23 variant of {@link EntitlementChecker} handle holder.
+ */
+public class Java23EntitlementCheckerHandle {
+
+    public static Java23EntitlementChecker instance() {
+        return Holder.instance;
+    }
+
+    private static class Holder {
+        private static final Java23EntitlementChecker instance = HandleLoader.load(Java23EntitlementChecker.class);
+    }
+
+    // no construction
+    private Java23EntitlementCheckerHandle() {}
+}

--- a/libs/entitlement/build.gradle
+++ b/libs/entitlement/build.gradle
@@ -6,10 +6,13 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+
+import org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask
+
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
-
 apply plugin: 'elasticsearch.embedded-providers'
+apply plugin: 'elasticsearch.mrjar'
 
 embeddedProviders {
   impl 'entitlement', project(':libs:entitlement:asm-provider')
@@ -23,8 +26,13 @@ dependencies {
   testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'entitlement'
   }
+
+  // guarding for intellij
+  if (sourceSets.findByName("main23")) {
+    main23CompileOnly project(path: ':libs:entitlement:bridge', configuration: 'java23')
+  }
 }
 
-tasks.named('forbiddenApisMain').configure {
+tasks.withType(CheckForbiddenApisTask).configureEach {
   replaceSignatureFiles 'jdk-signatures'
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -15,6 +15,7 @@ import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachine;
 
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.entitlement.initialization.EntitlementInitialization;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -22,15 +23,33 @@ import org.elasticsearch.logging.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
 
 public class EntitlementBootstrap {
 
+    public record BootstrapArgs(Collection<Tuple<Path, Boolean>> pluginData, Function<Class<?>, String> pluginResolver) {}
+
+    private static BootstrapArgs bootstrapArgs;
+
+    public static BootstrapArgs bootstrapArgs() {
+        return bootstrapArgs;
+    }
+
     /**
-     * Activates entitlement checking. Once this method returns, calls to forbidden methods
-     * will throw {@link org.elasticsearch.entitlement.runtime.api.NotEntitledException}.
+     * Activates entitlement checking. Once this method returns, calls to methods protected by Entitlements from classes without a valid
+     * policy will throw {@link org.elasticsearch.entitlement.runtime.api.NotEntitledException}.
+     * @param pluginData a collection of (plugin path, boolean), that holds the paths of all the installed Elasticsearch modules and
+     *                   plugins, and whether they are Java modular or not.
+     * @param pluginResolver a functor to map a Java Class to the plugin it belongs to (the plugin name).
      */
-    public static void bootstrap() {
+    public static void bootstrap(Collection<Tuple<Path, Boolean>> pluginData, Function<Class<?>, String> pluginResolver) {
         logger.debug("Loading entitlement agent");
+        if (EntitlementBootstrap.bootstrapArgs != null) {
+            throw new IllegalStateException("plugin data is already set");
+        }
+        EntitlementBootstrap.bootstrapArgs = new BootstrapArgs(Objects.requireNonNull(pluginData), Objects.requireNonNull(pluginResolver));
         exportInitializationToAgent();
         loadAgent(findAgentJar());
     }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -9,18 +9,35 @@
 
 package org.elasticsearch.entitlement.initialization;
 
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.core.internal.provider.ProviderLocator;
+import org.elasticsearch.entitlement.bootstrap.EntitlementBootstrap;
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.instrumentation.CheckerMethod;
 import org.elasticsearch.entitlement.instrumentation.InstrumentationService;
 import org.elasticsearch.entitlement.instrumentation.MethodKey;
 import org.elasticsearch.entitlement.instrumentation.Transformer;
 import org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker;
+import org.elasticsearch.entitlement.runtime.policy.Policy;
+import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyParser;
+import org.elasticsearch.entitlement.runtime.policy.Scope;
 
+import java.io.IOException;
 import java.lang.instrument.Instrumentation;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ALL_UNNAMED;
 
 /**
  * Called by the agent during {@code agentmain} to configure the entitlement system,
@@ -30,6 +47,9 @@ import java.util.stream.Collectors;
  * to begin injecting our instrumentation.
  */
 public class EntitlementInitialization {
+
+    private static final String POLICY_FILE_NAME = "entitlement-policy.yaml";
+
     private static ElasticsearchEntitlementChecker manager;
 
     // Note: referenced by bridge reflectively
@@ -39,7 +59,7 @@ public class EntitlementInitialization {
 
     // Note: referenced by agent reflectively
     public static void initialize(Instrumentation inst) throws Exception {
-        manager = new ElasticsearchEntitlementChecker();
+        manager = new ElasticsearchEntitlementChecker(createPolicyManager());
 
         Map<MethodKey, CheckerMethod> methodMap = INSTRUMENTER_FACTORY.lookupMethodsToInstrument(
             "org.elasticsearch.entitlement.bridge.EntitlementChecker"
@@ -59,6 +79,66 @@ public class EntitlementInitialization {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static PolicyManager createPolicyManager() throws IOException {
+        Map<String, Policy> pluginPolicies = createPluginPolicies(EntitlementBootstrap.bootstrapArgs().pluginData());
+
+        // TODO: What should the name be?
+        // TODO(ES-10031): Decide what goes in the elasticsearch default policy and extend it
+        var serverPolicy = new Policy("server", List.of());
+        return new PolicyManager(serverPolicy, pluginPolicies, EntitlementBootstrap.bootstrapArgs().pluginResolver());
+    }
+
+    private static Map<String, Policy> createPluginPolicies(Collection<Tuple<Path, Boolean>> pluginData) throws IOException {
+        Map<String, Policy> pluginPolicies = new HashMap<>(pluginData.size());
+        for (Tuple<Path, Boolean> entry : pluginData) {
+            Path pluginRoot = entry.v1();
+            boolean isModular = entry.v2();
+
+            String pluginName = pluginRoot.getFileName().toString();
+            final Policy policy = loadPluginPolicy(pluginRoot, isModular, pluginName);
+
+            pluginPolicies.put(pluginName, policy);
+        }
+        return pluginPolicies;
+    }
+
+    private static Policy loadPluginPolicy(Path pluginRoot, boolean isModular, String pluginName) throws IOException {
+        Path policyFile = pluginRoot.resolve(POLICY_FILE_NAME);
+
+        final Set<String> moduleNames = getModuleNames(pluginRoot, isModular);
+        final Policy policy = parsePolicyIfExists(pluginName, policyFile);
+
+        // TODO: should this check actually be part of the parser?
+        for (Scope scope : policy.scopes) {
+            if (moduleNames.contains(scope.name) == false) {
+                throw new IllegalStateException("policy [" + policyFile + "] contains invalid module [" + scope.name + "]");
+            }
+        }
+        return policy;
+    }
+
+    private static Policy parsePolicyIfExists(String pluginName, Path policyFile) throws IOException {
+        if (Files.exists(policyFile)) {
+            return new PolicyParser(Files.newInputStream(policyFile, StandardOpenOption.READ), pluginName).parsePolicy();
+        }
+        return new Policy(pluginName, List.of());
+    }
+
+    private static Set<String> getModuleNames(Path pluginRoot, boolean isModular) {
+        if (isModular) {
+            ModuleFinder moduleFinder = ModuleFinder.of(pluginRoot);
+            Set<ModuleReference> moduleReferences = moduleFinder.findAll();
+
+            return moduleReferences.stream().map(mr -> mr.descriptor().name()).collect(Collectors.toUnmodifiableSet());
+        }
+        // When isModular == false we use the same "ALL-UNNAMED" constant as the JDK to indicate (any) unnamed module for this plugin
+        return Set.of(ALL_UNNAMED);
+    }
+
+    private static String internalName(Class<?> c) {
+        return c.getName().replace('.', '/');
     }
 
     private static final InstrumentationService INSTRUMENTER_FACTORY = new ProviderLocator<>(

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/CheckerMethod.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/CheckerMethod.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.instrumentation;
+
+import java.util.List;
+
+/**
+ * A structure to use as a representation of the checker method the instrumentation will inject.
+ *
+ * @param className the "internal name" of the class: includes the package info, but with periods replaced by slashes
+ * @param methodName the checker method name
+ * @param parameterDescriptors a list of
+ *                             <a href="https://docs.oracle.com/javase/specs/jvms/se23/html/jvms-4.html#jvms-4.3">type descriptors</a>)
+ *                             for methodName parameters.
+ */
+public record CheckerMethod(String className, String methodName, List<String> parameterDescriptors) {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/InstrumentationService.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/InstrumentationService.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.entitlement.instrumentation;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
@@ -16,10 +17,12 @@ import java.util.Map;
  * The SPI service entry point for instrumentation.
  */
 public interface InstrumentationService {
-    Instrumenter newInstrumenter(String classNameSuffix, Map<MethodKey, Method> instrumentationMethods);
+    Instrumenter newInstrumenter(String classNameSuffix, Map<MethodKey, CheckerMethod> instrumentationMethods);
 
     /**
      * @return a {@link MethodKey} suitable for looking up the given {@code targetMethod} in the entitlements trampoline
      */
     MethodKey methodKeyForTarget(Method targetMethod);
+
+    Map<MethodKey, CheckerMethod> lookupMethodsToInstrument(String entitlementCheckerClassName) throws ClassNotFoundException, IOException;
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/MethodKey.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/MethodKey.java
@@ -12,7 +12,10 @@ package org.elasticsearch.entitlement.instrumentation;
 import java.util.List;
 
 /**
+ * A structure to use as a key/lookup for a method target of instrumentation
  *
- * @param className the "internal name" of the class: includes the package info, but with periods replaced by slashes
+ * @param className      the "internal name" of the class: includes the package info, but with periods replaced by slashes
+ * @param methodName     the method name
+ * @param parameterTypes a list of "internal names" for the parameter types
  */
-public record MethodKey(String className, String methodName, List<String> parameterTypes, boolean isStatic) {}
+public record MethodKey(String className, String methodName, List<String> parameterTypes) {}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -44,7 +44,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
-    public void checkSystemExit(Class<?> callerClass, int status) {
+    public void check$java_lang_System$exit(Class<?> callerClass, int status) {
         var requestingModule = requestingModule(callerClass);
         if (isTriviallyAllowed(requestingModule)) {
             return;

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -10,14 +10,8 @@
 package org.elasticsearch.entitlement.runtime.api;
 
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
-
-import java.lang.module.ModuleFinder;
-import java.lang.module.ModuleReference;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import org.elasticsearch.entitlement.runtime.policy.FlagEntitlementType;
+import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 
 /**
  * Implementation of the {@link EntitlementChecker} interface, providing additional
@@ -25,70 +19,14 @@ import java.util.stream.Collectors;
  * The trampoline module loads this object via SPI.
  */
 public class ElasticsearchEntitlementChecker implements EntitlementChecker {
-    private static final Logger logger = LogManager.getLogger(ElasticsearchEntitlementChecker.class);
+    private final PolicyManager policyManager;
 
-    private static final Set<Module> systemModules = findSystemModules();
-
-    private static Set<Module> findSystemModules() {
-        var systemModulesDescriptors = ModuleFinder.ofSystem()
-            .findAll()
-            .stream()
-            .map(ModuleReference::descriptor)
-            .collect(Collectors.toUnmodifiableSet());
-
-        return ModuleLayer.boot()
-            .modules()
-            .stream()
-            .filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
-            .collect(Collectors.toUnmodifiableSet());
+    public ElasticsearchEntitlementChecker(PolicyManager policyManager) {
+        this.policyManager = policyManager;
     }
 
     @Override
     public void check$java_lang_System$exit(Class<?> callerClass, int status) {
-        var requestingModule = requestingModule(callerClass);
-        if (isTriviallyAllowed(requestingModule)) {
-            return;
-        }
-
-        // TODO: this will be checked using policies
-        if (requestingModule.isNamed() && requestingModule.getName().equals("org.elasticsearch.server")) {
-            logger.debug("Allowed: caller in {} is entitled to exit the JVM", requestingModule.getName());
-            return;
-        }
-
-        // Hard-forbidden until we develop the permission granting scheme
-        throw new NotEntitledException("Missing entitlement for " + requestingModule);
-    }
-
-    private static Module requestingModule(Class<?> callerClass) {
-        if (callerClass != null) {
-            Module callerModule = callerClass.getModule();
-            if (systemModules.contains(callerModule) == false) {
-                // fast path
-                return callerModule;
-            }
-        }
-        int framesToSkip = 1  // getCallingClass (this method)
-            + 1  // the checkXxx method
-            + 1  // the runtime config method
-            + 1  // the instrumented method
-        ;
-        Optional<Module> module = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
-            .walk(
-                s -> s.skip(framesToSkip)
-                    .map(f -> f.getDeclaringClass().getModule())
-                    .filter(m -> systemModules.contains(m) == false)
-                    .findFirst()
-            );
-        return module.orElse(null);
-    }
-
-    private static boolean isTriviallyAllowed(Module requestingModule) {
-        if (requestingModule == null) {
-            logger.debug("Trivially allowed: entire call stack is in composed of classes in system modules");
-            return true;
-        }
-        logger.trace("Not trivially allowed");
-        return false;
+        policyManager.checkFlagEntitlement(callerClass, FlagEntitlementType.SYSTEM_EXIT);
     }
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FlagEntitlementType.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FlagEntitlementType.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+public enum FlagEntitlementType {
+    SYSTEM_EXIT;
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker;
+import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class PolicyManager {
+    private static final Logger logger = LogManager.getLogger(ElasticsearchEntitlementChecker.class);
+
+    protected final Policy serverPolicy;
+    protected final Map<String, Policy> pluginPolicies;
+    private final Function<Class<?>, String> pluginResolver;
+
+    public static final String ALL_UNNAMED = "ALL-UNNAMED";
+
+    private static final Set<Module> systemModules = findSystemModules();
+
+    private static Set<Module> findSystemModules() {
+        var systemModulesDescriptors = ModuleFinder.ofSystem()
+            .findAll()
+            .stream()
+            .map(ModuleReference::descriptor)
+            .collect(Collectors.toUnmodifiableSet());
+
+        return ModuleLayer.boot()
+            .modules()
+            .stream()
+            .filter(m -> systemModulesDescriptors.contains(m.getDescriptor()))
+            .collect(Collectors.toUnmodifiableSet());
+    }
+
+    public PolicyManager(Policy defaultPolicy, Map<String, Policy> pluginPolicies, Function<Class<?>, String> pluginResolver) {
+        this.serverPolicy = Objects.requireNonNull(defaultPolicy);
+        this.pluginPolicies = Collections.unmodifiableMap(Objects.requireNonNull(pluginPolicies));
+        this.pluginResolver = pluginResolver;
+    }
+
+    public void checkFlagEntitlement(Class<?> callerClass, FlagEntitlementType type) {
+        var requestingModule = requestingModule(callerClass);
+        if (isTriviallyAllowed(requestingModule)) {
+            return;
+        }
+
+        // TODO: real policy check. For now, we only allow our hardcoded System.exit policy for server.
+        // TODO: this will be checked using policies
+        if (requestingModule.isNamed()
+            && requestingModule.getName().equals("org.elasticsearch.server")
+            && type == FlagEntitlementType.SYSTEM_EXIT) {
+            logger.debug("Allowed: caller [{}] in module [{}] has entitlement [{}]", callerClass, requestingModule.getName(), type);
+            return;
+        }
+
+        // TODO: plugins policy check using pluginResolver and pluginPolicies
+        throw new NotEntitledException(
+            Strings.format("Missing entitlement [%s] for caller [%s] in module [%s]", type, callerClass, requestingModule.getName())
+        );
+    }
+
+    private static Module requestingModule(Class<?> callerClass) {
+        if (callerClass != null) {
+            Module callerModule = callerClass.getModule();
+            if (systemModules.contains(callerModule) == false) {
+                // fast path
+                return callerModule;
+            }
+        }
+        int framesToSkip = 1  // getCallingClass (this method)
+            + 1  // the checkXxx method
+            + 1  // the runtime config method
+            + 1  // the instrumented method
+        ;
+        Optional<Module> module = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+            .walk(
+                s -> s.skip(framesToSkip)
+                    .map(f -> f.getDeclaringClass().getModule())
+                    .filter(m -> systemModules.contains(m) == false)
+                    .findFirst()
+            );
+        return module.orElse(null);
+    }
+
+    private static boolean isTriviallyAllowed(Module requestingModule) {
+        if (requestingModule == null) {
+            logger.debug("Trivially allowed: entire call stack is in composed of classes in system modules");
+            return true;
+        }
+        logger.trace("Not trivially allowed");
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "PolicyManager{" + "serverPolicy=" + serverPolicy + ", pluginPolicies=" + pluginPolicies + '}';
+    }
+}

--- a/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.api;
+
+import org.elasticsearch.entitlement.bridge.Java23EntitlementChecker;
+import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+
+public class Java23ElasticsearchEntitlementChecker extends ElasticsearchEntitlementChecker implements Java23EntitlementChecker {
+
+    public Java23ElasticsearchEntitlementChecker(PolicyManager policyManager) {
+        super(policyManager);
+    }
+
+    @Override
+    public void check$java_lang_System$exit(Class<?> callerClass, int status) {
+        // TODO: this is just an example, we shouldn't really override a method implemented in the superclass
+        super.check$java_lang_System$exit(callerClass, status);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
@@ -210,12 +210,12 @@ public class PluginsUtils {
     }
 
     /** Get bundles for plugins installed in the given modules directory. */
-    static Set<PluginBundle> getModuleBundles(Path modulesDirectory) throws IOException {
+    public static Set<PluginBundle> getModuleBundles(Path modulesDirectory) throws IOException {
         return findBundles(modulesDirectory, "module");
     }
 
     /** Get bundles for plugins installed in the given plugins directory. */
-    static Set<PluginBundle> getPluginBundles(final Path pluginsDirectory) throws IOException {
+    public static Set<PluginBundle> getPluginBundles(final Path pluginsDirectory) throws IOException {
         return findBundles(pluginsDirectory, "plugin");
     }
 


### PR DESCRIPTION
Backports several entitlements PRs:
* Add java version variants of entitlements checker (#116878)
* Policy manager for entitlements (#116695)
* [Entitlements] Implement entry point definitions via checker function signature (#116754)
* [Entitlements] Consider only system modules in the boot layer (#117017)