### PR TITLE
[DOCS] Fix "What's new?" heading level

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
+[chapter]
 [[release-highlights]]
-== What's new in {minor-version}
-
-coming::[{minor-version}]
-
+= What's new in {minor-version}
 Here are the highlights of what's new and improved in {es} {minor-version}!
 ifeval::["{release-state}"!="unreleased"]
 For detailed information about this release, see the <<es-release-notes>> and


### PR DESCRIPTION
reverts to the change made in https://github.com/elastic/elasticsearch/commit/656b3871672780d396b1516b4bc3f5e36896ae34#diff-6084df60d0e64f7e1c8b55063a278fb627eda6ace267952dba756f6bf4912bf7

I think this got messed up by automation
