### PR TITLE
Store plugin loader separately from instance

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -62,7 +62,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * @param descriptor Metadata about the plugin, usually loaded from plugin properties
      * @param instance The constructed instance of the plugin's main class
      */
-    record LoadedPlugin(PluginDescriptor descriptor, Plugin instance) {
+    record LoadedPlugin(PluginDescriptor descriptor, Plugin instance, ClassLoader classLoader) {
 
         LoadedPlugin {
             Objects.requireNonNull(descriptor);
@@ -426,7 +426,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 }
                 plugin = loadPlugin(pluginClass, settings, configPath);
             }
-            loadedPlugins.put(name, new LoadedPlugin(pluginBundle.plugin, plugin));
+            loadedPlugins.put(name, new LoadedPlugin(pluginBundle.plugin, plugin, pluginLayer.pluginClassLoader()));
         } finally {
             privilegedSetContextClassLoader(cl);
         }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -466,7 +466,8 @@ public class PluginsServiceTests extends ESTestCase {
             List.of(
                 new PluginsService.LoadedPlugin(
                     new PluginDescriptor("extensible", null, null, null, null, classname, null, List.of(), false, false, false, false),
-                    extensiblePlugin
+                    extensiblePlugin,
+                    null
                 )
             )
         );
@@ -480,7 +481,8 @@ public class PluginsServiceTests extends ESTestCase {
             List.of(
                 new PluginsService.LoadedPlugin(
                     new PluginDescriptor("extensible", null, null, null, null, classname, null, List.of(), false, false, false, false),
-                    extensiblePlugin
+                    extensiblePlugin,
+                    null
                 ),
                 new PluginsService.LoadedPlugin(
                     new PluginDescriptor(
@@ -497,7 +499,8 @@ public class PluginsServiceTests extends ESTestCase {
                         false,
                         false
                     ),
-                    testPlugin
+                    testPlugin,
+                    null
                 )
             )
         );
@@ -885,20 +888,22 @@ public class PluginsServiceTests extends ESTestCase {
     // We can use the direct ClassLoader from the plugin because tests do not use any parent SPI ClassLoaders.
     static void closePluginLoaders(PluginsService pluginService) {
         for (var lp : pluginService.plugins()) {
-            if (lp.instance().getClass().getClassLoader() instanceof URLClassLoader urlClassLoader) {
+            if (lp.classLoader() instanceof URLClassLoader urlClassLoader) {
                 try {
                     PrivilegedOperations.closeURLClassLoader(urlClassLoader);
                 } catch (IOException unexpected) {
                     throw new UncheckedIOException(unexpected);
                 }
-            }
-            if (lp.instance().getClass().getClassLoader() instanceof UberModuleClassLoader loader) {
+            } else if (lp.classLoader() instanceof UberModuleClassLoader loader) {
                 try {
                     PrivilegedOperations.closeURLClassLoader(loader.getInternalLoader());
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+            } else {
+                throw new AssertionError("Cannot close unexpected classloader " + lp.classLoader());
             }
+
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
@@ -72,7 +72,7 @@ public class MockPluginsService extends PluginsService {
             if (logger.isTraceEnabled()) {
                 logger.trace("plugin loaded from classpath [{}]", pluginInfo);
             }
-            pluginsLoaded.add(new LoadedPlugin(pluginInfo, plugin));
+            pluginsLoaded.add(new LoadedPlugin(pluginInfo, plugin, MockPluginsService.class.getClassLoader()));
         }
         loadExtensions(pluginsLoaded);
         this.classpathPlugins = List.copyOf(pluginsLoaded);


### PR DESCRIPTION
Stable plugins do not have a plugin instance, so their loader cannot be retrieved by looking at the instance class (which is a placeholder). This commit adds back the class loader of each plugin to the LoadedPlugin record so that it can be closed by tests.

closes #117220