### PR TITLE
[8.x] Add a blank line between java and javax imports (#117602)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -209,7 +209,7 @@ indent_size = 4
 max_line_length = 140
 ij_java_class_count_to_use_import_on_demand = 999
 ij_java_names_count_to_use_import_on_demand = 999
-ij_java_imports_layout = *,|,com.**,|,org.**,|,java.**,javax.**,|,$*
+ij_java_imports_layout = *,|,com.**,|,org.**,|,java.**,|,javax.**,|,$*
 
 [*.json]
 indent_size = 2


### PR DESCRIPTION
Backports the following commits to 8.x:
 - Add a blank line between java and javax imports (#117602)