### PR TITLE
Adjust SyntheticSourceLicenseService (#116647)

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsDBPlugin.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettingProvider;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.license.LicenseService;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.core.XPackPlugin;
@@ -47,7 +49,8 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public Collection<?> createComponents(PluginServices services) {
-        licenseService.setLicenseState(XPackPlugin.getSharedLicenseState());
+        licenseService.setLicenseService(getLicenseService());
+        licenseService.setLicenseState(getLicenseState());
         var clusterSettings = services.clusterService().getClusterSettings();
         clusterSettings.addSettingsUpdateConsumer(FALLBACK_SETTING, licenseService::setSyntheticSourceFallback);
         clusterSettings.addSettingsUpdateConsumer(
@@ -86,5 +89,13 @@ public class LogsDBPlugin extends Plugin implements ActionPlugin {
         actions.add(new ActionPlugin.ActionHandler<>(XPackUsageFeatureAction.LOGSDB, LogsDBUsageTransportAction.class));
         actions.add(new ActionPlugin.ActionHandler<>(XPackInfoFeatureAction.LOGSDB, LogsDBInfoTransportAction.class));
         return actions;
+    }
+
+    protected XPackLicenseState getLicenseState() {
+        return XPackPlugin.getSharedLicenseState();
+    }
+
+    protected LicenseService getLicenseService() {
+        return XPackPlugin.getSharedLicenseService();
     }
 }

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseService.java
@@ -7,18 +7,30 @@
 
 package org.elasticsearch.xpack.logsdb;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * Determines based on license and fallback setting whether synthetic source usages should fallback to stored source.
  */
 final class SyntheticSourceLicenseService {
 
-    private static final String MAPPINGS_FEATURE_FAMILY = "mappings";
+    static final String MAPPINGS_FEATURE_FAMILY = "mappings";
+    // You can only override this property if you received explicit approval from Elastic.
+    private static final String CUTOFF_DATE_SYS_PROP_NAME =
+        "es.mapping.synthetic_source_fallback_to_stored_source.cutoff_date_restricted_override";
+    private static final Logger LOGGER = LogManager.getLogger(SyntheticSourceLicenseService.class);
+    static final long DEFAULT_CUTOFF_DATE = LocalDateTime.of(2024, 12, 12, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
 
     /**
      * A setting that determines whether source mode should always be stored source. Regardless of licence.
@@ -30,31 +42,71 @@ final class SyntheticSourceLicenseService {
         Setting.Property.Dynamic
     );
 
-    private static final LicensedFeature.Momentary SYNTHETIC_SOURCE_FEATURE = LicensedFeature.momentary(
+    static final LicensedFeature.Momentary SYNTHETIC_SOURCE_FEATURE = LicensedFeature.momentary(
         MAPPINGS_FEATURE_FAMILY,
         "synthetic-source",
         License.OperationMode.ENTERPRISE
     );
 
+    static final LicensedFeature.Momentary SYNTHETIC_SOURCE_FEATURE_LEGACY = LicensedFeature.momentary(
+        MAPPINGS_FEATURE_FAMILY,
+        "synthetic-source-legacy",
+        License.OperationMode.GOLD
+    );
+
+    private final long cutoffDate;
+    private LicenseService licenseService;
     private XPackLicenseState licenseState;
     private volatile boolean syntheticSourceFallback;
 
     SyntheticSourceLicenseService(Settings settings) {
-        syntheticSourceFallback = FALLBACK_SETTING.get(settings);
+        this(settings, System.getProperty(CUTOFF_DATE_SYS_PROP_NAME));
+    }
+
+    SyntheticSourceLicenseService(Settings settings, String cutoffDate) {
+        this.syntheticSourceFallback = FALLBACK_SETTING.get(settings);
+        this.cutoffDate = getCutoffDate(cutoffDate);
     }
 
     /**
      * @return whether synthetic source mode should fallback to stored source.
      */
-    public boolean fallbackToStoredSource(boolean isTemplateValidation) {
+    public boolean fallbackToStoredSource(boolean isTemplateValidation, boolean legacyLicensedUsageOfSyntheticSourceAllowed) {
         if (syntheticSourceFallback) {
             return true;
         }
 
+        var licenseStateSnapshot = licenseState.copyCurrentLicenseState();
+        if (checkFeature(SYNTHETIC_SOURCE_FEATURE, licenseStateSnapshot, isTemplateValidation)) {
+            return false;
+        }
+
+        var license = licenseService.getLicense();
+        if (license == null) {
+            return true;
+        }
+
+        boolean beforeCutoffDate = license.startDate() <= cutoffDate;
+        if (legacyLicensedUsageOfSyntheticSourceAllowed
+            && beforeCutoffDate
+            && checkFeature(SYNTHETIC_SOURCE_FEATURE_LEGACY, licenseStateSnapshot, isTemplateValidation)) {
+            // platinum license will allow synthetic source with gold legacy licensed feature too.
+            LOGGER.debug("legacy license [{}] is allowed to use synthetic source", licenseStateSnapshot.getOperationMode().description());
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean checkFeature(
+        LicensedFeature.Momentary licensedFeature,
+        XPackLicenseState licenseStateSnapshot,
+        boolean isTemplateValidation
+    ) {
         if (isTemplateValidation) {
-            return SYNTHETIC_SOURCE_FEATURE.checkWithoutTracking(licenseState) == false;
+            return licensedFeature.checkWithoutTracking(licenseStateSnapshot);
         } else {
-            return SYNTHETIC_SOURCE_FEATURE.check(licenseState) == false;
+            return licensedFeature.check(licenseStateSnapshot);
         }
     }
 
@@ -62,7 +114,26 @@ final class SyntheticSourceLicenseService {
         this.syntheticSourceFallback = syntheticSourceFallback;
     }
 
+    void setLicenseService(LicenseService licenseService) {
+        this.licenseService = licenseService;
+    }
+
     void setLicenseState(XPackLicenseState licenseState) {
         this.licenseState = licenseState;
+    }
+
+    private static long getCutoffDate(String cutoffDateAsString) {
+        if (cutoffDateAsString != null) {
+            long cutoffDate = LocalDateTime.parse(cutoffDateAsString).toInstant(ZoneOffset.UTC).toEpochMilli();
+            LOGGER.warn("Configuring [{}] is only allowed with explicit approval from Elastic.", CUTOFF_DATE_SYS_PROP_NAME);
+            LOGGER.info(
+                "Configuring [{}] to [{}]",
+                CUTOFF_DATE_SYS_PROP_NAME,
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(cutoffDate), ZoneOffset.UTC)
+            );
+            return cutoffDate;
+        } else {
+            return DEFAULT_CUTOFF_DATE;
+        }
     }
 }

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LegacyLicenceIntegrationTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/LegacyLicenceIntegrationTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.license.AbstractLicensesIntegrationTestCase;
+import org.elasticsearch.license.GetFeatureUsageRequest;
+import org.elasticsearch.license.GetFeatureUsageResponse;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicenseService;
+import org.elasticsearch.license.LicensedFeature;
+import org.elasticsearch.license.TransportGetFeatureUsageAction;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
+import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createEnterpriseLicense;
+import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createGoldOrPlatinumLicense;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+@ESIntegTestCase.ClusterScope(scope = TEST, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
+public class LegacyLicenceIntegrationTests extends AbstractLicensesIntegrationTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(P.class);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        wipeAllLicenses();
+        ensureGreen();
+        License license = createGoldOrPlatinumLicense();
+        putLicense(license);
+        ensureGreen();
+    }
+
+    public void testSyntheticSourceUsageDisallowed() {
+        createIndexWithSyntheticSourceAndAssertExpectedType("test", "STORED");
+
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
+    }
+
+    public void testSyntheticSourceUsageWithLegacyLicense() {
+        createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-stacktraces", "synthetic");
+
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, not(nullValue()));
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
+    }
+
+    public void testSyntheticSourceUsageWithLegacyLicensePastCutoff() throws Exception {
+        long startPastCutoff = LocalDateTime.of(2025, 11, 12, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        putLicense(createGoldOrPlatinumLicense(startPastCutoff));
+        ensureGreen();
+
+        createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-stacktraces", "STORED");
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, nullValue());
+    }
+
+    public void testSyntheticSourceUsageWithEnterpriseLicensePastCutoff() throws Exception {
+        long startPastCutoff = LocalDateTime.of(2025, 11, 12, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        putLicense(createEnterpriseLicense(startPastCutoff));
+        ensureGreen();
+
+        createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-traces", "synthetic");
+        // also supports non-exceptional indices
+        createIndexWithSyntheticSourceAndAssertExpectedType("test", "synthetic");
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, nullValue());
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, not(nullValue()));
+    }
+
+    public void testSyntheticSourceUsageTracksBothLegacyAndRegularFeature() throws Exception {
+        createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-traces", "synthetic");
+
+        putLicense(createEnterpriseLicense());
+        ensureGreen();
+
+        createIndexWithSyntheticSourceAndAssertExpectedType(".profiling-traces-v2", "synthetic");
+
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY, not(nullValue()));
+        assertFeatureUsage(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE, not(nullValue()));
+    }
+
+    private void createIndexWithSyntheticSourceAndAssertExpectedType(String indexName, String expectedType) {
+        var settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "synthetic").build();
+        createIndex(indexName, settings);
+        var response = admin().indices().getSettings(new GetSettingsRequest().indices(indexName)).actionGet();
+        assertThat(
+            response.getIndexToSettings().get(indexName).get(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey()),
+            equalTo(expectedType)
+        );
+    }
+
+    private List<GetFeatureUsageResponse.FeatureUsageInfo> getFeatureUsageInfo() {
+        return client().execute(TransportGetFeatureUsageAction.TYPE, new GetFeatureUsageRequest()).actionGet().getFeatures();
+    }
+
+    private void assertFeatureUsage(LicensedFeature.Momentary syntheticSourceFeature, Matcher<Object> matcher) {
+        GetFeatureUsageResponse.FeatureUsageInfo featureUsage = getFeatureUsageInfo().stream()
+            .filter(f -> f.getFamily().equals(SyntheticSourceLicenseService.MAPPINGS_FEATURE_FAMILY))
+            .filter(f -> f.getName().equals(syntheticSourceFeature.getName()))
+            .findAny()
+            .orElse(null);
+        assertThat(featureUsage, matcher);
+    }
+
+    public static class P extends LocalStateCompositeXPackPlugin {
+
+        public P(final Settings settings, final Path configPath) {
+            super(settings, configPath);
+            plugins.add(new LogsDBPlugin(settings) {
+                @Override
+                protected XPackLicenseState getLicenseState() {
+                    return P.this.getLicenseState();
+                }
+
+                @Override
+                protected LicenseService getLicenseService() {
+                    return P.this.getLicenseService();
+                }
+            });
+        }
+
+    }
+}

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProviderLegacyLicenseTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProviderLegacyLicenseTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.logsdb;
+
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.MapperTestUtils;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicenseService;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.internal.XPackLicenseStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.elasticsearch.xpack.logsdb.SyntheticSourceIndexSettingsProviderTests.getLogsdbIndexModeSettingsProvider;
+import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createGoldOrPlatinumLicense;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SyntheticSourceIndexSettingsProviderLegacyLicenseTests extends ESTestCase {
+
+    private SyntheticSourceIndexSettingsProvider provider;
+
+    @Before
+    public void setup() throws Exception {
+        long time = LocalDateTime.of(2024, 11, 12, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        License license = createGoldOrPlatinumLicense();
+        var licenseState = new XPackLicenseState(() -> time, new XPackLicenseStatus(license.operationMode(), true, null));
+
+        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        licenseService.setLicenseState(licenseState);
+        var mockLicenseService = mock(LicenseService.class);
+        when(mockLicenseService.getLicense()).thenReturn(license);
+
+        SyntheticSourceLicenseService syntheticSourceLicenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        syntheticSourceLicenseService.setLicenseState(licenseState);
+        syntheticSourceLicenseService.setLicenseService(mockLicenseService);
+
+        provider = new SyntheticSourceIndexSettingsProvider(
+            syntheticSourceLicenseService,
+            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
+            getLogsdbIndexModeSettingsProvider(false),
+            IndexVersion::current
+        );
+    }
+
+    public void testGetAdditionalIndexSettingsDefault() {
+        Settings settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "SYNTHETIC").build();
+        String dataStreamName = "metrics-my-app";
+        String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 0);
+        var result = provider.getAdditionalIndexSettings(indexName, dataStreamName, null, null, null, settings, List.of());
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey()), equalTo("STORED"));
+    }
+
+    public void testGetAdditionalIndexSettingsApm() throws IOException {
+        Settings settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "SYNTHETIC").build();
+        String dataStreamName = "metrics-apm.app.test";
+        String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 0);
+        var result = provider.getAdditionalIndexSettings(indexName, dataStreamName, null, null, null, settings, List.of());
+        assertThat(result.size(), equalTo(0));
+    }
+
+    public void testGetAdditionalIndexSettingsProfiling() throws IOException {
+        Settings settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "SYNTHETIC").build();
+        for (String dataStreamName : new String[] { "profiling-metrics", "profiling-events" }) {
+            String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 0);
+            var result = provider.getAdditionalIndexSettings(indexName, dataStreamName, null, null, null, settings, List.of());
+            assertThat(result.size(), equalTo(0));
+        }
+
+        for (String indexName : new String[] { ".profiling-sq-executables", ".profiling-sq-leafframes", ".profiling-stacktraces" }) {
+            var result = provider.getAdditionalIndexSettings(indexName, null, null, null, null, settings, List.of());
+            assertThat(result.size(), equalTo(0));
+        }
+    }
+
+    public void testGetAdditionalIndexSettingsTsdb() throws IOException {
+        Settings settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "SYNTHETIC").build();
+        String dataStreamName = "metrics-my-app";
+        String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 0);
+        var result = provider.getAdditionalIndexSettings(indexName, dataStreamName, IndexMode.TIME_SERIES, null, null, settings, List.of());
+        assertThat(result.size(), equalTo(0));
+    }
+
+    public void testGetAdditionalIndexSettingsTsdbAfterCutoffDate() throws Exception {
+        long start = LocalDateTime.of(2024, 12, 20, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        License license = createGoldOrPlatinumLicense(start);
+        long time = LocalDateTime.of(2024, 12, 31, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        var licenseState = new XPackLicenseState(() -> time, new XPackLicenseStatus(license.operationMode(), true, null));
+
+        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        licenseService.setLicenseState(licenseState);
+        var mockLicenseService = mock(LicenseService.class);
+        when(mockLicenseService.getLicense()).thenReturn(license);
+
+        SyntheticSourceLicenseService syntheticSourceLicenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        syntheticSourceLicenseService.setLicenseState(licenseState);
+        syntheticSourceLicenseService.setLicenseService(mockLicenseService);
+
+        provider = new SyntheticSourceIndexSettingsProvider(
+            syntheticSourceLicenseService,
+            im -> MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), im.getSettings(), im.getIndex().getName()),
+            getLogsdbIndexModeSettingsProvider(false),
+            IndexVersion::current
+        );
+
+        Settings settings = Settings.builder().put(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "SYNTHETIC").build();
+        String dataStreamName = "metrics-my-app";
+        String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 0);
+        var result = provider.getAdditionalIndexSettings(indexName, dataStreamName, IndexMode.TIME_SERIES, null, null, settings, List.of());
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get(SourceFieldMapper.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey()), equalTo("STORED"));
+    }
+}

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProviderTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceIndexSettingsProviderTests.java
@@ -18,6 +18,8 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.MapperTestUtils;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.common.settings.Settings.builder;
+import static org.elasticsearch.xpack.logsdb.SyntheticSourceLicenseServiceTests.createEnterpriseLicense;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -39,18 +42,22 @@ public class SyntheticSourceIndexSettingsProviderTests extends ESTestCase {
     private SyntheticSourceIndexSettingsProvider provider;
     private final AtomicInteger newMapperServiceCounter = new AtomicInteger();
 
-    private static LogsdbIndexModeSettingsProvider getLogsdbIndexModeSettingsProvider(boolean enabled) {
+    static LogsdbIndexModeSettingsProvider getLogsdbIndexModeSettingsProvider(boolean enabled) {
         return new LogsdbIndexModeSettingsProvider(Settings.builder().put("cluster.logsdb.enabled", enabled).build());
     }
 
     @Before
-    public void setup() {
-        MockLicenseState licenseState = mock(MockLicenseState.class);
+    public void setup() throws Exception {
+        MockLicenseState licenseState = MockLicenseState.createMock();
         when(licenseState.isAllowed(any())).thenReturn(true);
         var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
         licenseService.setLicenseState(licenseState);
+        var mockLicenseService = mock(LicenseService.class);
+        License license = createEnterpriseLicense();
+        when(mockLicenseService.getLicense()).thenReturn(license);
         syntheticSourceLicenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
         syntheticSourceLicenseService.setLicenseState(licenseState);
+        syntheticSourceLicenseService.setLicenseService(mockLicenseService);
 
         provider = new SyntheticSourceIndexSettingsProvider(syntheticSourceLicenseService, im -> {
             newMapperServiceCounter.incrementAndGet();

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseServiceTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/SyntheticSourceLicenseServiceTests.java
@@ -8,54 +8,195 @@
 package org.elasticsearch.xpack.logsdb;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 import org.mockito.Mockito;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import static org.elasticsearch.license.TestUtils.dateMath;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SyntheticSourceLicenseServiceTests extends ESTestCase {
 
+    private LicenseService mockLicenseService;
+    private SyntheticSourceLicenseService licenseService;
+
+    @Before
+    public void setup() throws Exception {
+        mockLicenseService = mock(LicenseService.class);
+        License license = createEnterpriseLicense();
+        when(mockLicenseService.getLicense()).thenReturn(license);
+        licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+    }
+
     public void testLicenseAllowsSyntheticSource() {
-        MockLicenseState licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(any())).thenReturn(true);
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
-        assertFalse("synthetic source is allowed, so not fallback to stored source", licenseService.fallbackToStoredSource(false));
+        licenseService.setLicenseService(mockLicenseService);
+        assertFalse(
+            "synthetic source is allowed, so not fallback to stored source",
+            licenseService.fallbackToStoredSource(false, randomBoolean())
+        );
         Mockito.verify(licenseState, Mockito.times(1)).featureUsed(any());
     }
 
     public void testLicenseAllowsSyntheticSourceTemplateValidation() {
-        MockLicenseState licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(any())).thenReturn(true);
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
-        assertFalse("synthetic source is allowed, so not fallback to stored source", licenseService.fallbackToStoredSource(true));
+        licenseService.setLicenseService(mockLicenseService);
+        assertFalse(
+            "synthetic source is allowed, so not fallback to stored source",
+            licenseService.fallbackToStoredSource(true, randomBoolean())
+        );
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
     }
 
     public void testDefaultDisallow() {
-        MockLicenseState licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(any())).thenReturn(false);
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
         licenseService.setLicenseState(licenseState);
-        assertTrue("synthetic source is not allowed, so fallback to stored source", licenseService.fallbackToStoredSource(false));
+        licenseService.setLicenseService(mockLicenseService);
+        assertTrue(
+            "synthetic source is not allowed, so fallback to stored source",
+            licenseService.fallbackToStoredSource(false, randomBoolean())
+        );
         Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
     }
 
     public void testFallback() {
-        MockLicenseState licenseState = mock(MockLicenseState.class);
-        when(licenseState.isAllowed(any())).thenReturn(true);
-        var licenseService = new SyntheticSourceLicenseService(Settings.EMPTY);
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(true);
         licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
         licenseService.setSyntheticSourceFallback(true);
         assertTrue(
             "synthetic source is allowed, but fallback has been enabled, so fallback to stored source",
-            licenseService.fallbackToStoredSource(false)
+            licenseService.fallbackToStoredSource(false, randomBoolean())
         );
         Mockito.verifyNoInteractions(licenseState);
+        Mockito.verifyNoInteractions(mockLicenseService);
     }
 
+    public void testGoldOrPlatinumLicense() throws Exception {
+        mockLicenseService = mock(LicenseService.class);
+        License license = createGoldOrPlatinumLicense();
+        when(mockLicenseService.getLicense()).thenReturn(license);
+
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.getOperationMode()).thenReturn(license.operationMode());
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
+        assertFalse(
+            "legacy licensed usage is allowed, so not fallback to stored source",
+            licenseService.fallbackToStoredSource(false, true)
+        );
+        Mockito.verify(licenseState, Mockito.times(1)).featureUsed(any());
+    }
+
+    public void testGoldOrPlatinumLicenseLegacyLicenseNotAllowed() throws Exception {
+        mockLicenseService = mock(LicenseService.class);
+        License license = createGoldOrPlatinumLicense();
+        when(mockLicenseService.getLicense()).thenReturn(license);
+
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.getOperationMode()).thenReturn(license.operationMode());
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
+        assertTrue(
+            "legacy licensed usage is not allowed, so fallback to stored source",
+            licenseService.fallbackToStoredSource(false, false)
+        );
+        Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE));
+    }
+
+    public void testGoldOrPlatinumLicenseBeyondCutoffDate() throws Exception {
+        long start = LocalDateTime.of(2025, 1, 1, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        License license = createGoldOrPlatinumLicense(start);
+        mockLicenseService = mock(LicenseService.class);
+        when(mockLicenseService.getLicense()).thenReturn(license);
+
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.getOperationMode()).thenReturn(license.operationMode());
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE))).thenReturn(false);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
+        assertTrue("beyond cutoff date, so fallback to stored source", licenseService.fallbackToStoredSource(false, true));
+        Mockito.verify(licenseState, Mockito.never()).featureUsed(any());
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE));
+    }
+
+    public void testGoldOrPlatinumLicenseCustomCutoffDate() throws Exception {
+        licenseService = new SyntheticSourceLicenseService(Settings.EMPTY, "2025-01-02T00:00");
+
+        long start = LocalDateTime.of(2025, 1, 1, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        License license = createGoldOrPlatinumLicense(start);
+        mockLicenseService = mock(LicenseService.class);
+        when(mockLicenseService.getLicense()).thenReturn(license);
+
+        MockLicenseState licenseState = MockLicenseState.createMock();
+        when(licenseState.getOperationMode()).thenReturn(license.operationMode());
+        when(licenseState.isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY))).thenReturn(true);
+        licenseService.setLicenseState(licenseState);
+        licenseService.setLicenseService(mockLicenseService);
+        assertFalse("custom cutoff date, so fallback to stored source", licenseService.fallbackToStoredSource(false, true));
+        Mockito.verify(licenseState, Mockito.times(1)).featureUsed(any());
+        Mockito.verify(licenseState, Mockito.times(1)).isAllowed(same(SyntheticSourceLicenseService.SYNTHETIC_SOURCE_FEATURE_LEGACY));
+    }
+
+    static License createEnterpriseLicense() throws Exception {
+        long start = LocalDateTime.of(2024, 11, 12, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        return createEnterpriseLicense(start);
+    }
+
+    static License createEnterpriseLicense(long start) throws Exception {
+        String uid = UUID.randomUUID().toString();
+        long currentTime = System.currentTimeMillis();
+        final License.Builder builder = License.builder()
+            .uid(uid)
+            .version(License.VERSION_CURRENT)
+            .expiryDate(dateMath("now+2d", currentTime))
+            .startDate(start)
+            .issueDate(currentTime)
+            .type("enterprise")
+            .issuedTo("customer")
+            .issuer("elasticsearch")
+            .maxResourceUnits(10);
+        return TestUtils.generateSignedLicense(builder);
+    }
+
+    static License createGoldOrPlatinumLicense() throws Exception {
+        long start = LocalDateTime.of(2024, 11, 12, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        return createGoldOrPlatinumLicense(start);
+    }
+
+    static License createGoldOrPlatinumLicense(long start) throws Exception {
+        String uid = UUID.randomUUID().toString();
+        long currentTime = System.currentTimeMillis();
+        final License.Builder builder = License.builder()
+            .uid(uid)
+            .version(License.VERSION_CURRENT)
+            .expiryDate(dateMath("now+100d", currentTime))
+            .startDate(start)
+            .issueDate(currentTime)
+            .type(randomBoolean() ? "gold" : "platinum")
+            .issuedTo("customer")
+            .issuer("elasticsearch")
+            .maxNodes(5);
+        return TestUtils.generateSignedLicense(builder);
+    }
 }


### PR DESCRIPTION
Allow gold and platinum license to use synthetic source for a limited time. If the start time of a license is before the cut off date, then gold and platinum licenses will not fallback to stored source if synthetic source is used.