### PR TITLE
[8.x] [Build] Reapply updating to Gradle 8.11.1 (#117394)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
@@ -18,7 +18,6 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
 import org.gradle.api.plugins.BasePluginExtension;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -88,7 +87,7 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
 
     private void configureDependency(Project project, boolean shadowed, ProjectDependency dep) {
         // we should use variant aware dependency management to resolve artifacts required for javadoc here
-        Project upstreamProject = project.project(((ProjectDependencyInternal) dep).getIdentityPath().getPath());
+        Project upstreamProject = project.project(dep.getPath());
         if (upstreamProject == null) {
             return;
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestWithDependenciesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestWithDependenciesPlugin.java
@@ -18,7 +18,6 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
-import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -69,10 +68,7 @@ public class TestWithDependenciesPlugin implements Plugin<Project> {
                 project.getObjects().named(LibraryElements.class, LibraryElements.RESOURCES)
             );
         DependencyHandler dependencyHandler = project.getDependencies();
-        ProjectDependencyInternal pluginProject = (ProjectDependencyInternal) projectDependency;
-
-        String path = pluginProject.getIdentityPath().getPath();
-        Dependency pluginMetadataDependency = dependencyHandler.project(Map.of("path", path));
+        Dependency pluginMetadataDependency = dependencyHandler.project(Map.of("path", projectDependency.getPath()));
         dependencyHandler.add(metadataConfiguration, pluginMetadataDependency);
         project.getTasks().register(taskName, Copy.class, copy -> {
             copy.into(outputDir);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -246,7 +246,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
         configuration.getDependencies()
             .stream()
             .filter(d -> d instanceof ProjectDependency)
-            .map(d -> project.getDependencies().project(Map.of("path", ((ProjectDependencyInternal) d).getIdentityPath().getPath())))
+            .map(d -> project.getDependencies().project(Map.of("path", ((ProjectDependencyInternal) d).getPath())))
             .forEach(dependencies::add);
     }
 
@@ -325,9 +325,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
                         Dependency dependency = iterator.next();
                         // this logic of relying on other projects metadata should probably live in a build service
                         if (dependency instanceof ProjectDependency projectDependency) {
-                            Project dependencyProject = project.project(
-                                ((ProjectDependencyInternal) projectDependency).getIdentityPath().getPath()
-                            );
+                            Project dependencyProject = project.project(projectDependency.getPath());
                             List<String> extendedPlugins = dependencyProject.getExtensions()
                                 .getByType(PluginPropertiesExtension.class)
                                 .getExtendedPlugins();
@@ -337,8 +335,8 @@ public class RestTestBasePlugin implements Plugin<Project> {
                                 iterator.remove();
                                 additionalDependencies.add(
                                     useExploded
-                                        ? getExplodedBundleDependency(project, dependencyProject.getPath())
-                                        : getBundleZipTaskDependency(project, dependencyProject.getPath())
+                                        ? getExplodedBundleDependency(project, projectDependency.getPath())
+                                        : getBundleZipTaskDependency(project, projectDependency.getPath())
                                 );
                             }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Build] Reapply updating to Gradle 8.11.1 (#117394)](https://github.com/elastic/elasticsearch/pull/117394)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)