### PR TITLE
Implement lifecycle on `SimulatePipelineRequest`

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -41,7 +41,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.After;
 
@@ -67,6 +66,7 @@ import java.util.stream.StreamSupport;
 import java.util.zip.GZIPInputStream;
 
 import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonSimulatePipelineRequest;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDefaultDatabases;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
@@ -494,7 +494,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             builder.endObject();
             bytes = BytesReference.bytes(builder);
         }
-        SimulatePipelineRequest simulateRequest = new SimulatePipelineRequest(bytes, XContentType.JSON);
+        SimulatePipelineRequest simulateRequest = jsonSimulatePipelineRequest(bytes);
         simulateRequest.setId("_id");
         // Avoid executing on a coordinating only node, because databases are not available there and geoip processor won't do any lookups.
         // (some test seeds repeatedly hit such nodes causing failures)

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonSimulatePipelineRequest;
 import static org.elasticsearch.ingest.IngestPipelineTestUtils.putJsonPipelineRequest;
 import static org.elasticsearch.test.NodeRoles.nonIngestNode;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
@@ -97,7 +98,7 @@ public class IngestClientIT extends ESIntegTestCase {
         if (randomBoolean()) {
             response = clusterAdmin().prepareSimulatePipeline(bytes, XContentType.JSON).setId("_id").get();
         } else {
-            SimulatePipelineRequest request = new SimulatePipelineRequest(bytes, XContentType.JSON);
+            SimulatePipelineRequest request = jsonSimulatePipelineRequest(bytes);
             request.setId("_id");
             response = clusterAdmin().simulatePipeline(request).get();
         }

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequestBuilder.java
@@ -12,6 +12,7 @@ package org.elasticsearch.action.ingest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.xcontent.XContentType;
 
 public class SimulatePipelineRequestBuilder extends ActionRequestBuilder<SimulatePipelineRequest, SimulatePipelineResponse> {
@@ -20,7 +21,7 @@ public class SimulatePipelineRequestBuilder extends ActionRequestBuilder<Simulat
      * Create a new builder for {@link SimulatePipelineRequest}s
      */
     public SimulatePipelineRequestBuilder(ElasticsearchClient client, BytesReference source, XContentType xContentType) {
-        super(client, SimulatePipelineAction.INSTANCE, new SimulatePipelineRequest(source, xContentType));
+        super(client, SimulatePipelineAction.INSTANCE, new SimulatePipelineRequest(ReleasableBytesReference.wrap(source), xContentType));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestSimulatePipelineAction.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.rest.action.ingest;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ingest.SimulatePipelineRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
@@ -48,12 +47,9 @@ public class RestSimulatePipelineAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         Tuple<XContentType, ReleasableBytesReference> sourceTuple = restRequest.contentOrSourceParam();
-        var content = sourceTuple.v2();
-        SimulatePipelineRequest request = new SimulatePipelineRequest(sourceTuple.v2(), sourceTuple.v1(), restRequest.getRestApiVersion());
+        final var request = new SimulatePipelineRequest(sourceTuple.v2(), sourceTuple.v1(), restRequest.getRestApiVersion());
         request.setId(restRequest.param("id"));
         request.setVerbose(restRequest.paramAsBoolean("verbose", false));
-        return channel -> client.admin()
-            .cluster()
-            .simulatePipeline(request, ActionListener.withRef(new RestToXContentListener<>(channel), content));
+        return channel -> client.admin().cluster().simulatePipeline(request, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestTests.java
@@ -16,14 +16,14 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonSimulatePipelineRequest;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class SimulatePipelineRequestTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
-        SimulatePipelineRequest request = new SimulatePipelineRequest(new BytesArray(""), XContentType.JSON);
+        SimulatePipelineRequest request = jsonSimulatePipelineRequest(new BytesArray(""));
         // Sometimes we set an id
         if (randomBoolean()) {
             request.setId(randomAlphaOfLengthBetween(1, 10));
@@ -44,10 +44,7 @@ public class SimulatePipelineRequestTests extends ESTestCase {
     }
 
     public void testSerializationWithXContent() throws IOException {
-        SimulatePipelineRequest request = new SimulatePipelineRequest(
-            new BytesArray("{}".getBytes(StandardCharsets.UTF_8)),
-            XContentType.JSON
-        );
+        SimulatePipelineRequest request = jsonSimulatePipelineRequest("{}");
         assertEquals(XContentType.JSON, request.getXContentType());
 
         BytesStreamOutput output = new BytesStreamOutput();

--- a/test/framework/src/main/java/org/elasticsearch/ingest/IngestPipelineTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/IngestPipelineTestUtils.java
@@ -14,11 +14,13 @@ import org.elasticsearch.action.ingest.DeletePipelineRequest;
 import org.elasticsearch.action.ingest.DeletePipelineTransportAction;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
+import org.elasticsearch.action.ingest.SimulatePipelineRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
@@ -123,5 +125,19 @@ public class IngestPipelineTestUtils {
                 )
             );
         }
+    }
+
+    /**
+     * Construct a new {@link SimulatePipelineRequest} whose content is the given JSON document, represented as a {@link String}.
+     */
+    public static SimulatePipelineRequest jsonSimulatePipelineRequest(String jsonString) {
+        return jsonSimulatePipelineRequest(new BytesArray(jsonString));
+    }
+
+    /**
+     * Construct a new {@link SimulatePipelineRequest} whose content is the given JSON document, represented as a {@link BytesReference}.
+     */
+    public static SimulatePipelineRequest jsonSimulatePipelineRequest(BytesReference jsonBytes) {
+        return new SimulatePipelineRequest(ReleasableBytesReference.wrap(jsonBytes), XContentType.JSON);
     }
 }

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
@@ -9,9 +9,7 @@ package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.ingest.SimulateDocumentBaseResult;
-import org.elasticsearch.action.ingest.SimulatePipelineRequest;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -27,6 +25,7 @@ import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
 import java.util.Collection;
 import java.util.List;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonSimulatePipelineRequest;
 import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -90,7 +89,7 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
         var executePolicyRequest = new ExecuteEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, policyName);
         client().execute(ExecuteEnrichPolicyAction.INSTANCE, executePolicyRequest).actionGet();
 
-        var simulatePipelineRequest = new SimulatePipelineRequest(new BytesArray("""
+        var simulatePipelineRequest = jsonSimulatePipelineRequest("""
             {
               "pipeline": {
                 "processors": [
@@ -119,7 +118,7 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
                 }
               ]
             }
-            """), XContentType.JSON);
+            """);
         var response = clusterAdmin().simulatePipeline(simulatePipelineRequest).actionGet();
         var result = (SimulateDocumentBaseResult) response.getResults().get(0);
         assertThat(result.getFailure(), nullValue());
@@ -132,7 +131,7 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
         assertThat(statsResponse.getCacheStats().get(0).misses(), equalTo(1L));
         assertThat(statsResponse.getCacheStats().get(0).hits(), equalTo(0L));
 
-        simulatePipelineRequest = new SimulatePipelineRequest(new BytesArray("""
+        simulatePipelineRequest = jsonSimulatePipelineRequest("""
             {
               "pipeline": {
                 "processors": [
@@ -155,7 +154,7 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
                 }
               ]
             }
-            """), XContentType.JSON);
+            """);
         response = clusterAdmin().simulatePipeline(simulatePipelineRequest).actionGet();
         result = (SimulateDocumentBaseResult) response.getResults().get(0);
         assertThat(result.getFailure(), nullValue());

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -11,14 +11,12 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.ingest.SimulateDocumentBaseResult;
 import org.elasticsearch.action.ingest.SimulatePipelineAction;
-import org.elasticsearch.action.ingest.SimulatePipelineRequest;
 import org.elasticsearch.action.ingest.SimulatePipelineResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
@@ -61,13 +59,13 @@ import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 import org.junit.Before;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.jsonSimulatePipelineRequest;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
@@ -541,11 +539,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                 }}]
             }""", pipeline);
         PlainActionFuture<SimulatePipelineResponse> simulatePipelineListener = new PlainActionFuture<>();
-        client().execute(
-            SimulatePipelineAction.INSTANCE,
-            new SimulatePipelineRequest(new BytesArray(simulateSource.getBytes(StandardCharsets.UTF_8)), XContentType.JSON),
-            simulatePipelineListener
-        );
+        client().execute(SimulatePipelineAction.INSTANCE, jsonSimulatePipelineRequest(simulateSource), simulatePipelineListener);
 
         assertThat(simulatePipelineListener.actionGet().getResults(), is(not(empty())));
 
@@ -575,7 +569,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         // Simulating the pipeline should fail
         SimulateDocumentBaseResult simulateResponse = (SimulateDocumentBaseResult) client().execute(
             SimulatePipelineAction.INSTANCE,
-            new SimulatePipelineRequest(new BytesArray(simulateSource.getBytes(StandardCharsets.UTF_8)), XContentType.JSON)
+            jsonSimulatePipelineRequest(simulateSource)
         ).actionGet().getResults().get(0);
         assertThat(simulateResponse.getFailure(), is(not(nullValue())));
         assertThat((simulateResponse.getFailure()).getCause(), is(instanceOf(ElasticsearchSecurityException.class)));
@@ -588,11 +582,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         putJsonPipeline("test_infer_license_pipeline", pipeline);
 
         PlainActionFuture<SimulatePipelineResponse> simulatePipelineListenerNewLicense = new PlainActionFuture<>();
-        client().execute(
-            SimulatePipelineAction.INSTANCE,
-            new SimulatePipelineRequest(new BytesArray(simulateSource.getBytes(StandardCharsets.UTF_8)), XContentType.JSON),
-            simulatePipelineListenerNewLicense
-        );
+        client().execute(SimulatePipelineAction.INSTANCE, jsonSimulatePipelineRequest(simulateSource), simulatePipelineListenerNewLicense);
 
         assertThat(simulatePipelineListenerNewLicense.actionGet().getResults(), is(not(empty())));
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -282,7 +283,10 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
                     builder.startObject();
                     builder.field("docs", results);
                     builder.endObject();
-                    var pipelineRequest = new SimulatePipelineRequest(BytesReference.bytes(builder), XContentType.JSON);
+                    var pipelineRequest = new SimulatePipelineRequest(
+                        ReleasableBytesReference.wrap(BytesReference.bytes(builder)),
+                        XContentType.JSON
+                    );
                     pipelineRequest.setId(pipeline);
                     parentTaskClient.execute(SimulatePipelineAction.INSTANCE, pipelineRequest, pipelineResponseActionListener);
                 }


### PR DESCRIPTION
Rather than releasing the REST request body after computing the
response, we can link the lifecycles of the REST and transport requests
and release the REST request body sooner. Not that we expect these
bodies to be particularly large in this case, but still it's a better
pattern to follow.