### PR TITLE
[8.x] ESQL Add some tests for sorting the date nanos union type (#117567)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -626,6 +626,65 @@ sample_data_ts_nanos | 2023-10-23T12:27:28.948123456Z  |  172.21.2.113  |  27648
 sample_data_ts_nanos | 2023-10-23T12:15:03.360123456Z  |  172.21.2.162  |  3450233              |  Connected to 10.1.0.3
 ;
 
+multiIndex sort millis and nanos as nanos
+required_capability: to_date_nanos
+required_capability: union_types
+required_capability: metadata_fields
+required_capability: union_types_remove_fields
+
+FROM sample_data, sample_data_ts_nanos METADATA _index
+| EVAL ts = TO_DATE_NANOS(@timestamp)
+| KEEP _index, ts, client_ip, event_duration, message
+| SORT ts DESC
+;
+
+_index:keyword       | ts:date_nanos             |  client_ip:ip  |  event_duration:long  |  message:keyword
+sample_data_ts_nanos | 2023-10-23T13:55:01.543123456Z  |  172.21.3.15   |  1756467              |  Connected to 10.1.0.1
+sample_data          | 2023-10-23T13:55:01.543000000Z  |  172.21.3.15   |  1756467              |  Connected to 10.1.0.1
+sample_data_ts_nanos | 2023-10-23T13:53:55.832123456Z  |  172.21.3.15   |  5033755              |  Connection error
+sample_data          | 2023-10-23T13:53:55.832000000Z  |  172.21.3.15   |  5033755              |  Connection error
+sample_data_ts_nanos | 2023-10-23T13:52:55.015123456Z  |  172.21.3.15   |  8268153              |  Connection error
+sample_data          | 2023-10-23T13:52:55.015000000Z  |  172.21.3.15   |  8268153              |  Connection error
+sample_data_ts_nanos | 2023-10-23T13:51:54.732123456Z  |  172.21.3.15   |  725448               |  Connection error
+sample_data          | 2023-10-23T13:51:54.732000000Z  |  172.21.3.15   |  725448               |  Connection error
+sample_data_ts_nanos | 2023-10-23T13:33:34.937123456Z  |  172.21.0.5    |  1232382              |  Disconnected
+sample_data          | 2023-10-23T13:33:34.937000000Z  |  172.21.0.5    |  1232382              |  Disconnected
+sample_data_ts_nanos | 2023-10-23T12:27:28.948123456Z  |  172.21.2.113  |  2764889              |  Connected to 10.1.0.2
+sample_data          | 2023-10-23T12:27:28.948000000Z  |  172.21.2.113  |  2764889              |  Connected to 10.1.0.2
+sample_data_ts_nanos | 2023-10-23T12:15:03.360123456Z  |  172.21.2.162  |  3450233              |  Connected to 10.1.0.3
+sample_data          | 2023-10-23T12:15:03.360000000Z  |  172.21.2.162  |  3450233              |  Connected to 10.1.0.3
+;
+
+multiIndex sort millis and nanos as millis
+required_capability: to_date_nanos
+required_capability: union_types
+required_capability: metadata_fields
+required_capability: union_types_remove_fields
+
+FROM sample_data, sample_data_ts_nanos METADATA _index
+| EVAL ts = TO_DATETIME(@timestamp)
+| KEEP _index, ts, client_ip, event_duration, message
+| SORT ts DESC, _index DESC
+;
+
+_index:keyword       | ts:datetime               |  client_ip:ip  |  event_duration:long  |  message:keyword
+sample_data_ts_nanos | 2023-10-23T13:55:01.543Z  |  172.21.3.15   |  1756467              |  Connected to 10.1.0.1
+sample_data          | 2023-10-23T13:55:01.543Z  |  172.21.3.15   |  1756467              |  Connected to 10.1.0.1
+sample_data_ts_nanos | 2023-10-23T13:53:55.832Z  |  172.21.3.15   |  5033755              |  Connection error
+sample_data          | 2023-10-23T13:53:55.832Z  |  172.21.3.15   |  5033755              |  Connection error
+sample_data_ts_nanos | 2023-10-23T13:52:55.015Z  |  172.21.3.15   |  8268153              |  Connection error
+sample_data          | 2023-10-23T13:52:55.015Z  |  172.21.3.15   |  8268153              |  Connection error
+sample_data_ts_nanos | 2023-10-23T13:51:54.732Z  |  172.21.3.15   |  725448               |  Connection error
+sample_data          | 2023-10-23T13:51:54.732Z  |  172.21.3.15   |  725448               |  Connection error
+sample_data_ts_nanos | 2023-10-23T13:33:34.937Z  |  172.21.0.5    |  1232382              |  Disconnected
+sample_data          | 2023-10-23T13:33:34.937Z  |  172.21.0.5    |  1232382              |  Disconnected
+sample_data_ts_nanos | 2023-10-23T12:27:28.948Z  |  172.21.2.113  |  2764889              |  Connected to 10.1.0.2
+sample_data          | 2023-10-23T12:27:28.948Z  |  172.21.2.113  |  2764889              |  Connected to 10.1.0.2
+sample_data_ts_nanos | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233              |  Connected to 10.1.0.3
+sample_data          | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233              |  Connected to 10.1.0.3
+;
+
+
 multiIndexTsNanosRenameToNanosWithFiltering
 required_capability: to_date_nanos
 required_capability: date_nanos_binary_comparison


### PR DESCRIPTION
Backports the following commits to 8.x:
 - ESQL Add some tests for sorting the date nanos union type (#117567)