### PR TITLE
Fix enrich cache size setting name

### DIFF
--- a/docs/changelog/117576.yaml
+++ b/docs/changelog/117576.yaml
@@ -1,0 +1,5 @@
+pr: 117576
+summary: Fix enrich cache size setting name
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
The enrich cache size setting accidentally got renamed from `enrich.cache_size` to `enrich.cache.size` in #111412. This commit ensures we accept both versions, to avoid breaking BWC twice.

This is a manual (and altered) backport of #117575.