### PR TITLE
[8.x] [Build] Fix fips testing after buildparams rework (#116934)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -20,7 +20,7 @@ import org.elasticsearch.gradle.testclusters.TestDistribution
 // Common config when running with a FIPS-140 runtime JVM
 if (buildParams.inFipsJvm) {
   allprojects {
-    String javaSecurityFilename = buildParams.runtimeJavaDetails.toLowerCase().contains('oracle') ? 'fips_java_oracle.security' : 'fips_java.security'
+    String javaSecurityFilename = buildParams.runtimeJavaDetails.get().toLowerCase().contains('oracle') ? 'fips_java_oracle.security' : 'fips_java.security'
     File fipsResourcesDir = new File(project.buildDir, 'fips-resources')
     File fipsSecurity = new File(fipsResourcesDir, javaSecurityFilename)
     File fipsPolicy = new File(fipsResourcesDir, 'fips_java.policy')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Build] Fix fips testing after buildparams rework (#116934)](https://github.com/elastic/elasticsearch/pull/116934)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)