### PR TITLE
Changelog for default container image change to UBI

### DIFF
--- a/docs/changelog/116739.yaml
+++ b/docs/changelog/116739.yaml
@@ -1,5 +1,5 @@
 pr: 116739
 summary: Change default container image to be based on UBI minimal instead of Ubuntu
-area: Delivery/Packaging
+area: Infra/Core
 type: enhancement
 issues: []

--- a/docs/changelog/116739.yaml
+++ b/docs/changelog/116739.yaml
@@ -1,5 +1,5 @@
 pr: 116739
-summary: Change default container image to be based on UBI minimal instead of Ubuntu
+summary: Change default Docker image to be based on UBI minimal instead of Ubuntu
 area: Infra/Core
 type: enhancement
 issues: []

--- a/docs/changelog/116739.yaml
+++ b/docs/changelog/116739.yaml
@@ -1,0 +1,5 @@
+pr: 116739
+summary: Change default container image to be based on UBI minimal instead of Ubuntu
+area: Delivery/Packaging
+type: enhancement
+issues: []


### PR DESCRIPTION
The image has been changed in #116739. However, changelog has not been automatically created, probably because I have first created PR with `>no-issue` and then removed it.