### PR TITLE
[8.x] Add missing async_search query parameters to rest-api-spec (#117312)

### DIFF
--- a/docs/changelog/117312.yaml
+++ b/docs/changelog/117312.yaml
@@ -1,0 +1,5 @@
+pr: 117312
+summary: Add missing `async_search` query parameters to rest-api-spec
+area: Search
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -65,6 +65,11 @@
         "type":"boolean",
         "description":"Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
+      "ccs_minimize_roundtrips":{
+        "type":"boolean",
+        "default":false,
+        "description":"When doing a cross-cluster search, setting it to true may improve overall search latency, particularly when searching clusters with a large number of shards. However, when set to true, the progress of searches on the remote clusters will not be received until the search finishes on all clusters."
+      },
       "default_operator":{
         "type":"enum",
         "options":[
@@ -125,6 +130,16 @@
       "preference":{
         "type":"string",
         "description":"Specify the node or shard the operation should be performed on (default: random)"
+      },
+      "pre_filter_shard_size":{
+         "type":"number",
+         "default": 1,
+         "description":"Cannot be changed: this is to enforce the execution of a pre-filter roundtrip to retrieve statistics from each shard so that the ones that surely don’t hold any document matching the query get skipped."
+      },
+      "rest_total_hits_as_int":{
+        "type":"boolean",
+        "description":"Indicates whether hits.total should be rendered as an integer or an object in the rest search response",
+        "default":false
       },
       "q":{
         "type":"string",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add missing async_search query parameters to rest-api-spec (#117312)](https://github.com/elastic/elasticsearch/pull/117312)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)