### PR TITLE
[8.x] ESQL: Fix AttributeSet#add() returning the opposite expected value (#117367)

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeSet.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeSet.java
@@ -113,7 +113,7 @@ public class AttributeSet implements Set<Attribute> {
 
     @Override
     public boolean add(Attribute e) {
-        return delegate.put(e, PRESENT) != null;
+        return delegate.put(e, PRESENT) == null;
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeSet.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeSet.java
@@ -113,7 +113,7 @@ public class AttributeSet implements Set<Attribute> {
 
     @Override
     public boolean add(Attribute e) {
-        return delegate.put(e, PRESENT) != null;
+        return delegate.put(e, PRESENT) == null;
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL: Fix AttributeSet#add() returning the opposite expected value (#117367)