### PR TITLE
[8.17] Stop using _source.mode attribute in traces-otel builtin template (#117487)

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/traces-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/traces-otel@mappings.yaml
@@ -10,8 +10,6 @@ template:
       sort:
         field: [ "resource.attributes.host.name", "@timestamp" ]
   mappings:
-    _source:
-      mode: synthetic
     properties:
       trace_id:
         type: keyword

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 6
+version: 7
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Stop using _source.mode attribute in traces-otel builtin template (#117487)