### PR TITLE
Fix testCancelRequestWhenFailingFetchingPages (#117437)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -362,9 +362,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.bucket.MinDocCountIT
   method: testDateHistogramCountDesc
   issue: https://github.com/elastic/elasticsearch/issues/117412
-- class: org.elasticsearch.xpack.esql.action.EsqlActionTaskIT
-  method: testCancelRequestWhenFailingFetchingPages
-  issue: https://github.com/elastic/elasticsearch/issues/117397
 - class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
   method: testEveryActionIsEitherOperatorOnlyOrNonOperator
   issue: https://github.com/elastic/elasticsearch/issues/102992


### PR DESCRIPTION
Each data-node request involves two exchange sinks: an external one for fetching pages from the coordinator and an internal one for node-level reduction. Currently, the test selects one of these sinks randomly, leading to assertion failures. This update ensures the test consistently selects the external exchange sink.

Closes #117397
