### PR TITLE
Move some more code to ActionListener.delegateFailureAndWrap

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/ReindexDataStreamTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/ReindexDataStreamTransportAction.java
@@ -83,7 +83,7 @@ public class ReindexDataStreamTransportAction extends HandledTransportAction<Rei
             ReindexDataStreamTask.TASK_NAME,
             params,
             null,
-            ActionListener.wrap(startedTask -> listener.onResponse(new ReindexDataStreamResponse(persistentTaskId)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, startedTask) -> l.onResponse(new ReindexDataStreamResponse(persistentTaskId)))
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -105,7 +105,7 @@ public class ReplicationOperation<
      * </ul>
      */
     public void execute() throws Exception {
-        try (var pendingActionsListener = new RefCountingListener(ActionListener.wrap((ignored) -> {
+        try (var pendingActionsListener = new RefCountingListener(resultListener.delegateFailureAndWrap((l, ignored) -> {
             primaryResult.setShardInfo(
                 ReplicationResponse.ShardInfo.of(
                     totalShards.get(),
@@ -113,8 +113,8 @@ public class ReplicationOperation<
                     shardReplicaFailures.toArray(ReplicationResponse.NO_FAILURES)
                 )
             );
-            resultListener.onResponse(primaryResult);
-        }, resultListener::onFailure))) {
+            l.onResponse(primaryResult);
+        }))) {
             ActionListener.run(pendingActionsListener.acquire(), (primaryCoordinationListener) -> { // triggered when we finish coordination
                 final String activeShardCountFailure = checkActiveShardCount();
                 final ShardRouting primaryRouting = primary.routingEntry();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/UpdateIndexMigrationVersionAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/UpdateIndexMigrationVersionAction.java
@@ -175,7 +175,7 @@ public class UpdateIndexMigrationVersionAction extends ActionType<UpdateIndexMig
             updateIndexMigrationVersionTaskQueue.submitTask(
                 "Updating cluster state with a new index migration version",
                 new UpdateIndexMigrationVersionTask(
-                    ActionListener.wrap(response -> listener.onResponse(new UpdateIndexMigrationVersionResponse()), listener::onFailure),
+                    listener.delegateFailureAndWrap((l, response) -> l.onResponse(new UpdateIndexMigrationVersionResponse())),
                     request.getIndexMigrationVersion(),
                     request.getIndexName()
                 ),

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -109,14 +109,14 @@ public final class EnrichCache {
             listener.onResponse(response);
         } else {
             final long retrieveStart = relativeNanoTimeProvider.getAsLong();
-            searchResponseFetcher.accept(searchRequest, ActionListener.wrap(resp -> {
+            searchResponseFetcher.accept(searchRequest, listener.delegateFailureAndWrap((l, resp) -> {
                 CacheValue value = toCacheValue(resp);
                 put(searchRequest, value);
                 List<Map<?, ?>> copy = deepCopy(value.hits, false);
                 long databaseQueryAndCachePutTime = relativeNanoTimeProvider.getAsLong() - retrieveStart;
                 missesTimeInNanos.addAndGet(cacheRequestTime + databaseQueryAndCachePutTime);
                 listener.onResponse(copy);
-            }, listener::onFailure));
+            }));
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TransportPutQueryRuleAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TransportPutQueryRuleAction.java
@@ -43,7 +43,7 @@ public class TransportPutQueryRuleAction extends HandledTransportAction<PutQuery
     protected void doExecute(Task task, PutQueryRuleAction.Request request, ActionListener<PutQueryRuleAction.Response> listener) {
         String queryRulesetId = request.queryRulesetId();
         QueryRule queryRule = request.queryRule();
-        systemIndexService.putQueryRule(queryRulesetId, queryRule, ActionListener.wrap(listener::onResponse, listener::onFailure));
+        systemIndexService.putQueryRule(queryRulesetId, queryRule, listener.delegateFailureAndWrap(ActionListener::onResponse));
 
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TransportTestQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TransportTestQueryRulesetAction.java
@@ -49,15 +49,15 @@ public class TransportTestQueryRulesetAction extends HandledTransportAction<
             ENT_SEARCH_ORIGIN,
             GetQueryRulesetAction.TYPE,
             getQueryRulesetRequest,
-            ActionListener.wrap(getQueryRulesetResponse -> {
+            listener.delegateFailureAndWrap((l, getQueryRulesetResponse) -> {
                 List<TestQueryRulesetAction.MatchedRule> matchedRules = new ArrayList<>();
                 for (QueryRule rule : getQueryRulesetResponse.queryRuleset().rules()) {
                     if (rule.isRuleMatch(request.matchCriteria())) {
                         matchedRules.add(new TestQueryRulesetAction.MatchedRule(request.rulesetId(), rule.id()));
                     }
                 }
-                listener.onResponse(new TestQueryRulesetAction.Response(matchedRules.size(), matchedRules));
-            }, listener::onFailure)
+                l.onResponse(new TestQueryRulesetAction.Response(matchedRules.size(), matchedRules));
+            })
         );
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -239,7 +239,7 @@ public final class TransportEqlSearchAction extends HandledTransportAction<EqlSe
                 cfg,
                 request.query(),
                 params,
-                wrap(r -> listener.onResponse(createResponse(r, task.getExecutionId())), listener::onFailure)
+                listener.delegateFailureAndWrap((l, r) -> l.onResponse(createResponse(r, task.getExecutionId())))
             );
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportUpdateInferenceModelAction.java
@@ -155,16 +155,16 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
             })
             .<ModelConfigurations>andThen((listener, didUpdate) -> {
                 if (didUpdate) {
-                    modelRegistry.getModel(inferenceEntityId, ActionListener.wrap((unparsedModel) -> {
+                    modelRegistry.getModel(inferenceEntityId, listener.delegateFailureAndWrap((delegate, unparsedModel) -> {
                         if (unparsedModel == null) {
-                            listener.onFailure(
+                            delegate.onFailure(
                                 new ElasticsearchStatusException(
                                     "Failed to update model, updated model not found",
                                     RestStatus.INTERNAL_SERVER_ERROR
                                 )
                             );
                         } else {
-                            listener.onResponse(
+                            delegate.onResponse(
                                 service.get()
                                     .parsePersistedConfig(
                                         request.getInferenceEntityId(),
@@ -174,7 +174,7 @@ public class TransportUpdateInferenceModelAction extends TransportMasterNodeActi
                                     .getConfigurations()
                             );
                         }
-                    }, listener::onFailure));
+                    }));
                 } else {
                     listener.onFailure(new ElasticsearchStatusException("Failed to update model", RestStatus.INTERNAL_SERVER_ERROR));
                 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetStatusAction.java
@@ -130,10 +130,10 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
 
         @Override
         public void onTimeout(TimeValue timeout) {
-            resolver.execute(clusterService.state(), ActionListener.wrap(response -> {
+            resolver.execute(clusterService.state(), listener.delegateFailureAndWrap((l, response) -> {
                 response.setTimedOut(true);
-                listener.onResponse(response);
-            }, listener::onFailure));
+                l.onResponse(response);
+            }));
         }
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetTopNFunctionsAction.java
@@ -43,12 +43,12 @@ public class TransportGetTopNFunctionsAction extends TransportAction<GetStackTra
     protected void doExecute(Task task, GetStackTracesRequest request, ActionListener<GetTopNFunctionsResponse> listener) {
         Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), task);
         StopWatch watch = new StopWatch("getTopNFunctionsAction");
-        client.execute(GetStackTracesAction.INSTANCE, request, ActionListener.wrap(searchResponse -> {
+        client.execute(GetStackTracesAction.INSTANCE, request, listener.delegateFailureAndWrap((l, searchResponse) -> {
             StopWatch processingWatch = new StopWatch("Processing response");
             GetTopNFunctionsResponse topNFunctionsResponse = buildTopNFunctions(searchResponse, request.getLimit());
             log.debug(() -> watch.report() + " " + processingWatch.report());
-            listener.onResponse(topNFunctionsResponse);
-        }, listener::onFailure));
+            l.onResponse(topNFunctionsResponse);
+        }));
     }
 
     static GetTopNFunctionsResponse buildTopNFunctions(GetStackTracesResponse response, Integer limit) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexManager.java
@@ -111,7 +111,7 @@ public class ProfilingIndexManager extends AbstractProfilingPersistenceManager<P
                     priorIndexVersions.toArray(new String[0]),
                     // the cluster state that we are operating on is a snapshot and won't reflect that the alias has just gone.
                     // Therefore, we use putIndex here which does not check for the existence of an alias
-                    ActionListener.wrap(r -> putIndex(index.getName(), index.getAlias(), listener), listener::onFailure)
+                    listener.delegateFailureAndWrap((l, r) -> putIndex(index.getName(), index.getAlias(), l))
                 );
             } else {
                 createIndex(state, index, listener);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -299,7 +299,7 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
             client.execute(
                 TransportPutMappingAction.TYPE,
                 request,
-                ActionListener.wrap(putMappingResponse -> startPersistentTask(job, listener, persistentTasksService), listener::onFailure)
+                listener.delegateFailureAndWrap((l, putMappingResponse) -> startPersistentTask(job, l, persistentTasksService))
             );
         };
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -120,7 +120,7 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
 
         MultiSearchRequest msearch = createMSearchRequest(request, registry, rollupSearchContext);
 
-        client.multiSearch(msearch, ActionListener.wrap(msearchResponse -> {
+        client.multiSearch(msearch, listener.delegateFailureAndWrap((delegate, msearchResponse) -> {
             AggregationReduceContext.Builder reduceContextBuilder = new AggregationReduceContext.Builder() {
                 @Override
                 public AggregationReduceContext forPartialReduction() {
@@ -144,8 +144,8 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
                     );
                 }
             };
-            ActionListener.respondAndRelease(listener, processResponses(rollupSearchContext, msearchResponse, reduceContextBuilder));
-        }, listener::onFailure));
+            ActionListener.respondAndRelease(delegate, processResponses(rollupSearchContext, msearchResponse, reduceContextBuilder));
+        }));
     }
 
     static SearchResponse processResponses(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportDelegatePkiAuthenticationAction.java
@@ -108,12 +108,10 @@ public final class TransportDelegatePkiAuthenticationAction extends HandledTrans
                         delegateeAuthentication,
                         Map.of(),
                         false,
-                        ActionListener.wrap(tokenResult -> {
+                        listener.delegateFailureAndWrap((l, tokenResult) -> {
                             final TimeValue expiresIn = tokenService.getExpirationDelay();
-                            listener.onResponse(
-                                new DelegatePkiAuthenticationResponse(tokenResult.getAccessToken(), expiresIn, authentication)
-                            );
-                        }, listener::onFailure)
+                            l.onResponse(new DelegatePkiAuthenticationResponse(tokenResult.getAccessToken(), expiresIn, authentication));
+                        })
                     );
                 }, e -> {
                     logger.debug(() -> format("Delegated x509Token [%s] could not be authenticated", x509DelegatedToken), e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkUpdateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportBulkUpdateApiKeyAction.java
@@ -52,9 +52,8 @@ public final class TransportBulkUpdateApiKeyAction extends TransportBaseUpdateAp
     ) {
         resolver.resolveUserRoleDescriptors(
             authentication,
-            ActionListener.wrap(
-                roleDescriptors -> apiKeyService.updateApiKeys(authentication, request, roleDescriptors, listener),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, roleDescriptors) -> apiKeyService.updateApiKeys(authentication, request, roleDescriptors, l)
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateApiKeyAction.java
@@ -65,9 +65,8 @@ public final class TransportCreateApiKeyAction extends TransportAction<CreateApi
             }
             resolver.resolveUserRoleDescriptors(
                 authentication,
-                ActionListener.wrap(
-                    roleDescriptors -> apiKeyService.createApiKey(authentication, request, roleDescriptors, listener),
-                    listener::onFailure
+                listener.delegateFailureAndWrap(
+                    (l, roleDescriptors) -> apiKeyService.createApiKey(authentication, request, roleDescriptors, l)
                 )
             );
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportGrantApiKeyAction.java
@@ -79,9 +79,8 @@ public final class TransportGrantApiKeyAction extends TransportGrantAction<Grant
     ) {
         resolver.resolveUserRoleDescriptors(
             authentication,
-            ActionListener.wrap(
-                roleDescriptors -> apiKeyService.createApiKey(authentication, request.getApiKeyRequest(), roleDescriptors, listener),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, roleDescriptors) -> apiKeyService.createApiKey(authentication, request.getApiKeyRequest(), roleDescriptors, l)
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportInvalidateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportInvalidateApiKeyAction.java
@@ -66,16 +66,15 @@ public final class TransportInvalidateApiKeyAction extends HandledTransportActio
         final String username = getUsername(authentication, request);
         final String[] realms = getRealms(authentication, request);
         checkHasManageSecurityPrivilege(
-            ActionListener.wrap(
-                hasPrivilegesResponse -> apiKeyService.invalidateApiKeys(
+            listener.delegateFailureAndWrap(
+                (l, hasPrivilegesResponse) -> apiKeyService.invalidateApiKeys(
                     realms,
                     username,
                     apiKeyName,
                     apiKeyIds,
                     hasPrivilegesResponse.isCompleteMatch(),
-                    listener
-                ),
-                listener::onFailure
+                    l
+                )
             )
         );
     }
@@ -102,6 +101,6 @@ public final class TransportInvalidateApiKeyAction extends HandledTransportActio
         hasPrivilegesRequest.clusterPrivileges(ClusterPrivilegeResolver.MANAGE_SECURITY.name());
         hasPrivilegesRequest.indexPrivileges(new RoleDescriptor.IndicesPrivileges[0]);
         hasPrivilegesRequest.applicationPrivileges(new RoleDescriptor.ApplicationResourcePrivileges[0]);
-        client.execute(HasPrivilegesAction.INSTANCE, hasPrivilegesRequest, ActionListener.wrap(listener::onResponse, listener::onFailure));
+        client.execute(HasPrivilegesAction.INSTANCE, hasPrivilegesRequest, listener.delegateFailureAndWrap(ActionListener::onResponse));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyAction.java
@@ -118,34 +118,37 @@ public final class TransportQueryApiKeyAction extends TransportAction<QueryApiKe
         }
 
         final SearchRequest searchRequest = new SearchRequest(new String[] { SECURITY_MAIN_ALIAS }, searchSourceBuilder);
-        apiKeyService.queryApiKeys(searchRequest, request.withLimitedBy(), ActionListener.wrap(queryApiKeysResult -> {
-            if (request.withProfileUid()) {
-                profileService.resolveProfileUidsForApiKeys(
-                    queryApiKeysResult.apiKeyInfos(),
-                    ActionListener.wrap(
-                        ownerProfileUids -> listener.onResponse(
-                            new QueryApiKeyResponse(
-                                queryApiKeysResult.total(),
-                                queryApiKeysResult.apiKeyInfos(),
-                                queryApiKeysResult.sortValues(),
-                                ownerProfileUids,
-                                queryApiKeysResult.aggregations()
-                            )
-                        ),
-                        listener::onFailure
-                    )
-                );
-            } else {
-                listener.onResponse(
-                    new QueryApiKeyResponse(
-                        queryApiKeysResult.total(),
+        apiKeyService.queryApiKeys(
+            searchRequest,
+            request.withLimitedBy(),
+            listener.delegateFailureAndWrap((delegate, queryApiKeysResult) -> {
+                if (request.withProfileUid()) {
+                    profileService.resolveProfileUidsForApiKeys(
                         queryApiKeysResult.apiKeyInfos(),
-                        queryApiKeysResult.sortValues(),
-                        null,
-                        queryApiKeysResult.aggregations()
-                    )
-                );
-            }
-        }, listener::onFailure));
+                        delegate.delegateFailureAndWrap(
+                            (l, ownerProfileUids) -> l.onResponse(
+                                new QueryApiKeyResponse(
+                                    queryApiKeysResult.total(),
+                                    queryApiKeysResult.apiKeyInfos(),
+                                    queryApiKeysResult.sortValues(),
+                                    ownerProfileUids,
+                                    queryApiKeysResult.aggregations()
+                                )
+                            )
+                        )
+                    );
+                } else {
+                    delegate.onResponse(
+                        new QueryApiKeyResponse(
+                            queryApiKeysResult.total(),
+                            queryApiKeysResult.apiKeyInfos(),
+                            queryApiKeysResult.sortValues(),
+                            null,
+                            queryApiKeysResult.aggregations()
+                        )
+                    );
+                }
+            })
+        );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateApiKeyAction.java
@@ -51,17 +51,13 @@ public final class TransportUpdateApiKeyAction extends TransportBaseUpdateApiKey
     ) {
         resolver.resolveUserRoleDescriptors(
             authentication,
-            ActionListener.wrap(
-                roleDescriptors -> apiKeyService.updateApiKeys(
+            listener.delegateFailureAndWrap(
+                (delegate, roleDescriptors) -> apiKeyService.updateApiKeys(
                     authentication,
                     BulkUpdateApiKeyRequest.wrap(request),
                     roleDescriptors,
-                    ActionListener.wrap(
-                        bulkResponse -> listener.onResponse(toSingleResponse(request.getId(), bulkResponse)),
-                        listener::onFailure
-                    )
-                ),
-                listener::onFailure
+                    delegate.delegateFailureAndWrap((l, bulkResponse) -> l.onResponse(toSingleResponse(request.getId(), bulkResponse)))
+                )
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateCrossClusterApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportUpdateCrossClusterApiKeyAction.java
@@ -62,7 +62,7 @@ public final class TransportUpdateCrossClusterApiKeyAction extends TransportBase
                 }
             },
             Set.of(),
-            ActionListener.wrap(bulkResponse -> listener.onResponse(toSingleResponse(request.getId(), bulkResponse)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, bulkResponse) -> l.onResponse(toSingleResponse(request.getId(), bulkResponse)))
         );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentAction.java
@@ -145,22 +145,28 @@ public class TransportNodeEnrollmentAction extends HandledTransportAction<NodeEn
 
         final List<String> nodeList = new ArrayList<>();
         final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().addMetric(NodesInfoMetrics.Metric.TRANSPORT.metricName());
-        executeAsyncWithOrigin(client, SECURITY_ORIGIN, TransportNodesInfoAction.TYPE, nodesInfoRequest, ActionListener.wrap(response -> {
-            for (NodeInfo nodeInfo : response.getNodes()) {
-                nodeList.add(nodeInfo.getInfo(TransportInfo.class).getAddress().publishAddress().toString());
-            }
-            try {
-                final String httpCaKey = Base64.getEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v1().getEncoded());
-                final String httpCaCert = Base64.getEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v2().getEncoded());
-                final String transportCaCert = Base64.getEncoder().encodeToString(transportCaCertificates.get(0).getEncoded());
-                final String transportKey = Base64.getEncoder().encodeToString(transportKeysAndCertificates.get(0).v1().getEncoded());
-                final String transportCert = Base64.getEncoder().encodeToString(transportKeysAndCertificates.get(0).v2().getEncoded());
-                listener.onResponse(
-                    new NodeEnrollmentResponse(httpCaKey, httpCaCert, transportCaCert, transportKey, transportCert, nodeList)
-                );
-            } catch (CertificateEncodingException e) {
-                listener.onFailure(new ElasticsearchException("Unable to enroll node", e));
-            }
-        }, listener::onFailure));
+        executeAsyncWithOrigin(
+            client,
+            SECURITY_ORIGIN,
+            TransportNodesInfoAction.TYPE,
+            nodesInfoRequest,
+            listener.delegateFailureAndWrap((delegate, response) -> {
+                for (NodeInfo nodeInfo : response.getNodes()) {
+                    nodeList.add(nodeInfo.getInfo(TransportInfo.class).getAddress().publishAddress().toString());
+                }
+                try {
+                    final String httpCaKey = Base64.getEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v1().getEncoded());
+                    final String httpCaCert = Base64.getEncoder().encodeToString(httpCaKeysAndCertificates.get(0).v2().getEncoded());
+                    final String transportCaCert = Base64.getEncoder().encodeToString(transportCaCertificates.get(0).getEncoded());
+                    final String transportKey = Base64.getEncoder().encodeToString(transportKeysAndCertificates.get(0).v1().getEncoded());
+                    final String transportCert = Base64.getEncoder().encodeToString(transportKeysAndCertificates.get(0).v2().getEncoded());
+                    delegate.onResponse(
+                        new NodeEnrollmentResponse(httpCaKey, httpCaCert, transportCaCert, transportKey, transportCert, nodeList)
+                    );
+                } catch (CertificateEncodingException e) {
+                    delegate.onFailure(new ElasticsearchException("Unable to enroll node", e));
+                }
+            })
+        );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectAuthenticateAction.java
@@ -97,9 +97,9 @@ public class TransportOpenIdConnectAuthenticateAction extends HandledTransportAc
                     originatingAuthentication,
                     tokenMetadata,
                     true,
-                    ActionListener.wrap(tokenResult -> {
+                    listener.delegateFailureAndWrap((l, tokenResult) -> {
                         final TimeValue expiresIn = tokenService.getExpirationDelay();
-                        listener.onResponse(
+                        l.onResponse(
                             new OpenIdConnectAuthenticateResponse(
                                 authentication,
                                 tokenResult.getAccessToken(),
@@ -107,7 +107,7 @@ public class TransportOpenIdConnectAuthenticateAction extends HandledTransportAc
                                 expiresIn
                             )
                         );
-                    }, listener::onFailure)
+                    })
                 );
             }, e -> {
                 logger.debug(() -> "OpenIDConnectToken [" + token + "] could not be authenticated", e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportGetPrivilegesAction.java
@@ -56,7 +56,7 @@ public class TransportGetPrivilegesAction extends HandledTransportAction<GetPriv
         this.privilegeStore.getPrivileges(
             applications,
             names,
-            ActionListener.wrap(privileges -> listener.onResponse(new GetPrivilegesResponse(privileges)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, privileges) -> l.onResponse(new GetPrivilegesResponse(privileges)))
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/privilege/TransportPutPrivilegesAction.java
@@ -49,7 +49,7 @@ public class TransportPutPrivilegesAction extends HandledTransportAction<PutPriv
             this.privilegeStore.putPrivileges(
                 request.getPrivileges(),
                 request.getRefreshPolicy(),
-                ActionListener.wrap(result -> listener.onResponse(buildResponse(result)), listener::onFailure)
+                listener.delegateFailureAndWrap((l, result) -> l.onResponse(buildResponse(result)))
             );
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportGetRolesAction.java
@@ -84,13 +84,13 @@ public class TransportGetRolesAction extends TransportAction<GetRolesRequest, Ge
     }
 
     private void getNativeRoles(Set<String> rolesToSearchFor, List<RoleDescriptor> foundRoles, ActionListener<GetRolesResponse> listener) {
-        nativeRolesStore.getRoleDescriptors(rolesToSearchFor, ActionListener.wrap((retrievalResult) -> {
+        nativeRolesStore.getRoleDescriptors(rolesToSearchFor, listener.delegateFailureAndWrap((l, retrievalResult) -> {
             if (retrievalResult.isSuccess()) {
                 foundRoles.addAll(retrievalResult.getDescriptors());
-                listener.onResponse(new GetRolesResponse(foundRoles.toArray(new RoleDescriptor[0])));
+                l.onResponse(new GetRolesResponse(foundRoles.toArray(new RoleDescriptor[0])));
             } else {
-                listener.onFailure(retrievalResult.getFailure());
+                l.onFailure(retrievalResult.getFailure());
             }
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportQueryRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportQueryRoleAction.java
@@ -90,9 +90,8 @@ public class TransportQueryRoleAction extends TransportAction<QueryRoleRequest, 
         }
         nativeRolesStore.queryRoleDescriptors(
             searchSourceBuilder,
-            ActionListener.wrap(
-                queryRoleResults -> listener.onResponse(new QueryRoleResponse(queryRoleResults.total(), queryRoleResults.items())),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, queryRoleResults) -> l.onResponse(new QueryRoleResponse(queryRoleResults.total(), queryRoleResults.items()))
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportGetRoleMappingsAction.java
@@ -64,14 +64,14 @@ public class TransportGetRoleMappingsAction extends HandledTransportAction<GetRo
         } else {
             names = new HashSet<>(Arrays.asList(request.getNames()));
         }
-        roleMappingStore.getRoleMappings(names, ActionListener.wrap(nativeRoleMappings -> {
+        roleMappingStore.getRoleMappings(names, listener.delegateFailureAndWrap((l, nativeRoleMappings) -> {
             final Collection<ExpressionRoleMapping> clusterStateRoleMappings = clusterStateRoleMapper.getMappings(
                 // if the API was queried with a reserved suffix for any of the names, we need to remove it because role mappings are
                 // stored without it in cluster-state
                 removeReadOnlySuffixIfPresent(names)
             );
-            listener.onResponse(buildResponse(clusterStateRoleMappings, nativeRoleMappings));
-        }, listener::onFailure));
+            l.onResponse(buildResponse(clusterStateRoleMappings, nativeRoleMappings));
+        }));
     }
 
     private GetRoleMappingsResponse buildResponse(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportPutRoleMappingAction.java
@@ -54,7 +54,7 @@ public class TransportPutRoleMappingAction extends HandledTransportAction<PutRol
         }
         roleMappingStore.putRoleMapping(
             request,
-            ActionListener.wrap(created -> listener.onResponse(new PutRoleMappingResponse(created)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, created) -> l.onResponse(new PutRoleMappingResponse(created)))
         );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -95,9 +95,9 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                     originatingAuthentication,
                     tokenMeta,
                     true,
-                    ActionListener.wrap(tokenResult -> {
+                    listener.delegateFailureAndWrap((l, tokenResult) -> {
                         final TimeValue expiresIn = tokenService.getExpirationDelay();
-                        listener.onResponse(
+                        l.onResponse(
                             new SamlAuthenticateResponse(
                                 authentication,
                                 tokenResult.getAccessToken(),
@@ -105,7 +105,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                                 expiresIn
                             )
                         );
-                    }, listener::onFailure)
+                    })
                 );
             }, e -> {
                 logger.debug(() -> "SamlToken [" + saml + "] could not be authenticated", e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -66,15 +66,15 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
 
     private void doExecuteForked(Task task, SamlLogoutRequest request, ActionListener<SamlLogoutResponse> listener) {
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
-        invalidateRefreshToken(request.getRefreshToken(), ActionListener.wrap(ignore -> {
+        invalidateRefreshToken(request.getRefreshToken(), listener.delegateFailureAndWrap((delegate, ignore) -> {
             try {
                 final String token = request.getToken();
-                tokenService.getAuthenticationAndMetadata(token, ActionListener.wrap(tuple -> {
+                tokenService.getAuthenticationAndMetadata(token, delegate.delegateFailureAndWrap((delegate2, tuple) -> {
                     Authentication authentication = tuple.v1();
                     assert false == authentication.isRunAs() : "saml realm authentication cannot have run-as";
                     final Map<String, Object> tokenMetadata = tuple.v2();
                     SamlLogoutResponse response = buildResponse(authentication, tokenMetadata);
-                    tokenService.invalidateAccessToken(token, ActionListener.wrap(created -> {
+                    tokenService.invalidateAccessToken(token, delegate2.delegateFailureAndWrap((delegate3, created) -> {
                         if (logger.isTraceEnabled()) {
                             logger.trace(
                                 "SAML Logout User [{}], Token [{}...{}]",
@@ -83,14 +83,14 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
                                 token.substring(token.length() - 8)
                             );
                         }
-                        listener.onResponse(response);
-                    }, listener::onFailure));
-                }, listener::onFailure));
+                        delegate3.onResponse(response);
+                    }));
+                }));
             } catch (ElasticsearchException e) {
                 logger.debug("Internal exception during SAML logout", e);
-                listener.onFailure(e);
+                delegate.onFailure(e);
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void invalidateRefreshToken(String refreshToken, ActionListener<TokensInvalidationResult> listener) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenAction.java
@@ -49,7 +49,7 @@ public class TransportDeleteServiceAccountTokenAction extends HandledTransportAc
     ) {
         serviceAccountService.deleteIndexToken(
             request,
-            ActionListener.wrap(found -> listener.onResponse(new DeleteServiceAccountTokenResponse(found)), listener::onFailure)
+            listener.delegateFailureAndWrap((l, found) -> l.onResponse(new DeleteServiceAccountTokenResponse(found)))
         );
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenAction.java
@@ -162,7 +162,7 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
             originatingAuth,
             Collections.emptyMap(),
             includeRefreshToken,
-            ActionListener.wrap(tokenResult -> {
+            listener.delegateFailureAndWrap((delegate, tokenResult) -> {
                 final String scope = getResponseScopeValue(request.getScope());
                 final String base64AuthenticateResponse = (grantType == GrantType.KERBEROS) ? extractOutToken() : null;
                 final CreateTokenResponse response = new CreateTokenResponse(
@@ -173,8 +173,8 @@ public final class TransportCreateTokenAction extends HandledTransportAction<Cre
                     base64AuthenticateResponse,
                     authentication
                 );
-                listener.onResponse(response);
-            }, listener::onFailure)
+                delegate.onResponse(response);
+            })
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenAction.java
@@ -41,9 +41,8 @@ public final class TransportInvalidateTokenAction extends HandledTransportAction
 
     @Override
     protected void doExecute(Task task, InvalidateTokenRequest request, ActionListener<InvalidateTokenResponse> listener) {
-        final ActionListener<TokensInvalidationResult> invalidateListener = ActionListener.wrap(
-            tokensInvalidationResult -> listener.onResponse(new InvalidateTokenResponse(tokensInvalidationResult)),
-            listener::onFailure
+        final ActionListener<TokensInvalidationResult> invalidateListener = listener.delegateFailureAndWrap(
+            (l, tokensInvalidationResult) -> l.onResponse(new InvalidateTokenResponse(tokensInvalidationResult))
         );
         if (Strings.hasText(request.getUserName()) || Strings.hasText(request.getRealmName())) {
             tokenService.invalidateActiveTokens(request.getRealmName(), request.getUserName(), null, invalidateListener);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/token/TransportRefreshTokenAction.java
@@ -32,7 +32,7 @@ public class TransportRefreshTokenAction extends HandledTransportAction<CreateTo
 
     @Override
     protected void doExecute(Task task, CreateTokenRequest request, ActionListener<CreateTokenResponse> listener) {
-        tokenService.refreshToken(request.getRefreshToken(), ActionListener.wrap(tokenResult -> {
+        tokenService.refreshToken(request.getRefreshToken(), listener.delegateFailureAndWrap(((l, tokenResult) -> {
             final String scope = getResponseScopeValue(request.getScope());
             final CreateTokenResponse response = new CreateTokenResponse(
                 tokenResult.getAccessToken(),
@@ -42,7 +42,7 @@ public class TransportRefreshTokenAction extends HandledTransportAction<CreateTo
                 null,
                 tokenResult.getAuthentication()
             );
-            listener.onResponse(response);
-        }, listener::onFailure));
+            l.onResponse(response);
+        })));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
@@ -83,21 +83,18 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
             }
         }
 
-        final ActionListener<Collection<Collection<User>>> sendingListener = ActionListener.wrap((userLists) -> {
+        final ActionListener<Collection<Collection<User>>> sendingListener = listener.delegateFailureAndWrap((delegate, userLists) -> {
             users.addAll(userLists.stream().flatMap(Collection::stream).filter(Objects::nonNull).toList());
             if (request.isWithProfileUid()) {
                 resolveProfileUids(
                     users,
-                    ActionListener.wrap(
-                        profileUidLookup -> listener.onResponse(new GetUsersResponse(users, profileUidLookup)),
-                        listener::onFailure
-                    )
+                    delegate.delegateFailureAndWrap((l, profileUidLookup) -> l.onResponse(new GetUsersResponse(users, profileUidLookup)))
                 );
             } else {
-                listener.onResponse(new GetUsersResponse(users));
+                delegate.onResponse(new GetUsersResponse(users));
             }
 
-        }, listener::onFailure);
+        });
         final GroupedActionListener<Collection<User>> groupListener = new GroupedActionListener<>(2, sendingListener);
         // We have two sources for the users object, the reservedRealm and the usersStore, we query both at the same time with a
         // GroupedActionListener
@@ -138,10 +135,10 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
             }
         }).toList();
 
-        profileService.searchProfilesForSubjects(subjects, ActionListener.wrap(resultsAndErrors -> {
+        profileService.searchProfilesForSubjects(subjects, listener.delegateFailureAndWrap((delegate, resultsAndErrors) -> {
             if (resultsAndErrors == null) {
                 // profile index does not exist
-                listener.onResponse(null);
+                delegate.onResponse(null);
             } else if (resultsAndErrors.errors().isEmpty()) {
                 assert users.size() == resultsAndErrors.results().size();
                 final Map<String, String> profileUidLookup = resultsAndErrors.results()
@@ -149,15 +146,15 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
                     .filter(t -> Objects.nonNull(t.v2()))
                     .map(t -> new Tuple<>(t.v1().getUser().principal(), t.v2().uid()))
                     .collect(Collectors.toUnmodifiableMap(Tuple::v1, Tuple::v2));
-                listener.onResponse(profileUidLookup);
+                delegate.onResponse(profileUidLookup);
             } else {
                 final ElasticsearchStatusException exception = new ElasticsearchStatusException(
                     "failed to retrieve profile for users. please retry without fetching profile uid (with_profile_uid=false)",
                     RestStatus.INTERNAL_SERVER_ERROR
                 );
                 resultsAndErrors.errors().values().forEach(exception::addSuppressed);
-                listener.onFailure(exception);
+                delegate.onFailure(exception);
             }
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportHasPrivilegesAction.java
@@ -70,12 +70,12 @@ public class TransportHasPrivilegesAction extends HandledTransportAction<HasPriv
 
         resolveApplicationPrivileges(
             request,
-            ActionListener.wrap(
-                applicationPrivilegeDescriptors -> authorizationService.checkPrivileges(
+            listener.delegateFailureAndWrap(
+                (l, applicationPrivilegeDescriptors) -> authorizationService.checkPrivileges(
                     authentication.getEffectiveSubject(),
                     request.getPrivilegesToCheck(),
                     applicationPrivilegeDescriptors,
-                    listener.map(privilegesCheckResult -> {
+                    l.map(privilegesCheckResult -> {
                         AuthorizationEngine.PrivilegesCheckResult.Details checkResultDetails = privilegesCheckResult.getDetails();
                         assert checkResultDetails != null : "runDetailedCheck is 'true' but the result has no details";
                         return new HasPrivilegesResponse(
@@ -86,8 +86,7 @@ public class TransportHasPrivilegesAction extends HandledTransportAction<HasPriv
                             checkResultDetails != null ? checkResultDetails.application() : Map.of()
                         );
                     })
-                ),
-                listener::onFailure
+                )
             )
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactory.java
@@ -199,9 +199,9 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
 
     @Override
     void getUnauthenticatedSessionWithPool(LDAPConnectionPool connectionPool, String user, ActionListener<LdapSession> listener) {
-        findUser(user, connectionPool, ActionListener.wrap((entry) -> {
+        findUser(user, connectionPool, listener.delegateFailureAndWrap((delgate, entry) -> {
             if (entry == null) {
-                listener.onResponse(null);
+                delgate.onResponse(null);
             } else {
                 final String dn = entry.getDN();
                 LdapSession session = new LdapSession(
@@ -214,9 +214,9 @@ class LdapUserSearchSessionFactory extends PoolingSessionFactory {
                     timeout,
                     entry.getAttributes()
                 );
-                listener.onResponse(session);
+                delgate.onResponse(session);
             }
-        }, listener::onFailure));
+        }));
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/RealmUserLookup.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/RealmUserLookup.java
@@ -45,13 +45,12 @@ public class RealmUserLookup {
     public void lookup(String principal, ActionListener<Tuple<User, Realm>> listener) {
         final IteratingActionListener<Tuple<User, Realm>, ? extends Realm> userLookupListener = new IteratingActionListener<>(
             listener,
-            (realm, lookupUserListener) -> realm.lookupUser(principal, ActionListener.wrap(foundUser -> {
-                if (foundUser != null) {
-                    lookupUserListener.onResponse(new Tuple<>(foundUser, realm));
-                } else {
-                    lookupUserListener.onResponse(null);
-                }
-            }, lookupUserListener::onFailure)),
+            (realm, lookupUserListener) -> realm.lookupUser(
+                principal,
+                lookupUserListener.delegateFailureAndWrap(
+                    (l, foundUser) -> l.onResponse(foundUser == null ? null : new Tuple<>(foundUser, realm))
+                )
+            ),
             realms,
             threadContext
         );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
@@ -34,9 +34,8 @@ public class CompositeRoleMapper implements UserRoleMapper {
     public void resolveRoles(UserData user, ActionListener<Set<String>> listener) {
         GroupedActionListener<Set<String>> groupListener = new GroupedActionListener<>(
             delegates.size(),
-            ActionListener.wrap(
-                composite -> listener.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet())),
-                listener::onFailure
+            listener.delegateFailureAndWrap(
+                (l, composite) -> l.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet()))
             )
         );
         this.delegates.forEach(mapper -> mapper.resolveRoles(user, groupListener));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -211,9 +211,8 @@ public class NativeRoleMappingStore extends AbstractRoleMapperClearRealmCache {
                 logger.trace("Modifying role mapping [{}] for [{}]", name, request.getClass().getSimpleName());
                 inner.accept(
                     request,
-                    ActionListener.wrap(
-                        r -> clearRealmCachesOnAllNodes(client, ActionListener.wrap(aVoid -> listener.onResponse(r), listener::onFailure)),
-                        listener::onFailure
+                    listener.delegateFailureAndWrap(
+                        (l, r) -> clearRealmCachesOnAllNodes(client, l.delegateFailureAndWrap((ll, aVoid) -> ll.onResponse(r)))
                     )
                 );
             } catch (Exception e) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/service/TransportDeleteServiceAccountTokenActionTests.java
@@ -47,8 +47,7 @@ public class TransportDeleteServiceAccountTokenActionTests extends ESTestCase {
             randomAlphaOfLengthBetween(3, 8),
             randomAlphaOfLengthBetween(3, 8)
         );
-        @SuppressWarnings("unchecked")
-        final ActionListener<DeleteServiceAccountTokenResponse> listener = mock(ActionListener.class);
+        final ActionListener<DeleteServiceAccountTokenResponse> listener = ActionListener.noop();
         transportDeleteServiceAccountTokenAction.doExecute(mock(Task.class), request, listener);
         verify(serviceAccountService).deleteIndexToken(eq(request), anyActionListener());
     }


### PR DESCRIPTION
Randomly saw we still have quite a lot of these in ml and security so I fixed up a couple more.

Avoid duplicate method references, save a little heap and make leak debugging easier by moving some more remaining spots to delegateFailureAndWrap.
