### PR TITLE
[8.17] Add version prefix to Inference Service API path

### DIFF
--- a/docs/changelog/117366.yaml
+++ b/docs/changelog/117366.yaml
@@ -1,0 +1,5 @@
+pr: 117366
+summary: "[8.17] Add version prefix to Inference Service API path"
+area: Inference
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSparseEmbeddingsModel.java
@@ -108,6 +108,6 @@ public class ElasticInferenceServiceSparseEmbeddingsModel extends ElasticInferen
             default -> throw new IllegalArgumentException("Unsupported model for EIS [" + modelId + "]");
         }
 
-        return new URI(elasticInferenceServiceComponents().eisGatewayUrl() + "/sparse-text-embedding/" + modelIdUriPath);
+        return new URI(elasticInferenceServiceComponents().eisGatewayUrl() + "/api/v1/sparse-text-embedding/" + modelIdUriPath);
     }
 }


### PR DESCRIPTION
Manual backport of #117095 (I forgot to set the auto-backport label on that PR).

---

This PR updates the configuration of the Elastic Inference Service's inference API path. It adds the `/api/v1` prefix to the path, i.e. `<EIS base URL>/api/v1/sparse-text-embedding/ELSERv2`.

Currently EIS exposes both the versioned and unversioned endpoint with identical behavior. Once this PR is merged, the unversioned endpoint can be removed as there is no other dependency on it.