### PR TITLE
[POC] "cluster-aware" rate limiting approximation inside the inference API

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -206,6 +206,7 @@ public class TransportVersions {
     public static final TransportVersion INGEST_PIPELINE_CONFIGURATION_AS_MAP = def(8_797_00_0);
     public static final TransportVersion INDEXING_PRESSURE_THROTTLING_STATS = def(8_798_00_0);
     public static final TransportVersion REINDEX_DATA_STREAMS = def(8_799_00_0);
+    public static final TransportVersion INFERENCE_API_CLUSTER_WIDE_RATE_LIMITS = def(8_800_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
+import org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorService;
+import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
+
+public class UpdateRateLimitsClusterService implements ClusterStateListener {
+
+    private static final Logger LOGGER = LogManager.getLogger(UpdateRateLimitsClusterService.class);
+
+    private final InferenceServiceRegistry inferenceServiceRegistry;
+
+    public UpdateRateLimitsClusterService(ClusterService clusterService, InferenceServiceRegistry inferenceServiceRegistry) {
+        this.inferenceServiceRegistry = inferenceServiceRegistry;
+        clusterService.addListener(this);
+        LOGGER.info("Added UpdateRateLimitsClusterService as a ClusterStateListener");
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        LOGGER.info("Received cluster changed event {}", event.source());
+
+        // TODO: check what this actually does and if it's necessary
+        if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
+
+        // TODO: check if the cluster is ready?
+
+        // TODO: other sanity checks?
+
+        if (event.nodesAdded() || event.nodesRemoved()) {
+            LOGGER.info("Received nodesAdded or nodesRemoved event");
+
+            var numNodes = event.state().nodes().getSize();
+
+            LOGGER.info("Number of nodes in the cluster: {}", numNodes);
+            var elasticInferenceServiceOptional = inferenceServiceRegistry.getService(ElasticInferenceService.NAME);
+
+            if (elasticInferenceServiceOptional.isPresent() == false) {
+                // TODO: adapt
+                LOGGER.info("ElasticInferenceService is not present");
+                return;
+            }
+
+            ElasticInferenceService elasticInferenceService = (ElasticInferenceService) elasticInferenceServiceOptional.get();
+            var sender = elasticInferenceService.getSender();
+
+            if (sender instanceof HttpRequestSender == false) {
+                // TODO: adapt
+                LOGGER.warn("sender is not type HttpRequestSender");
+                return;
+            }
+
+            HttpRequestSender httpRequestSender = (HttpRequestSender) sender;
+
+            LOGGER.info("Updating rate limits for {} endpoints", httpRequestSender.rateLimitingEndpointHandlers().size());
+            for (RequestExecutorService.RateLimitingEndpointHandler rateLimitingEndpointHandler : httpRequestSender
+                .rateLimitingEndpointHandlers()) {
+                var oldRequestsPerTimeUnit = rateLimitingEndpointHandler.requestsPerTimeUnit();
+                var clusterAwareTokenLimit = oldRequestsPerTimeUnit / numNodes;
+                LOGGER.info(
+                    "Updating rate limit for endpoint {} from {} to {} tokens per time unit",
+                    rateLimitingEndpointHandler.id(),
+                    oldRequestsPerTimeUnit,
+                    clusterAwareTokenLimit
+                );
+
+                rateLimitingEndpointHandler.updateTokensPerTimeUnit(clusterAwareTokenLimit);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterService.java
@@ -71,7 +71,7 @@ public class UpdateRateLimitsClusterService implements ClusterStateListener {
             LOGGER.info("Updating rate limits for {} endpoints", httpRequestSender.rateLimitingEndpointHandlers().size());
             for (RequestExecutorService.RateLimitingEndpointHandler rateLimitingEndpointHandler : httpRequestSender
                 .rateLimitingEndpointHandlers()) {
-                // TODO: treat a node joining and a node leaving differently, otherwise the rate limit will become smaller and smaller
+                // TODO: keep the original rate limit and always divide by the number of nodes to handle node leaving/joining correctly
                 var oldRequestsPerTimeUnit = rateLimitingEndpointHandler.requestsPerTimeUnit();
                 var clusterAwareTokenLimit = oldRequestsPerTimeUnit / numNodes;
                 LOGGER.info(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterService.java
@@ -71,6 +71,7 @@ public class UpdateRateLimitsClusterService implements ClusterStateListener {
             LOGGER.info("Updating rate limits for {} endpoints", httpRequestSender.rateLimitingEndpointHandlers().size());
             for (RequestExecutorService.RateLimitingEndpointHandler rateLimitingEndpointHandler : httpRequestSender
                 .rateLimitingEndpointHandlers()) {
+                // TODO: treat a node joining and a node leaving differently, otherwise the rate limit will become smaller and smaller
                 var oldRequestsPerTimeUnit = rateLimitingEndpointHandler.requestsPerTimeUnit();
                 var clusterAwareTokenLimit = oldRequestsPerTimeUnit / numNodes;
                 LOGGER.info(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
@@ -22,6 +22,8 @@ import org.elasticsearch.xpack.inference.external.http.retry.RetryingHttpSender;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -90,6 +92,15 @@ public class HttpRequestSender implements Sender {
             new RequestExecutorServiceSettings(settings, clusterService),
             requestSender
         );
+    }
+
+    public Collection<RequestExecutorService.RateLimitingEndpointHandler> rateLimitingEndpointHandlers() {
+        // TODO: there's probably a better way; just for the POC
+        if (service instanceof RequestExecutorService) {
+            return ((RequestExecutorService) service).rateLimitingEndpointHandlers();
+        }
+
+        return List.of();
     }
 
     /**

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
@@ -42,7 +42,7 @@ public abstract class SenderService implements InferenceService {
         this.serviceComponents = Objects.requireNonNull(serviceComponents);
     }
 
-    protected Sender getSender() {
+    public Sender getSender() {
         return sender;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettings.java
@@ -14,7 +14,10 @@ import java.util.List;
 
 public class ElasticInferenceServiceSettings {
 
-    static final Setting<String> EIS_GATEWAY_URL = Setting.simpleString("xpack.inference.eis.gateway.url", Setting.Property.NodeScope);
+    public static final Setting<String> EIS_GATEWAY_URL = Setting.simpleString(
+        "xpack.inference.eis.gateway.url",
+        Setting.Property.NodeScope
+    );
 
     // Adjust this variable to be volatile, if the setting can be updated at some point in time
     private final String eisGatewayUrl;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterServiceTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
+import org.elasticsearch.xpack.core.inference.action.PutInferenceModelAction;
+import org.elasticsearch.xpack.inference.InferencePlugin;
+import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceSettings;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_INTERVAL_SETTING;
+import static org.elasticsearch.cluster.coordination.LeaderChecker.LEADER_CHECK_RETRY_COUNT_SETTING;
+import static org.elasticsearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 0)
+public class UpdateRateLimitsClusterServiceTests extends ESIntegTestCase {
+
+    private MockLog mockLog;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        mockLog = MockLog.capture(UpdateRateLimitsClusterService.class, TransportService.class);
+    }
+
+    public void tearDown() throws Exception {
+        mockLog.close();
+        super.tearDown();
+    }
+
+    public void testNodeJoinsRateLimitsUpdated() {
+        // TODO: Expectation does not work, but I see the correct log message
+        final String rateLimitUpdatedPattern = "Updating rate limit for endpoint";
+        final MockLog.LoggingExpectation rateLimitUpdatedExpectation = new MockLog.SeenEventExpectation(
+                "rate limit updated",
+                UpdateRateLimitsClusterService.class.getCanonicalName(),
+                Level.INFO,
+                rateLimitUpdatedPattern
+        );
+
+        // This expectation works
+        final String publishAddressMessage = "publish_addresssss";
+        final MockLog.LoggingExpectation publishAddressExpectation = new MockLog.SeenEventExpectation(
+                "publish_address",
+                TransportService.class.getCanonicalName(),
+                Level.INFO,
+                publishAddressMessage
+        );
+
+
+        // TODO: re-enable as soon you know how to capture logs of newly joined nodes
+        //mockLog.addExpectation(rateLimitUpdatedExpectation);
+        mockLog.addExpectation(publishAddressExpectation);
+
+        var nodeSettings = Settings.builder()
+            .put(ElasticInferenceServiceSettings.EIS_GATEWAY_URL.getKey(), "http://localhost:8080")
+            .build();
+
+        var oneClusterNode = 1;
+        var putInferenceModelActionPayload = """
+            {
+                "service": "elastic",
+                "service_settings": {
+                    "model_id": ".elser_model_2"
+                }
+            }
+            """;
+
+        InternalTestCluster internalCluster = internalCluster();
+
+        // We need to start a non-master-only-node to be able to store an inference endpoint
+        internalCluster.startNode(nodeSettings);
+        ensureStableCluster(oneClusterNode);
+
+        var inferenceEntityId = "inference-endpoint-id";
+        var createInferenceEndpointRequest = new PutInferenceModelAction.Request(
+            TaskType.SPARSE_EMBEDDING,
+            inferenceEntityId,
+            new BytesArray(putInferenceModelActionPayload),
+            XContentType.JSON
+        );
+        client().execute(PutInferenceModelAction.INSTANCE, createInferenceEndpointRequest).actionGet();
+
+        // Perform inference so the rate limiting endpoint handler is stored
+        var performInferenceRequest = new InferenceAction.Request(
+            TaskType.SPARSE_EMBEDDING,
+            inferenceEntityId,
+            null,
+            List.of("some input"),
+            new HashMap<>(),
+            InputType.UNSPECIFIED,
+            TimeValue.THIRTY_SECONDS,
+            false
+        );
+        client().execute(InferenceAction.INSTANCE, performInferenceRequest).actionGet();
+
+        internalCluster.startNode(
+            Settings.builder()
+                .build()
+        );
+        ensureStableCluster(2);
+        client().admin().cluster().prepareNodesStats().get(TimeValue.timeValueSeconds(10));
+
+        mockLog.assertAllExpectationsMatched();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        // TODO: InternalSettingsPlugin needed?
+        return Arrays.asList(InferencePlugin.class);
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/UpdateRateLimitsClusterServiceTests.java
@@ -62,7 +62,7 @@ public class UpdateRateLimitsClusterServiceTests extends ESIntegTestCase {
         );
 
         // This expectation works
-        final String publishAddressMessage = "publish_addresssss";
+        final String publishAddressMessage = "publish_address";
         final MockLog.LoggingExpectation publishAddressExpectation = new MockLog.SeenEventExpectation(
                 "publish_address",
                 TransportService.class.getCanonicalName(),


### PR DESCRIPTION
POC for "cluster-aware" rate limiting approximation inside the inference API (I didn't think about good abstractions or edge cases, so take this with a grain of salt; this is just to get the main idea across).

The current rate limiting mechanism for inference endpoints works like the following: You specify a rate limit (or the default one is used) as `requests_per_minute`. We count the requests using the [`RateLimiter`](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/RateLimiter.java), which implements the [token bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket).

The problem is that counting does not use "cluster-wide" state, but "local node" state meaning that each node performs its own request counting. Assuming a ~ uniform distribution of requests the cluster-wide rate limit is effectively `|nodes| * requests_per_minute`. As we need a cluster-wide rate limit for our inference service we want to approximate a "cluster-wide" rate limit by dividing the specified rate limit by the number of nodes.

The rate limit update happens as soon as a node joins or leaves the cluster.

I couldn't figure out how to capture logs of newly started nodes yet, but I see the correct log messages coming from the `UpdateRateLimitsClusterService`:

Node added to cluster:
```
...
  1> [2024-11-26T13:38:07,923][INFO ][o.e.x.i.c.UpdateRateLimitsClusterService] [node_s0] Number of nodes in the cluster: 2
  1> [2024-11-26T13:38:07,923][INFO ][o.e.x.i.c.UpdateRateLimitsClusterService] [node_s0] Updating rate limits for 1 endpoints
  1> [2024-11-26T13:38:07,923][INFO ][o.e.x.i.c.UpdateRateLimitsClusterService] [node_s0] Decreasing per node rate limit for endpoint -163709627 from 1000 to 500 tokens per time unit (node added)
...
```

Node removed from cluster:
```
...
  1> [2024-11-26T13:38:08,027][INFO ][o.e.x.i.c.UpdateRateLimitsClusterService] [node_s0] Number of nodes in the cluster: 1
  1> [2024-11-26T13:38:08,027][INFO ][o.e.x.i.c.UpdateRateLimitsClusterService] [node_s0] Updating rate limits for 1 endpoints
  1> [2024-11-26T13:38:08,028][INFO ][o.e.x.i.c.UpdateRateLimitsClusterService] [node_s0] Increasing per node rate limit for endpoint -163709627 from 500 to 1000 tokens per time unit (node removed)

...
```
Command for running the test (it doesn't assert anything useful, but you can check the logs for the rate limit update):

```
./gradlew ":x-pack:plugin:inference:test" --tests "org.elasticsearch.xpack.inference.common.UpdateRateLimitsClusterServiceTests.testNodeJoinsRateLimitsUpdated"
```