### PR TITLE
[8.x] [Profiling] Add k8s namespace to events (#117323)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -9,6 +9,7 @@
         "sort": {
           "field": [
             "profiling.project.id",
+            "k8s.namespace.name",
             "orchestrator.resource.name",
             "host.name",
             "container.name",
@@ -81,6 +82,9 @@
           "type": "keyword"
         },
         "container.id": {
+          "type": "keyword"
+        },
+        "k8s.namespace.name": {
           "type": "keyword"
         }
       }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Profiling] Add k8s namespace to events (#117323)](https://github.com/elastic/elasticsearch/pull/117323)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)