### PR TITLE
[8.17] [ML] Explicitly set chunking settings in preconfigured endpoints (#117327)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
@@ -43,6 +43,14 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         super.tearDown();
     }
 
+    public void testGet() throws IOException {
+        var elserModel = getModel(ElasticsearchInternalService.DEFAULT_ELSER_ID);
+        assertDefaultElserConfig(elserModel);
+
+        var e5Model = getModel(ElasticsearchInternalService.DEFAULT_E5_ID);
+        assertDefaultE5Config(e5Model);
+    }
+
     @SuppressWarnings("unchecked")
     public void testInferDeploysDefaultElser() throws IOException {
         var model = getModel(ElasticsearchInternalService.DEFAULT_ELSER_ID);
@@ -71,6 +79,7 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
             adaptiveAllocations,
             Matchers.is(Map.of("enabled", true, "min_number_of_allocations", 0, "max_number_of_allocations", 32))
         );
+        assertDefaultChunkingSettings(modelConfig);
     }
 
     @SuppressWarnings("unchecked")
@@ -104,6 +113,17 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
             modelConfig.toString(),
             adaptiveAllocations,
             Matchers.is(Map.of("enabled", true, "min_number_of_allocations", 0, "max_number_of_allocations", 32))
+        );
+        assertDefaultChunkingSettings(modelConfig);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertDefaultChunkingSettings(Map<String, Object> modelConfig) {
+        var chunkingSettings = (Map<String, Object>) modelConfig.get("chunking_settings");
+        assertThat(
+            modelConfig.toString(),
+            chunkingSettings,
+            Matchers.is(Map.of("strategy", "sentence", "max_chunk_size", 250, "sentence_overlap", 1))
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -861,6 +861,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         );
     }
 
+    @Override
     public void defaultConfigs(ActionListener<List<Model>> defaultsListener) {
         preferredModelVariantFn.accept(defaultsListener.delegateFailureAndWrap((delegate, preferredModelVariant) -> {
             if (PreferredModelVariant.LINUX_X86_OPTIMIZED.equals(preferredModelVariant)) {
@@ -891,7 +892,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
             ),
             ElserMlNodeTaskSettings.DEFAULT,
-            null // default chunking settings
+            ChunkingSettingsBuilder.DEFAULT_SETTINGS
         );
         var defaultE5 = new MultilingualE5SmallModel(
             DEFAULT_E5_ID,
@@ -903,7 +904,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                 useLinuxOptimizedModel ? MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86 : MULTILINGUAL_E5_SMALL_MODEL_ID,
                 new AdaptiveAllocationsSettings(Boolean.TRUE, 0, 32)
             ),
-            null // default chunking settings
+            ChunkingSettingsBuilder.DEFAULT_SETTINGS
         );
         return List.of(defaultElser, defaultE5);
     }


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [ML] Explicitly set chunking settings in preconfigured endpoints (#117327)