### PR TITLE
[8.16] Update tsds-reindex.asciidoc (#117446)

### DIFF
--- a/docs/reference/data-streams/tsds-reindex.asciidoc
+++ b/docs/reference/data-streams/tsds-reindex.asciidoc
@@ -202,7 +202,7 @@ POST /_component_template/destination_template
 POST /_index_template/2
 {
   "index_patterns": [
-    "k8s*"
+    "k9s*"
   ],
   "composed_of": [
     "destination_template"


### PR DESCRIPTION
Backports the following commits to 8.16:
 - Update tsds-reindex.asciidoc (#117446)