### PR TITLE
Stop using _source.mode attribute in traces-otel builtin template

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/traces-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/traces-otel@mappings.yaml
@@ -10,8 +10,6 @@ template:
       sort:
         field: [ "resource.attributes.host.name", "@timestamp" ]
   mappings:
-    _source:
-      mode: synthetic
     properties:
       trace_id:
         type: keyword

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/traces-otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/traces-otel@template.yaml
@@ -20,6 +20,10 @@ ignore_missing_component_templates:
   - traces@custom
   - traces-otel@custom
 template:
+  settings:
+    index:
+      mapping:
+        source.mode: synthetic
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/traces-otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/traces-otel@template.yaml
@@ -20,10 +20,6 @@ ignore_missing_component_templates:
   - traces@custom
   - traces-otel@custom
 template:
-  settings:
-    index:
-      mapping:
-        source.mode: synthetic
   mappings:
     properties:
       data_stream.type:

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 6
+version: 7
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
The `traces-otel@mappings` component template is configured to use logsdb. No need to configure source mode separately.