### PR TITLE
[8.x] Fix constand_keyword test run and properly test recent behavior change (#117284)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -51,6 +51,10 @@ public class MapperFeatures implements FeatureSpecification {
         );
     }
 
+    public static final NodeFeature CONSTANT_KEYWORD_SYNTHETIC_SOURCE_WRITE_FIX = new NodeFeature(
+        "mapper.constant_keyword.synthetic_source_write_fix"
+    );
+
     @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
@@ -59,7 +63,8 @@ public class MapperFeatures implements FeatureSpecification {
             SourceFieldMapper.REMOVE_SYNTHETIC_SOURCE_ONLY_VALIDATION,
             SourceFieldMapper.SOURCE_MODE_FROM_INDEX_SETTING,
             IgnoredSourceFieldMapper.ALWAYS_STORE_OBJECT_ARRAYS_IN_NESTED_OBJECTS,
-            MapperService.LOGSDB_DEFAULT_IGNORE_DYNAMIC_BEYOND_LIMIT
+            MapperService.LOGSDB_DEFAULT_IGNORE_DYNAMIC_BEYOND_LIMIT,
+            CONSTANT_KEYWORD_SYNTHETIC_SOURCE_WRITE_FIX
         );
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/build.gradle
+++ b/x-pack/plugin/mapper-constant-keyword/build.gradle
@@ -1,7 +1,7 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 esplugin {
   name 'constant-keyword'

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/java/org/elasticsearch/xpack/constantkeyword/ConstantKeywordClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/java/org/elasticsearch/xpack/constantkeyword/ConstantKeywordClientYamlTestSuiteIT.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xpack.constantkeyword;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 /** Runs yaml rest tests */
 public class ConstantKeywordClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
@@ -23,5 +25,13 @@ public class ConstantKeywordClientYamlTestSuiteIT extends ESClientYamlSuiteTestC
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("constant-keyword").build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
@@ -1,7 +1,7 @@
 constant_keyword:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.constant_keyword.synthetic_source_write_fix" ]
+      reason: "Behavior fix"
 
   - do:
       indices.create:
@@ -27,12 +27,34 @@ constant_keyword:
           kwd: foo
 
   - do:
+      index:
+        index:   test
+        id:      2
+        refresh: true
+        body:
+          kwd: foo
+          const_kwd: bar
+
+  - do:
       search:
         index: test
         body:
           query:
             ids:
               values: [1]
+
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [2]
+
   - match:
       hits.hits.0._source:
         kwd: foo


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Fix constand_keyword test run and properly test recent behavior change (#117284)