### PR TITLE
Log shard `completed snapshot` message at `TRACE`

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -425,9 +425,9 @@ public final class SnapshotShardsService extends AbstractLifecycleComponent impl
                 final ShardGeneration newGeneration = shardSnapshotResult.getGeneration();
                 assert newGeneration != null;
                 assert newGeneration.equals(snapshotStatus.generation());
-                if (logger.isDebugEnabled()) {
+                if (logger.isTraceEnabled()) {
                     final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
-                    logger.debug(
+                    logger.trace(
                         "[{}][{}] completed snapshot to [{}] with status [{}] at generation [{}]",
                         shardId,
                         snapshot,


### PR DESCRIPTION
This message is on the happy path, no need to log it at `DEBUG`.

Relates ES-8773
