### PR TITLE
[8.x] [Build] Do not create empty buildkite build artifacts (#117400)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchBuildCompletePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchBuildCompletePlugin.java
@@ -147,12 +147,17 @@ public abstract class ElasticsearchBuildCompletePlugin implements Plugin<Project
         @SuppressWarnings("checkstyle:DescendantToken")
         @Override
         public void execute(BuildFinishedFlowAction.Parameters parameters) throws FileNotFoundException {
+            List<File> filesToArchive = parameters.getFilteredFiles().get();
+            if (filesToArchive.isEmpty()) {
+                return;
+            }
             File uploadFile = parameters.getUploadFile().get();
             if (uploadFile.exists()) {
                 getFileSystemOperations().delete(spec -> spec.delete(uploadFile));
             }
             uploadFile.getParentFile().mkdirs();
-            createBuildArchiveTar(parameters.getFilteredFiles().get(), parameters.getProjectDir().get(), uploadFile);
+
+            createBuildArchiveTar(filesToArchive, parameters.getProjectDir().get(), uploadFile);
             if (uploadFile.exists() && "true".equals(System.getenv("BUILDKITE"))) {
                 String uploadFilePath = uploadFile.getName();
                 File uploadFileDir = uploadFile.getParentFile();


### PR DESCRIPTION
Backports the following commits to 8.x:
 - [Build] Do not create empty buildkite build artifacts (#117400)