### PR TITLE
[8.x] InternalMultiBucketAggregation.InternalBucket does not implement writable anymore (#117310)

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<InternalAdjacencyMatrix, InternalAdjacencyMatrix.InternalBucket>
     implements
         AdjacencyMatrix {
-    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements AdjacencyMatrix.Bucket {
+    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucketWritable implements AdjacencyMatrix.Bucket {
 
         private final String key;
         private final long docCount;

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -34,7 +34,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
     /**
      * A bucket associated with a specific time series (identified by its key)
      */
-    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket {
+    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucketWritable {
         protected long bucketOrd;
         protected final BytesRef key;
         // TODO: make computing docCount optional

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -220,7 +220,7 @@ public abstract class InternalMultiBucketAggregation<
         return reducedBuckets;
     }
 
-    public abstract static class InternalBucket implements Bucket, Writeable {
+    public abstract static class InternalBucket implements Bucket {
 
         public Object getProperty(String containingAggName, List<String> path) {
             if (path.isEmpty()) {
@@ -248,4 +248,8 @@ public abstract class InternalMultiBucketAggregation<
             return aggregation.getProperty(path.subList(1, path.size()));
         }
     }
+
+    /** A {@link InternalBucket} that implements the {@link Writeable} interface. Most implementation might want
+     * to use this one except when specific logic is need to write into the stream. */
+    public abstract static class InternalBucketWritable extends InternalBucket implements Writeable {}
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -320,7 +320,9 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         return Objects.hash(super.hashCode(), size, buckets, afterKey, Arrays.hashCode(reverseMuls), Arrays.hashCode(missingOrders));
     }
 
-    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements CompositeAggregation.Bucket {
+    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucketWritable
+        implements
+            CompositeAggregation.Bucket {
 
         private final CompositeKey key;
         private final long docCount;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class InternalFilters extends InternalMultiBucketAggregation<InternalFilters, InternalFilters.InternalBucket> implements Filters {
-    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucket implements Filters.Bucket {
+    public static class InternalBucket extends InternalMultiBucketAggregation.InternalBucketWritable implements Filters.Bucket {
 
         private final String key;
         private long docCount;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGridBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGridBucket.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public abstract class InternalGeoGridBucket extends InternalMultiBucketAggregation.InternalBucket
+public abstract class InternalGeoGridBucket extends InternalMultiBucketAggregation.InternalBucketWritable
     implements
         GeoGrid.Bucket,
         Comparable<InternalGeoGridBucket> {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramBucket.java
@@ -16,7 +16,7 @@ import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 /**
  * A bucket in the histogram where documents fall in
  */
-public abstract class AbstractHistogramBucket extends InternalMultiBucketAggregation.InternalBucket {
+public abstract class AbstractHistogramBucket extends InternalMultiBucketAggregation.InternalBucketWritable {
 
     protected final long docCount;
     protected final InternalAggregations aggregations;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpPrefix, InternalIpPrefix.Bucket> {
 
-    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucketWritable
         implements
             IpPrefix.Bucket,
             KeyComparable<InternalIpPrefix.Bucket> {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -36,7 +36,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
     implements
         Range {
 
-    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucketWritable implements Range.Bucket {
 
         private final transient DocValueFormat format;
         private final String key;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -36,7 +36,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
     @SuppressWarnings("rawtypes")
     static final Factory FACTORY = new Factory();
 
-    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Range.Bucket {
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucketWritable implements Range.Bucket {
 
         protected final transient DocValueFormat format;
         protected final double from;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -63,8 +63,6 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
 
         protected abstract void setDocCountError(long docCountError);
 
-        protected abstract boolean getShowDocCountError();
-
         protected abstract long getDocCountError();
 
         protected abstract void bucketToXContent(XContentBuilder builder, Params params, boolean showDocCountError) throws IOException;
@@ -91,6 +89,8 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
 
     protected abstract int getRequiredSize();
 
+    protected abstract boolean getShowDocCountError();
+
     protected abstract B createBucket(long docCount, InternalAggregations aggs, long docCountError, B prototype);
 
     private B reduceBucket(List<B> buckets, AggregationReduceContext context) {
@@ -104,7 +104,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         for (B bucket : buckets) {
             docCount += bucket.getDocCount();
             if (docCountError != -1) {
-                if (bucket.getShowDocCountError() == false || bucket.getDocCountError() == -1) {
+                if (getShowDocCountError() == false || bucket.getDocCountError() == -1) {
                     docCountError = -1;
                 } else {
                     docCountError += bucket.getDocCountError();
@@ -257,6 +257,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             }
             otherDocCount[0] += terms.getSumOfOtherDocCounts();
             final long thisAggDocCountError = getDocCountError(terms);
+            setDocCountError(thisAggDocCountError);
             if (sumDocCountError != -1) {
                 if (thisAggDocCountError == -1) {
                     sumDocCountError = -1;
@@ -264,16 +265,17 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                     sumDocCountError += thisAggDocCountError;
                 }
             }
-            setDocCountError(thisAggDocCountError);
-            for (B bucket : terms.getBuckets()) {
-                // If there is already a doc count error for this bucket
-                // subtract this aggs doc count error from it to make the
-                // new value for the bucket. This then means that when the
-                // final error for the bucket is calculated below we account
-                // for the existing error calculated in a previous reduce.
-                // Note that if the error is unbounded (-1) this will be fixed
-                // later in this method.
-                bucket.updateDocCountError(-thisAggDocCountError);
+            if (getShowDocCountError()) {
+                for (B bucket : terms.getBuckets()) {
+                    // If there is already a doc count error for this bucket
+                    // subtract this aggs doc count error from it to make the
+                    // new value for the bucket. This then means that when the
+                    // final error for the bucket is calculated below we account
+                    // for the existing error calculated in a previous reduce.
+                    // Note that if the error is unbounded (-1) this will be fixed
+                    // later in this method.
+                    bucket.updateDocCountError(-thisAggDocCountError);
+                }
             }
             if (terms.getBuckets().isEmpty() == false) {
                 bucketsList.add(terms.getBuckets());
@@ -319,17 +321,17 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                     result.add(bucket.reduced(AbstractInternalTerms.this::reduceBucket, reduceContext));
                 });
             }
-            for (B r : result) {
-                if (sumDocCountError == -1) {
-                    r.setDocCountError(-1);
-                } else {
-                    r.updateDocCountError(sumDocCountError);
+            if (getShowDocCountError()) {
+                for (B r : result) {
+                    if (sumDocCountError == -1) {
+                        r.setDocCountError(-1);
+                    } else {
+                        r.updateDocCountError(sumDocCountError);
+                    }
                 }
             }
-            long docCountError;
-            if (sumDocCountError == -1) {
-                docCountError = -1;
-            } else {
+            long docCountError = -1;
+            if (sumDocCountError != -1) {
                 docCountError = size == 1 ? 0 : sumDocCountError;
             }
             return create(name, result, reduceContext.isFinalReduce() ? getOrder() : thisReduceOrder, docCountError, otherDocCount[0]);
@@ -349,7 +351,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                     b -> createBucket(
                         samplingContext.scaleUp(b.getDocCount()),
                         InternalAggregations.finalizeSampling(b.getAggregations(), samplingContext),
-                        b.getShowDocCountError() ? samplingContext.scaleUp(b.getDocCountError()) : 0,
+                        getShowDocCountError() ? samplingContext.scaleUp(b.getDocCountError()) : 0,
                         b
                     )
                 )

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -164,8 +164,8 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
             prototype.term,
             prototype.docCount,
             aggregations,
-            prototype.showDocCountError,
-            prototype.docCountError,
+            showTermDocCountError,
+            prototype.getDocCountError(),
             prototype.format
         );
     }
@@ -216,6 +216,6 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
 
     @Override
     protected Bucket createBucket(long docCount, InternalAggregations aggs, long docCountError, DoubleTerms.Bucket prototype) {
-        return new Bucket(prototype.term, docCount, aggs, prototype.showDocCountError, docCountError, format);
+        return new Bucket(prototype.term, docCount, aggs, showTermDocCountError, docCountError, format);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -876,7 +876,6 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
             BytesRef term = BytesRef.deepCopyOf(lookupGlobalOrd.apply(temp.globalOrd));
             StringTerms.Bucket result = new StringTerms.Bucket(term, temp.docCount, null, showTermDocCountError, 0, format);
             result.bucketOrd = temp.bucketOrd;
-            result.docCountError = 0;
             return result;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedTerms.java
@@ -87,12 +87,20 @@ public abstract class InternalMappedTerms<A extends InternalTerms<A, B>, B exten
         writeSize(shardSize, out);
         out.writeBoolean(showTermDocCountError);
         out.writeVLong(otherDocCount);
-        out.writeCollection(buckets);
+        out.writeVInt(buckets.size());
+        for (var bucket : buckets) {
+            bucket.writeTo(out, showTermDocCountError);
+        }
     }
 
     @Override
     protected void setDocCountError(long docCountError) {
         this.docCountError = docCountError;
+    }
+
+    @Override
+    protected boolean getShowDocCountError() {
+        return showTermDocCountError;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -29,10 +30,11 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
     implements
         RareTerms {
 
-    public abstract static class Bucket<B extends Bucket<B>> extends InternalMultiBucketAggregation.InternalBucket
+    public abstract static class Bucket<B extends Bucket<B>> extends InternalMultiBucketAggregation.InternalBucketWritable
         implements
             RareTerms.Bucket,
-            KeyComparable<B> {
+            KeyComparable<B>,
+            Writeable {
         /**
          * Reads a bucket. Should be a constructor reference.
          */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -45,7 +45,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
     public static final String BG_COUNT = "bg_count";
 
     @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
-    public abstract static class Bucket<B extends Bucket<B>> extends InternalMultiBucketAggregation.InternalBucket
+    public abstract static class Bucket<B extends Bucket<B>> extends InternalMultiBucketAggregation.InternalBucketWritable
         implements
             SignificantTerms.Bucket {
         /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -41,9 +41,8 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         long bucketOrd;
 
         protected long docCount;
-        protected long docCountError;
+        private long docCountError;
         protected InternalAggregations aggregations;
-        protected final boolean showDocCountError;
         protected final DocValueFormat format;
 
         protected Bucket(
@@ -53,29 +52,23 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
             long docCountError,
             DocValueFormat formatter
         ) {
-            this.showDocCountError = showDocCountError;
             this.format = formatter;
             this.docCount = docCount;
             this.aggregations = aggregations;
-            this.docCountError = docCountError;
+            this.docCountError = showDocCountError ? docCountError : -1;
         }
 
         /**
          * Read from a stream.
          */
         protected Bucket(StreamInput in, DocValueFormat formatter, boolean showDocCountError) throws IOException {
-            this.showDocCountError = showDocCountError;
             this.format = formatter;
             docCount = in.readVLong();
-            docCountError = -1;
-            if (showDocCountError) {
-                docCountError = in.readLong();
-            }
+            docCountError = showDocCountError ? in.readLong() : -1;
             aggregations = InternalAggregations.readFrom(in);
         }
 
-        @Override
-        public final void writeTo(StreamOutput out) throws IOException {
+        final void writeTo(StreamOutput out, boolean showDocCountError) throws IOException {
             out.writeVLong(getDocCount());
             if (showDocCountError) {
                 out.writeLong(docCountError);
@@ -105,9 +98,6 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
 
         @Override
         public long getDocCountError() {
-            if (showDocCountError == false) {
-                throw new IllegalStateException("show_terms_doc_count_error is false");
-            }
             return docCountError;
         }
 
@@ -119,11 +109,6 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         @Override
         protected void updateDocCountError(long docCountErrorDiff) {
             this.docCountError += docCountErrorDiff;
-        }
-
-        @Override
-        protected boolean getShowDocCountError() {
-            return showDocCountError;
         }
 
         @Override
@@ -155,23 +140,15 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
                 return false;
             }
             Bucket<?> that = (Bucket<?>) obj;
-            if (showDocCountError && docCountError != that.docCountError) {
-                /*
-                 * docCountError doesn't matter if not showing it and
-                 * serialization sets it to -1 no matter what it was
-                 * before.
-                 */
-                return false;
-            }
-            return Objects.equals(docCount, that.docCount)
-                && Objects.equals(showDocCountError, that.showDocCountError)
+            return Objects.equals(docCountError, that.docCountError)
+                && Objects.equals(docCount, that.docCount)
                 && Objects.equals(format, that.format)
                 && Objects.equals(aggregations, that.aggregations);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getClass(), docCount, format, showDocCountError, showDocCountError ? docCountError : -1, aggregations);
+            return Objects.hash(getClass(), docCount, format, docCountError, aggregations);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -178,8 +178,8 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
             prototype.term,
             prototype.docCount,
             aggregations,
-            prototype.showDocCountError,
-            prototype.docCountError,
+            showTermDocCountError,
+            prototype.getDocCountError(),
             prototype.format
         );
     }
@@ -260,7 +260,7 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
 
     @Override
     protected Bucket createBucket(long docCount, InternalAggregations aggs, long docCountError, LongTerms.Bucket prototype) {
-        return new Bucket(prototype.term, docCount, aggs, prototype.showDocCountError, docCountError, format);
+        return new Bucket(prototype.term, docCount, aggs, showTermDocCountError, docCountError, format);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -184,15 +184,15 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
             prototype.termBytes,
             prototype.docCount,
             aggregations,
-            prototype.showDocCountError,
-            prototype.docCountError,
+            showTermDocCountError,
+            prototype.getDocCountError(),
             prototype.format
         );
     }
 
     @Override
     protected Bucket createBucket(long docCount, InternalAggregations aggs, long docCountError, StringTerms.Bucket prototype) {
-        return new Bucket(prototype.termBytes, docCount, aggs, prototype.showDocCountError, docCountError, format);
+        return new Bucket(prototype.termBytes, docCount, aggs, showTermDocCountError, docCountError, format);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -115,6 +115,11 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
     }
 
     @Override
+    protected boolean getShowDocCountError() {
+        return false;
+    }
+
+    @Override
     protected void setDocCountError(long docCountError) {}
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpersTests.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
@@ -56,10 +55,6 @@ public class BucketHelpersTests extends ESTestCase {
         };
 
         InternalMultiBucketAggregation.InternalBucket bucket = new InternalMultiBucketAggregation.InternalBucket() {
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-
-            }
 
             @Override
             public Object getKey() {
@@ -131,10 +126,6 @@ public class BucketHelpersTests extends ESTestCase {
         };
 
         InternalMultiBucketAggregation.InternalBucket bucket = new InternalMultiBucketAggregation.InternalBucket() {
-            @Override
-            public void writeTo(StreamOutput out) throws IOException {
-
-            }
 
             @Override
             public Object getKey() {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -42,8 +42,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
         protected long docCount;
         protected InternalAggregations aggregations;
-        protected final boolean showDocCountError;
-        protected long docCountError;
+        private long docCountError;
         protected final List<DocValueFormat> formats;
         protected List<Object> terms;
         protected List<KeyConverter> keyConverters;
@@ -60,8 +59,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
             this.terms = terms;
             this.docCount = docCount;
             this.aggregations = aggregations;
-            this.showDocCountError = showDocCountError;
-            this.docCountError = docCountError;
+            this.docCountError = showDocCountError ? docCountError : -1;
             this.formats = formats;
             this.keyConverters = keyConverters;
         }
@@ -71,7 +69,6 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
             terms = in.readCollectionAsList(StreamInput::readGenericValue);
             docCount = in.readVLong();
             aggregations = InternalAggregations.readFrom(in);
-            this.showDocCountError = showDocCountError;
             docCountError = -1;
             if (showDocCountError) {
                 docCountError = in.readLong();
@@ -80,8 +77,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
             this.keyConverters = keyConverters;
         }
 
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
+        private void writeTo(StreamOutput out, boolean showDocCountError) throws IOException {
             out.writeCollection(terms, StreamOutput::writeGenericValue);
             out.writeVLong(docCount);
             aggregations.writeTo(out);
@@ -136,9 +132,6 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
         @Override
         public long getDocCountError() {
-            if (showDocCountError == false) {
-                throw new IllegalStateException("show_terms_doc_count_error is false");
-            }
             return docCountError;
         }
 
@@ -153,11 +146,6 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         }
 
         @Override
-        protected boolean getShowDocCountError() {
-            return showDocCountError;
-        }
-
-        @Override
         public int compareKey(Bucket other) {
             return TERMS_COMPARATOR.compare(terms, other.terms);
         }
@@ -168,19 +156,16 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
                 return false;
             }
             Bucket other = (Bucket) obj;
-            if (showDocCountError && docCountError != other.docCountError) {
-                return false;
-            }
             return docCount == other.docCount
                 && aggregations.equals(other.aggregations)
-                && showDocCountError == other.showDocCountError
+                && docCountError == other.docCountError
                 && terms.equals(other.terms)
                 && keyConverters.equals(other.keyConverters);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(docCount, aggregations, showDocCountError, showDocCountError ? docCountError : -1, terms, keyConverters);
+            return Objects.hash(docCount, aggregations, docCountError, terms, keyConverters);
         }
     }
 
@@ -343,7 +328,10 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         out.writeVLong(otherDocCount);
         out.writeNamedWriteableCollection(formats);
         out.writeCollection(keyConverters, StreamOutput::writeEnum);
-        out.writeCollection(buckets);
+        out.writeVInt(buckets.size());
+        for (var bucket : buckets) {
+            bucket.writeTo(out, showTermDocCountError);
+        }
     }
 
     @Override
@@ -413,9 +401,14 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
     }
 
     @Override
+    protected boolean getShowDocCountError() {
+        return showTermDocCountError;
+    }
+
+    @Override
     @SuppressWarnings("HiddenField")
     protected Bucket createBucket(long docCount, InternalAggregations aggs, long docCountError, Bucket prototype) {
-        return new Bucket(prototype.terms, docCount, aggs, prototype.showDocCountError, docCountError, formats, keyConverters);
+        return new Bucket(prototype.terms, docCount, aggs, showTermDocCountError, docCountError, formats, keyConverters);
     }
 
     @Override
@@ -471,7 +464,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
                     newKeys.get(i),
                     oldBucket.docCount,
                     oldBucket.aggregations,
-                    oldBucket.showDocCountError,
+                    showTermDocCountError,
                     oldBucket.docCountError,
                     formats,
                     newKeyConverters

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -86,7 +86,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
         }
     }
 
-    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket
+    public static class Bucket extends InternalMultiBucketAggregation.InternalBucketWritable
         implements
             MultiBucketsAggregation.Bucket,
             Comparable<Bucket> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointBucket.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointBucket.java
@@ -18,7 +18,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class ChangePointBucket extends InternalMultiBucketAggregation.InternalBucket implements ToXContent {
+public class ChangePointBucket extends InternalMultiBucketAggregation.InternalBucketWritable implements ToXContent {
     private final Object key;
     private final long docCount;
     private final InternalAggregations aggregations;


### PR DESCRIPTION
Backports the following commits to 8.x:
 - InternalMultiBucketAggregation.InternalBucket does not implement writable anymore (#117310)