### PR TITLE
[8.x] Make spatial search functions not preview (#117489)

### DIFF
--- a/docs/reference/esql/functions/spatial-functions.asciidoc
+++ b/docs/reference/esql/functions/spatial-functions.asciidoc
@@ -8,19 +8,19 @@
 {esql} supports these spatial functions:
 
 // tag::spatial_list[]
-* experimental:[] <<esql-st_intersects>>
-* experimental:[] <<esql-st_disjoint>>
-* experimental:[] <<esql-st_contains>>
-* experimental:[] <<esql-st_within>>
-* experimental:[] <<esql-st_x>>
-* experimental:[] <<esql-st_y>>
-* experimental:[] <<esql-st_distance>>
+* <<esql-st_distance>>
+* <<esql-st_intersects>>
+* <<esql-st_disjoint>>
+* <<esql-st_contains>>
+* <<esql-st_within>>
+* <<esql-st_x>>
+* <<esql-st_y>>
 // end::spatial_list[]
 
+include::layout/st_distance.asciidoc[]
 include::layout/st_intersects.asciidoc[]
 include::layout/st_disjoint.asciidoc[]
 include::layout/st_contains.asciidoc[]
 include::layout/st_within.asciidoc[]
 include::layout/st_x.asciidoc[]
 include::layout/st_y.asciidoc[]
-include::layout/st_distance.asciidoc[]

--- a/docs/reference/geospatial-analysis.asciidoc
+++ b/docs/reference/geospatial-analysis.asciidoc
@@ -38,11 +38,11 @@ Data is often messy and incomplete. <<ingest,Ingest pipelines>> lets you clean, 
 
 <<esql,ES|QL>> has support for <<esql-spatial-functions, Geospatial Search>> functions, enabling efficient index searching for documents that intersect with, are within, are contained by, or are disjoint from a query geometry. In addition, the `ST_DISTANCE` function calculates the distance between two points.
 
-* experimental:[] <<esql-st_intersects>>
-* experimental:[] <<esql-st_disjoint>>
-* experimental:[] <<esql-st_contains>>
-* experimental:[] <<esql-st_within>>
-* experimental:[] <<esql-st_distance>>
+* <<esql-st_intersects>>
+* <<esql-st_disjoint>>
+* <<esql-st_contains>>
+* <<esql-st_within>>
+* <<esql-st_distance>>
 
 [discrete]
 [[geospatial-aggregate]]


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Make spatial search functions not preview (#117489)