### PR TITLE
[8.x] Stop using _source.mode attribute in builtin templates (#117448)

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@mappings.yaml
@@ -5,8 +5,6 @@ _meta:
   managed: true
 template:
   mappings:
-    _source:
-      mode: synthetic
     properties:
       processor.event:
         type: constant_keyword

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@settings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@settings.yaml
@@ -5,10 +5,12 @@ _meta:
   managed: true
 template:
   settings:
-    codec: best_compression
-    mapping:
-      # apm@settings sets `ignore_malformed: true`, but we need
-      # to disable this for metrics since they use synthetic source,
-      # and this combination is incompatible with the
-      # aggregate_metric_double field type.
-      ignore_malformed: false
+    index:
+      codec: best_compression
+      mapping:
+        # apm@settings sets `ignore_malformed: true`, but we need
+        # to disable this for metrics since they use synthetic source,
+        # and this combination is incompatible with the
+        # aggregate_metric_double field type.
+        ignore_malformed: false
+        source.mode: synthetic

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 11
+version: 12
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -14,14 +14,16 @@
             "container.name",
             "process.thread.name"
           ]
+        },
+        "mapping": {
+          "source": {
+            "mode": "synthetic"
+          }
         }
       },
       "codec": "best_compression"
     },
     "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
         "index-version": ${xpack.profiling.index.events.version},

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-executables.json
@@ -5,13 +5,15 @@
         "auto_expand_replicas": "0-1",
         "refresh_interval": "10s",
         "hidden": true,
-        "lifecycle.rollover_alias": "profiling-executables"
+        "lifecycle.rollover_alias": "profiling-executables",
+        "mapping": {
+          "source": {
+            "mode": "synthetic"
+          }
+        }
       }
     },
     "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
         "index-version": ${xpack.profiling.index.executables.version},

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-metrics.json
@@ -10,14 +10,16 @@
             "@timestamp",
             "host.id"
           ]
+        },
+        "mapping": {
+          "source": {
+            "mode": "synthetic"
+          }
         }
       },
       "codec": "best_compression"
     },
     "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
         "index-version": ${xpack.profiling.index.metrics.version},

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-stacktraces.json
@@ -11,13 +11,15 @@
           "field": [
             "Stacktrace.frame.ids"
           ]
+        },
+        "mapping": {
+          "source": {
+            "mode": "synthetic"
+          }
         }
       }
     },
     "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
         "index-version": ${xpack.profiling.index.stacktraces.version},

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-executables.json
@@ -7,13 +7,15 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "refresh_interval": "10s",
-        "hidden": true
+        "hidden": true,
+        "mapping": {
+          "source": {
+            "mode": "synthetic"
+          }
+        }
       }
     },
     "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
         "index-version": ${xpack.profiling.index.sq.executables.version},

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-leafframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-leafframes.json
@@ -7,13 +7,15 @@
       "index": {
         "auto_expand_replicas": "0-1",
         "refresh_interval": "10s",
-        "hidden": true
+        "hidden": true,
+        "mapping": {
+          "source": {
+            "mode": "synthetic"
+          }
+        }
       }
     },
     "mappings": {
-      "_source": {
-        "mode": "synthetic"
-      },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
         "index-version": ${xpack.profiling.index.sq.leafframes.version},

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -54,7 +54,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 11: Added 'profiling.agent.protocol' keyword mapping to profiling-hosts
     // version 12: Added 'profiling.agent.env_https_proxy' keyword mapping to profiling-hosts
     // version 13: Added 'container.id' keyword mapping to profiling-events
-    public static final int INDEX_TEMPLATE_VERSION = 13;
+    public static final int INDEX_TEMPLATE_VERSION = 14;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 5;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Stop using _source.mode attribute in builtin templates (#117448)