### PR TITLE
[8.16] Mute default ELSER tests (#117390)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -283,6 +283,9 @@ tests:
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
   issue: https://github.com/elastic/elasticsearch/issues/117027
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117349
 
 # Examples:
 #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Mute default ELSER tests (#117390)](https://github.com/elastic/elasticsearch/pull/117390)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)