### PR TITLE
Remove extraneous entitlement parameter from parser

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyParser.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.entitlement.runtime.policy;
 
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
@@ -30,8 +29,6 @@ import static org.elasticsearch.entitlement.runtime.policy.PolicyParserException
  * A parser to parse policy files for entitlements.
  */
 public class PolicyParser {
-
-    protected static final ParseField ENTITLEMENTS_PARSEFIELD = new ParseField("entitlements");
 
     protected static final String entitlementPackageName = Entitlement.class.getPackage().getName();
 
@@ -65,13 +62,6 @@ public class PolicyParser {
 
     protected Scope parseScope(String scopeName) throws IOException {
         try {
-            if (policyParser.nextToken() != XContentParser.Token.START_OBJECT) {
-                throw newPolicyParserException(scopeName, "expected object [" + ENTITLEMENTS_PARSEFIELD.getPreferredName() + "]");
-            }
-            if (policyParser.nextToken() != XContentParser.Token.FIELD_NAME
-                || policyParser.currentName().equals(ENTITLEMENTS_PARSEFIELD.getPreferredName()) == false) {
-                throw newPolicyParserException(scopeName, "expected object [" + ENTITLEMENTS_PARSEFIELD.getPreferredName() + "]");
-            }
             if (policyParser.nextToken() != XContentParser.Token.START_ARRAY) {
                 throw newPolicyParserException(scopeName, "expected array of <entitlement type>");
             }
@@ -89,9 +79,6 @@ public class PolicyParser {
                 if (policyParser.nextToken() != XContentParser.Token.END_OBJECT) {
                     throw newPolicyParserException(scopeName, "expected closing object");
                 }
-            }
-            if (policyParser.nextToken() != XContentParser.Token.END_OBJECT) {
-                throw newPolicyParserException(scopeName, "expected closing object");
             }
             return new Scope(scopeName, entitlements);
         } catch (IOException ioe) {

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyParserFailureTests.java
@@ -29,11 +29,10 @@ public class PolicyParserFailureTests extends ESTestCase {
     public void testEntitlementDoesNotExist() throws IOException {
         PolicyParserException ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
             entitlement-module-name:
-              entitlements:
-                - does_not_exist: {}
+              - does_not_exist: {}
             """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml").parsePolicy());
         assertEquals(
-            "[3:7] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name]: "
+            "[2:5] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name]: "
                 + "unknown entitlement type [does_not_exist]",
             ppe.getMessage()
         );
@@ -42,23 +41,21 @@ public class PolicyParserFailureTests extends ESTestCase {
     public void testEntitlementMissingParameter() throws IOException {
         PolicyParserException ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
             entitlement-module-name:
-              entitlements:
-                - file: {}
+              - file: {}
             """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml").parsePolicy());
         assertEquals(
-            "[3:14] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
+            "[2:12] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
                 + "for entitlement type [file]: missing entitlement parameter [path]",
             ppe.getMessage()
         );
 
         ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
             entitlement-module-name:
-              entitlements:
-                - file:
-                    path: test-path
+              - file:
+                  path: test-path
             """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml").parsePolicy());
         assertEquals(
-            "[5:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
+            "[4:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
                 + "for entitlement type [file]: missing entitlement parameter [actions]",
             ppe.getMessage()
         );
@@ -67,15 +64,14 @@ public class PolicyParserFailureTests extends ESTestCase {
     public void testEntitlementExtraneousParameter() throws IOException {
         PolicyParserException ppe = expectThrows(PolicyParserException.class, () -> new PolicyParser(new ByteArrayInputStream("""
             entitlement-module-name:
-              entitlements:
-                - file:
-                    path: test-path
-                    actions:
-                      - read
-                    extra: test
+              - file:
+                  path: test-path
+                  actions:
+                    - read
+                  extra: test
             """.getBytes(StandardCharsets.UTF_8)), "test-failure-policy.yaml").parsePolicy());
         assertEquals(
-            "[8:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
+            "[7:1] policy parsing error for [test-failure-policy.yaml] in scope [entitlement-module-name] "
                 + "for entitlement type [file]: extraneous entitlement parameter(s) {extra=test}",
             ppe.getMessage()
         );

--- a/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
+++ b/libs/entitlement/src/test/resources/org/elasticsearch/entitlement/runtime/policy/test-policy.yaml
@@ -1,7 +1,6 @@
 entitlement-module-name:
-  entitlements:
-    - file:
-        path: "test/path/to/file"
-        actions:
-          - "read"
-          - "write"
+  - file:
+      path: "test/path/to/file"
+      actions:
+        - "read"
+        - "write"


### PR DESCRIPTION
This changes our entitlement file format from:

```
entitlement-module-name:
  entitlements:
    - file:
        path: "test/path/to/file"
        actions:
          - "read"
          - "write"
```

to 

```
entitlement-module-name:
  - file:
      path: "test/path/to/file"
      actions:
        - "read"
        - "write"
```