### PR TITLE
[8.x] Fix and unmute synonyms tests using timeout (#117486)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/10_synonyms_put.yml
@@ -16,6 +16,13 @@ setup:
   - match: { result: "created" }
 
   - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
+  - do:
       synonyms.get_synonym:
         id: test-update-synonyms
 
@@ -57,6 +64,13 @@ setup:
           synonyms_set: []
 
   - match: { result: "created" }
+
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
 
   - do:
       synonyms.get_synonym:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
@@ -11,6 +11,14 @@ setup:
           synonyms_set:
             synonyms: "foo => bar, baz"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/20_synonyms_get.yml
@@ -14,6 +14,13 @@ setup:
             - synonyms: "test => check"
               id: "test-id-3"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
 
 ---
 "Get synonyms set":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -12,6 +12,14 @@ setup:
             - synonyms: "bye => goodbye"
               id: "test-id-2"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
 ---
 "Delete synonyms set":
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -9,6 +9,15 @@ setup:
           synonyms_set:
             - synonyms: "hello, hi"
             - synonyms: "goodbye, bye"
+
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
   - do:
       synonyms.put_synonym:
         id: test-synonyms-1

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/50_synonym_rule_put.yml
@@ -14,6 +14,13 @@ setup:
             - synonyms: "test => check"
               id: "test-id-3"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
 
 ---
 "Update a synonyms rule":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/60_synonym_rule_get.yml
@@ -14,6 +14,13 @@ setup:
             - synonyms: "test => check"
               id: "test-id-3"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
 
 ---
 "Get a synonym rule":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/70_synonym_rule_delete.yml
@@ -14,6 +14,14 @@ setup:
             - synonyms: "test => check"
               id: "test-id-3"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
 ---
 "Delete synonym rule":
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/80_synonyms_from_index.yml
@@ -14,6 +14,14 @@ setup:
             - synonyms: "bye => goodbye"
               id: "synonym-rule-2"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
   # Create an index with synonym_filter that uses that synonyms set
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/90_synonyms_reloading_for_synset.yml
@@ -26,6 +26,14 @@
             - synonyms: "bye => goodbye"
               id: "synonym-rule-2"
 
+  # This is to ensure that all index shards (write and read) are available. In serverless this can take some time.
+  - do:
+      cluster.health:
+        index: .synonyms-2
+        timeout: 2s
+        wait_for_status: green
+        ignore: 408
+
   # Create my_index1 with synonym_filter that uses synonyms_set1
   - do:
       indices.create:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix and unmute synonyms tests using timeout (#117486)](https://github.com/elastic/elasticsearch/pull/117486)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)