### PR TITLE
Fix leftover exchange in ManyShardsIT (#117309)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -67,12 +67,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroidTests
   method: testAggregateIntermediate {TestCase=<geo_point>}
   issue: https://github.com/elastic/elasticsearch/issues/112463
-- class: org.elasticsearch.xpack.esql.action.ManyShardsIT
-  method: testRejection
-  issue: https://github.com/elastic/elasticsearch/issues/112406
-- class: org.elasticsearch.xpack.esql.action.ManyShardsIT
-  method: testConcurrentQueries
-  issue: https://github.com/elastic/elasticsearch/issues/112424
 - class: org.elasticsearch.xpack.inference.external.http.RequestBasedTaskRunnerTests
   method: testLoopOneAtATime
   issue: https://github.com/elastic/elasticsearch/issues/112471


### PR DESCRIPTION
In the ManyShardsIT#testRejection test, we intercept exchange requests and fail them with EsRejectedExecutionException, verifying that we return a 400 response instead of a 500.

The issue with the current test is that if a data-node request never arrives because the whole request was canceled after the exchange request failed—the leftover exchange sink remains until it times out, which defaults to 5 minutes. This change adjusts the test to use a single data node and ensures exchange requests are only failed after the data-node request has arrived.

Closes #112406
Closes #112418
Closes #112424