### PR TITLE
Add `@UpdateForV10` annotation to `allow_insecure_settings`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -11,6 +11,7 @@ package org.elasticsearch.common.settings;
 
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.UpdateForV10;
 
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
@@ -26,6 +27,7 @@ import java.util.Set;
 public abstract class SecureSetting<T> extends Setting<T> {
 
     /** Determines whether legacy settings with sensitive values should be allowed. */
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // this should no longer be in use, even in v9, so can go away in v10
     private static final boolean ALLOW_INSECURE_SETTINGS = Booleans.parseBoolean(System.getProperty("es.allow_insecure_settings", "false"));
 
     private static final Set<Property> ALLOWED_PROPERTIES = EnumSet.of(


### PR DESCRIPTION
This hasn't really been necessary since reloadable secure settings
landed in 7.0. It's been deprecated for a long time and the last known
user has agreed to stop using it in v9. This commit adds a reminder to
drop this functionality entirely in v10.